### PR TITLE
feat: integrate snapshot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We plan to release a preview version for testing by June 2025, followed by the f
 Rstest has been inspired by several outstanding projects in the community. We would like to acknowledge and express our sincere gratitude to the following projects:
 
 - Several API design patterns have been influenced by [Jest](https://jestjs.io/) and [Vitest](https://vitest.dev/).
-- Some functions in Rstest are referenced from Vitest, such as the `expect` and `expect.poll` API, etc.
+- Some functions in Rstest are referenced from Vitest, such as the `expect`, `expect.poll` and `snapshot` API, etc.
 
 ## 📖 License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "@rstest/tsconfig": "workspace:*",
     "@types/babel__code-frame": "^7.0.6",
     "@vitest/expect": "^3.0.9",
+    "@vitest/snapshot": "^3.0.9",
     "cac": "^6.7.14",
     "picocolors": "^1.1.1",
     "rslog": "^1.2.3",

--- a/packages/core/src/api/expect.ts
+++ b/packages/core/src/api/expect.ts
@@ -1,7 +1,6 @@
 /**
  * This method is modified based on source found in
- * https://github.com/vitest-dev/vitest/blob/master/packages/vitest/src/integrations/chai/poll.ts
- *
+ * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/integrations/chai/poll.ts
  */
 import * as chai from 'chai';
 
@@ -20,11 +19,11 @@ import {
 } from '@vitest/expect';
 import type { RstestExpect, TestCase, WorkerState } from '../types';
 import { createExpectPoll } from './poll';
+import { SnapshotPlugin } from './snapshot';
 
 chai.use(JestExtend);
 chai.use(JestChaiExpect);
-// TODO
-// chai.use(SnapshotPlugin);
+chai.use(SnapshotPlugin);
 chai.use(JestAsymmetricMatchers);
 export { GLOBAL_EXPECT };
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -23,7 +23,7 @@ export const createRstestRuntime = (
   };
   api: Rstest;
 } => {
-  const { runner, api: runnerAPI } = createRunner();
+  const { runner, api: runnerAPI } = createRunner({ workerState });
 
   const expect: RstestExpect = createExpect({
     workerState,

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -5,7 +5,6 @@ import type {
   RunnerHooks,
   TestCase,
   TestSummaryResult,
-  WorkerContext,
   WorkerState,
 } from '../types';
 import { GLOBAL_EXPECT, createExpect } from './expect';
@@ -16,7 +15,6 @@ export const createRstestRuntime = (
   runner: {
     runTest: (
       testPath: string,
-      context: WorkerContext,
       hooks: RunnerHooks,
     ) => Promise<TestSummaryResult>;
     getCurrentTest: () => TestCase | undefined;

--- a/packages/core/src/api/poll.ts
+++ b/packages/core/src/api/poll.ts
@@ -1,6 +1,6 @@
 /**
  * This method is modified based on source found in
- * https://github.com/vitest-dev/vitest/blob/master/packages/vitest/src/integrations/chai/poll.ts
+ * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/integrations/chai/poll.ts
  *
  */
 import type { Assertion } from '@vitest/expect';

--- a/packages/core/src/api/public.ts
+++ b/packages/core/src/api/public.ts
@@ -1,3 +1,4 @@
+import '../types/global';
 import type { Rstest } from '../types';
 
 export declare const expect: Rstest['expect'];

--- a/packages/core/src/api/snapshot.ts
+++ b/packages/core/src/api/snapshot.ts
@@ -1,0 +1,330 @@
+/**
+ * This method is modified based on source found in
+ * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/integrations/snapshot/chai.ts
+ */
+import type { Assertion, ChaiPlugin } from '@vitest/expect';
+import { equals, iterableEquality, subsetEquality } from '@vitest/expect';
+import {
+  SnapshotClient,
+  addSerializer,
+  stripSnapshotIndentation,
+} from '@vitest/snapshot';
+import type { TestCase } from '../types';
+
+let _client: SnapshotClient;
+
+export function getSnapshotClient(): SnapshotClient {
+  if (!_client) {
+    _client = new SnapshotClient({
+      isEqual: (received, expected) => {
+        return equals(received, expected, [iterableEquality, subsetEquality]);
+      },
+    });
+  }
+  return _client;
+}
+
+function recordAsyncExpect(
+  _test: any,
+  promise: Promise<any>,
+  assertion: string,
+  error: Error,
+): Promise<any> {
+  const test = _test as TestCase | undefined;
+  // record promise for test, that resolves before test ends
+  if (test && promise instanceof Promise) {
+    // if promise is explicitly awaited, remove it from the list
+    // biome-ignore lint/style/noParameterAssign: reassigning
+    promise = promise.finally(() => {
+      if (!test.promises) {
+        return;
+      }
+      const index = test.promises.indexOf(promise);
+      if (index !== -1) {
+        test.promises.splice(index, 1);
+      }
+    });
+
+    // record promise
+    if (!test.promises) {
+      test.promises = [];
+    }
+    test.promises.push(promise);
+
+    let resolved = false;
+    test.onFinished ??= [];
+    test.onFinished.push(() => {
+      if (!resolved) {
+        const processor =
+          (globalThis as any).__vitest_worker__?.onFilterStackTrace ||
+          ((s: string) => s || '');
+        const stack = processor(error.stack);
+        console.warn(
+          [
+            `Promise returned by \`${assertion}\` was not awaited. `,
+            'Rstest currently auto-awaits hanging assertions at the end of the test.',
+            'Please remember to await the assertion.\n',
+            stack,
+          ].join(''),
+        );
+      }
+    });
+
+    return {
+      // biome-ignore lint/suspicious/noThenProperty: promise
+      then(onFulfilled, onRejected) {
+        resolved = true;
+        return promise.then(onFulfilled, onRejected);
+      },
+      catch(onRejected) {
+        return promise.catch(onRejected);
+      },
+      finally(onFinally) {
+        return promise.finally(onFinally);
+      },
+      [Symbol.toStringTag]: 'Promise',
+    } satisfies Promise<any>;
+  }
+
+  return promise;
+}
+
+function createAssertionMessage(
+  util: Chai.ChaiUtils,
+  assertion: Assertion,
+  hasArgs: boolean,
+) {
+  const not = util.flag(assertion, 'negate') ? 'not.' : '';
+  const name = `${util.flag(assertion, '_name')}(${hasArgs ? 'expected' : ''})`;
+  const promiseName = util.flag(assertion, 'promise');
+  const promise = promiseName ? `.${promiseName}` : '';
+  return `expect(actual)${promise}.${not}${name}`;
+}
+
+function getError(expected: () => void | Error, promise: string | undefined) {
+  if (typeof expected !== 'function') {
+    if (!promise) {
+      throw new Error(
+        `expected must be a function, received ${typeof expected}`,
+      );
+    }
+
+    // when "promised", it receives thrown error
+    return expected;
+  }
+
+  try {
+    expected();
+  } catch (e) {
+    return e;
+  }
+
+  throw new Error("snapshot function didn't throw");
+}
+
+function getTestNames(test: TestCase) {
+  return {
+    filepath: test.filePath,
+    name: test.description,
+    // TODO
+    // name: getNames(test).slice(1).join(' > '),
+    // testId: test.id,
+  };
+}
+
+export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
+  function getTest(assertionName: string, obj: object) {
+    const test = utils.flag(obj, 'vitest-test');
+    if (!test) {
+      throw new Error(`'${assertionName}' cannot be used without test context`);
+    }
+    return test as TestCase;
+  }
+
+  for (const key of ['matchSnapshot', 'toMatchSnapshot']) {
+    utils.addMethod(
+      chai.Assertion.prototype,
+      key,
+      function (
+        this: Record<string, unknown>,
+        properties?: object,
+        message?: string,
+      ) {
+        utils.flag(this, '_name', key);
+        const isNot = utils.flag(this, 'negate');
+        if (isNot) {
+          throw new Error(`${key} cannot be used with "not"`);
+        }
+        const expected = utils.flag(this, 'object');
+        const test = getTest(key, this);
+        if (typeof properties === 'string' && typeof message === 'undefined') {
+          // biome-ignore lint/style/noParameterAssign: reassigning
+          message = properties;
+          // biome-ignore lint/style/noParameterAssign: reassigning
+          properties = undefined;
+        }
+        const errorMessage = utils.flag(this, 'message');
+        getSnapshotClient().assert({
+          received: expected,
+          message,
+          isInline: false,
+          properties,
+          errorMessage,
+          ...getTestNames(test),
+        });
+      },
+    );
+  }
+
+  utils.addMethod(
+    chai.Assertion.prototype,
+    'toMatchFileSnapshot',
+    function (this: Assertion, file: string, message?: string) {
+      utils.flag(this, '_name', 'toMatchFileSnapshot');
+      const isNot = utils.flag(this, 'negate');
+      if (isNot) {
+        throw new Error('toMatchFileSnapshot cannot be used with "not"');
+      }
+      const error = new Error('resolves');
+      const expected = utils.flag(this, 'object');
+      const test = getTest('toMatchFileSnapshot', this);
+      const errorMessage = utils.flag(this, 'message');
+
+      const promise = getSnapshotClient().assertRaw({
+        received: expected,
+        message,
+        isInline: false,
+        rawSnapshot: {
+          file,
+        },
+        errorMessage,
+        ...getTestNames(test),
+      });
+
+      return recordAsyncExpect(
+        test,
+        promise,
+        createAssertionMessage(utils, this, true),
+        error,
+      );
+    },
+  );
+
+  utils.addMethod(
+    chai.Assertion.prototype,
+    'toMatchInlineSnapshot',
+    function __INLINE_SNAPSHOT__(
+      this: Record<string, unknown>,
+      properties?: object,
+      inlineSnapshot?: string,
+      message?: string,
+    ) {
+      utils.flag(this, '_name', 'toMatchInlineSnapshot');
+      const isNot = utils.flag(this, 'negate');
+      if (isNot) {
+        throw new Error('toMatchInlineSnapshot cannot be used with "not"');
+      }
+      const test = getTest('toMatchInlineSnapshot', this);
+      // TODO
+      //   const isInsideEach = test.each || test.suite?.each;
+      //   if (isInsideEach) {
+      //     throw new Error(
+      //       'InlineSnapshot cannot be used inside of test.each or describe.each',
+      //     );
+      //   }
+      const expected = utils.flag(this, 'object');
+      const error = utils.flag(this, 'error');
+      if (typeof properties === 'string') {
+        // biome-ignore lint/style/noParameterAssign: reassigning
+        message = inlineSnapshot;
+        // biome-ignore lint/style/noParameterAssign: reassigning
+        inlineSnapshot = properties;
+        // biome-ignore lint/style/noParameterAssign: reassigning
+        properties = undefined;
+      }
+      if (inlineSnapshot) {
+        // biome-ignore lint/style/noParameterAssign: reassigning
+        inlineSnapshot = stripSnapshotIndentation(inlineSnapshot);
+      }
+      const errorMessage = utils.flag(this, 'message');
+
+      getSnapshotClient().assert({
+        received: expected,
+        message,
+        isInline: true,
+        properties,
+        inlineSnapshot,
+        error,
+        errorMessage,
+        ...getTestNames(test),
+      });
+    },
+  );
+  utils.addMethod(
+    chai.Assertion.prototype,
+    'toThrowErrorMatchingSnapshot',
+    function (this: Record<string, unknown>, message?: string) {
+      utils.flag(this, '_name', 'toThrowErrorMatchingSnapshot');
+      const isNot = utils.flag(this, 'negate');
+      if (isNot) {
+        throw new Error(
+          'toThrowErrorMatchingSnapshot cannot be used with "not"',
+        );
+      }
+      const expected = utils.flag(this, 'object');
+      const test = getTest('toThrowErrorMatchingSnapshot', this);
+      const promise = utils.flag(this, 'promise') as string | undefined;
+      const errorMessage = utils.flag(this, 'message');
+      getSnapshotClient().assert({
+        received: getError(expected, promise),
+        message,
+        errorMessage,
+        ...getTestNames(test),
+      });
+    },
+  );
+  utils.addMethod(
+    chai.Assertion.prototype,
+    'toThrowErrorMatchingInlineSnapshot',
+    function __INLINE_SNAPSHOT__(
+      this: Record<string, unknown>,
+      inlineSnapshot: string,
+      message: string,
+    ) {
+      const isNot = utils.flag(this, 'negate');
+      if (isNot) {
+        throw new Error(
+          'toThrowErrorMatchingInlineSnapshot cannot be used with "not"',
+        );
+      }
+      const test = getTest('toThrowErrorMatchingInlineSnapshot', this);
+      // TODO
+      //   const isInsideEach = test.each || test.suite?.each;
+      //   if (isInsideEach) {
+      //     throw new Error(
+      //       'InlineSnapshot cannot be used inside of test.each or describe.each',
+      //     );
+      //   }
+      const expected = utils.flag(this, 'object');
+      const error = utils.flag(this, 'error');
+      const promise = utils.flag(this, 'promise') as string | undefined;
+      const errorMessage = utils.flag(this, 'message');
+
+      if (inlineSnapshot) {
+        // biome-ignore lint/style/noParameterAssign: reassigning
+        inlineSnapshot = stripSnapshotIndentation(inlineSnapshot);
+      }
+
+      getSnapshotClient().assert({
+        received: getError(expected, promise),
+        message,
+        inlineSnapshot,
+        isInline: true,
+        error,
+        errorMessage,
+        ...getTestNames(test),
+      });
+    },
+  );
+  utils.addMethod(chai.expect, 'addSnapshotSerializer', addSerializer);
+};

--- a/packages/core/src/core/context.ts
+++ b/packages/core/src/core/context.ts
@@ -1,3 +1,4 @@
+import { SnapshotManager } from '@vitest/snapshot/manager';
 import { withDefaultConfig } from '../config';
 import { DefaultReporter } from '../reporter';
 import type { RstestCommand, RstestConfig, RstestContext } from '../types';
@@ -15,12 +16,16 @@ export function createContext(
   const rstestConfig = withDefaultConfig(userConfig);
 
   const reporters = [new DefaultReporter({ rootPath })];
+  const snapshotManager = new SnapshotManager({
+    updateSnapshot: 'all',
+  });
 
   return {
     command,
     version: RSTEST_VERSION,
     rootPath,
     reporters,
+    snapshotManager,
     originalConfig: userConfig,
     normalizedConfig: rstestConfig,
   };

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -82,10 +82,18 @@ export const runInPool = async ({
     },
   });
 
+  const { updateSnapshot } = context.snapshotManager.options;
+
   const results = await Promise.all(
     entries.map((entryInfo) =>
       pool.runTest({
-        options: { entryInfo, assetFiles, context, setupEntries },
+        options: {
+          entryInfo,
+          assetFiles,
+          context,
+          setupEntries,
+          updateSnapshot,
+        },
         rpcMethods: {
           onTestCaseResult: async (result) => {
             await Promise.all(

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -4,12 +4,13 @@ import type {
   TestAPI,
   TestSummaryResult,
   WorkerContext,
+  WorkerState,
 } from '../types';
 
 import { TestRunner } from './runner';
 import { RunnerRuntime } from './runtime';
 
-export function createRunner(): {
+export function createRunner({ workerState }: { workerState: WorkerState }): {
   api: RunnerAPI;
   runner: {
     runTest: (
@@ -20,7 +21,7 @@ export function createRunner(): {
     getCurrentTest: RunnerRuntime['getCurrentTest'];
   };
 } {
-  const runtimeAPI: RunnerRuntime = new RunnerRuntime();
+  const runtimeAPI: RunnerRuntime = new RunnerRuntime(workerState.sourcePath);
   const testRunner: TestRunner = new TestRunner();
 
   const describe: (description: string, fn: () => void) => void =

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -3,7 +3,6 @@ import type {
   RunnerHooks,
   TestAPI,
   TestSummaryResult,
-  WorkerContext,
   WorkerState,
 } from '../types';
 
@@ -15,7 +14,6 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   runner: {
     runTest: (
       testFilePath: string,
-      context: WorkerContext,
       hooks: RunnerHooks,
     ) => Promise<TestSummaryResult>;
     getCurrentTest: RunnerRuntime['getCurrentTest'];
@@ -39,15 +37,11 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
       test: it,
     },
     runner: {
-      runTest: async (
-        testFilePath: string,
-        context: WorkerContext,
-        hooks: RunnerHooks,
-      ) => {
+      runTest: async (testFilePath: string, hooks: RunnerHooks) => {
         return testRunner.runTests(
           runtimeAPI.getTests(),
           testFilePath,
-          context,
+          workerState,
           hooks,
         );
       },

--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -1,4 +1,6 @@
 import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect';
+import { NodeSnapshotEnvironment } from '@vitest/snapshot/environment';
+import { getSnapshotClient } from '../api/snapshot';
 import type {
   RunnerHooks,
   Test,
@@ -51,6 +53,12 @@ export class TestRunner {
     }
 
     hooks.onTestFileStart?.({ filePath: testPath });
+    const snapshotClient = getSnapshotClient();
+
+    await snapshotClient.setup(testPath, {
+      updateSnapshot: 'all',
+      snapshotEnvironment: new NodeSnapshotEnvironment(),
+    });
 
     const runTest = async (test: Test, prefix = '') => {
       if (test.type === 'suite') {
@@ -165,6 +173,9 @@ export class TestRunner {
     for (const test of tests) {
       await runTest(test);
     }
+
+    // saves files and returns SnapshotResult
+    await snapshotClient.finish(testPath);
 
     return {
       testPath,

--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -1,13 +1,13 @@
 import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect';
-import { NodeSnapshotEnvironment } from '@vitest/snapshot/environment';
 import { getSnapshotClient } from '../api/snapshot';
 import type {
   RunnerHooks,
   Test,
+  TestError,
   TestResult,
   TestResultStatus,
   TestSummaryResult,
-  WorkerContext,
+  WorkerState,
 } from '../types';
 
 const getTestStatus = (results: TestResult[]): TestResultStatus => {
@@ -23,16 +23,32 @@ const getTestStatus = (results: TestResult[]): TestResultStatus => {
         : 'pass';
 };
 
+const formatTestError = (err: any): TestError[] => {
+  const errors = Array.isArray(err) ? err : [err];
+
+  return errors.map((error) => {
+    const errObj: TestError = {
+      ...error,
+      // Some error attributes cannot be enumerated
+      message: error.message,
+      name: err.name,
+      stack: err.stack,
+    };
+    return errObj;
+  });
+};
+
 export class TestRunner {
   async runTests(
     tests: Test[],
     testPath: string,
-    context: WorkerContext,
+    state: WorkerState,
     hooks: RunnerHooks,
   ): Promise<TestSummaryResult> {
     const {
       normalizedConfig: { passWithNoTests },
-    } = context;
+      snapshotOptions,
+    } = state;
     const results: TestResult[] = [];
     if (tests.length === 0) {
       if (passWithNoTests) {
@@ -55,10 +71,7 @@ export class TestRunner {
     hooks.onTestFileStart?.({ filePath: testPath });
     const snapshotClient = getSnapshotClient();
 
-    await snapshotClient.setup(testPath, {
-      updateSnapshot: 'all',
-      snapshotEnvironment: new NodeSnapshotEnvironment(),
-    });
+    await snapshotClient.setup(testPath, snapshotOptions);
 
     const runTest = async (test: Test, prefix = '') => {
       if (test.type === 'suite') {
@@ -158,7 +171,7 @@ export class TestRunner {
             prefix,
             name: test.description,
             duration: Date.now() - start,
-            errors: Array.isArray(error) ? error : [error],
+            errors: formatTestError(error),
             testPath,
           };
           hooks.onTestCaseResult?.(result);

--- a/packages/core/src/runner/runtime.ts
+++ b/packages/core/src/runner/runtime.ts
@@ -3,8 +3,13 @@ import type { Test, TestCase, TestSuite } from '../types';
 export class RunnerRuntime {
   private tests: Array<Test> = [];
   private _test: TestCase | undefined;
+  private sourcePath: string;
 
   private _currentTest: Test[] = [];
+
+  constructor(sourcePath: string) {
+    this.sourcePath = sourcePath;
+  }
 
   describe(description: string, fn: () => void): void {
     const currentSuite: TestSuite = {
@@ -46,8 +51,11 @@ export class RunnerRuntime {
     return this.tests;
   }
 
-  addTestCase(test: TestCase): void {
-    this.addTest(test);
+  addTestCase(test: Omit<TestCase, 'filePath'>): void {
+    this.addTest({
+      ...test,
+      filePath: this.sourcePath,
+    });
     this.resetCurrentTest();
   }
 

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -1,3 +1,4 @@
+import type { SnapshotManager } from '@vitest/snapshot/manager';
 import type { NormalizedConfig, RstestConfig } from './config';
 import type { Reporter } from './reporter';
 
@@ -20,6 +21,7 @@ export type RstestContext = {
    */
   command: RstestCommand;
   reporters: Reporter[];
+  snapshotManager: SnapshotManager;
 };
 
 export type RstestInstance = {

--- a/packages/core/src/types/global.ts
+++ b/packages/core/src/types/global.ts
@@ -1,0 +1,94 @@
+/**
+ * This method is modified based on source found in
+ * https://github.com/vitest-dev/vitest/blob/9a1b50122359123ad7f5999b85ee2f314d91e83d/packages/vitest/src/types/global.ts
+ */
+import type { PromisifyAssertion, Tester } from '@vitest/expect';
+import type { SnapshotState, addSerializer } from '@vitest/snapshot';
+
+interface SnapshotMatcher<T> {
+  <U extends { [P in keyof T]: any }>(
+    snapshot: Partial<U>,
+    message?: string,
+  ): void;
+  (message?: string): void;
+}
+
+interface InlineSnapshotMatcher<T> {
+  <U extends { [P in keyof T]: any }>(
+    properties: Partial<U>,
+    snapshot?: string,
+    message?: string,
+  ): void;
+  (message?: string): void;
+}
+
+declare module '@vitest/expect' {
+  interface MatcherState {
+    environment: string;
+    snapshotState: SnapshotState;
+  }
+
+  interface ExpectPollOptions {
+    interval?: number;
+    timeout?: number;
+    message?: string;
+  }
+
+  interface ExpectStatic {
+    unreachable: (message?: string) => never;
+    soft: <T>(actual: T, message?: string) => Assertion<T>;
+    poll: <T>(
+      actual: () => T,
+      options?: ExpectPollOptions,
+    ) => PromisifyAssertion<Awaited<T>>;
+    addEqualityTesters: (testers: Array<Tester>) => void;
+    assertions: (expected: number) => void;
+    hasAssertions: () => void;
+    addSnapshotSerializer: typeof addSerializer;
+  }
+
+  interface Assertion<T> {
+    // Snapshots are extended in @vitest/snapshot and are not part of @vitest/expect
+    matchSnapshot: SnapshotMatcher<T>;
+    toMatchSnapshot: SnapshotMatcher<T>;
+    toMatchInlineSnapshot: InlineSnapshotMatcher<T>;
+
+    /**
+     * Checks that an error thrown by a function matches a previously recorded snapshot.
+     *
+     * @param message - Optional custom error message.
+     *
+     * @example
+     * expect(functionWithError).toThrowErrorMatchingSnapshot();
+     */
+    toThrowErrorMatchingSnapshot: (message?: string) => void;
+
+    /**
+     * Checks that an error thrown by a function matches an inline snapshot within the test file.
+     * Useful for keeping snapshots close to the test code.
+     *
+     * @param snapshot - Optional inline snapshot string to match.
+     * @param message - Optional custom error message.
+     *
+     * @example
+     * const throwError = () => { throw new Error('Error occurred') };
+     * expect(throwError).toThrowErrorMatchingInlineSnapshot(`"Error occurred"`);
+     */
+    toThrowErrorMatchingInlineSnapshot: (
+      snapshot?: string,
+      message?: string,
+    ) => void;
+
+    /**
+     * Compares the received value to a snapshot saved in a specified file.
+     * Useful for cases where snapshot content is large or needs to be shared across tests.
+     *
+     * @param filepath - Path to the snapshot file.
+     * @param message - Optional custom error message.
+     *
+     * @example
+     * await expect(largeData).toMatchFileSnapshot('path/to/snapshot.json');
+     */
+    toMatchFileSnapshot: (filepath: string, message?: string) => Promise<void>;
+  }
+}

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,4 +1,6 @@
+// TODO: Unify filePath、testPath、originPath、sourcePath
 export type TestCase = {
+  filePath: string;
   description: string;
   fn: () => void | Promise<void>;
   skipped?: boolean;
@@ -9,6 +11,10 @@ export type TestCase = {
   // TODO
   onFinished?: any[];
   type: 'case';
+  /**
+   * Store promises (from async expects) to wait for them before finishing the test
+   */
+  promises?: Promise<any>[];
 };
 
 export type TestSuite = {

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -33,7 +33,7 @@ export type Test = TestSuite | TestCase;
 
 export type TestResultStatus = 'skip' | 'pass' | 'fail' | 'todo';
 
-type TestError = {
+export type TestError = {
   message: string;
   name?: string;
   stack?: string;

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -1,3 +1,5 @@
+import type { SnapshotUpdateState } from '@vitest/snapshot';
+import type { SnapshotEnvironment } from '@vitest/snapshot/environment';
 import type { RstestContext } from './core';
 import type { TestFileInfo, TestResult } from './testSuite';
 
@@ -27,14 +29,19 @@ export type RunWorkerOptions = {
     setupEntries: EntryInfo[];
     assetFiles: Record<string, string>;
     context: WorkerContext;
+    updateSnapshot: SnapshotUpdateState;
   };
   rpcMethods: RuntimeRPC;
 };
 
-export type WorkerState = {
+export type WorkerState = WorkerContext & {
   environment: string;
   /** Test file source code path */
   sourcePath: string;
   /** Test file path (distPath) */
   filePath: string;
+  snapshotOptions: {
+    updateSnapshot: SnapshotUpdateState;
+    snapshotEnvironment: SnapshotEnvironment;
+  };
 };

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -33,5 +33,8 @@ export type RunWorkerOptions = {
 
 export type WorkerState = {
   environment: string;
+  /** Test file source code path */
+  sourcePath: string;
+  /** Test file path (distPath) */
   filePath: string;
 };

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -32,6 +32,7 @@ const runInPool = async ({
 
   const workerState: WorkerState = {
     filePath,
+    sourcePath: originPath,
     environment: 'node',
   };
 

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -1,3 +1,4 @@
+import { NodeSnapshotEnvironment } from '@vitest/snapshot/environment';
 import { globalApis } from '../constants';
 import type {
   Rstest,
@@ -22,6 +23,7 @@ const runInPool = async ({
   entryInfo: { filePath, originPath },
   setupEntries,
   assetFiles,
+  updateSnapshot,
   context,
 }: RunWorkerOptions['options']): Promise<TestSummaryResult> => {
   const { rpc } = createRuntimeRpc(createForksRpcOptions());
@@ -31,6 +33,11 @@ const runInPool = async ({
   } = context;
 
   const workerState: WorkerState = {
+    ...context,
+    snapshotOptions: {
+      updateSnapshot,
+      snapshotEnvironment: new NodeSnapshotEnvironment(),
+    },
     filePath,
     sourcePath: originPath,
     environment: 'node',
@@ -68,7 +75,7 @@ const runInPool = async ({
       assetFiles,
     });
 
-    const results = await runner.runTest(originPath, context, {
+    const results = await runner.runTest(originPath, {
       onTestFileStart: async (test) => {
         await rpc.onTestFileStart(test);
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@vitest/expect':
         specifier: ^3.0.9
         version: 3.0.9
+      '@vitest/snapshot':
+        specifier: ^3.0.9
+        version: 3.0.9
       cac:
         specifier: ^6.7.14
         version: 6.7.14
@@ -621,6 +624,9 @@ packages:
 
   '@vitest/pretty-format@3.0.9':
     resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
+
+  '@vitest/snapshot@3.0.9':
+    resolution: {integrity: sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==}
 
   '@vitest/spy@3.0.9':
     resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
@@ -1293,6 +1299,9 @@ packages:
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
     engines: {node: '>=18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -2127,6 +2136,12 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/snapshot@3.0.9':
+    dependencies:
+      '@vitest/pretty-format': 3.0.9
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
   '@vitest/spy@3.0.9':
     dependencies:
       tinyspy: 3.0.2
@@ -2774,6 +2789,8 @@ snapshots:
   path-type@4.0.0: {}
 
   path-type@6.0.0: {}
+
+  pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 

--- a/tests/snapshot/__snapshots__/index.test.ts.snap
+++ b/tests/snapshot/__snapshots__/index.test.ts.snap
@@ -1,0 +1,3 @@
+// Snapshot v1
+
+exports[`test toMatchInlineSnapshot API 1`] = `"hello world"`;

--- a/tests/snapshot/index.test.ts
+++ b/tests/snapshot/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('test snapshot', () => {
+  it('test toMatchSnapshot API', () => {
+    expect('hello world').toMatchSnapshot();
+  });
+
+  it.todo('test toMatchInlineSnapshot API', () => {
+    expect('hello world').toMatchInlineSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary

Integrate snapshot API, the core snapshot API is provided by `@vitest/snapshot` ❤️ .

https://www.npmjs.com/package/@vitest/snapshot

```ts
  it('test toMatchSnapshot API', () => {
    expect('hello world').toMatchSnapshot();
  });
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
