### PR TITLE
chore(workflow): run multiple node versions in e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
-        node_version: [18, 20, 22]
 
     steps:
       - name: Checkout
@@ -72,6 +71,7 @@ jobs:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
+        node_version: [18, 20, 22]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Support run multiple node versions in e2e tests. Compared with UT, Rstest e2e should test node version compatibility.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
