### PR TITLE
feat: support register async suite

### DIFF
--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -36,12 +36,8 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
     },
     runner: {
       runTest: async (testFilePath: string, hooks: RunnerHooks) => {
-        return testRunner.runTests(
-          runtimeAPI.getTests(),
-          testFilePath,
-          workerState,
-          hooks,
-        );
+        const tests = await runtimeAPI.getTests();
+        return testRunner.runTests(tests, testFilePath, workerState, hooks);
       },
       getCurrentTest: () => testRunner.getCurrentTest(),
     },

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -1,0 +1,41 @@
+import { RunnerRuntime } from '../../src/runner/runtime';
+import type { TestSuite } from '../../src/types';
+
+describe('RunnerRuntime', () => {
+  it('should add test correctly', async () => {
+    const runtime = new RunnerRuntime(__filename);
+
+    runtime.describe('suite - 0', () => {
+      runtime.it('test - 0', () => {});
+      runtime.describe('test - 1', async () => {
+        await new Promise<void>((resolve) => {
+          setTimeout(() => {
+            resolve();
+          }, 100);
+        });
+        runtime.it('test - 1 - 1', () => {});
+      });
+    });
+
+    runtime.describe('suite - 1', () => {});
+    runtime.it('test - 2', () => {});
+
+    const tests = await runtime.getTests();
+
+    expect(tests.map((test) => test.description)).toEqual([
+      'suite - 0',
+      'suite - 1',
+      'test - 2',
+    ]);
+
+    expect(
+      (tests[0] as TestSuite).tests.map((test) => test.description),
+    ).toEqual(['test - 0', 'test - 1']);
+
+    expect(
+      ((tests[0] as TestSuite).tests[1] as TestSuite).tests.map(
+        (test) => test.description,
+      ),
+    ).toEqual(['test - 1 - 1']);
+  });
+});

--- a/tests/isolate/test/index.test.ts
+++ b/tests/isolate/test/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
+import { sleep } from '../../scripts/utils';
 import { getCount, increment } from '../src/index';
 
 process.env.index = '1';
