### PR TITLE
feat: support hooks timeout

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -19,11 +19,10 @@ export type RunnerAPI = {
   describe: (description: string, fn: () => void) => void;
   it: TestAPI;
   test: TestAPI;
-  // TODO: support timeout
-  beforeAll: (fn: BeforeAllListener) => MaybePromise<void>;
-  afterAll: (fn: AfterAllListener) => MaybePromise<void>;
-  beforeEach: (fn: BeforeEachListener) => MaybePromise<void>;
-  afterEach: (fn: AfterEachListener) => MaybePromise<void>;
+  beforeAll: (fn: BeforeAllListener, timeout?: number) => MaybePromise<void>;
+  afterAll: (fn: AfterAllListener, timeout?: number) => MaybePromise<void>;
+  beforeEach: (fn: BeforeEachListener, timeout?: number) => MaybePromise<void>;
+  afterEach: (fn: AfterEachListener, timeout?: number) => MaybePromise<void>;
 };
 
 export type RstestExpect = ExpectStatic;

--- a/tests/lifecycle/fixtures/timeout.test.ts
+++ b/tests/lifecycle/fixtures/timeout.test.ts
@@ -1,0 +1,37 @@
+import { beforeAll, beforeEach, describe, expect, it } from '@rstest/core';
+import { sleep } from '../../scripts';
+
+beforeAll(async () => {
+  console.log('[beforeAll] root');
+  await sleep(100);
+}, 10);
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  beforeEach(() => {
+    console.log('[beforeEach] in level A');
+  });
+
+  describe('level B-A', () => {
+    it('it in level B-A', () => {
+      expect(2 + 1).toBe(3);
+    });
+
+    beforeEach(() => {
+      console.log('[beforeEach] in level B-A');
+    });
+  });
+
+  describe('level B-B', () => {
+    it('it in level B-B', () => {
+      expect(2 + 2).toBe(4);
+    });
+
+    beforeEach(() => {
+      console.log('[beforeEach] in level B-B');
+    });
+  });
+});

--- a/tests/lifecycle/timeout.test.ts
+++ b/tests/lifecycle/timeout.test.ts
@@ -1,0 +1,43 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test timeout', () => {
+  it('should throw timeout error when hooks timeout', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'timeout.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[beforeAll] root",
+      ]
+    `);
+
+    expect(
+      logs.find((log) =>
+        log.includes('Error: beforeAll hook timed out in 10ms'),
+      ),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('/fixtures/timeout.test.ts:4:10')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('Test Files 1 failed')),
+    ).toBeTruthy();
+  });
+});

--- a/tests/lifecycle/timeout.test.ts
+++ b/tests/lifecycle/timeout.test.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('test timeout', () => {
-  it('should throw timeout error when hooks timeout', async () => {
+  it('should throw timeout error when hook timeout', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'timeout.test'],
@@ -34,7 +34,7 @@ describe('test timeout', () => {
       ),
     ).toBeTruthy();
     expect(
-      logs.find((log) => log.includes('/fixtures/timeout.test.ts:4:10')),
+      logs.find((log) => log.includes('timeout.test.ts:4:10')),
     ).toBeTruthy();
     expect(
       logs.find((log) => log.includes('Test Files 1 failed')),


### PR DESCRIPTION
## Summary

 Support hooks timeout, the default is 5 seconds. should throw timeout error when hook timeout.

<img width="970" alt="image" src="https://github.com/user-attachments/assets/fc7ed752-0bfe-4dff-a07a-b81aff0f0d78" />


* Added the `wrapTimeout` function to handle hook timeouts and modified the `RunnerRuntime` class to use this function in `beforeAll`, `afterAll`, `beforeEach`, and `afterEach` methods. 
* Updated the `RunnerAPI` type to support optional timeout parameters for `beforeAll`, `afterAll`, `beforeEach`, and `afterEach` methods.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
