### PR TITLE
feat: print more test info via reporter

### DIFF
--- a/packages/core/src/core/context.ts
+++ b/packages/core/src/core/context.ts
@@ -14,7 +14,7 @@ export function createContext(
 
   const rstestConfig = withDefaultConfig(userConfig);
 
-  const reporters = [new DefaultReporter()];
+  const reporters = [new DefaultReporter({ rootPath })];
 
   return {
     command,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -83,9 +83,14 @@ export const runInPool = async ({
       pool.runTest({
         options: { entryInfo, assetFiles, context, setupEntries },
         rpcMethods: {
-          onTestCaseResult: async (result: TestResult) => {
+          onTestCaseResult: async (result) => {
             await Promise.all(
               reporters.map((reporter) => reporter.onTestCaseResult?.(result)),
+            );
+          },
+          onTestFileStart: async (test) => {
+            await Promise.all(
+              reporters.map((reporter) => reporter.onTestFileStart?.(test)),
             );
           },
         },

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -1,13 +1,31 @@
+import { parse, relative } from 'node:path';
 import type {
   Duration,
   Reporter,
+  TestFileInfo,
   TestResult,
   TestSummaryResult,
 } from '../types';
 import { color, prettyTime } from '../utils';
-import { printSummaryLog } from './summary';
+import { printSummaryErrorLogs, printSummaryLog } from './summary';
 
 export class DefaultReporter implements Reporter {
+  private rootPath: string;
+
+  constructor({ rootPath }: { rootPath: string }) {
+    this.rootPath = rootPath;
+  }
+
+  onTestFileStart(test: TestFileInfo): void {
+    const { rootPath } = this;
+    const relativePath = relative(rootPath, test.filePath);
+    const { dir, base } = parse(relativePath);
+
+    console.log('');
+    console.log(`${color.gray(`> ${dir ? `${dir}/` : ''}`)}${base}`);
+    console.log('');
+  }
+
   onTestCaseResult(result: TestResult): void {
     const statusColorfulStr = {
       fail: color.red('✗'),
@@ -26,6 +44,12 @@ export class DefaultReporter implements Reporter {
     console.log(
       `  ${icon} ${result.prefix}${result.name}${color.gray(duration)}`,
     );
+
+    if (result.errors) {
+      for (const error of result.errors) {
+        console.error(color.red(`    ${error.message}`));
+      }
+    }
   }
 
   onTestRunEnd(
@@ -33,6 +57,7 @@ export class DefaultReporter implements Reporter {
     testResults: TestResult[],
     duration: Duration,
   ): void {
+    printSummaryErrorLogs({ testResults, rootPath: this.rootPath });
     printSummaryLog(results, testResults, duration);
   }
 }

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -1,3 +1,4 @@
+import { relative } from 'node:path';
 import type { Duration, TestResult, TestSummaryResult } from '../types';
 import { color, logger, prettyTime } from '../utils';
 
@@ -45,4 +46,31 @@ export const printSummaryLog = (
     `${color.gray('Duration'.padStart(12))} ${prettyTime(duration.totalTime)} ${color.gray(`(build ${prettyTime(duration.buildTime)}, tests ${prettyTime(duration.testTime)}`)})`,
   );
   logger.log('');
+};
+
+export const printSummaryErrorLogs = ({
+  testResults,
+  rootPath,
+}: { rootPath: string; testResults: TestResult[] }): void => {
+  const failedTests = testResults.filter((i) => i.status === 'fail');
+
+  if (failedTests.length === 0) {
+    return;
+  }
+
+  logger.log('');
+  logger.log(color.bold('  Summary of all failing tests:'));
+  logger.log('');
+
+  for (const test of failedTests) {
+    const relativePath = relative(rootPath, test.testPath);
+    logger.log(
+      `  ${color.bgRed(' FAIL ')} ${relativePath} > ${test.prefix}${test.name}`,
+    );
+    if (test.errors) {
+      for (const error of test.errors) {
+        logger.log(color.red(`    ${error.message}`));
+      }
+    }
+  }
 };

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -1,4 +1,4 @@
-import type { TestResult, TestSummaryResult } from './testSuite';
+import type { TestFileInfo, TestResult, TestSummaryResult } from './testSuite';
 
 export type Duration = {
   totalTime: number;
@@ -6,6 +6,10 @@ export type Duration = {
   testTime: number;
 };
 export interface Reporter {
+  /**
+   * Called before test file run.
+   */
+  onTestFileStart?: (test: TestFileInfo) => void;
   /**
    * Called when the test has finished running or was just skipped.
    */

--- a/packages/core/src/types/runner.ts
+++ b/packages/core/src/types/runner.ts
@@ -1,6 +1,10 @@
-import type { TestResult } from './testSuite';
+import type { TestFileInfo, TestResult } from './testSuite';
 
 export type RunnerHooks = {
+  /**
+   * Called before test file run.
+   */
+  onTestFileStart?: (test: TestFileInfo) => Promise<void>;
   /**
    * Called after the test is finished running.
    */

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -19,20 +19,32 @@ export type TestSuite = {
   type: 'suite';
 };
 
+export type TestFileInfo = {
+  filePath: string;
+};
+
 export type Test = TestSuite | TestCase;
 
 export type TestResultStatus = 'skip' | 'pass' | 'fail' | 'todo';
 
+type TestError = {
+  message: string;
+};
+
 export type TestResult = {
   status: TestResultStatus;
   name: string;
+  testPath: string;
   prefix?: string;
   duration?: number;
+  errors?: TestError[];
 };
 
+// TODO: rename to TestFileResult
 export type TestSummaryResult = {
   status: 'skip' | 'pass' | 'fail' | 'todo';
   name: string;
   results: TestResult[];
   duration?: number;
+  testPath: string;
 };

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -1,5 +1,6 @@
 import type { RstestContext } from './core';
-import type { TestResult } from './testSuite';
+import type { TestFileInfo, TestResult } from './testSuite';
+
 export type EntryInfo = {
   filePath: string;
   originPath: string;
@@ -11,6 +12,7 @@ export type ServerRPC = {};
 
 /** Runtime to Server */
 export type RuntimeRPC = {
+  onTestFileStart: (test: TestFileInfo) => Promise<void>;
   onTestCaseResult: (result: TestResult) => Promise<void>;
 };
 

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -2,7 +2,6 @@ import { globalApis } from '../constants';
 import type {
   Rstest,
   RunWorkerOptions,
-  TestResult,
   TestSummaryResult,
   WorkerState,
 } from '../types';
@@ -69,7 +68,10 @@ const runInPool = async ({
     });
 
     const results = await runner.runTest(originPath, context, {
-      onTestCaseResult: async (result: TestResult) => {
+      onTestFileStart: async (test) => {
+        await rpc.onTestFileStart(test);
+      },
+      onTestCaseResult: async (result) => {
         await rpc.onTestCaseResult(result);
       },
     });
@@ -81,6 +83,7 @@ const runInPool = async ({
       err instanceof Error ? err.message : err,
     );
     return {
+      testPath: originPath,
       status: 'fail',
       name: originPath,
       results: [],


### PR DESCRIPTION
## Summary

- add `onTestFileStart` hook & print test info when test file start run.
- print summary error logs

<img width="755" alt="image" src="https://github.com/user-attachments/assets/a725ce2c-f4ff-4d1f-a352-871699b63b22" />

<img width="861" alt="image" src="https://github.com/user-attachments/assets/d3e5c400-aa40-44b8-bc70-5bf55baba649" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
