### PR TITLE
ci: disable pr labeler due to permission

### DIFF
--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -1,5 +1,5 @@
 name: PR Labeler
-// 因为权限问题禁用 PR Labeler CI
+
 on:
   # TODO: Disabled due to private repo permission
   # pull_request_target:


### PR DESCRIPTION
## Summary

disable pr labeler CI due to private repo permission.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
