### PR TITLE
fix: correct cli filter

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -4,12 +4,13 @@ import { createContext } from './context';
 export function createRstest(
   config: RstestConfig,
   command: RstestCommand,
+  fileFilters: string[],
 ): RstestInstance {
   const context = createContext({ cwd: process.cwd(), command }, config);
 
   const runTests = async (): Promise<void> => {
     const { runTests } = await import('./runTests');
-    await runTests(context);
+    await runTests(context, fileFilters);
   };
 
   return {

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -4,14 +4,25 @@ import { color, getTestEntries, logger } from '../utils';
 import { createRsbuildServer } from './rsbuild';
 import { printSummaryLog } from './summary';
 
-export async function runTests(context: RstestContext): Promise<void> {
+export async function runTests(
+  context: RstestContext,
+  fileFilters: string[],
+): Promise<void> {
   const { include, exclude, root, name } = context.normalizedConfig;
 
-  const sourceEntries = await getTestEntries({ include, exclude, root });
+  const sourceEntries = await getTestEntries({
+    include,
+    exclude,
+    root,
+    fileFilters,
+  });
 
   if (!Object.keys(sourceEntries).length) {
     logger.log(color.red('No test files found.'));
     logger.log('');
+    if (fileFilters.length) {
+      logger.log(color.gray('filter: '), fileFilters.join(color.gray(', ')));
+    }
     logger.log(color.gray('include:'), include.join(color.gray(', ')));
     logger.log(color.gray('exclude:'), exclude.join(color.gray(', ')));
     logger.log('');

--- a/packages/core/src/utils/entries.ts
+++ b/packages/core/src/utils/entries.ts
@@ -1,18 +1,53 @@
 import path from 'node:path';
 import { glob } from 'tinyglobby';
 
+const filterFiles = (
+  testFiles: string[],
+  filters: string[],
+  dir: string,
+): string[] => {
+  if (!filters.length) {
+    return testFiles;
+  }
+
+  const fileFilters =
+    process.platform === 'win32'
+      ? filters.map((f) => f.split(path.sep).join('/'))
+      : filters;
+
+  return testFiles.filter((t) => {
+    const testFile = path.relative(dir, t).toLocaleLowerCase();
+    return fileFilters.some((f) => {
+      // if filter is a full file path, we should include it if it's in the same folder
+      if (path.isAbsolute(f) && t.startsWith(f)) {
+        return true;
+      }
+
+      const relativePath = f.endsWith('/')
+        ? path.join(path.relative(dir, f), '/')
+        : path.relative(dir, f);
+      return (
+        testFile.includes(f.toLocaleLowerCase()) ||
+        testFile.includes(relativePath.toLocaleLowerCase())
+      );
+    });
+  });
+};
+
 export const getTestEntries = async ({
   include,
   exclude,
   root,
+  fileFilters,
 }: {
   include: string[];
   exclude: string[];
+  fileFilters: string[];
   root: string;
 }): Promise<{
   [name: string]: string;
 }> => {
-  const entries = await glob(include, {
+  const testFiles = await glob(include, {
     cwd: root,
     absolute: true,
     ignore: exclude,
@@ -21,7 +56,7 @@ export const getTestEntries = async ({
   });
 
   return Object.fromEntries(
-    entries.map((entry) => {
+    filterFiles(testFiles, fileFilters, root).map((entry) => {
       const name = path.relative(root, entry);
       return [name, entry];
     }),


### PR DESCRIPTION
## Summary

When `filter` is passed in CLI, rstest will run only the test file that contains `filter` in their paths. 


<img width="709" alt="image" src="https://github.com/user-attachments/assets/e5ff06d5-4b05-4523-91d9-12449ff54b77" />

<img width="567" alt="image" src="https://github.com/user-attachments/assets/85c38ca8-1130-4675-893c-d4a49cec0212" />



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
