### PR TITLE
enhance: optimize task name output

### DIFF
--- a/packages/core/src/api/snapshot.ts
+++ b/packages/core/src/api/snapshot.ts
@@ -10,7 +10,7 @@ import {
   stripSnapshotIndentation,
 } from '@vitest/snapshot';
 import type { TestCase } from '../types';
-import { getTaskNames } from '../utils';
+import { getTaskNameWithPrefix } from '../utils';
 
 let _client: SnapshotClient;
 
@@ -126,7 +126,7 @@ function getError(expected: () => void | Error, promise: string | undefined) {
 function getTestNames(test: TestCase) {
   return {
     filepath: test.filePath,
-    name: getTaskNames(test).join(' > '),
+    name: getTaskNameWithPrefix(test),
     // testId: test.id,
   };
 }

--- a/packages/core/src/api/snapshot.ts
+++ b/packages/core/src/api/snapshot.ts
@@ -10,6 +10,7 @@ import {
   stripSnapshotIndentation,
 } from '@vitest/snapshot';
 import type { TestCase } from '../types';
+import { getTaskNames } from '../utils';
 
 let _client: SnapshotClient;
 
@@ -125,9 +126,7 @@ function getError(expected: () => void | Error, promise: string | undefined) {
 function getTestNames(test: TestCase) {
   return {
     filepath: test.filePath,
-    name: test.description,
-    // TODO
-    // name: getNames(test).slice(1).join(' > '),
+    name: getTaskNames(test).join(' > '),
     // testId: test.id,
   };
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -5,10 +5,13 @@ import {
   mergeRsbuildConfig,
 } from '@rsbuild/core';
 import { dirname, isAbsolute, join } from 'pathe';
-import { DEFAULT_CONFIG_EXTENSIONS, DEFAULT_CONFIG_NAME } from './constants';
 import type { NormalizedConfig, RstestConfig } from './types';
-import { color } from './utils/helper';
-import { logger } from './utils/logger';
+import {
+  DEFAULT_CONFIG_EXTENSIONS,
+  DEFAULT_CONFIG_NAME,
+  color,
+  logger,
+} from './utils';
 
 export type RstestConfigAsyncFn = () => Promise<RstestConfig>;
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,6 +2,10 @@ import type { Rstest } from './types';
 
 export const DEFAULT_CONFIG_NAME = 'rstest.config';
 
+export const TEST_DELIMITER = '>';
+
+export const ROOT_SUITE_NAME = 'Rstest:_internal_root_suite';
+
 export const DEFAULT_CONFIG_EXTENSIONS = [
   '.js',
   '.ts',

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -1,5 +1,4 @@
 import { relative } from 'pathe';
-import { TEST_DELIMITER } from '../constants';
 import type {
   Duration,
   GetSourcemap,
@@ -9,7 +8,13 @@ import type {
   TestFileResult,
   TestResult,
 } from '../types';
-import { color, getTaskNames, parsePosix, prettyTime } from '../utils';
+import {
+  TEST_DELIMITER,
+  color,
+  getTaskNameWithPrefix,
+  parsePosix,
+  prettyTime,
+} from '../utils';
 import { printSummaryErrorLogs, printSummaryLog } from './summary';
 
 export class DefaultReporter implements Reporter {
@@ -45,7 +50,7 @@ export class DefaultReporter implements Reporter {
         : '';
 
     const icon = statusColorfulStr[result.status];
-    const nameStr = getTaskNames(result).join(` ${TEST_DELIMITER} `);
+    const nameStr = getTaskNameWithPrefix(result);
 
     console.log(`  ${icon} ${nameStr}${color.gray(duration)}`);
 

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -1,4 +1,5 @@
 import { relative } from 'pathe';
+import { TEST_DELIMITER } from '../constants';
 import type {
   Duration,
   GetSourcemap,
@@ -8,7 +9,7 @@ import type {
   TestFileResult,
   TestResult,
 } from '../types';
-import { color, parsePosix, prettyTime } from '../utils';
+import { color, getTaskNames, parsePosix, prettyTime } from '../utils';
 import { printSummaryErrorLogs, printSummaryLog } from './summary';
 
 export class DefaultReporter implements Reporter {
@@ -24,7 +25,9 @@ export class DefaultReporter implements Reporter {
     const { dir, base } = parsePosix(relativePath);
 
     console.log('');
-    console.log(`${color.gray(`> ${dir ? `${dir}/` : ''}`)}${base}`);
+    console.log(
+      `${color.gray(`${TEST_DELIMITER} ${dir ? `${dir}/` : ''}`)}${base}`,
+    );
     console.log('');
   }
 
@@ -42,10 +45,9 @@ export class DefaultReporter implements Reporter {
         : '';
 
     const icon = statusColorfulStr[result.status];
+    const nameStr = getTaskNames(result).join(` ${TEST_DELIMITER} `);
 
-    console.log(
-      `  ${icon} ${result.prefix}${result.name}${color.gray(duration)}`,
-    );
+    console.log(`  ${icon} ${nameStr}${color.gray(duration)}`);
 
     if (result.errors) {
       for (const error of result.errors) {

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -3,14 +3,20 @@ import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
 import type { SnapshotSummary } from '@vitest/snapshot';
 import path from 'pathe';
 import { type StackFrame, parse as stackTraceParse } from 'stacktrace-parser';
-import { TEST_DELIMITER } from '../constants';
 import type {
   Duration,
   GetSourcemap,
   TestFileResult,
   TestResult,
 } from '../types';
-import { color, getTaskNames, logger, prettyTime, slash } from '../utils';
+import {
+  TEST_DELIMITER,
+  color,
+  getTaskNameWithPrefix,
+  logger,
+  prettyTime,
+  slash,
+} from '../utils';
 
 export const getSummaryStatusString = (
   tasks: TestResult[],
@@ -179,11 +185,11 @@ export const printSummaryErrorLogs = async ({
 
   for (const test of failedTests) {
     const relativePath = path.relative(rootPath, test.testPath);
-    const names = getTaskNames(test);
+    const nameStr = getTaskNameWithPrefix(test);
 
     //  FAIL  tests/index.test.ts > suite name > test case name
     logger.log(
-      `${color.bgRed(' FAIL ')} ${relativePath} ${names.length ? `${TEST_DELIMITER} ${names.join(` ${TEST_DELIMITER} `)}` : ''}`,
+      `${color.bgRed(' FAIL ')} ${relativePath} ${nameStr.length ? `${TEST_DELIMITER} ${nameStr}` : ''}`,
     );
 
     if (test.errors) {

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -3,13 +3,14 @@ import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
 import type { SnapshotSummary } from '@vitest/snapshot';
 import path from 'pathe';
 import { type StackFrame, parse as stackTraceParse } from 'stacktrace-parser';
+import { TEST_DELIMITER } from '../constants';
 import type {
   Duration,
   GetSourcemap,
   TestFileResult,
   TestResult,
 } from '../types';
-import { color, logger, prettyTime, slash } from '../utils';
+import { color, getTaskNames, logger, prettyTime, slash } from '../utils';
 
 export const getSummaryStatusString = (
   tasks: TestResult[],
@@ -178,10 +179,11 @@ export const printSummaryErrorLogs = async ({
 
   for (const test of failedTests) {
     const relativePath = path.relative(rootPath, test.testPath);
-    const testName = `${test.prefix || ''}${test.name}`;
+    const names = getTaskNames(test);
 
+    //  FAIL  tests/index.test.ts > suite name > test case name
     logger.log(
-      `${color.bgRed(' FAIL ')} ${relativePath} ${testName ? `> ${testName}` : ''}`,
+      `${color.bgRed(' FAIL ')} ${relativePath} ${names.length ? `${TEST_DELIMITER} ${names.join(` ${TEST_DELIMITER} `)}` : ''}`,
     );
 
     if (test.errors) {

--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -1,6 +1,5 @@
 import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect';
 import { getSnapshotClient } from '../api/snapshot';
-import { ROOT_SUITE_NAME } from '../constants';
 import type {
   RunnerHooks,
   Test,
@@ -10,6 +9,7 @@ import type {
   TestResultStatus,
   WorkerState,
 } from '../types';
+import { ROOT_SUITE_NAME } from '../utils';
 import { formatTestError } from '../utils/runtime';
 
 const getTestStatus = (results: TestResult[]): TestResultStatus => {

--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -1,5 +1,6 @@
 import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect';
 import { getSnapshotClient } from '../api/snapshot';
+import { ROOT_SUITE_NAME } from '../constants';
 import type {
   RunnerHooks,
   Test,
@@ -62,24 +63,27 @@ export class TestRunner {
 
     await snapshotClient.setup(testPath, snapshotOptions);
 
-    const runTest = async (test: Test, prefix = '') => {
+    const runTest = async (test: Test, prefixes: string[] = []) => {
       if (test.type === 'suite') {
         if (test.tests.length === 0) {
           if (passWithNoTests) {
-            console.warn(`   No test found in suite: ${test.description}\n`);
+            console.warn(`   No test found in suite: ${test.name}\n`);
             return;
           }
           const result = {
             status: 'fail' as const,
-            prefix,
-            name: test.description,
+            prefixes,
+            name: test.name,
             testPath,
           };
           hooks.onTestCaseResult?.(result);
         }
 
         for (const suite of test.tests) {
-          await runTest(suite, `${prefix}${test.description} > `);
+          await runTest(
+            suite,
+            test.name === ROOT_SUITE_NAME ? prefixes : [...prefixes, test.name],
+          );
         }
 
         if (test.afterAllListeners) {
@@ -94,8 +98,8 @@ export class TestRunner {
         if (test.skipped) {
           const result = {
             status: 'skip' as const,
-            prefix,
-            name: test.description,
+            prefixes,
+            name: test.name,
             testPath,
           };
           hooks.onTestCaseResult?.(result);
@@ -105,8 +109,8 @@ export class TestRunner {
         if (test.todo) {
           const result = {
             status: 'todo' as const,
-            prefix,
-            name: test.description,
+            prefixes,
+            name: test.name,
             testPath,
           };
           hooks.onTestCaseResult?.(result);
@@ -115,7 +119,7 @@ export class TestRunner {
         }
 
         let result: TestResult;
-        this.setCurrentTest(test);
+        this.setCurrentTest(test, prefixes);
 
         if (test.fails) {
           try {
@@ -125,8 +129,8 @@ export class TestRunner {
 
             result = {
               status: 'fail' as const,
-              prefix,
-              name: test.description,
+              prefixes,
+              name: test.name,
               duration: Date.now() - start,
               testPath,
               errors: [
@@ -138,8 +142,8 @@ export class TestRunner {
           } catch (error) {
             result = {
               status: 'pass' as const,
-              prefix,
-              name: test.description,
+              prefixes,
+              name: test.name,
               testPath,
               duration: Date.now() - start,
             };
@@ -151,16 +155,16 @@ export class TestRunner {
             this.afterRunTest();
             result = {
               status: 'pass' as const,
-              prefix,
-              name: test.description,
+              prefixes,
+              name: test.name,
               duration: Date.now() - start,
               testPath,
             };
           } catch (error) {
             result = {
               status: 'fail' as const,
-              prefix,
-              name: test.description,
+              prefixes,
+              name: test.name,
               duration: Date.now() - start,
               errors: formatTestError(error),
               testPath,
@@ -199,8 +203,11 @@ export class TestRunner {
     this._test = undefined;
   }
 
-  private setCurrentTest(test: TestCase): void {
-    this._test = test;
+  private setCurrentTest(test: TestCase, prefixes: string[]): void {
+    this._test = {
+      ...test,
+      prefixes,
+    };
   }
 
   getCurrentTest(): TestCase | undefined {

--- a/packages/core/src/runner/runtime.ts
+++ b/packages/core/src/runner/runtime.ts
@@ -1,5 +1,4 @@
 import type { MaybePromise } from 'src/types/utils';
-import { ROOT_SUITE_NAME } from '../constants';
 import type {
   AfterAllListener,
   Test,
@@ -7,6 +6,7 @@ import type {
   TestSuite,
   TestSuiteListeners,
 } from '../types';
+import { ROOT_SUITE_NAME } from '../utils';
 
 type ListenersKey<T extends TestSuiteListeners> =
   T extends `${infer U}Listeners` ? U : never;

--- a/packages/core/src/runner/runtime.ts
+++ b/packages/core/src/runner/runtime.ts
@@ -1,4 +1,5 @@
 import type { MaybePromise } from 'src/types/utils';
+import { ROOT_SUITE_NAME } from '../constants';
 import type {
   AfterAllListener,
   Test,
@@ -49,15 +50,15 @@ export class RunnerRuntime {
 
   getDefaultRootSuite(): TestSuite {
     return {
-      description: 'Rstest:_internal_root_suite',
+      name: ROOT_SUITE_NAME,
       tests: [],
       type: 'suite',
     };
   }
 
-  describe(description: string, fn: () => MaybePromise<void>): void {
+  describe(name: string, fn: () => MaybePromise<void>): void {
     const currentSuite: TestSuite = {
-      description,
+      name,
       tests: [],
       type: 'suite',
     };
@@ -144,8 +145,8 @@ export class RunnerRuntime {
     }
   }
 
-  it(description: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ description, fn, type: 'case' });
+  it(name: string, fn: () => void | Promise<void>): void {
+    this.addTestCase({ name, fn, type: 'case' });
   }
 
   getCurrentSuite(): TestSuite {
@@ -161,15 +162,15 @@ export class RunnerRuntime {
     throw new Error('Expect to find a suite, but got undefined');
   }
 
-  skip(description: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ description, fn, skipped: true, type: 'case' });
+  skip(name: string, fn: () => void | Promise<void>): void {
+    this.addTestCase({ name, fn, skipped: true, type: 'case' });
   }
 
-  todo(description: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ description, fn, todo: true, type: 'case' });
+  todo(name: string, fn: () => void | Promise<void>): void {
+    this.addTestCase({ name, fn, todo: true, type: 'case' });
   }
 
-  fails(description: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ description, fn, fails: true, type: 'case' });
+  fails(name: string, fn: () => void | Promise<void>): void {
+    this.addTestCase({ name, fn, fails: true, type: 'case' });
   }
 }

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -5,7 +5,7 @@ import type { MaybePromise } from './utils';
 
 export type TestCase = {
   filePath: string;
-  description: string;
+  name: string;
   fn: () => void | Promise<void>;
   skipped?: boolean;
   todo?: boolean;
@@ -15,6 +15,7 @@ export type TestCase = {
   // TODO
   onFinished?: any[];
   type: 'case';
+  prefixes?: string[];
   /**
    * Store promises (from async expects) to wait for them before finishing the test
    */
@@ -24,7 +25,7 @@ export type TestCase = {
 export type AfterAllListener = () => MaybePromise<void>;
 
 export type TestSuite = {
-  description: string;
+  name: string;
   // TODO
   filepath?: string;
   /** nested cases and suite could in a suite */
@@ -53,7 +54,7 @@ export type TestResult = {
   status: TestResultStatus;
   name: string;
   testPath: string;
-  prefix?: string;
+  prefixes?: string[];
   duration?: number;
   errors?: TestError[];
 };

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import type { Rstest } from './types';
+import type { Rstest } from '../types';
 
 export const DEFAULT_CONFIG_NAME = 'rstest.config';
 

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, join, parse, sep } from 'pathe';
 import color from 'picocolors';
+import type { TestResult } from '../types';
 
 export function getAbsolutePath(base: string, filepath: string): string {
   return isAbsolute(filepath) ? filepath : join(base, filepath);
@@ -70,5 +71,9 @@ export const prettyTime = (milliseconds: number): string => {
   const minutes = seconds / 60;
   return `${format(minutes.toFixed(2))} m`;
 };
+
+export const getTaskNames = (
+  test: Pick<TestResult, 'name' | 'prefixes'>,
+): string[] => (test.prefixes || []).concat(test.name).filter(Boolean);
 
 export { color };

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, join, parse, sep } from 'pathe';
 import color from 'picocolors';
 import type { TestResult } from '../types';
+import { TEST_DELIMITER } from './constants';
 
 export function getAbsolutePath(base: string, filepath: string): string {
   return isAbsolute(filepath) ? filepath : join(base, filepath);
@@ -72,8 +73,11 @@ export const prettyTime = (milliseconds: number): string => {
   return `${format(minutes.toFixed(2))} m`;
 };
 
-export const getTaskNames = (
+const getTaskNames = (test: Pick<TestResult, 'name' | 'prefixes'>): string[] =>
+  (test.prefixes || []).concat(test.name).filter(Boolean);
+
+export const getTaskNameWithPrefix = (
   test: Pick<TestResult, 'name' | 'prefixes'>,
-): string[] => (test.prefixes || []).concat(test.name).filter(Boolean);
+): string => getTaskNames(test).join(` ${TEST_DELIMITER} `);
 
 export { color };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './helper';
 export * from './logger';
 export * from './testFiles';
+export * from './constants';

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -1,10 +1,10 @@
-import { globalApis } from '../constants';
 import type {
   Rstest,
   RunWorkerOptions,
   TestFileResult,
   WorkerState,
 } from '../types';
+import { globalApis } from '../utils/constants';
 import { formatTestError } from '../utils/runtime';
 import { loadModule } from './loadModule';
 import { createForksRpcOptions, createRuntimeRpc } from './rpc';

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -22,19 +22,20 @@ describe('RunnerRuntime', () => {
 
     const tests = await runtime.getTests();
 
-    expect(tests.map((test) => test.description)).toEqual([
+    expect(tests.map((test) => test.name)).toEqual([
       'suite - 0',
       'suite - 1',
       'test - 2',
     ]);
 
-    expect(
-      (tests[0] as TestSuite).tests.map((test) => test.description),
-    ).toEqual(['test - 0', 'test - 1']);
+    expect((tests[0] as TestSuite).tests.map((test) => test.name)).toEqual([
+      'test - 0',
+      'test - 1',
+    ]);
 
     expect(
       ((tests[0] as TestSuite).tests[1] as TestSuite).tests.map(
-        (test) => test.description,
+        (test) => test.name,
       ),
     ).toEqual(['test - 1 - 1']);
   });

--- a/tests/afterAll/index.test.ts
+++ b/tests/afterAll/index.test.ts
@@ -19,15 +19,21 @@ describe('afterAll', () => {
     });
 
     await cli.exec;
-    const logs = cli.stdout
-      .split('\n')
-      .filter((log) => log.startsWith('[afterAll]'));
+    const logs = cli.stdout.split('\n').filter(Boolean);
 
-    expect(logs).toEqual([
+    expect(logs.filter((log) => log.startsWith('[afterAll]'))).toEqual([
       '[afterAll] in level B-A',
       '[afterAll] in level B-B',
       '[afterAll] in level A',
       '[afterAll] root',
     ]);
+
+    // test log print
+    expect(
+      logs.find((log) => log.includes('✓ level A > it in level A')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('_internal_root_suite')),
+    ).toBeFalsy();
   });
 });

--- a/tests/snapshot/__snapshots__/file.test.ts.snap
+++ b/tests/snapshot/__snapshots__/file.test.ts.snap
@@ -1,0 +1,11 @@
+// Snapshot v1
+
+exports[`test snapshot > test snapshot file state > test toMatchSnapshot API - 1 1`] = `"hello world - 1"`;
+
+exports[`test snapshot > test snapshot file state > test toMatchSnapshot API 1`] = `"hello world"`;
+
+exports[`test snapshot > test snapshot file state > test toMatchSnapshot API 2`] = `"hello Rstest"`;
+
+exports[`test snapshot > test snapshot file state > test toMatchSnapshot API 3`] = `"hello world 1"`;
+
+exports[`test snapshot > test snapshot file state > test toMatchSnapshot name > say hi 1`] = `"hi"`;

--- a/tests/snapshot/file.test.ts
+++ b/tests/snapshot/file.test.ts
@@ -7,8 +7,8 @@ import { runRstestCli, waitFile } from '../scripts';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('test snapshot file state', () => {
-  it('should generator snapshot file correctly', async () => {
+describe('test snapshot', () => {
+  it('should generator snapshot file correctly with -u', async () => {
     const snapshotFilePath = join(
       __dirname,
       'fixtures/__snapshots__/index.test.ts.snap',
@@ -35,22 +35,29 @@ describe('test snapshot file state', () => {
 
     // should generator snapshot name correctly
     expect(content).toContain(
-      '[`test toMatchSnapshot API 1`] = `"hello world"`',
-    );
-    expect(content).toContain(
-      '[`test toMatchSnapshot API 2`] = `"hello Rstest"`',
-    );
-    expect(content).toContain(
-      '[`test toMatchSnapshot API 3`] = `"hello world 1"`',
-    );
-
-    expect(content).toContain(
-      '[`test toMatchSnapshot API - 1 1`] = `"hello world - 1"`',
-    );
-    expect(content).toContain(
-      '[`test toMatchSnapshot name > say hi 1`] = `"hi"`',
+      '[`test snapshot > test snapshot generate 1`] = `"hello world"`',
     );
 
     fs.rmSync(snapshotFilePath);
+  });
+
+  describe('test snapshot file state', () => {
+    it('test toMatchSnapshot API', () => {
+      expect('hello world').toMatchSnapshot();
+      expect('hello Rstest').toMatchSnapshot();
+    });
+
+    it('test toMatchSnapshot API', () => {
+      // test repeat test case name
+      expect('hello world 1').toMatchSnapshot();
+    });
+
+    it('test toMatchSnapshot API - 1', () => {
+      expect('hello world - 1').toMatchSnapshot();
+    });
+
+    it('test toMatchSnapshot name', () => {
+      expect('hi').toMatchSnapshot('say hi');
+    });
   });
 });

--- a/tests/snapshot/fixtures/index.test.ts
+++ b/tests/snapshot/fixtures/index.test.ts
@@ -1,21 +1,7 @@
 import { describe, expect, it } from '@rstest/core';
 
 describe('test snapshot', () => {
-  it('test toMatchSnapshot API', () => {
+  it('test snapshot generate', () => {
     expect('hello world').toMatchSnapshot();
-    expect('hello Rstest').toMatchSnapshot();
-  });
-
-  it('test toMatchSnapshot API', () => {
-    // test repeat test case name
-    expect('hello world 1').toMatchSnapshot();
-  });
-
-  it('test toMatchSnapshot API - 1', () => {
-    expect('hello world - 1').toMatchSnapshot();
-  });
-
-  it('test toMatchSnapshot name', () => {
-    expect('hi').toMatchSnapshot('say hi');
   });
 });


### PR DESCRIPTION
## Summary

Omit  rstest `_internal_root_suite` name when task name outputs.

before:
![image](https://github.com/user-attachments/assets/af828dbc-a359-45d1-88b9-0a4c599d14ec)

after:
<img width="554" alt="image" src="https://github.com/user-attachments/assets/cec62c3f-24a1-43b9-a0c7-d342a777fe05" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
