### PR TITLE
feat: support beforeAll cleanup function

### DIFF
--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -26,7 +26,7 @@ export type TestCase = {
 };
 
 export type AfterAllListener = () => MaybePromise<void>;
-export type BeforeAllListener = () => MaybePromise<void>;
+export type BeforeAllListener = () => MaybePromise<void | AfterAllListener>;
 
 export type TestSuite = {
   name: string;

--- a/tests/lifecycle/fixtures/cleanup.test.ts
+++ b/tests/lifecycle/fixtures/cleanup.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
+import { sleep } from '../../scripts';
+
+beforeAll(() => {
+  return async () => {
+    await sleep(100);
+    console.log('[beforeAll] cleanup root');
+  };
+});
+
+afterAll(() => {
+  console.log('[afterAll] root');
+});
+
+beforeAll(() => {
+  return () => {
+    console.log('[beforeAll] cleanup root1');
+  };
+});
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  beforeAll(() => {
+    return () => {
+      console.log('[beforeAll] cleanup in level A');
+    };
+  });
+
+  describe('level B-A', () => {
+    it('it in level B-A', () => {
+      expect(2 + 1).toBe(3);
+    });
+
+    beforeAll(() => {
+      return () => {
+        console.log('[beforeAll] cleanup in level B-A');
+      };
+    });
+  });
+
+  describe('level B-B', () => {
+    it('it in level B-B', () => {
+      expect(2 + 2).toBe(4);
+    });
+
+    beforeAll(() => {
+      return () => {
+        console.log('[beforeAll] cleanup in level B-B');
+      };
+    });
+  });
+});

--- a/tests/lifecycle/index.test.ts
+++ b/tests/lifecycle/index.test.ts
@@ -61,6 +61,34 @@ describe('beforeAll', () => {
       '[beforeAll] in level B-B',
     ]);
   });
+
+  it('cleanup function should be invoked in the correct order', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'cleanup'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.filter(
+        (log) => log.startsWith('[beforeAll]') || log.startsWith('[afterAll]'),
+      ),
+    ).toEqual([
+      '[beforeAll] cleanup in level B-A',
+      '[beforeAll] cleanup in level B-B',
+      '[beforeAll] cleanup in level A',
+      '[afterAll] root',
+      '[beforeAll] cleanup root',
+      '[beforeAll] cleanup root1',
+    ]);
+  });
 });
 
 describe('skipped', () => {


### PR DESCRIPTION
## Summary

Supports calling the beforeAll cleanup function after all tests run.

```ts
import { beforeAll } from '@rstest/core'

beforeAll(async () => {
  await doSomething() // called once before all tests run

  // clean up function, called once after all tests run
  return async () => {
    await clean()
  }
})

```

## Related Links

https://github.com/web-infra-dev/rstest/pull/87

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
