### PR TITLE
feat: support run setupFiles

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -27,8 +27,10 @@ export const runInPool = async ({
   entries,
   context,
   assetFiles,
+  setupEntries,
 }: {
   entries: EntryInfo[];
+  setupEntries: EntryInfo[];
   assetFiles: Record<string, string>;
   context: RstestContext;
 }): Promise<{
@@ -78,7 +80,7 @@ export const runInPool = async ({
   const results = await Promise.all(
     entries.map((entryInfo) =>
       pool.runTest({
-        options: { entryInfo, assetFiles, context },
+        options: { entryInfo, assetFiles, context, setupEntries },
         rpcMethods: {},
       }),
     ),

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -37,6 +37,10 @@ export interface RstestConfig {
    */
   exclude?: string[];
   /**
+   * Path to setup files. They will be run before each test file.
+   */
+  setupFiles?: string[] | string;
+  /**
    * Allows the test suite to pass when no files are found.
    *
    * @default false
@@ -60,6 +64,9 @@ export interface RstestConfig {
   globals?: boolean;
 }
 
-export type NormalizedConfig = Required<Omit<RstestConfig, 'pool'>> & {
+export type NormalizedConfig = Required<
+  Omit<RstestConfig, 'pool' | 'setupFiles'>
+> & {
   pool: RstestPoolOptions;
+  setupFiles?: string[] | string;
 };

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -13,6 +13,7 @@ export type RuntimeRPC = {};
 export type RunWorkerOptions = {
   options: {
     entryInfo: EntryInfo;
+    setupEntries: EntryInfo[];
     assetFiles: Record<string, string>;
     context: RstestContext;
   };

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -5,6 +5,13 @@ export function getAbsolutePath(base: string, filepath: string): string {
   return isAbsolute(filepath) ? filepath : join(base, filepath);
 }
 
+export const castArray = <T>(arr?: T | T[]): T[] => {
+  if (arr === undefined) {
+    return [];
+  }
+  return Array.isArray(arr) ? arr : [arr];
+};
+
 export const isPlainObject = (obj: unknown): obj is Record<string, any> => {
   return (
     obj !== null &&

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,3 @@
 export * from './helper';
 export * from './logger';
-export * from './entries';
+export * from './testFiles';

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { glob } from 'tinyglobby';
+import { castArray, getAbsolutePath } from '../utils';
 
 export const filterFiles = (
   testFiles: string[],
@@ -59,6 +60,19 @@ export const getTestEntries = async ({
     filterFiles(testFiles, fileFilters, root).map((entry) => {
       const name = path.relative(root, entry);
       return [name, entry];
+    }),
+  );
+};
+
+export const getSetupFiles = (
+  setups: string[] | string | undefined,
+  rootPath: string,
+): Record<string, string> => {
+  return Object.fromEntries(
+    castArray(setups).map((setupFile) => {
+      const setupFilePath = getAbsolutePath(rootPath, setupFile);
+      const name = path.relative(rootPath, setupFilePath);
+      return [name, setupFilePath];
     }),
   );
 };

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -5,7 +5,7 @@ import type {
   TestResult,
   WorkerState,
 } from '../types';
-import { logger } from '../utils/logger';
+import { logger } from '../utils';
 import { loadModule } from './loadModule';
 
 const getGlobalApi = (api: Rstest) => {
@@ -19,6 +19,7 @@ const getGlobalApi = (api: Rstest) => {
 
 const runInPool = async ({
   entryInfo: { filePath, originPath },
+  setupEntries,
   assetFiles,
   context,
 }: RunWorkerOptions['options']): Promise<TestResult> => {
@@ -44,6 +45,19 @@ const runInPool = async ({
   };
 
   try {
+    // run setup files
+    for (const { filePath, originPath } of setupEntries) {
+      const setupCodeContent = assetFiles[filePath]!;
+
+      loadModule({
+        codeContent: setupCodeContent,
+        distPath: filePath,
+        originPath: originPath,
+        rstestContext,
+        assetFiles,
+      });
+    }
+
     loadModule({
       codeContent,
       distPath: filePath,

--- a/packages/core/tests/utils/testFiles.test.ts
+++ b/packages/core/tests/utils/testFiles.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { filterFiles } from '../../src/utils/entries';
+import { filterFiles } from '../../src/utils/testFiles';
 
 describe('test filterFiles', () => {
   it('should filter files correctly', () => {

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -2,4 +2,5 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   passWithNoTests: true,
+  setupFiles: ['./rstest.setup.ts'],
 });

--- a/tests/rstest.setup.ts
+++ b/tests/rstest.setup.ts
@@ -1,0 +1,1 @@
+process.env.RETEST_SETUP_FLAG = '1';

--- a/tests/setup/index.test.ts
+++ b/tests/setup/index.test.ts
@@ -1,0 +1,5 @@
+import { expect, it } from '@rstest/core';
+
+it('should run setup file correctly', () => {
+  expect(process.env.RETEST_SETUP_FLAG).toBe('1');
+});


### PR DESCRIPTION
## Summary

`setupFiles` is a list of paths to modules that run some code to configure or set up the testing environment.

```ts
export default defineConfig({
  setupFiles: ['./rstest.setup.ts'],
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
