### PR TITLE
fix(reporter): print posix file path

### DIFF
--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -1,4 +1,4 @@
-import { parse, relative } from 'node:path';
+import { posix } from 'node:path';
 import type {
   Duration,
   GetSourcemap,
@@ -19,8 +19,8 @@ export class DefaultReporter implements Reporter {
 
   onTestFileStart(test: TestFileInfo): void {
     const { rootPath } = this;
-    const relativePath = relative(rootPath, test.filePath);
-    const { dir, base } = parse(relativePath);
+    const relativePath = posix.relative(rootPath, test.filePath);
+    const { dir, base } = posix.parse(relativePath);
 
     console.log('');
     console.log(`${color.gray(`> ${dir ? `${dir}/` : ''}`)}${base}`);

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { relative } from 'node:path';
+import { posix } from 'node:path';
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
 import { type StackFrame, parse as stackTraceParse } from 'stacktrace-parser';
 import type {
@@ -76,7 +76,7 @@ export const printSummaryErrorLogs = async ({
   logger.log('');
 
   for (const test of failedTests) {
-    const relativePath = relative(rootPath, test.testPath);
+    const relativePath = posix.relative(rootPath, test.testPath);
     logger.log(
       `${color.bgRed(' FAIL ')} ${relativePath} > ${test.prefix}${test.name}`,
     );


### PR DESCRIPTION
## Summary

should print posix file path in windows.
<img width="768" alt="image" src="https://github.com/user-attachments/assets/07ba40a7-30ec-4f52-8ee6-e7750f39ae57" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
