### PR TITLE
feat: support beforeEach & afterEach API

### DIFF
--- a/packages/core/src/api/public.ts
+++ b/packages/core/src/api/public.ts
@@ -7,3 +7,5 @@ export declare const test: Rstest['test'];
 export declare const describe: Rstest['describe'];
 export declare const beforeAll: Rstest['beforeAll'];
 export declare const afterAll: Rstest['afterAll'];
+export declare const beforeEach: Rstest['beforeEach'];
+export declare const afterEach: Rstest['afterEach'];

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -34,6 +34,8 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
       test: it,
       afterAll: runtimeAPI.afterAll.bind(runtimeAPI),
       beforeAll: runtimeAPI.beforeAll.bind(runtimeAPI),
+      afterEach: runtimeAPI.afterEach.bind(runtimeAPI),
+      beforeEach: runtimeAPI.beforeEach.bind(runtimeAPI),
     },
     runner: {
       runTest: async (testFilePath: string, hooks: RunnerHooks) => {

--- a/packages/core/src/runner/runtime.ts
+++ b/packages/core/src/runner/runtime.ts
@@ -1,7 +1,9 @@
 import type { MaybePromise } from 'src/types/utils';
 import type {
   AfterAllListener,
+  AfterEachListener,
   BeforeAllListener,
+  BeforeEachListener,
   Test,
   TestCase,
   TestSuite,
@@ -52,6 +54,16 @@ export class RunnerRuntime {
   beforeAll(fn: BeforeAllListener): MaybePromise<void> {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(currentSuite!, 'beforeAll', fn);
+  }
+
+  afterEach(fn: AfterEachListener): MaybePromise<void> {
+    const currentSuite = this.getCurrentSuite();
+    registerTestSuiteListener(currentSuite!, 'afterEach', fn);
+  }
+
+  beforeEach(fn: BeforeEachListener): MaybePromise<void> {
+    const currentSuite = this.getCurrentSuite();
+    registerTestSuiteListener(currentSuite!, 'beforeEach', fn);
   }
 
   getDefaultRootSuite(): TestSuite {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -1,5 +1,10 @@
 import type { ExpectStatic } from '@vitest/expect';
-import type { AfterAllListener, BeforeAllListener } from './testSuite';
+import type {
+  AfterAllListener,
+  AfterEachListener,
+  BeforeAllListener,
+  BeforeEachListener,
+} from './testSuite';
 import type { MaybePromise } from './utils';
 
 type TestFn = (description: string, fn: () => MaybePromise<void>) => void;
@@ -17,6 +22,8 @@ export type RunnerAPI = {
   // TODO: support timeout
   beforeAll: (fn: BeforeAllListener) => MaybePromise<void>;
   afterAll: (fn: AfterAllListener) => MaybePromise<void>;
+  beforeEach: (fn: BeforeEachListener) => MaybePromise<void>;
+  afterEach: (fn: AfterEachListener) => MaybePromise<void>;
 };
 
 export type RstestExpect = ExpectStatic;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -27,6 +27,8 @@ export type TestCase = {
 
 export type AfterAllListener = () => MaybePromise<void>;
 export type BeforeAllListener = () => MaybePromise<void | AfterAllListener>;
+export type AfterEachListener = () => MaybePromise<void>;
+export type BeforeEachListener = () => MaybePromise<void | AfterEachListener>;
 
 export type TestSuite = {
   name: string;
@@ -38,11 +40,16 @@ export type TestSuite = {
   type: 'suite';
   afterAllListeners?: AfterAllListener[];
   beforeAllListeners?: BeforeAllListener[];
+  afterEachListeners?: AfterEachListener[];
+  beforeEachListeners?: BeforeEachListener[];
 };
 
 export type TestSuiteListeners = keyof Pick<
   TestSuite,
-  'afterAllListeners' | 'beforeAllListeners'
+  | 'afterAllListeners'
+  | 'beforeAllListeners'
+  | 'afterEachListeners'
+  | 'beforeEachListeners'
 >;
 
 export type TestFileInfo = {

--- a/tests/lifecycle/fixtures/afterEach.test.ts
+++ b/tests/lifecycle/fixtures/afterEach.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from '@rstest/core';
+
+afterEach(() => {
+  console.log('[afterEach] root');
+});
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  afterEach(() => {
+    console.log('[afterEach] in level A');
+  });
+
+  describe('level B-A', () => {
+    it('it in level B-A', () => {
+      expect(2 + 1).toBe(3);
+    });
+
+    afterEach(() => {
+      console.log('[afterEach] in level B-A');
+    });
+  });
+
+  describe('level B-B', () => {
+    it('it in level B-B', () => {
+      expect(2 + 2).toBe(4);
+    });
+
+    afterEach(() => {
+      console.log('[afterEach] in level B-B');
+    });
+  });
+});

--- a/tests/lifecycle/fixtures/beforeEach.test.ts
+++ b/tests/lifecycle/fixtures/beforeEach.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from '@rstest/core';
+import { sleep } from '../../scripts';
+
+beforeEach(() => {
+  console.log('[beforeEach] root');
+});
+
+beforeEach(async () => {
+  await sleep(100);
+  console.log('[beforeEach] root async');
+});
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  beforeEach(() => {
+    console.log('[beforeEach] in level A');
+  });
+
+  describe('level B-A', () => {
+    it('it in level B-A', () => {
+      expect(2 + 1).toBe(3);
+    });
+
+    beforeEach(() => {
+      console.log('[beforeEach] in level B-A');
+    });
+  });
+
+  describe('level B-B', () => {
+    it('it in level B-B', () => {
+      expect(2 + 2).toBe(4);
+    });
+
+    beforeEach(() => {
+      console.log('[beforeEach] in level B-B');
+    });
+  });
+});

--- a/tests/lifecycle/fixtures/cleanup.test.ts
+++ b/tests/lifecycle/fixtures/cleanup.test.ts
@@ -1,4 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from '@rstest/core';
 import { sleep } from '../../scripts';
 
 beforeAll(() => {
@@ -18,6 +25,12 @@ beforeAll(() => {
   };
 });
 
+beforeEach(() => {
+  return () => {
+    console.log('[beforeEach] cleanup root');
+  };
+});
+
 describe('level A', () => {
   it('it in level A', () => {
     expect(1 + 1).toBe(2);
@@ -26,6 +39,12 @@ describe('level A', () => {
   beforeAll(() => {
     return () => {
       console.log('[beforeAll] cleanup in level A');
+    };
+  });
+
+  beforeEach(() => {
+    return () => {
+      console.log('[beforeEach] cleanup in level A');
     };
   });
 

--- a/tests/lifecycle/fixtures/skip.test.ts
+++ b/tests/lifecycle/fixtures/skip.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from '@rstest/core';
 
 beforeAll(() => {
   console.log('[beforeAll] should not run root');
@@ -13,12 +21,20 @@ describe('level A', () => {
     console.log('[beforeAll] should not run');
   });
 
+  beforeEach(() => {
+    console.log('[beforeEach] should not run');
+  });
+
   it.skip('it in level A', () => {
     expect(2 + 2).toBe(4);
   });
 
   it.todo('it in level A', () => {
     expect(2 + 2).toBe(4);
+  });
+
+  afterEach(() => {
+    console.log('[afterEach] should not run');
   });
 
   afterAll(() => {

--- a/tests/lifecycle/index.test.ts
+++ b/tests/lifecycle/index.test.ts
@@ -61,11 +61,13 @@ describe('beforeAll', () => {
       '[beforeAll] in level B-B',
     ]);
   });
+});
 
-  it('cleanup function should be invoked in the correct order', async () => {
+describe('beforeEach', () => {
+  it('beforeEach should be invoked in the correct order', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',
-      args: ['run', 'cleanup'],
+      args: ['run', 'beforeEach'],
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -76,19 +78,88 @@ describe('beforeAll', () => {
     await cli.exec;
     const logs = cli.stdout.split('\n').filter(Boolean);
 
-    expect(
-      logs.filter(
-        (log) => log.startsWith('[beforeAll]') || log.startsWith('[afterAll]'),
-      ),
-    ).toEqual([
-      '[beforeAll] cleanup in level B-A',
-      '[beforeAll] cleanup in level B-B',
-      '[beforeAll] cleanup in level A',
-      '[afterAll] root',
-      '[beforeAll] cleanup root',
-      '[beforeAll] cleanup root1',
+    expect(logs.filter((log) => log.startsWith('[beforeEach]'))).toEqual([
+      '[beforeEach] root',
+      '[beforeEach] root async',
+      '[beforeEach] in level A',
+
+      '[beforeEach] root',
+      '[beforeEach] root async',
+      '[beforeEach] in level A',
+      '[beforeEach] in level B-A',
+
+      '[beforeEach] root',
+      '[beforeEach] root async',
+      '[beforeEach] in level A',
+      '[beforeEach] in level B-B',
     ]);
   });
+});
+
+describe('afterEach', () => {
+  it('afterEach should be invoked in the correct order', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'afterEach'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('[afterEach]'))).toEqual([
+      '[afterEach] in level A',
+      '[afterEach] root',
+
+      '[afterEach] in level B-A',
+      '[afterEach] in level A',
+      '[afterEach] root',
+
+      '[afterEach] in level B-B',
+      '[afterEach] in level A',
+      '[afterEach] root',
+    ]);
+  });
+});
+
+it('cleanup function should be invoked in the correct order', async () => {
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'cleanup'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await cli.exec;
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expect(
+    logs.filter((log) => log.startsWith('[before') || log.startsWith('[after')),
+  ).toEqual([
+    '[beforeEach] cleanup root',
+    '[beforeEach] cleanup in level A',
+
+    '[beforeEach] cleanup root',
+    '[beforeEach] cleanup in level A',
+    '[beforeAll] cleanup in level B-A',
+
+    '[beforeEach] cleanup root',
+    '[beforeEach] cleanup in level A',
+    '[beforeAll] cleanup in level B-B',
+
+    '[beforeAll] cleanup in level A',
+
+    '[afterAll] root',
+    '[beforeAll] cleanup root',
+    '[beforeAll] cleanup root1',
+  ]);
 });
 
 describe('skipped', () => {


### PR DESCRIPTION
## Summary

- `beforeEach`: Support register a callback to be called before each test run.
- `afterEach`: Support register a callback to be called after each test run.

```ts
import { beforeEach, afterEach } from '@rstest/core'

beforeEach(async () => {
  await doSomething() //  called before each test run

   // clean up function, called after each test run
  return async () => {
    await resetSomething()
  }
})

afterEach(async () => {
  await clean() // called  after each test run
})
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
