### PR TITLE
feat: support afterAll

### DIFF
--- a/packages/core/src/api/public.ts
+++ b/packages/core/src/api/public.ts
@@ -5,3 +5,4 @@ export declare const expect: Rstest['expect'];
 export declare const it: Rstest['it'];
 export declare const test: Rstest['test'];
 export declare const describe: Rstest['describe'];
+export declare const afterAll: Rstest['afterAll'];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,7 @@
 export { defineConfig } from './config';
 
 export * from './api/public';
+
+// TODO: Move below to @rstest/node exports point.
+export { createRstest } from './core';
+export type { RstestConfig } from './types';

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -22,19 +22,17 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   const runtimeAPI: RunnerRuntime = new RunnerRuntime(workerState.sourcePath);
   const testRunner: TestRunner = new TestRunner();
 
-  const describe: (description: string, fn: () => void) => void =
-    runtimeAPI.describe.bind(runtimeAPI);
   const it = runtimeAPI.it.bind(runtimeAPI) as TestAPI;
-
   it.fails = runtimeAPI.fails.bind(runtimeAPI);
   it.todo = runtimeAPI.todo.bind(runtimeAPI);
   it.skip = runtimeAPI.skip.bind(runtimeAPI);
 
   return {
     api: {
-      describe,
+      describe: runtimeAPI.describe.bind(runtimeAPI),
       it,
       test: it,
+      afterAll: runtimeAPI.afterAll.bind(runtimeAPI),
     },
     runner: {
       runTest: async (testFilePath: string, hooks: RunnerHooks) => {

--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -92,6 +92,14 @@ export class TestRunner {
         for (const suite of test.tests) {
           await runTest(suite, `${prefix}${test.description} > `);
         }
+
+        if (test.afterAllListeners) {
+          for (const fn of test.afterAllListeners) {
+            try {
+              await fn();
+            } catch (error) {}
+          }
+        }
       } else {
         const start = Date.now();
         if (test.skipped) {

--- a/packages/core/src/runner/runtime.ts
+++ b/packages/core/src/runner/runtime.ts
@@ -1,14 +1,50 @@
-import type { Test, TestCase, TestSuite } from '../types';
+import type { MaybePromise } from 'src/types/utils';
+import type {
+  AfterAllListener,
+  Test,
+  TestCase,
+  TestSuite,
+  TestSuiteListeners,
+} from '../types';
+
+type ListenersKey<T extends TestSuiteListeners> =
+  T extends `${infer U}Listeners` ? U : never;
+function registerTestSuiteListener(
+  suite: TestSuite,
+  key: ListenersKey<TestSuiteListeners>,
+  fn: (...args: any[]) => any,
+): void {
+  const listenersKey = `${key}Listeners` as TestSuiteListeners;
+  suite[listenersKey] ??= [];
+  suite[listenersKey].push(fn);
+}
 
 export class RunnerRuntime {
-  private tests: Array<Test> = [];
+  /** all test cases */
+  private tests: Test[] = [];
+  /** current test case */
   private _test: TestCase | undefined;
-  private sourcePath: string;
-
+  /** current test suite, could be undefined if no explicit suite declared */
+  // private _suite: TestSuite | undefined;
+  /** a calling stack of the current test suites and case */
   private _currentTest: Test[] = [];
+  private sourcePath: string;
 
   constructor(sourcePath: string) {
     this.sourcePath = sourcePath;
+  }
+
+  afterAll(fn: AfterAllListener): MaybePromise<void> {
+    const currentSuite = this.getCurrentSuite();
+    registerTestSuiteListener(currentSuite!, 'afterAll', fn);
+  }
+
+  getDefaultRootSuite(): TestSuite {
+    return {
+      description: 'Rstest:_internal_root_suite',
+      tests: [],
+      type: 'suite',
+    };
   }
 
   describe(description: string, fn: () => void): void {
@@ -59,12 +95,35 @@ export class RunnerRuntime {
     this.resetCurrentTest();
   }
 
+  /**
+   * Ensure that the current test suite is not empty and is used
+   * for `beforeAll` or `afterAll` at the file scope.
+   */
+  ensureRootSuite(): void {
+    if (this._currentTest.length === 0) {
+      this.addTest(this.getDefaultRootSuite());
+    }
+  }
+
   it(description: string, fn: () => void | Promise<void>): void {
     this.addTestCase({ description, fn, type: 'case' });
   }
 
   getCurrentTest(): TestCase | undefined {
     return this._test;
+  }
+
+  getCurrentSuite(): TestSuite {
+    this.ensureRootSuite();
+
+    for (let i = this._currentTest.length - 1; i >= 0; i--) {
+      const test = this._currentTest[i];
+      if (test!.type === 'suite') {
+        return test!;
+      }
+    }
+
+    throw new Error('Expect to find a suite, but got undefined');
   }
 
   skip(description: string, fn: () => void | Promise<void>): void {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -4,6 +4,8 @@ import type {
   PromisifyAssertion,
   Tester,
 } from '@vitest/expect';
+import type { AfterAllListener } from './testSuite';
+import type { MaybePromise } from './utils';
 
 type TestFn = (description: string, fn: () => void | Promise<void>) => void;
 
@@ -13,10 +15,13 @@ export type TestAPI = TestFn & {
   skip: TestFn;
 };
 
+type AfterAllAPI = (fn: AfterAllListener) => MaybePromise<void>;
+
 export type RunnerAPI = {
   describe: (description: string, fn: () => void) => void;
   it: TestAPI;
   test: TestAPI;
+  afterAll: AfterAllAPI;
 };
 
 interface ExpectPollOptions {

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,4 +1,6 @@
 // TODO: Unify filePath、testPath、originPath、sourcePath
+import type { MaybePromise } from './utils';
+
 export type TestCase = {
   filePath: string;
   description: string;
@@ -17,13 +19,19 @@ export type TestCase = {
   promises?: Promise<any>[];
 };
 
+export type AfterAllListener = () => MaybePromise<void>;
+
 export type TestSuite = {
   description: string;
   // TODO
   filepath?: string;
+  /** nested cases and suite could in a suite */
   tests: Array<TestSuite | TestCase>;
   type: 'suite';
+  afterAllListeners?: AfterAllListener[];
 };
+
+export type TestSuiteListeners = keyof Pick<TestSuite, 'afterAllListeners'>;
 
 export type TestFileInfo = {
   filePath: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,18 @@ importers:
       '@rstest/core':
         specifier: workspace:*
         version: link:../packages/core
+      tinyexec:
+        specifier: ^1.0.1
+        version: 1.0.1
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
+
+  tests/afterAll:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../packages/core
 
 packages:
 
@@ -1514,6 +1523,9 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  tinyexec@1.0.1:
+    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
@@ -2980,6 +2992,8 @@ snapshots:
       readable-stream: 3.6.2
 
   term-size@2.2.1: {}
+
+  tinyexec@1.0.1: {}
 
   tinyglobby@0.2.12:
     dependencies:

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -129,6 +129,7 @@ systemjs
 tailwindcss
 taze
 templating
+tinyexec
 tinyglobby
 transpiling
 treeshaking

--- a/tests/afterAll/fixtures/index.test.ts
+++ b/tests/afterAll/fixtures/index.test.ts
@@ -1,0 +1,35 @@
+import { afterAll, describe, expect, it } from '@rstest/core';
+
+afterAll(() => {
+  console.log('[afterAll] root');
+});
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  afterAll(() => {
+    console.log('[afterAll] in level A');
+  });
+
+  describe('level B-A', () => {
+    it('it in level B-A', () => {
+      expect(2 + 1).toBe(3);
+    });
+
+    afterAll(() => {
+      console.log('[afterAll] in level B-A');
+    });
+  });
+
+  describe('level B-B', () => {
+    it('it in level B-B', () => {
+      expect(2 + 2).toBe(4);
+    });
+
+    afterAll(() => {
+      console.log('[afterAll] in level B-B');
+    });
+  });
+});

--- a/tests/afterAll/index.test.ts
+++ b/tests/afterAll/index.test.ts
@@ -1,0 +1,33 @@
+import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('afterAll', () => {
+  it('afterAll should be invoked in the correct order', async () => {
+    const process = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    const logs = process.stdout
+      .split('\n')
+      .filter((log) => log.startsWith('[afterAll]'));
+
+    expect(logs).toEqual([
+      '[afterAll] in level B-A',
+      '[afterAll] in level B-B',
+      '[afterAll] in level A',
+      '[afterAll] root',
+    ]);
+  });
+});

--- a/tests/afterAll/package.json
+++ b/tests/afterAll/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "@rstest/tests-after-all",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*"
+  }
+}

--- a/tests/afterAll/rstest.config.ts
+++ b/tests/afterAll/rstest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  include: ['**/fixtures/**'],
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@rstest/core": "workspace:*",
+    "tinyexec": "^1.0.1",
     "typescript": "^5.8.2"
   }
 }

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -3,4 +3,5 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   passWithNoTests: true,
   setupFiles: ['./rstest.setup.ts'],
+  exclude: ['**/node_modules/**', '**/dist/**', '**/fixtures/**'],
 });

--- a/tests/scripts/index.ts
+++ b/tests/scripts/index.ts
@@ -1,0 +1,11 @@
+import type { Options } from 'tinyexec';
+import { x } from 'tinyexec';
+
+export async function runRstestCli({
+  command,
+  options,
+  args,
+}: { command: string; options?: Partial<Options>; args?: any[] }) {
+  const subprocess = await x(command, args, options as Options);
+  return subprocess;
+}


### PR DESCRIPTION
## Summary

Pre-request test functionality for https://github.com/web-infra-dev/rstest/pull/63.

- will adding `beforeAll` after this PR got merged.
- using CLI util to run Rstest in order to get the stdout in sub process to ensure the `afterAll` executed in correct order.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
