### PR TITLE
feat: support `toMatchInlineSnapshot` API

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -9,6 +9,29 @@ export default defineConfig({
         bundle: false,
         distPath: './dist-types',
       },
+      output: {
+        minify: {
+          jsOptions: {
+            minimizerOptions: {
+              mangle: false,
+              minify: false,
+              compress: {
+                defaults: false,
+                unused: true,
+                dead_code: true,
+                toplevel: true,
+                // fix `Couldn't infer stack frame for inline snapshot` error
+                // should keep function name used to filter stack trace
+                keep_fnames: true,
+              },
+              format: {
+                comments: 'some',
+                preserve_annotations: true,
+              },
+            },
+          },
+        },
+      },
       source: {
         entry: {
           index: './src/index.ts',
@@ -22,4 +45,11 @@ export default defineConfig({
       },
     },
   ],
+  tools: {
+    rspack: {
+      watchOptions: {
+        ignored: /\.git/,
+      },
+    },
+  },
 });

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -39,7 +39,7 @@ export async function runTests(
 
   const rsbuildInstance = await prepareRsbuild(name, sourceEntries, setupFiles);
 
-  const { close, entries, assetFiles, setupEntries, getSourcemap } =
+  const { close, entries, assetFiles, sourceMaps, setupEntries, getSourcemap } =
     await createRsbuildServer({
       name,
       sourceEntries,
@@ -54,6 +54,7 @@ export async function runTests(
     entries,
     assetFiles,
     setupEntries,
+    sourceMaps,
     context,
   });
   const testEnd = Date.now();

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -2,6 +2,7 @@ import os from 'node:os';
 import type {
   EntryInfo,
   RstestContext,
+  SourceMapInput,
   TestFileResult,
   TestResult,
 } from '../types';
@@ -32,10 +33,12 @@ export const runInPool = async ({
   context,
   assetFiles,
   setupEntries,
+  sourceMaps,
 }: {
   entries: EntryInfo[];
   setupEntries: EntryInfo[];
   assetFiles: Record<string, string>;
+  sourceMaps: Record<string, SourceMapInput>;
   context: RstestContext;
 }): Promise<{
   results: TestFileResult[];
@@ -91,6 +94,7 @@ export const runInPool = async ({
           entryInfo,
           assetFiles,
           context,
+          sourceMaps,
           setupEntries,
           updateSnapshot,
         },

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -12,9 +12,7 @@ export type Duration = {
 
 export type { SourceMapInput, SnapshotSummary };
 
-export type GetSourcemap = (
-  sourcePath: string,
-) => Promise<SourceMapInput | null>;
+export type GetSourcemap = (sourcePath: string) => SourceMapInput | null;
 
 export type { BuiltInReporterNames };
 

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -1,6 +1,7 @@
 import type { SnapshotUpdateState } from '@vitest/snapshot';
 import type { SnapshotEnvironment } from '@vitest/snapshot/environment';
 import type { RstestContext } from './core';
+import type { SourceMapInput } from './reporter';
 import type { TestFileInfo, TestResult } from './testSuite';
 
 export type EntryInfo = {
@@ -28,6 +29,7 @@ export type RunWorkerOptions = {
     entryInfo: EntryInfo;
     setupEntries: EntryInfo[];
     assetFiles: Record<string, string>;
+    sourceMaps: Record<string, SourceMapInput>;
     context: WorkerContext;
     updateSnapshot: SnapshotUpdateState;
   };

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -1,4 +1,3 @@
-import { NodeSnapshotEnvironment } from '@vitest/snapshot/environment';
 import { globalApis } from '../constants';
 import type {
   Rstest,
@@ -9,6 +8,7 @@ import type {
 import { logger } from '../utils';
 import { loadModule } from './loadModule';
 import { createForksRpcOptions, createRuntimeRpc } from './rpc';
+import { RstestSnapshotEnvironment } from './snapshot';
 
 const getGlobalApi = (api: Rstest) => {
   return globalApis.reduce<{
@@ -23,6 +23,7 @@ const runInPool = async ({
   entryInfo: { filePath, originPath },
   setupEntries,
   assetFiles,
+  sourceMaps,
   updateSnapshot,
   context,
 }: RunWorkerOptions['options']): Promise<TestFileResult> => {
@@ -36,7 +37,9 @@ const runInPool = async ({
     ...context,
     snapshotOptions: {
       updateSnapshot,
-      snapshotEnvironment: new NodeSnapshotEnvironment(),
+      snapshotEnvironment: new RstestSnapshotEnvironment({
+        sourceMaps,
+      }),
     },
     filePath,
     sourcePath: originPath,
@@ -86,10 +89,7 @@ const runInPool = async ({
 
     return results;
   } catch (err) {
-    logger.error(
-      `run file ${originPath} failed:\n`,
-      err instanceof Error ? err.message : err,
-    );
+    logger.error(`run file ${originPath} failed:\n`, err);
     return {
       testPath: originPath,
       status: 'fail',

--- a/packages/core/src/worker/snapshot.ts
+++ b/packages/core/src/worker/snapshot.ts
@@ -1,0 +1,46 @@
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+import { NodeSnapshotEnvironment } from '@vitest/snapshot/environment';
+import type { SourceMapInput } from '../types';
+
+interface ParsedStack {
+  method: string;
+  file: string;
+  line: number;
+  column: number;
+}
+
+export class RstestSnapshotEnvironment extends NodeSnapshotEnvironment {
+  private sourceMaps: Record<string, SourceMapInput> = {};
+
+  constructor({
+    sourceMaps,
+  }: {
+    sourceMaps: Record<string, SourceMapInput>;
+  }) {
+    super();
+    this.sourceMaps = sourceMaps;
+  }
+
+  // StackTrace is used to parse inline snapshot position
+  // The inline snapshot should run code in dist and save snapshot in source
+  processStackTrace(stack: ParsedStack): ParsedStack {
+    const sourcemap = this.sourceMaps[stack.file];
+
+    if (sourcemap) {
+      const traceMap = new TraceMap(sourcemap);
+      const { line, column, source, name } = originalPositionFor(traceMap, {
+        line: stack.line,
+        column: stack.column!,
+      });
+
+      return {
+        file: source!,
+        line: line!,
+        method: name!,
+        column: column!,
+      };
+    }
+
+    return stack;
+  }
+}

--- a/tests/snapshot/index.test.ts
+++ b/tests/snapshot/index.test.ts
@@ -5,7 +5,13 @@ describe('test snapshot', () => {
     expect('hello world').toMatchSnapshot();
   });
 
-  it.todo('test toMatchInlineSnapshot API', () => {
-    expect('hello world').toMatchInlineSnapshot();
+  it('test toMatchInlineSnapshot API', () => {
+    expect('hello world').toMatchInlineSnapshot(`"hello world"`);
+    expect({ a: 1, b: 2 }).toMatchInlineSnapshot(`
+      {
+        "a": 1,
+        "b": 2,
+      }
+    `);
   });
 });


### PR DESCRIPTION

Support `toMatchInlineSnapshot` API. The inline snapshot should run code in `dist` and save snapshot in `source`.

* Add `RstestSnapshotEnvironment` to handle source maps for inline snapshots, ensuring accurate stack traces (StackTrace is used to parse inline snapshot position)
* Added `keep_fnames` minification options to the `rslib.config.ts` file to preserve function names for stack traces

<img width="739" alt="image" src="https://github.com/user-attachments/assets/1f4efcf8-f1f4-4694-a347-04e7b9749174" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