@@ -6,13 +7,13 @@ globalThis.index = '1';
 
 describe('Test isolate', () => {
   it('should get process.env index correctly', async () => {
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await sleep(200);
     expect(process.env.index).toBe('1');
     expect(process.env.index1).toBeUndefined();
   });
 
   it('should get globalThis index correctly', async () => {
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await sleep(200);
     expect(globalThis.index).toBe('1');
     expect(globalThis.index1).toBeUndefined();
   });

--- a/tests/isolate/test/index1.test.ts
+++ b/tests/isolate/test/index1.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
+import { sleep } from '../../scripts/utils';
 import { getCount, increment } from '../src/index';
 
 process.env.index1 = '1';
@@ -6,13 +7,13 @@ globalThis.index1 = '1';
 
 describe('Test isolate - 1', () => {
   it('should get process.env index1 correctly', async () => {
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await sleep(200);
     expect(process.env.index1).toBe('1');
     expect(process.env.index).toBeUndefined();
   });
 
   it('should get global index1 correctly', async () => {
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await sleep(200);
     expect(globalThis.index1).toBe('1');
     expect(globalThis.index).toBeUndefined();
   });

--- a/tests/runner/test/async.test.ts
+++ b/tests/runner/test/async.test.ts
@@ -1,0 +1,58 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('Test Async Suite', () => {
+  it('should run async suite in the correct order', async () => {
+    const process = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/async.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    const logs = process.stdout.split('\n').filter(Boolean);
+
+    // test execution order
+    expect(logs.filter((log) => log.startsWith('run'))).toMatchInlineSnapshot(`
+      [
+        "run 0-0",
+        "run 0-1-0",
+        "run 0-1-1-0",
+        "run 0-2-0",
+        "run 0-3",
+        "run 1-0",
+        "run 2-0-0",
+        "run 2-1",
+        "run 3-0",
+      ]
+    `);
+
+    // test suite reference
+    expect(
+      logs
+        .filter((log) => log.includes('Test Async Suite'))
+        // slice `✓ Test Async Suite > 2 > 2-0 > 2-0-0 (0 ms)` to `> 2 > 2-0 > 2-0-0`
+        .map((log) => log.split('Test Async Suite')[1].split('(')[0]),
+    ).toMatchInlineSnapshot(`
+      [
+        " > 0 > 0-0 ",
+        " > 0 > 0-1 > 0-1-0 ",
+        " > 0 > 0-1 > 0-1-1 > 0-1-1-0 ",
+        " > 0 > 0-2 > 0-2-0 ",
+        " > 0 > 0-3 ",
+        " > 1 ",
+        " > 2 > 2-0 > 2-0-0 ",
+        " > 2 > 2-1 ",
+        " > 3 ",
+      ]
+    `);
+  });
+});

--- a/tests/runner/test/async.test.ts
+++ b/tests/runner/test/async.test.ts
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 
 describe('Test Async Suite', () => {
   it('should run async suite in the correct order', async () => {
-    const process = await runRstestCli({
+    const { cli } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/async.test.ts'],
       options: {
@@ -18,7 +18,9 @@ describe('Test Async Suite', () => {
       },
     });
 
-    const logs = process.stdout.split('\n').filter(Boolean);
+    await cli.exec;
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
 
     // test execution order
     expect(logs.filter((log) => log.startsWith('run'))).toMatchInlineSnapshot(`

--- a/tests/runner/test/fixtures/async.test.ts
+++ b/tests/runner/test/fixtures/async.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('Test Async Suite', () => {
+  describe('0', async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 100);
+    });
+
+    it('0-0', () => {
+      console.log('run 0-0');
+      expect(1 + 1).toBe(2);
+    });
+
+    describe('0-1', async () => {
+      it('0-1-0', () => {
+        console.log('run 0-1-0');
+        expect(1 + 1).toBe(2);
+      });
+
+      describe('0-1-1', () => {
+        it('0-1-1-0', () => {
+          console.log('run 0-1-1-0');
+          expect(1 + 1).toBe(2);
+        });
+      });
+    });
+
+    describe('0-2', () => {
+      it('0-2-0', () => {
+        console.log('run 0-2-0');
+        expect(1 + 1).toBe(2);
+      });
+    });
+
+    it('0-3', () => {
+      console.log('run 0-3');
+      expect(1 + 1).toBe(2);
+    });
+  });
+
+  it('1', () => {
+    console.log('run 1-0');
+    expect(1 + 1).toBe(2);
+  });
+
+  describe('2', () => {
+    describe('2-0', async () => {
+      it('2-0-0', () => {
+        console.log('run 2-0-0');
+        expect(1 + 1).toBe(2);
+      });
+    });
+
+    it('2-1', () => {
+      console.log('run 2-1');
+      expect(1 + 1).toBe(2);
+    });
+  });
+
+  it('3', () => {
+    console.log('run 3-0');
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/tests/runner/test/fixtures/async.test.ts
+++ b/tests/runner/test/fixtures/async.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, it } from '@rstest/core';
+import { sleep } from '../../../scripts/utils';
 
 describe('Test Async Suite', () => {
   describe('0', async () => {
-    await new Promise<void>((resolve) => {
-      setTimeout(() => {
-        resolve();
-      }, 100);
-    });
+    await sleep(100);
 
     it('0-0', () => {
       console.log('run 0-0');

--- a/tests/scripts/utils.ts
+++ b/tests/scripts/utils.ts
@@ -15,3 +15,9 @@ export const waitFile = async (filePath: string, timeout = 3000) => {
     }, timeout);
   });
 };
+
+export const sleep = (ms: number) => {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};


### PR DESCRIPTION
## Summary

Support register **async** suite. BTW, If you have some preparations that need to be executed before testing, it is recommended to use `beforeEach` / `beforeAll`.

```ts
  describe('Test Async Suite', async () => {
    // do something async...
    await new Promise<void>((resolve) => {
      setTimeout(() => {
        resolve();
      }, 100);
    });

   it('should add two numbers correctly', () => {
      expect(1 + 1).toBe(2);
    });
  });
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
