### PR TITLE
feat: support describe skip & todo

### DIFF
--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -1,4 +1,5 @@
 import type {
+  DescribeAPI,
   RunnerAPI,
   RunnerHooks,
   TestAPI,
@@ -22,14 +23,18 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   const runtimeAPI: RunnerRuntime = new RunnerRuntime(workerState.sourcePath);
   const testRunner: TestRunner = new TestRunner();
 
-  const it = runtimeAPI.it.bind(runtimeAPI) as TestAPI;
+  const it = ((name, fn) => runtimeAPI.it(name, fn)) as TestAPI;
   it.fails = runtimeAPI.fails.bind(runtimeAPI);
-  it.todo = runtimeAPI.todo.bind(runtimeAPI);
-  it.skip = runtimeAPI.skip.bind(runtimeAPI);
+  it.todo = (name, fn) => runtimeAPI.it(name, fn, 'todo');
+  it.skip = (name, fn) => runtimeAPI.it(name, fn, 'todo');
+
+  const describe = ((name, fn) => runtimeAPI.describe(name, fn)) as DescribeAPI;
+  describe.todo = (name, fn) => runtimeAPI.describe(name, fn, 'todo');
+  describe.skip = (name, fn) => runtimeAPI.describe(name, fn, 'skip');
 
   return {
     api: {
-      describe: runtimeAPI.describe.bind(runtimeAPI),
+      describe,
       it,
       test: it,
       afterAll: runtimeAPI.afterAll.bind(runtimeAPI),

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -6,6 +6,7 @@ import type {
   BeforeEachListener,
   Test,
   TestCase,
+  TestRunMode,
   TestSuite,
   TestSuiteListeners,
 } from '../../types';
@@ -176,10 +177,14 @@ export class RunnerRuntime {
     };
   }
 
-  describe(name: string, fn: () => MaybePromise<void>): void {
+  describe(
+    name: string,
+    fn: () => MaybePromise<void>,
+    runMode: TestRunMode = 'run',
+  ): void {
     const currentSuite: TestSuite = {
       name,
-      runMode: 'run',
+      runMode,
       tests: [],
       type: 'suite',
     };
@@ -266,8 +271,12 @@ export class RunnerRuntime {
     }
   }
 
-  it(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ name, fn, runMode: 'run', type: 'case' });
+  it(
+    name: string,
+    fn: () => void | Promise<void>,
+    runMode: TestRunMode = 'run',
+  ): void {
+    this.addTestCase({ name, fn, runMode, type: 'case' });
   }
 
   getCurrentSuite(): TestSuite {
@@ -281,20 +290,6 @@ export class RunnerRuntime {
     }
 
     throw new Error('Expect to find a suite, but got undefined');
-  }
-
-  skip(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({
-      name,
-      fn,
-      skipped: true,
-      runMode: 'skip',
-      type: 'case',
-    });
-  }
-
-  todo(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ name, fn, todo: true, runMode: 'todo', type: 'case' });
   }
 
   fails(name: string, fn: () => void | Promise<void>): void {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -15,8 +15,15 @@ export type TestAPI = TestFn & {
   skip: TestFn;
 };
 
+type DescribeFn = (description: string, fn: () => void) => void;
+
+export type DescribeAPI = DescribeFn & {
+  todo: DescribeFn;
+  skip: DescribeFn;
+};
+
 export type RunnerAPI = {
-  describe: (description: string, fn: () => void) => void;
+  describe: DescribeAPI;
   it: TestAPI;
   test: TestAPI;
   beforeAll: (fn: BeforeAllListener, timeout?: number) => MaybePromise<void>;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -10,8 +10,6 @@ export type TestCase = {
   name: string;
   fn: () => void | Promise<void>;
   runMode: TestRunMode;
-  skipped?: boolean;
-  todo?: boolean;
   fails?: boolean;
   // TODO
   only?: boolean;

--- a/tests/describe/fixtures/skip.test.ts
+++ b/tests/describe/fixtures/skip.test.ts
@@ -1,0 +1,20 @@
+import { beforeAll, beforeEach, describe, expect, it } from '@rstest/core';
+
+beforeAll(() => {
+  console.log('[beforeAll] should not run');
+});
+
+beforeEach(() => {
+  console.log('[beforeEach] should not run');
+});
+
+describe.skip('should skip', () => {
+  it('test 1', () => {
+    console.log('[test 1] should not run');
+    expect(1 + 1).toBe(2);
+  });
+
+  it('test 2', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/tests/describe/fixtures/todo.test.ts
+++ b/tests/describe/fixtures/todo.test.ts
@@ -1,0 +1,20 @@
+import { beforeAll, beforeEach, describe, expect, it } from '@rstest/core';
+
+beforeAll(() => {
+  console.log('[beforeAll] should not run');
+});
+
+beforeEach(() => {
+  console.log('[beforeEach] should not run');
+});
+
+describe.todo('should skip', () => {
+  it('test 1', () => {
+    console.log('[test 1] should not run');
+    expect(1 + 1).toBe(2);
+  });
+
+  it('test 2', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/tests/describe/index.test.ts
+++ b/tests/describe/index.test.ts
@@ -1,0 +1,53 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test describe API', () => {
+  it('should skip test when describe skipped', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'skip.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toEqual([]);
+
+    // test log print
+    expect(
+      logs.find((log) => log.includes('Test Files 1 skipped')),
+    ).toBeTruthy();
+    expect(logs.find((log) => log.includes('Tests 2 skipped'))).toBeTruthy();
+  });
+
+  it('should skip test when describe todo', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'todo.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toEqual([]);
+
+    // test log print
+    expect(logs.find((log) => log.includes('Test Files 1 todo'))).toBeTruthy();
+    expect(logs.find((log) => log.includes('Tests 2 todo'))).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Use `describe.todo` to stub suites to be implemented later. 

```ts
describe.todo('unimplemented suite', () => {
  test('todo', () => {
    // ......
  })
})
```

Use `describe.skip` in a suite to avoid running a particular describe block.

```ts
describe.skip('skipped suite', () => {
  test('skip', () => {
    // Suite skipped
  })
})
```


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
