### PR TITLE
feat: support filter by testNamePattern

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -14,6 +14,7 @@ type CommonOptions = {
   globals?: boolean;
   passWithNoTests?: boolean;
   update?: boolean;
+  testNamePattern?: RegExp | string;
 };
 
 const applyCommonOptions = (cli: CAC) => {
@@ -38,6 +39,10 @@ const applyCommonOptions = (cli: CAC) => {
     .option(
       '--passWithNoTests',
       'Allows the test suite to pass when no files are found.',
+    )
+    .option(
+      '-t, --testNamePattern <testNamePattern>',
+      'Run only tests with a name that matches the regex.',
     );
 };
 
@@ -59,6 +64,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'globals',
     'passWithNoTests',
     'update',
+    'testNamePattern',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -78,11 +78,16 @@ export interface RstestConfig {
     | Reporter
     | BuiltInReporterNames
     | (Reporter | BuiltInReporterNames)[];
+  /**
+   * Run only tests with a name that matches the regex.
+   */
+  testNamePattern?: string | RegExp;
 }
 
 export type NormalizedConfig = Required<
-  Omit<RstestConfig, 'pool' | 'setupFiles'>
+  Omit<RstestConfig, 'pool' | 'setupFiles' | 'testNamePattern'>
 > & {
   pool: RstestPoolOptions;
   setupFiles?: string[] | string;
+  testNamePattern?: RstestConfig['testNamePattern'];
 };

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -16,7 +16,7 @@ export type TestCase = {
   // TODO
   onFinished?: any[];
   type: 'case';
-  prefixes?: string[];
+  parentNames?: string[];
   /**
    * Store promises (from async expects) to wait for them before finishing the test
    */
@@ -30,6 +30,7 @@ export type BeforeEachListener = () => MaybePromise<void | AfterEachListener>;
 
 export type TestSuite = {
   name: string;
+  parentNames?: string[];
   runMode: TestRunMode;
   // TODO
   filepath?: string;
@@ -69,7 +70,7 @@ export type TestResult = {
   status: TestResultStatus;
   name: string;
   testPath: string;
-  prefixes?: string[];
+  parentNames?: string[];
   duration?: number;
   errors?: TestError[];
 };

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -73,11 +73,13 @@ export const prettyTime = (milliseconds: number): string => {
   return `${format(minutes.toFixed(2))} m`;
 };
 
-const getTaskNames = (test: Pick<TestResult, 'name' | 'prefixes'>): string[] =>
-  (test.prefixes || []).concat(test.name).filter(Boolean);
+const getTaskNames = (
+  test: Pick<TestResult, 'name' | 'parentNames'>,
+): string[] => (test.parentNames || []).concat(test.name).filter(Boolean);
 
 export const getTaskNameWithPrefix = (
-  test: Pick<TestResult, 'name' | 'prefixes'>,
-): string => getTaskNames(test).join(` ${TEST_DELIMITER} `);
+  test: Pick<TestResult, 'name' | 'parentNames'>,
+  delimiter: string = TEST_DELIMITER,
+): string => getTaskNames(test).join(` ${delimiter} `);
 
 export { color };

--- a/packages/core/tests/runner/runner.test.ts
+++ b/packages/core/tests/runner/runner.test.ts
@@ -1,104 +1,18 @@
 import {
+  traverseUpdateTest,
   traverseUpdateTestRunMode,
   updateTestModes,
 } from '../../src/runtime/runner/task';
 import type { TestCase, TestSuite } from '../../src/types';
 
-describe('traverseUpdateTestRunMode', () => {
-  it('should set the suite to run when some tests are run', () => {
-    const testA = {
-      name: 'testA',
-      runMode: 'run',
-      type: 'suite',
-      tests: [
-        {
-          name: 'test-1',
-          type: 'case',
-          runMode: 'run',
-        },
-        {
-          name: 'test-2',
-          type: 'case',
-          runMode: 'skip',
-        },
-      ],
-    };
-
-    traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
-
-    expect(testA.runMode).toBe('run');
-  });
-
-  it('should set the suite to skip when all tests are skip', () => {
-    const testA = {
-      name: 'testA',
-      runMode: 'run',
-      type: 'suite',
-      tests: [
-        {
-          name: 'test-1',
-          type: 'case',
-          runMode: 'skip',
-        },
-      ],
-    };
-
-    traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
-
-    expect(testA.runMode).toBe('skip');
-  });
-
-  it('should update nested test suite run mode correctly', () => {
-    const testA = {
-      name: 'testA',
-      runMode: 'run',
-      type: 'suite',
-      tests: [
-        {
-          name: 'test-1',
-          type: 'case',
-          runMode: 'skip',
-        },
-        {
-          name: 'test-1',
-          type: 'case',
-          runMode: 'run',
-        },
-        {
-          name: 'test-2',
-          type: 'suite',
-          runMode: 'run',
-          tests: [
-            {
-              name: 'test-2-1',
-              type: 'case',
-              runMode: 'skip',
-            },
-          ],
-        },
-      ],
-    };
-
-    traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
-
-    expect(testA.runMode).toBe('run');
-    expect(testA.tests[2]?.runMode).toBe('skip');
-  });
-});
-
-describe('updateTestModes', () => {
-  it('should update test run mode correctly when has only test case', () => {
-    const tests: [TestSuite, TestCase] = [
-      {
+describe('traverseUpdateTest', () => {
+  describe('traverseUpdateTestRunMode', () => {
+    it('should set the suite to run when some tests are run', () => {
+      const testA = {
         name: 'testA',
         runMode: 'run',
         type: 'suite',
         tests: [
-          {
-            name: 'test-0',
-            type: 'case',
-            runMode: 'only',
-          },
           {
             name: 'test-1',
             type: 'case',
@@ -106,104 +20,249 @@ describe('updateTestModes', () => {
           },
           {
             name: 'test-2',
-            type: 'suite',
-            runMode: 'run',
-            tests: [
-              {
-                name: 'test-2-1',
-                type: 'case',
-                runMode: 'run',
-              },
-              {
-                name: 'test-2-2',
-                type: 'case',
-                runMode: 'only',
-              },
-            ],
-          },
-          {
-            name: 'test-4',
-            type: 'suite',
-            runMode: 'run',
-            tests: [
-              {
-                name: 'test-4-1',
-                type: 'case',
-                runMode: 'run',
-              },
-            ],
+            type: 'case',
+            runMode: 'skip',
           },
         ],
-      } as TestSuite,
-      {
-        name: 'testB',
-        runMode: 'run',
-        type: 'case',
-      } as TestCase,
-    ];
+      };
 
-    updateTestModes(tests);
+      traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
 
-    expect(tests[0].runMode).toBe('run');
-    expect(tests[0].tests[0]?.runMode).toBe('only');
-    expect(tests[0].tests[1]?.runMode).toBe('skip');
-    expect(tests[0].tests[2]?.runMode).toBe('run');
-    expect((tests[0].tests[2] as TestSuite).tests[0]?.runMode).toBe('skip');
-    expect((tests[0].tests[2] as TestSuite).tests[1]?.runMode).toBe('only');
-    expect(tests[0].tests[3]?.runMode).toBe('skip');
-    expect(tests[1].runMode).toBe('skip');
-  });
+      expect(testA.runMode).toBe('run');
+    });
 
-  it('should update test run mode correctly when has only test suite', () => {
-    const tests: [TestSuite, TestCase] = [
-      {
+    it('should set the suite to skip when all tests are skip', () => {
+      const testA = {
         name: 'testA',
-        runMode: 'only',
+        runMode: 'run',
         type: 'suite',
         tests: [
           {
-            name: 'test-0',
+            name: 'test-1',
+            type: 'case',
+            runMode: 'skip',
+          },
+        ],
+      };
+
+      traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
+
+      expect(testA.runMode).toBe('skip');
+    });
+
+    it('should update nested test suite run mode correctly', () => {
+      const testA = {
+        name: 'testA',
+        runMode: 'run',
+        type: 'suite',
+        tests: [
+          {
+            name: 'test-1',
+            type: 'case',
+            runMode: 'skip',
+          },
+          {
+            name: 'test-1',
             type: 'case',
             runMode: 'run',
           },
           {
-            name: 'test-1',
+            name: 'test-2',
             type: 'suite',
             runMode: 'run',
             tests: [
               {
-                name: 'test-1-1',
-                type: 'case',
-                runMode: 'run',
-              },
-            ],
-          },
-          {
-            name: 'test-2',
-            type: 'suite',
-            runMode: 'only',
-            tests: [
-              {
                 name: 'test-2-1',
-                type: 'case',
-                runMode: 'run',
-              },
-              {
-                name: 'test-2-2',
                 type: 'case',
                 runMode: 'skip',
               },
+            ],
+          },
+        ],
+      };
+
+      traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
+
+      expect(testA.runMode).toBe('run');
+      expect(testA.tests[2]?.runMode).toBe('skip');
+    });
+  });
+
+  describe('updateTestMode with only', () => {
+    it('should update test run mode correctly when has only test case', () => {
+      const tests: [TestSuite, TestCase] = [
+        {
+          name: 'testA',
+          runMode: 'run',
+          type: 'suite',
+          tests: [
+            {
+              name: 'test-0',
+              type: 'case',
+              runMode: 'only',
+            },
+            {
+              name: 'test-1',
+              type: 'case',
+              runMode: 'run',
+            },
+            {
+              name: 'test-2',
+              type: 'suite',
+              runMode: 'run',
+              tests: [
+                {
+                  name: 'test-2-1',
+                  type: 'case',
+                  runMode: 'run',
+                },
+                {
+                  name: 'test-2-2',
+                  type: 'case',
+                  runMode: 'only',
+                },
+              ],
+            },
+            {
+              name: 'test-4',
+              type: 'suite',
+              runMode: 'run',
+              tests: [
+                {
+                  name: 'test-4-1',
+                  type: 'case',
+                  runMode: 'run',
+                },
+              ],
+            },
+          ],
+        } as TestSuite,
+        {
+          name: 'testB',
+          runMode: 'run',
+          type: 'case',
+        } as TestCase,
+      ];
+
+      updateTestModes(tests);
+
+      expect(tests[0].runMode).toBe('run');
+      expect(tests[0].tests[0]?.runMode).toBe('only');
+      expect(tests[0].tests[1]?.runMode).toBe('skip');
+      expect(tests[0].tests[2]?.runMode).toBe('run');
+      expect((tests[0].tests[2] as TestSuite).tests[0]?.runMode).toBe('skip');
+      expect((tests[0].tests[2] as TestSuite).tests[1]?.runMode).toBe('only');
+      expect(tests[0].tests[3]?.runMode).toBe('skip');
+      expect(tests[1].runMode).toBe('skip');
+    });
+
+    it('should update test run mode correctly when has only test suite', () => {
+      const tests: [TestSuite, TestCase] = [
+        {
+          name: 'testA',
+          runMode: 'only',
+          type: 'suite',
+          tests: [
+            {
+              name: 'test-0',
+              type: 'case',
+              runMode: 'run',
+            },
+            {
+              name: 'test-1',
+              type: 'suite',
+              runMode: 'run',
+              tests: [
+                {
+                  name: 'test-1-1',
+                  type: 'case',
+                  runMode: 'run',
+                },
+              ],
+            },
+            {
+              name: 'test-2',
+              type: 'suite',
+              runMode: 'only',
+              tests: [
+                {
+                  name: 'test-2-1',
+                  type: 'case',
+                  runMode: 'run',
+                },
+                {
+                  name: 'test-2-2',
+                  type: 'case',
+                  runMode: 'skip',
+                },
+                {
+                  name: 'test-2-3',
+                  type: 'suite',
+                  runMode: 'run',
+                  tests: [
+                    {
+                      name: 'test-2-3-1',
+                      type: 'case',
+                      runMode: 'run',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        } as TestSuite,
+        {
+          name: 'testB',
+          runMode: 'run',
+          type: 'case',
+        } as TestCase,
+      ];
+
+      updateTestModes(tests);
+
+      expect(tests[0].runMode).toBe('only');
+      expect(tests[0].tests[0]?.runMode).toBe('skip');
+      expect(tests[0].tests[1]?.runMode).toBe('skip');
+      expect((tests[0].tests[1] as TestSuite).tests[0]?.runMode).toBe('skip');
+      expect(tests[0].tests[2]?.runMode).toBe('only');
+      expect((tests[0].tests[2] as TestSuite).tests[0]?.runMode).toBe('run');
+      expect((tests[0].tests[2] as TestSuite).tests[1]?.runMode).toBe('skip');
+      expect((tests[0].tests[2] as TestSuite).tests[2]?.runMode).toBe('run');
+      expect(tests[1].runMode).toBe('skip');
+    });
+  });
+
+  it('updateTestMode with testNamePattern', () => {
+    const tests: [TestSuite, TestCase] = [
+      {
+        name: 'testA',
+        runMode: 'run',
+        type: 'suite',
+        tests: [
+          {
+            name: 'test-0',
+            type: 'case',
+            runMode: 'run',
+          },
+          {
+            name: 'test-1',
+            type: 'case',
+            runMode: 'run',
+          },
+          {
+            name: 'test-2',
+            type: 'suite',
+            runMode: 'run',
+            tests: [
               {
-                name: 'test-2-3',
-                type: 'suite',
+                name: 'test-2-1',
+                type: 'case',
                 runMode: 'run',
-                tests: [
-                  {
-                    name: 'test-2-3-1',
-                    type: 'case',
-                    runMode: 'run',
-                  },
-                ],
+              },
+              {
+                name: 'test-2-2',
+                type: 'case',
+                runMode: 'run',
               },
             ],
           },
@@ -216,16 +275,64 @@ describe('updateTestModes', () => {
       } as TestCase,
     ];
 
-    updateTestModes(tests);
-
-    expect(tests[0].runMode).toBe('only');
-    expect(tests[0].tests[0]?.runMode).toBe('skip');
-    expect(tests[0].tests[1]?.runMode).toBe('skip');
-    expect((tests[0].tests[1] as TestSuite).tests[0]?.runMode).toBe('skip');
-    expect(tests[0].tests[2]?.runMode).toBe('only');
-    expect((tests[0].tests[2] as TestSuite).tests[0]?.runMode).toBe('run');
-    expect((tests[0].tests[2] as TestSuite).tests[1]?.runMode).toBe('skip');
-    expect((tests[0].tests[2] as TestSuite).tests[2]?.runMode).toBe('run');
-    expect(tests[1].runMode).toBe('skip');
+    traverseUpdateTest(tests, /2-1/);
+    expect(tests).toMatchInlineSnapshot(`
+      [
+        {
+          "name": "testA",
+          "runMode": "run",
+          "tests": [
+            {
+              "name": "test-0",
+              "parentNames": [
+                "testA",
+              ],
+              "runMode": "skip",
+              "type": "case",
+            },
+            {
+              "name": "test-1",
+              "parentNames": [
+                "testA",
+              ],
+              "runMode": "skip",
+              "type": "case",
+            },
+            {
+              "name": "test-2",
+              "runMode": "run",
+              "tests": [
+                {
+                  "name": "test-2-1",
+                  "parentNames": [
+                    "testA",
+                    "test-2",
+                  ],
+                  "runMode": "run",
+                  "type": "case",
+                },
+                {
+                  "name": "test-2-2",
+                  "parentNames": [
+                    "testA",
+                    "test-2",
+                  ],
+                  "runMode": "skip",
+                  "type": "case",
+                },
+              ],
+              "type": "suite",
+            },
+          ],
+          "type": "suite",
+        },
+        {
+          "name": "testB",
+          "parentNames": [],
+          "runMode": "skip",
+          "type": "case",
+        },
+      ]
+    `);
   });
 });

--- a/tests/filter/fixtures/testNamePattern.test.ts
+++ b/tests/filter/fixtures/testNamePattern.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from '@rstest/core';
+
+// biome-ignore lint/suspicious/noFocusedTests: <explanation>
+describe.only('level-A', () => {
+  describe('level-B', () => {
+    it('it in level-B-A', () => {
+      console.log('[test] in level-B-A');
+      expect(2 + 1).toBe(3);
+    });
+
+    it.skip('it in level-B-B', () => {
+      console.log('[test] in level-B-B');
+      expect(2 + 1).toBe(3);
+    });
+
+    describe('level-B-C', () => {
+      it('it in level-B-C-A', () => {
+        console.log('[test] in level-B-C-A');
+        expect(2 + 1).toBe(3);
+      });
+    });
+  });
+
+  it('it in level-C', () => {
+    console.log('[test] in level-C');
+    expect(2 + 2).toBe(4);
+  });
+
+  describe('level-D', () => {
+    it('it in level-D-A', () => {
+      console.log('[test] in level-D-A');
+      expect(2 + 1).toBe(3);
+    });
+  });
+});
+
+describe('level-E', () => {
+  it('it in level-E-A', () => {
+    console.log('[test] in level-E-A');
+    expect(2 + 1).toBe(3);
+  });
+});

--- a/tests/filter/testNamePattern.test.ts
+++ b/tests/filter/testNamePattern.test.ts
@@ -1,0 +1,103 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test testNamePattern', () => {
+  it('should run success without filter', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testNamePattern.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[test] in level-B-A",
+        "[test] in level-B-C-A",
+        "[test] in level-C",
+        "[test] in level-D-A",
+      ]
+    `);
+  });
+
+  it('should filter test case name success', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testNamePattern.test.ts', '-t=level-B-A'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[test] in level-B-A",
+      ]
+    `);
+  });
+
+  it('should filter test suite name success', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testNamePattern.test.ts', '-t=level-B'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[test] in level-B-A",
+        "[test] in level-B-C-A",
+      ]
+    `);
+  });
+
+  it('should not run tests when filter test skipped', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testNamePattern.test.ts', '-t=level-B-B'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(
+      '[]',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

support filter by `testNamePattern`, will run only tests with a name that matches the regex.

without filter:
<img width="626" alt="image" src="https://github.com/user-attachments/assets/fc7c8885-1914-4d97-8343-d40db21046dd" />

with filter `B`:
<img width="685" alt="image" src="https://github.com/user-attachments/assets/c4f1b386-0682-46ef-b6b1-5c8b9f1acba9" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
