### PR TITLE
feat: support only run certain tests / suites

### DIFF
--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -27,6 +27,7 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   it.fails = runtimeAPI.fails.bind(runtimeAPI);
   it.todo = (name, fn) => runtimeAPI.it(name, fn, 'todo');
   it.skip = (name, fn) => runtimeAPI.it(name, fn, 'skip');
+  it.only = (name, fn) => runtimeAPI.it(name, fn, 'only');
 
   const describe = ((name, fn) => runtimeAPI.describe(name, fn)) as DescribeAPI;
   describe.todo = (name, fn) => runtimeAPI.describe(name, fn, 'todo');

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -30,6 +30,7 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   it.only = (name, fn) => runtimeAPI.it(name, fn, 'only');
 
   const describe = ((name, fn) => runtimeAPI.describe(name, fn)) as DescribeAPI;
+  describe.only = (name, fn) => runtimeAPI.describe(name, fn, 'only');
   describe.todo = (name, fn) => runtimeAPI.describe(name, fn, 'todo');
   describe.skip = (name, fn) => runtimeAPI.describe(name, fn, 'skip');
 

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -76,7 +76,7 @@ export class TestRunner {
         const cleanups: Array<() => void> = [];
         let hasBeforeAllError = false;
 
-        if (test.runMode === 'run' && test.beforeAllListeners) {
+        if (['run', 'only'].includes(test.runMode) && test.beforeAllListeners) {
           try {
             for (const fn of test.beforeAllListeners) {
               const cleanupFn = await fn();
@@ -113,7 +113,7 @@ export class TestRunner {
           .reverse()
           .concat(cleanups);
 
-        if (test.runMode === 'run' && afterAllFns.length) {
+        if (['run', 'only'].includes(test.runMode) && afterAllFns.length) {
           try {
             for (const fn of afterAllFns) {
               await fn();

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -1,0 +1,113 @@
+import type {
+  Test,
+  TestResult,
+  TestResultStatus,
+  TestRunMode,
+  TestSuite,
+} from '../../types';
+
+export const getTestStatus = (
+  results: TestResult[],
+  defaultStatus: TestResultStatus,
+): TestResultStatus => {
+  if (results.length === 0) {
+    return defaultStatus;
+  }
+  return results.some((result) => result.status === 'fail')
+    ? 'fail'
+    : results.every((result) => result.status === 'todo')
+      ? 'todo'
+      : results.every((result) => result.status === 'skip')
+        ? 'skip'
+        : 'pass';
+};
+
+export function hasOnlyTest(test: Test[]): boolean {
+  return test.some((t) => {
+    return t.runMode === 'only' || (t.type === 'suite' && hasOnlyTest(t.tests));
+  });
+}
+
+export const traverseUpdateTestRunMode = (
+  testSuite: TestSuite,
+  parentRunMode: TestRunMode,
+  runOnly: boolean,
+): void => {
+  if (testSuite.tests.length === 0) {
+    return;
+  }
+
+  if (
+    runOnly &&
+    testSuite.runMode !== 'only' &&
+    !hasOnlyTest(testSuite.tests)
+  ) {
+    testSuite.runMode = 'skip';
+  } else if (['skip', 'todo'].includes(parentRunMode)) {
+    testSuite.runMode = parentRunMode;
+  }
+
+  const tests = testSuite.tests.map((test) => {
+    if (test.type === 'case') {
+      if (['skip', 'todo'].includes(testSuite.runMode)) {
+        test.runMode = testSuite.runMode;
+      }
+      if (runOnly && test.runMode !== 'only') {
+        test.runMode = 'skip';
+      }
+      return test;
+    }
+    traverseUpdateTestRunMode(test, testSuite.runMode, runOnly);
+    return test;
+  });
+
+  if (testSuite.runMode !== 'run') {
+    return;
+  }
+
+  const hasRunTest = tests.some(
+    (test) => test.runMode === 'run' || test.runMode === 'only',
+  );
+
+  if (hasRunTest) {
+    testSuite.runMode = 'run';
+    return;
+  }
+
+  const allTodoTest = tests.every((test) => test.runMode === 'todo');
+
+  testSuite.runMode = allTodoTest ? 'todo' : 'skip';
+};
+
+/**
+ * sets the runMode of the test based on the runMode of its parent suite
+ * - if the parent suite is 'todo', set the test to 'todo'
+ * - if the parent suite is 'skip', set the test to 'skip'
+ *
+ * sets the runMode of the test suite based on the runMode of its tests
+ * - if some tests are 'run', set the suite to 'run'
+ * - if all tests are 'todo', set the suite to 'todo'
+ * - if all tests are 'skip', set the suite to 'skip'
+ *
+ * If any tasks been marked as `only`, mark all other tasks as `skip`.
+ */
+export const updateTestModes = (tests: Test[]): void => {
+  const hasOnly = hasOnlyTest(tests);
+
+  for (const test of tests) {
+    if (test.type === 'suite') {
+      traverseUpdateTestRunMode(test, 'run', hasOnly);
+    } else if (hasOnly && test.runMode !== 'only') {
+      test.runMode = 'skip';
+    }
+  }
+};
+
+export const markAllTestAsSkipped = (test: Test[]): void => {
+  for (const t of test) {
+    t.runMode = 'skip';
+    if (t.type === 'suite') {
+      markAllTestAsSkipped(t.tests);
+    }
+  }
+};

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -48,16 +48,21 @@ export const traverseUpdateTestRunMode = (
   }
 
   const tests = testSuite.tests.map((test) => {
+    const runSubOnly =
+      runOnly && testSuite.runMode !== 'only'
+        ? runOnly
+        : hasOnlyTest(testSuite.tests);
+
     if (test.type === 'case') {
       if (['skip', 'todo'].includes(testSuite.runMode)) {
         test.runMode = testSuite.runMode;
       }
-      if (runOnly && test.runMode !== 'only') {
+      if (runSubOnly && test.runMode !== 'only') {
         test.runMode = 'skip';
       }
       return test;
     }
-    traverseUpdateTestRunMode(test, testSuite.runMode, runOnly);
+    traverseUpdateTestRunMode(test, testSuite.runMode, runSubOnly);
     return test;
   });
 

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -11,6 +11,7 @@ type TestFn = (description: string, fn?: () => MaybePromise<void>) => void;
 
 export type TestAPI = TestFn & {
   fails: TestFn;
+  only: TestFn;
   todo: TestFn;
   skip: TestFn;
 };

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -19,6 +19,7 @@ export type TestAPI = TestFn & {
 type DescribeFn = (description: string, fn?: () => void) => void;
 
 export type DescribeAPI = DescribeFn & {
+  only: DescribeFn;
   todo: DescribeFn;
   skip: DescribeFn;
 };

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -3,7 +3,7 @@ import type { SnapshotResult } from '@vitest/snapshot';
 // TODO: Unify filePath、testPath、originPath、sourcePath
 import type { MaybePromise } from './utils';
 
-export type TestRunMode = 'run' | 'skip' | 'todo';
+export type TestRunMode = 'run' | 'skip' | 'todo' | 'only';
 
 export type TestCase = {
   filePath: string;

--- a/packages/core/tests/runner/runner.test.ts
+++ b/packages/core/tests/runner/runner.test.ts
@@ -1,11 +1,15 @@
-import { traverseUpdateTestRunMode } from '../../src/runtime/runner/runner';
-import type { TestSuite } from '../../src/types';
+import {
+  traverseUpdateTestRunMode,
+  updateTestModes,
+} from '../../src/runtime/runner/task';
+import type { TestCase, TestSuite } from '../../src/types';
 
 describe('traverseUpdateTestRunMode', () => {
   it('should set the suite to run when some tests are run', () => {
     const testA = {
       name: 'testA',
       runMode: 'run',
+      type: 'suite',
       tests: [
         {
           name: 'test-1',
@@ -20,7 +24,7 @@ describe('traverseUpdateTestRunMode', () => {
       ],
     };
 
-    traverseUpdateTestRunMode(testA as TestSuite);
+    traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
 
     expect(testA.runMode).toBe('run');
   });
@@ -29,6 +33,7 @@ describe('traverseUpdateTestRunMode', () => {
     const testA = {
       name: 'testA',
       runMode: 'run',
+      type: 'suite',
       tests: [
         {
           name: 'test-1',
@@ -38,7 +43,7 @@ describe('traverseUpdateTestRunMode', () => {
       ],
     };
 
-    traverseUpdateTestRunMode(testA as TestSuite);
+    traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
 
     expect(testA.runMode).toBe('skip');
   });
@@ -47,6 +52,7 @@ describe('traverseUpdateTestRunMode', () => {
     const testA = {
       name: 'testA',
       runMode: 'run',
+      type: 'suite',
       tests: [
         {
           name: 'test-1',
@@ -73,9 +79,78 @@ describe('traverseUpdateTestRunMode', () => {
       ],
     };
 
-    traverseUpdateTestRunMode(testA as TestSuite);
+    traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
 
     expect(testA.runMode).toBe('run');
     expect(testA.tests[2]?.runMode).toBe('skip');
+  });
+});
+
+describe('updateTestModes', () => {
+  it('should update test run mode correctly when has only test case', () => {
+    const tests: [TestSuite, TestCase] = [
+      {
+        name: 'testA',
+        runMode: 'run',
+        type: 'suite',
+        tests: [
+          {
+            name: 'test-0',
+            type: 'case',
+            runMode: 'only',
+          },
+          {
+            name: 'test-1',
+            type: 'case',
+            runMode: 'run',
+          },
+          {
+            name: 'test-2',
+            type: 'suite',
+            runMode: 'run',
+            tests: [
+              {
+                name: 'test-2-1',
+                type: 'case',
+                runMode: 'run',
+              },
+              {
+                name: 'test-2-2',
+                type: 'case',
+                runMode: 'only',
+              },
+            ],
+          },
+          {
+            name: 'test-4',
+            type: 'suite',
+            runMode: 'run',
+            tests: [
+              {
+                name: 'test-4-1',
+                type: 'case',
+                runMode: 'run',
+              },
+            ],
+          },
+        ],
+      } as TestSuite,
+      {
+        name: 'testB',
+        runMode: 'run',
+        type: 'case',
+      } as TestCase,
+    ];
+
+    updateTestModes(tests);
+
+    expect(tests[0].runMode).toBe('run');
+    expect(tests[0].tests[0]?.runMode).toBe('only');
+    expect(tests[0].tests[1]?.runMode).toBe('skip');
+    expect(tests[0].tests[2]?.runMode).toBe('run');
+    expect((tests[0].tests[2] as TestSuite).tests[0]?.runMode).toBe('skip');
+    expect((tests[0].tests[2] as TestSuite).tests[1]?.runMode).toBe('only');
+    expect(tests[0].tests[3]?.runMode).toBe('skip');
+    expect(tests[1].runMode).toBe('skip');
   });
 });

--- a/packages/core/tests/runner/runner.test.ts
+++ b/packages/core/tests/runner/runner.test.ts
@@ -153,4 +153,79 @@ describe('updateTestModes', () => {
     expect(tests[0].tests[3]?.runMode).toBe('skip');
     expect(tests[1].runMode).toBe('skip');
   });
+
+  it('should update test run mode correctly when has only test suite', () => {
+    const tests: [TestSuite, TestCase] = [
+      {
+        name: 'testA',
+        runMode: 'only',
+        type: 'suite',
+        tests: [
+          {
+            name: 'test-0',
+            type: 'case',
+            runMode: 'run',
+          },
+          {
+            name: 'test-1',
+            type: 'suite',
+            runMode: 'run',
+            tests: [
+              {
+                name: 'test-1-1',
+                type: 'case',
+                runMode: 'run',
+              },
+            ],
+          },
+          {
+            name: 'test-2',
+            type: 'suite',
+            runMode: 'only',
+            tests: [
+              {
+                name: 'test-2-1',
+                type: 'case',
+                runMode: 'run',
+              },
+              {
+                name: 'test-2-2',
+                type: 'case',
+                runMode: 'skip',
+              },
+              {
+                name: 'test-2-3',
+                type: 'suite',
+                runMode: 'run',
+                tests: [
+                  {
+                    name: 'test-2-3-1',
+                    type: 'case',
+                    runMode: 'run',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as TestSuite,
+      {
+        name: 'testB',
+        runMode: 'run',
+        type: 'case',
+      } as TestCase,
+    ];
+
+    updateTestModes(tests);
+
+    expect(tests[0].runMode).toBe('only');
+    expect(tests[0].tests[0]?.runMode).toBe('skip');
+    expect(tests[0].tests[1]?.runMode).toBe('skip');
+    expect((tests[0].tests[1] as TestSuite).tests[0]?.runMode).toBe('skip');
+    expect(tests[0].tests[2]?.runMode).toBe('only');
+    expect((tests[0].tests[2] as TestSuite).tests[0]?.runMode).toBe('run');
+    expect((tests[0].tests[2] as TestSuite).tests[1]?.runMode).toBe('skip');
+    expect((tests[0].tests[2] as TestSuite).tests[2]?.runMode).toBe('run');
+    expect(tests[1].runMode).toBe('skip');
+  });
 });

--- a/tests/describe/fixtures/only.test.ts
+++ b/tests/describe/fixtures/only.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from '@rstest/core';
+
+beforeEach(() => {
+  console.log('[beforeEach] root');
+});
+
+describe('level A', () => {
+  it('it in level A', () => {
+    console.log('[test] in level A');
+    expect(1 + 1).toBe(2);
+  });
+
+  // biome-ignore lint/suspicious/noFocusedTests: <explanation>
+  describe.only('level B', () => {
+    it('it in level B-A', () => {
+      console.log('[test] in level B-A');
+      expect(2 + 1).toBe(3);
+    });
+
+    it.skip('it in level B-B', () => {
+      console.log('[test] in level B-B');
+      expect(2 + 1).toBe(3);
+    });
+
+    describe('level B-C', () => {
+      it('it in level B-C-A', () => {
+        console.log('[test] in level B-C-A');
+        expect(2 + 1).toBe(3);
+      });
+    });
+  });
+
+  it('it in level C', () => {
+    console.log('[test] in level C');
+    expect(2 + 2).toBe(4);
+  });
+
+  describe('level D', () => {
+    it('it in level D-A', () => {
+      console.log('[test] in level D-A');
+      expect(2 + 1).toBe(3);
+    });
+  });
+});
+
+// biome-ignore lint/suspicious/noFocusedTests: <explanation>
+describe.only('level E', () => {
+  it('it in level E-A', () => {
+    console.log('[test] in level E-A');
+    expect(2 + 1).toBe(3);
+  });
+});

--- a/tests/describe/index.test.ts
+++ b/tests/describe/index.test.ts
@@ -73,4 +73,41 @@ describe('test describe API', () => {
     ).toBeTruthy();
     expect(logs.find((log) => log.includes('Tests no tests'))).toBeTruthy();
   });
+
+  it('test only', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/only.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[beforeEach] root",
+        "[test] in level B-A",
+        "[beforeEach] root",
+        "[test] in level B-C-A",
+        "[beforeEach] root",
+        "[test] in level E-A",
+      ]
+    `);
+
+    expect(
+      logs.find((log) => log.includes('Test Files 1 passed')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('Tests 3 passed | 4 skipped')),
+    ).toBeTruthy();
+  });
 });

--- a/tests/expect/test/fixtures/only.test.ts
+++ b/tests/expect/test/fixtures/only.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from '@rstest/core';
+
+beforeEach(() => {
+  console.log('[beforeEach] root');
+});
+
+describe('level A', () => {
+  // biome-ignore lint/suspicious/noFocusedTests: <explanation>
+  it.only('it in level A', () => {
+    console.log('[test] in level A');
+    expect(1 + 1).toBe(2);
+  });
+
+  describe('level B', () => {
+    it('it in level B-A', () => {
+      console.log('[test] in level B-A');
+      expect(2 + 1).toBe(3);
+    });
+
+    // biome-ignore lint/suspicious/noFocusedTests: <explanation>
+    it.only('it in level B-B', () => {
+      console.log('[test] in level B-B');
+      expect(2 + 1).toBe(3);
+    });
+  });
+
+  it('it in level C', () => {
+    console.log('[test] in level C');
+    expect(2 + 2).toBe(4);
+  });
+});
+
+// biome-ignore lint/suspicious/noFocusedTests: <explanation>
+it.only('it in level D', () => {
+  console.log('[test] in level D');
+  expect(1 + 1).toBe(2);
+});
+
+describe('level E', () => {
+  it('it in level E-A', () => {
+    console.log('[test] in level E-A');
+    expect(2 + 1).toBe(3);
+  });
+});

--- a/tests/expect/test/index.test.ts
+++ b/tests/expect/test/index.test.ts
@@ -88,4 +88,41 @@ describe('Expect API', () => {
       ),
     ).toBeTruthy();
   });
+
+  it('test only', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/only.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[beforeEach] root",
+        "[test] in level A",
+        "[beforeEach] root",
+        "[test] in level B-B",
+        "[beforeEach] root",
+        "[test] in level D",
+      ]
+    `);
+
+    expect(
+      logs.find((log) => log.includes('Test Files 1 passed')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('Tests 3 passed | 3 skipped')),
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Use `test.only` to only run certain tests in a given suite.

```ts
describe('suite', () => {
  it.only('should add two numbers correctly', () => {
    expect(1 + 1).toBe(2);
  });

  it('other test', () => {
     // ... will be skipped
  });
})

describe('other suite', () => {
  // ... will be skipped
})

```

Use `describe.only` to only run certain suites.

```ts
// Only this suite (and others marked with only) are run
describe.only('suite', () => {
  it('should add two numbers correctly', () => {
    expect(1 + 1).toBe(2);
  });
})

it('other test', () => {
   // ... will be skipped
});

describe('other suite', () => {
  // ... will be skipped
})

```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
