### PR TITLE
chore: move `api/` into `runtime/`

### DIFF
--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -1,6 +1,6 @@
 import type { RstestConfig } from './types';
 
-export * from './api/public';
+export * from './runtime/api/public';
 
 export type { RstestConfig };
 

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -17,7 +17,7 @@ import {
   getState,
   setState,
 } from '@vitest/expect';
-import type { RstestExpect, TestCase, WorkerState } from '../types';
+import type { RstestExpect, TestCase, WorkerState } from '../../types';
 import { createExpectPoll } from './poll';
 import { SnapshotPlugin } from './snapshot';
 

--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -1,4 +1,3 @@
-import { createRunner } from '../runtime/runner';
 import type {
   Rstest,
   RstestExpect,
@@ -6,7 +5,8 @@ import type {
   TestCase,
   TestFileResult,
   WorkerState,
-} from '../types';
+} from '../../types';
+import { createRunner } from '../runner';
 import { GLOBAL_EXPECT, createExpect } from './expect';
 
 export const createRstestRuntime = (

--- a/packages/core/src/runtime/api/poll.ts
+++ b/packages/core/src/runtime/api/poll.ts
@@ -5,7 +5,7 @@
  */
 import type { Assertion } from '@vitest/expect';
 import * as chai from 'chai';
-import type { RstestExpect, TestCase } from '../types';
+import type { RstestExpect, TestCase } from '../../types';
 
 // these matchers are not supported because they don't make sense with poll
 const unsupported = [

--- a/packages/core/src/runtime/api/public.ts
+++ b/packages/core/src/runtime/api/public.ts
@@ -1,5 +1,5 @@
-import '../types/global';
-import type { Rstest } from '../types';
+import '../../types/global';
+import type { Rstest } from '../../types';
 
 export declare const expect: Rstest['expect'];
 export declare const it: Rstest['it'];

--- a/packages/core/src/runtime/api/snapshot.ts
+++ b/packages/core/src/runtime/api/snapshot.ts
@@ -9,8 +9,8 @@ import {
   addSerializer,
   stripSnapshotIndentation,
 } from '@vitest/snapshot';
-import type { TestCase } from '../types';
-import { getTaskNameWithPrefix } from '../utils';
+import type { TestCase } from '../../types';
+import { getTaskNameWithPrefix } from '../../utils';
 
 let _client: SnapshotClient;
 

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -1,5 +1,4 @@
 import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect';
-import { getSnapshotClient } from '../../api/snapshot';
 import type {
   AfterEachListener,
   BeforeEachListener,
@@ -14,6 +13,7 @@ import type {
   WorkerState,
 } from '../../types';
 import { ROOT_SUITE_NAME } from '../../utils';
+import { getSnapshotClient } from '../api/snapshot';
 import { formatTestError } from '../util';
 
 const getTestStatus = (results: TestResult[]): TestResultStatus => {

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -46,7 +46,7 @@ const runInPool = async ({
     environment: 'node',
   };
 
-  const { createRstestRuntime } = await import('../../api');
+  const { createRstestRuntime } = await import('../api');
   const { api, runner } = createRstestRuntime(workerState);
 
   const rstestContext = {


### PR DESCRIPTION
## Summary

moving files from `api` to `runtime/api`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
