### PR TITLE
feat: allow run test without suite wrapped

### DIFF
--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -12,7 +12,7 @@ export const createRstestRuntime = (
   workerState: WorkerState,
 ): {
   runner: {
-    runTest: (testPath: string) => Promise<TestResult>;
+    runTest: (testPath: string, rootPath: string) => Promise<TestResult>;
     getCurrentTest: () => TestCase | undefined;
   };
   api: Rstest;

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -6,7 +6,7 @@ import { RunnerRuntime } from './runtime';
 export function createRunner(): {
   api: RunnerAPI;
   runner: {
-    runTest: (testFilePath: string) => Promise<TestResult>;
+    runTest: (testFilePath: string, rootPath: string) => Promise<TestResult>;
     getCurrentTest: RunnerRuntime['getCurrentTest'];
   };
 } {
@@ -28,8 +28,12 @@ export function createRunner(): {
       test: it,
     },
     runner: {
-      runTest: async (testFilePath: string) => {
-        return testRunner.runTest(runtimeAPI.getTests(), testFilePath);
+      runTest: async (testFilePath: string, rootPath: string) => {
+        return testRunner.runTests(
+          runtimeAPI.getTests(),
+          testFilePath,
+          rootPath,
+        );
       },
       getCurrentTest: () => runtimeAPI.getCurrentTest(),
     },

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -5,13 +5,21 @@ export type TestCase = {
   todo?: boolean;
   fails?: boolean;
   // TODO
+  only?: boolean;
+  // TODO
   onFinished?: any[];
+  type: 'case';
 };
 
 export type TestSuite = {
   description: string;
-  tests: TestCase[];
+  // TODO
+  filepath?: string;
+  tests: Array<TestSuite | TestCase>;
+  type: 'suite';
 };
+
+export type Test = TestSuite | TestCase;
 
 export type TestSuiteResult = {
   status: 'skip' | 'pass' | 'fail' | 'todo';

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -26,6 +26,7 @@ const runInPool = async ({
   const codeContent = assetFiles[filePath]!;
   const {
     normalizedConfig: { globals },
+    rootPath,
   } = context;
 
   const workerState: WorkerState = {
@@ -52,7 +53,7 @@ const runInPool = async ({
       assetFiles,
     });
 
-    const results = await runner.runTest(originPath);
+    const results = await runner.runTest(originPath, rootPath);
 
     return results;
   } catch (err) {

--- a/tests/runner/test/index.test.ts
+++ b/tests/runner/test/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@rstest/core';
+
+it('should allow run test without suite wrapped', () => {
+  expect(1 + 1).toBe(2);
+});
+
+describe('Test Suite', () => {
+  it('should allow run test in suite', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  describe('Test Suite Nested', () => {
+    it('should allow run test in nested suite', () => {
+      expect(1 + 1).toBe(2);
+    });
+  });
+
+  it('should allow run test in suite - 1', () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+
+describe('Test Suite - 1', () => {
+  it('should ok', () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

-  allow run test without suite wrapped
-  allow run test in nested suite

<img width="857" alt="image" src="https://github.com/user-attachments/assets/1b737d95-3682-4bb5-821f-22b800a383c3" />


```ts
import { describe, expect, it } from '@rstest/core';

it('should allow run test without suite wrapped', () => {
  expect(1 + 1).toBe(2);
});

describe('Test Suite', () => {
  it('should allow run test in suite', () => {
    expect(1 + 1).toBe(2);
  });

  describe('Test Suite Nested', () => {
    it('should allow run test in nested suite', () => {
      expect(1 + 1).toBe(2);
    });
  });

  it('should allow run test in suite - 1', () => {
    expect(1 + 1).toBe(2);
  });
});

describe('Test Suite - 1', () => {
  it('should ok', () => {
    expect(1 + 1).toBe(2);
  });
});

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
