### PR TITLE
feat: support print snapshot summary log

### DIFF
--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -13,6 +13,7 @@ export async function runTests(
     normalizedConfig: { include, exclude, root, name, setupFiles: setups },
     rootPath,
     reporters,
+    snapshotManager,
   } = context;
 
   const sourceEntries = await getTestEntries({
@@ -71,6 +72,7 @@ export async function runTests(
     await reporter.onTestRunEnd?.({
       results,
       testResults,
+      snapshotSummary: snapshotManager.summary,
       duration,
       getSourcemap,
     });

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -110,6 +110,12 @@ export const runInPool = async ({
     ),
   );
 
+  for (const result of results) {
+    if (result.snapshotResult) {
+      context.snapshotManager.add(result.snapshotResult);
+    }
+  }
+
   const testResults = results.flatMap((r) => r.results!);
 
   return { results, testResults };

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -3,6 +3,7 @@ import type {
   Duration,
   GetSourcemap,
   Reporter,
+  SnapshotSummary,
   TestFileInfo,
   TestResult,
   TestSummaryResult,
@@ -58,10 +59,12 @@ export class DefaultReporter implements Reporter {
     testResults,
     duration,
     getSourcemap,
+    snapshotSummary,
   }: {
     results: TestSummaryResult[];
     testResults: TestResult[];
     duration: Duration;
+    snapshotSummary: SnapshotSummary;
     getSourcemap: GetSourcemap;
   }): Promise<void> {
     await printSummaryErrorLogs({
@@ -69,6 +72,12 @@ export class DefaultReporter implements Reporter {
       rootPath: this.rootPath,
       getSourcemap,
     });
-    printSummaryLog(results, testResults, duration);
+    printSummaryLog({
+      results,
+      testResults,
+      duration,
+      rootPath: this.rootPath,
+      snapshotSummary,
+    });
   }
 }

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
-import { posix } from 'node:path';
+import path from 'node:path';
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+import type { SnapshotSummary } from '@vitest/snapshot';
 import { type StackFrame, parse as stackTraceParse } from 'stacktrace-parser';
 import type {
   Duration,
@@ -8,7 +9,7 @@ import type {
   TestResult,
   TestSummaryResult,
 } from '../types';
-import { color, logger, prettyTime } from '../utils';
+import { color, logger, prettyTime, slash } from '../utils';
 
 export const getSummaryStatusString = (
   tasks: TestResult[],
@@ -37,12 +38,107 @@ export const getSummaryStatusString = (
   );
 };
 
-export const printSummaryLog = (
-  results: TestSummaryResult[],
-  testResults: TestResult[],
-  duration: Duration,
+/**
+ * This method is modified based on source found in
+ * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/node/reporters/renderers/utils.ts#L52
+ */
+export const formatTestPath = (root: string, testFilePath: string): string => {
+  let testPath = testFilePath;
+  if (path.isAbsolute(testPath)) {
+    testPath = path.relative(root, testPath);
+  }
+
+  const dir = path.dirname(testPath);
+  const ext = testPath.match(/(\.(spec|test)\.[cm]?[tj]sx?)$/)?.[0] || '';
+  const base = path.basename(testPath, ext);
+
+  return slash(color.dim(`${dir}/`) + color.bold(base)) + color.dim(ext);
+};
+
+/**
+ * This method is modified based on source found in
+ * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/node/reporters/renderers/utils.ts#L67
+ */
+export const printSnapshotSummaryLog = (
+  snapshots: SnapshotSummary,
+  rootDir: string,
 ): void => {
+  const summary: string[] = [];
+
+  if (snapshots.added) {
+    summary.push(color.bold(color.green(`${snapshots.added} written`)));
+  }
+  if (snapshots.unmatched) {
+    summary.push(color.bold(color.red(`${snapshots.unmatched} failed`)));
+  }
+  if (snapshots.updated) {
+    summary.push(color.bold(color.green(`${snapshots.updated} updated `)));
+  }
+
+  if (snapshots.filesRemoved) {
+    if (snapshots.didUpdate) {
+      summary.push(
+        color.bold(color.green(`${snapshots.filesRemoved} files removed `)),
+      );
+    } else {
+      summary.push(
+        color.bold(color.yellow(`${snapshots.filesRemoved} files obsolete `)),
+      );
+    }
+  }
+  const F_DOWN_RIGHT = '↳';
+
+  if (snapshots.filesRemovedList?.length) {
+    const [head, ...tail] = snapshots.filesRemovedList;
+    summary.push(
+      `${color.gray(F_DOWN_RIGHT)} ${formatTestPath(rootDir, head!)}`,
+    );
+
+    for (const key of tail) {
+      summary.push(
+        `  ${color.gray(F_DOWN_RIGHT)} ${formatTestPath(rootDir, key)}`,
+      );
+    }
+  }
+
+  if (snapshots.unchecked) {
+    if (snapshots.didUpdate) {
+      summary.push(color.bold(color.green(`${snapshots.unchecked} removed`)));
+    } else {
+      summary.push(color.bold(color.yellow(`${snapshots.unchecked} obsolete`)));
+    }
+
+    for (const uncheckedFile of snapshots.uncheckedKeysByFile) {
+      summary.push(
+        `${color.gray(F_DOWN_RIGHT)} ${formatTestPath(rootDir, uncheckedFile.filePath)}`,
+      );
+      for (const key of uncheckedFile.keys) {
+        summary.push(`  ${color.gray(F_DOWN_RIGHT)} ${key}`);
+      }
+    }
+  }
+
+  for (const [index, snapshot] of summary.entries()) {
+    const title = index === 0 ? 'Snapshots' : '';
+    logger.log(`${color.gray(title.padStart(12))} ${snapshot}`);
+  }
+};
+
+export const printSummaryLog = ({
+  results,
+  testResults,
+  snapshotSummary,
+  duration,
+  rootPath,
+}: {
+  results: TestSummaryResult[];
+  testResults: TestResult[];
+  snapshotSummary: SnapshotSummary;
+  duration: Duration;
+  rootPath: string;
+}): void => {
   logger.log('');
+  printSnapshotSummaryLog(snapshotSummary, rootPath);
   logger.log(
     `${color.gray('Test Files'.padStart(12))} ${getSummaryStatusString(results)}`,
   );
@@ -51,7 +147,7 @@ export const printSummaryLog = (
   );
 
   logger.log(
-    `${color.gray('Duration'.padStart(12))} ${prettyTime(duration.totalTime)} ${color.gray(`(build ${prettyTime(duration.buildTime)}, tests ${prettyTime(duration.testTime)}`)})`,
+    `${color.gray('Duration'.padStart(12))} ${prettyTime(duration.totalTime)} ${color.gray(`(build ${prettyTime(duration.buildTime)}, tests ${prettyTime(duration.testTime)})`)}`,
   );
   logger.log('');
 };
@@ -76,7 +172,7 @@ export const printSummaryErrorLogs = async ({
   logger.log('');
 
   for (const test of failedTests) {
-    const relativePath = posix.relative(rootPath, test.testPath);
+    const relativePath = path.posix.relative(rootPath, test.testPath);
     logger.log(
       `${color.bgRed(' FAIL ')} ${relativePath} > ${test.prefix}${test.name}`,
     );
@@ -141,6 +237,7 @@ const stackIgnores: (RegExp | string)[] = [
   /\/@rstest\/core/,
   /rstest\/packages\/core\/dist/,
   /node_modules\/tinypool/,
+  /node_modules\/chai/,
 ];
 
 function parseErrorStacktrace({

--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -196,13 +196,14 @@ export class TestRunner {
     }
 
     // saves files and returns SnapshotResult
-    await snapshotClient.finish(testPath);
+    const snapshotResult = await snapshotClient.finish(testPath);
 
     return {
       testPath,
       name: 'test',
       status: getTestStatus(results),
       results,
+      snapshotResult,
       duration: Date.now() - start,
     };
   }

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -1,4 +1,5 @@
 import type { SourceMapInput } from '@jridgewell/trace-mapping';
+import type { SnapshotSummary } from '@vitest/snapshot';
 import type { TestFileInfo, TestResult, TestSummaryResult } from './testSuite';
 import type { MaybePromise } from './utils';
 
@@ -8,7 +9,7 @@ export type Duration = {
   testTime: number;
 };
 
-export type { SourceMapInput };
+export type { SourceMapInput, SnapshotSummary };
 
 export type GetSourcemap = (
   sourcePath: string,
@@ -30,10 +31,12 @@ export interface Reporter {
     testResults,
     duration,
     getSourcemap,
+    snapshotSummary,
   }: {
     results: TestSummaryResult[];
     testResults: TestResult[];
     duration: Duration;
     getSourcemap: GetSourcemap;
+    snapshotSummary: SnapshotSummary;
   }) => MaybePromise<void>;
 }

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,3 +1,5 @@
+import type { SnapshotResult } from '@vitest/snapshot';
+
 // TODO: Unify filePath、testPath、originPath、sourcePath
 import type { MaybePromise } from './utils';
 
@@ -63,4 +65,5 @@ export type TestSummaryResult = {
   results: TestResult[];
   duration?: number;
   testPath: string;
+  snapshotResult?: SnapshotResult;
 };

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -14,6 +14,10 @@ export const parsePosix = (filePath: string): { dir: string; base: string } => {
   };
 };
 
+export function slash(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
 export const castArray = <T>(arr?: T | T[]): T[] => {
   if (arr === undefined) {
     return [];


### PR DESCRIPTION
## Summary

Support print snapshot summary log.

This feature is modified based on `Vitest` renderSnapshotSummary method. ❤️ 
https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/node/reporters/renderers/utils.ts#L67


<img width="970" alt="image" src="https://github.com/user-attachments/assets/2c3c4887-2852-4150-ba4b-1179dd5bb0d2" />

<img width="605" alt="image" src="https://github.com/user-attachments/assets/e252a5b0-0722-42a5-8ffd-20db63ad1f09" />

<img width="629" alt="image" src="https://github.com/user-attachments/assets/b7205ef6-5a8f-43da-90d5-47b769d2a604" />



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
