### PR TITLE
feat: allow test function undefined

### DIFF
--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -26,7 +26,7 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   const it = ((name, fn) => runtimeAPI.it(name, fn)) as TestAPI;
   it.fails = runtimeAPI.fails.bind(runtimeAPI);
   it.todo = (name, fn) => runtimeAPI.it(name, fn, 'todo');
-  it.skip = (name, fn) => runtimeAPI.it(name, fn, 'todo');
+  it.skip = (name, fn) => runtimeAPI.it(name, fn, 'skip');
 
   const describe = ((name, fn) => runtimeAPI.describe(name, fn)) as DescribeAPI;
   describe.todo = (name, fn) => runtimeAPI.describe(name, fn, 'todo');

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -244,7 +244,7 @@ export class TestRunner {
           if (test.fails) {
             try {
               this.beforeRunTest(testPath);
-              await test.fn();
+              await test.fn?.();
               this.afterRunTest();
 
               result = {
@@ -269,7 +269,7 @@ export class TestRunner {
           } else {
             try {
               this.beforeRunTest(testPath);
-              await test.fn();
+              await test.fn?.();
               this.afterRunTest();
               result = {
                 status: 'pass' as const,

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -279,10 +279,14 @@ export class RunnerRuntime {
 
   it(
     name: string,
-    fn: () => void | Promise<void>,
+    fn?: () => void | Promise<void>,
     runMode: TestRunMode = 'run',
   ): void {
     this.addTestCase({ name, fn, runMode, type: 'case' });
+  }
+
+  fails(name: string, fn?: () => void | Promise<void>): void {
+    this.addTestCase({ name, fn, fails: true, runMode: 'run', type: 'case' });
   }
 
   getCurrentSuite(): TestSuite {
@@ -296,9 +300,5 @@ export class RunnerRuntime {
     }
 
     throw new Error('Expect to find a suite, but got undefined');
-  }
-
-  fails(name: string, fn: () => void | Promise<void>): void {
-    this.addTestCase({ name, fn, fails: true, runMode: 'run', type: 'case' });
   }
 }

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -7,7 +7,7 @@ import type {
 } from './testSuite';
 import type { MaybePromise } from './utils';
 
-type TestFn = (description: string, fn: () => MaybePromise<void>) => void;
+type TestFn = (description: string, fn?: () => MaybePromise<void>) => void;
 
 export type TestAPI = TestFn & {
   fails: TestFn;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -8,7 +8,7 @@ export type TestRunMode = 'run' | 'skip' | 'todo';
 export type TestCase = {
   filePath: string;
   name: string;
-  fn: () => void | Promise<void>;
+  fn?: () => void | Promise<void>;
   runMode: TestRunMode;
   fails?: boolean;
   // TODO

--- a/tests/expect/test/fixtures/undefined.test.ts
+++ b/tests/expect/test/fixtures/undefined.test.ts
@@ -4,6 +4,6 @@ it('should passed');
 
 it.skip('should skip');
 
-it.todo('todo');
+it.todo('should todo');
 
 it.fails('should failed');

--- a/tests/expect/test/fixtures/undefined.test.ts
+++ b/tests/expect/test/fixtures/undefined.test.ts
@@ -1,0 +1,9 @@
+import { it } from '@rstest/core';
+
+it('should passed');
+
+it.skip('should skip');
+
+it.todo('todo');
+
+it.fails('should failed');

--- a/tests/expect/test/index.test.ts
+++ b/tests/expect/test/index.test.ts
@@ -1,4 +1,7 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../../scripts';
 
 describe('Expect API', () => {
   it('test expect API', () => {
@@ -56,5 +59,33 @@ describe('Expect API', () => {
     expect.assertions(2);
     expect(1 + 2).toBe(3);
     expect(1 + 3).toBe(4);
+  });
+
+  it('test function undefined', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/undefined.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('Test Files 1 failed')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) =>
+        log.includes('Tests 1 failed | 1 passed | 1 skipped | 1 todo'),
+      ),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

allow test function undefined.

```ts
it('should passed');

it.skip('should skip');

it.todo('should todo');

it.fails('should failed');
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
