### PR TITLE
chore: simplify rstest expect type

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,9 +1,4 @@
-import type {
-  Assertion,
-  ExpectStatic,
-  PromisifyAssertion,
-  Tester,
-} from '@vitest/expect';
+import type { ExpectStatic } from '@vitest/expect';
 import type { AfterAllListener } from './testSuite';
 import type { MaybePromise } from './utils';
 
@@ -24,43 +19,7 @@ export type RunnerAPI = {
   afterAll: AfterAllAPI;
 };
 
-interface ExpectPollOptions {
-  /**
-   * @default 50
-   */
-  interval?: number;
-  /**
-   * @default 1000
-   */
-  timeout?: number;
-  message?: string;
-}
-
-export type RstestExpect = ExpectStatic & {
-  unreachable: (message?: string) => never;
-  soft: <T>(actual: T, message?: string) => Assertion<T>;
-  poll: <T>(
-    actual: () => T,
-    options?: ExpectPollOptions,
-  ) => Omit<
-    PromisifyAssertion<Awaited<T>>,
-    | 'rejects'
-    | 'resolves'
-    | 'toThrow'
-    | 'toThrowError'
-    | 'throw'
-    | 'throws'
-    | 'matchSnapshot'
-    | 'toMatchSnapshot'
-    | 'toMatchInlineSnapshot'
-    | 'toThrowErrorMatchingSnapshot'
-    | 'toThrowErrorMatchingInlineSnapshot'
-  >;
-  addEqualityTesters: (testers: Array<Tester>) => void;
-  assertions: (expected: number) => void;
-  hasAssertions: () => void;
-  // addSnapshotSerializer: (plugin: PrettyFormatPlugin) => void
-};
+export type RstestExpect = ExpectStatic;
 
 export type Rstest = RunnerAPI & {
   expect: RstestExpect;

--- a/packages/core/src/types/global.ts
+++ b/packages/core/src/types/global.ts
@@ -29,7 +29,13 @@ declare module '@vitest/expect' {
   }
 
   interface ExpectPollOptions {
+    /**
+     * @default 50
+     */
     interval?: number;
+    /**
+     * @default 1000
+     */
     timeout?: number;
     message?: string;
   }
@@ -40,7 +46,20 @@ declare module '@vitest/expect' {
     poll: <T>(
       actual: () => T,
       options?: ExpectPollOptions,
-    ) => PromisifyAssertion<Awaited<T>>;
+    ) => Omit<
+      PromisifyAssertion<Awaited<T>>,
+      | 'rejects'
+      | 'resolves'
+      | 'toThrow'
+      | 'toThrowError'
+      | 'throw'
+      | 'throws'
+      | 'matchSnapshot'
+      | 'toMatchSnapshot'
+      | 'toMatchInlineSnapshot'
+      | 'toThrowErrorMatchingSnapshot'
+      | 'toThrowErrorMatchingInlineSnapshot'
+    >;
     addEqualityTesters: (testers: Array<Tester>) => void;
     assertions: (expected: number) => void;
     hasAssertions: () => void;


### PR DESCRIPTION
## Summary

`RstestExpect` is reference from `ExpectStatic` type, and we update the `ExpectStatic` type by declaring `@vitest/expect` module.

https://github.com/web-infra-dev/rstest/blob/538ce2243d1f292d5e9e22d32087caa96e60c1e0/packages/core/src/types/global.ts#L25-L43

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
