### PR TITLE
fix: should not run hooks when no test case execution

### DIFF
--- a/packages/core/src/runner/runner.ts
+++ b/packages/core/src/runner/runner.ts
@@ -26,7 +26,13 @@ const getTestStatus = (results: TestResult[]): TestResultStatus => {
         : 'pass';
 };
 
-const traverseUpdateTestRunMode = (testSuite: TestSuite) => {
+/**
+ * sets the runMode of the test suite based on the runMode of its tests
+ * - if some tests are 'run', set the suite to 'run'
+ * - if all tests are 'todo', set the suite to 'todo'
+ * - if all tests are 'skip', set the suite to 'skip'
+ */
+export const traverseUpdateTestRunMode = (testSuite: TestSuite): void => {
   if (testSuite.tests.length === 0) {
     testSuite.runMode = 'skip';
     return;
@@ -40,9 +46,7 @@ const traverseUpdateTestRunMode = (testSuite: TestSuite) => {
     return test;
   });
 
-  const hasRunTest = tests.some((test) => {
-    return test.runMode === 'run';
-  });
+  const hasRunTest = tests.some((test) => test.runMode === 'run');
 
   if (hasRunTest) {
     testSuite.runMode = 'run';
@@ -51,13 +55,7 @@ const traverseUpdateTestRunMode = (testSuite: TestSuite) => {
 
   const allTodoTest = tests.every((test) => test.runMode === 'todo');
 
-  if (allTodoTest) {
-    testSuite.runMode = 'todo';
-    return;
-  }
-
-  testSuite.runMode = 'skip';
-  return;
+  testSuite.runMode = allTodoTest ? 'todo' : 'skip';
 };
 
 export class TestRunner {

--- a/packages/core/src/runner/runtime.ts
+++ b/packages/core/src/runner/runtime.ts
@@ -56,6 +56,7 @@ export class RunnerRuntime {
 
   getDefaultRootSuite(): TestSuite {
     return {
+      runMode: 'run',
       name: ROOT_SUITE_NAME,
       tests: [],
       type: 'suite',
@@ -65,6 +66,7 @@ export class RunnerRuntime {
   describe(name: string, fn: () => MaybePromise<void>): void {
     const currentSuite: TestSuite = {
       name,
+      runMode: 'run',
       tests: [],
       type: 'suite',
     };
@@ -152,7 +154,7 @@ export class RunnerRuntime {
   }
 
   it(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ name, fn, type: 'case' });
+    this.addTestCase({ name, fn, runMode: 'run', type: 'case' });
   }
 
   getCurrentSuite(): TestSuite {
@@ -169,14 +171,20 @@ export class RunnerRuntime {
   }
 
   skip(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ name, fn, skipped: true, type: 'case' });
+    this.addTestCase({
+      name,
+      fn,
+      skipped: true,
+      runMode: 'skip',
+      type: 'case',
+    });
   }
 
   todo(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ name, fn, todo: true, type: 'case' });
+    this.addTestCase({ name, fn, todo: true, runMode: 'todo', type: 'case' });
   }
 
   fails(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ name, fn, fails: true, type: 'case' });
+    this.addTestCase({ name, fn, fails: true, runMode: 'run', type: 'case' });
   }
 }

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -3,10 +3,13 @@ import type { SnapshotResult } from '@vitest/snapshot';
 // TODO: Unify filePath、testPath、originPath、sourcePath
 import type { MaybePromise } from './utils';
 
+export type TestRunMode = 'run' | 'skip' | 'todo';
+
 export type TestCase = {
   filePath: string;
   name: string;
   fn: () => void | Promise<void>;
+  runMode: TestRunMode;
   skipped?: boolean;
   todo?: boolean;
   fails?: boolean;
@@ -27,6 +30,7 @@ export type BeforeAllListener = () => MaybePromise<void>;
 
 export type TestSuite = {
   name: string;
+  runMode: TestRunMode;
   // TODO
   filepath?: string;
   /** nested cases and suite could in a suite */

--- a/packages/core/tests/runner/runner.test.ts
+++ b/packages/core/tests/runner/runner.test.ts
@@ -1,0 +1,81 @@
+import { traverseUpdateTestRunMode } from '../../src/runner/runner';
+import type { TestSuite } from '../../src/types';
+
+describe('traverseUpdateTestRunMode', () => {
+  it('should set the suite to run when some tests are run', () => {
+    const testA = {
+      name: 'testA',
+      runMode: 'run',
+      tests: [
+        {
+          name: 'test-1',
+          type: 'case',
+          runMode: 'run',
+        },
+        {
+          name: 'test-2',
+          type: 'case',
+          runMode: 'skip',
+        },
+      ],
+    };
+
+    traverseUpdateTestRunMode(testA as TestSuite);
+
+    expect(testA.runMode).toBe('run');
+  });
+
+  it('should set the suite to skip when all tests are skip', () => {
+    const testA = {
+      name: 'testA',
+      runMode: 'run',
+      tests: [
+        {
+          name: 'test-1',
+          type: 'case',
+          runMode: 'skip',
+        },
+      ],
+    };
+
+    traverseUpdateTestRunMode(testA as TestSuite);
+
+    expect(testA.runMode).toBe('skip');
+  });
+
+  it('should update nested test suite run mode correctly', () => {
+    const testA = {
+      name: 'testA',
+      runMode: 'run',
+      tests: [
+        {
+          name: 'test-1',
+          type: 'case',
+          runMode: 'skip',
+        },
+        {
+          name: 'test-1',
+          type: 'case',
+          runMode: 'run',
+        },
+        {
+          name: 'test-2',
+          type: 'suite',
+          runMode: 'run',
+          tests: [
+            {
+              name: 'test-2-1',
+              type: 'case',
+              runMode: 'skip',
+            },
+          ],
+        },
+      ],
+    };
+
+    traverseUpdateTestRunMode(testA as TestSuite);
+
+    expect(testA.runMode).toBe('run');
+    expect(testA.tests[2]?.runMode).toBe('skip');
+  });
+});

--- a/tests/lifecycle/fixtures/skip.test.ts
+++ b/tests/lifecycle/fixtures/skip.test.ts
@@ -1,0 +1,31 @@
+import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
+
+beforeAll(() => {
+  console.log('[beforeAll] should not run root');
+});
+
+afterAll(() => {
+  console.log('[afterAll] should not run root');
+});
+
+describe('level A', () => {
+  beforeAll(() => {
+    console.log('[beforeAll] should not run');
+  });
+
+  it.skip('it in level A', () => {
+    expect(2 + 2).toBe(4);
+  });
+
+  it.todo('it in level A', () => {
+    expect(2 + 2).toBe(4);
+  });
+
+  afterAll(() => {
+    console.log('[afterAll] should not run');
+  });
+});
+
+it.skip('it in level B', () => {
+  expect(2 + 2).toBe(4);
+});

--- a/tests/lifecycle/index.test.ts
+++ b/tests/lifecycle/index.test.ts
@@ -62,3 +62,23 @@ describe('beforeAll', () => {
     ]);
   });
 });
+
+describe('skipped', () => {
+  it('should not run hooks when no test case execution', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'skip'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.find((log) => log.includes('[afterAll]'))).toBeFalsy();
+    expect(logs.find((log) => log.includes('[beforeAll]'))).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

fix: should not run hooks when no test case execution.

Add a new `runMode` property to manage the execution state  (`run`, `skip`, `todo`) of test cases and test suites, and sets the runMode of the test suite based on the runMode of its tests.

```ts
describe('level A', () => {
  beforeAll(() => {
    console.log('[beforeAll] should not run');
  });

  it.skip('it in level A', () => {
    expect(2 + 2).toBe(4);
  });

  afterAll(() => {
    console.log('[afterAll] should not run');
  });
});
```



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
