### PR TITLE
feat: support testNamePattern RegExp

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -6,7 +6,7 @@ import type {
   TestFileResult,
   TestResult,
 } from '../types';
-import { serializableConfig } from '../utils';
+import { serializeConfig } from '../utils';
 import { createForksPool } from './forks';
 
 const getNumCpus = (): number => {
@@ -98,7 +98,7 @@ export const runInPool = async ({
           assetFiles,
           context: {
             ...context,
-            normalizedConfig: serializableConfig(context.normalizedConfig),
+            normalizedConfig: serializeConfig(context.normalizedConfig),
           },
           sourceMaps,
           setupEntries,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -6,6 +6,7 @@ import type {
   TestFileResult,
   TestResult,
 } from '../types';
+import { serializableConfig } from '../utils';
 import { createForksPool } from './forks';
 
 const getNumCpus = (): number => {
@@ -95,7 +96,10 @@ export const runInPool = async ({
         options: {
           entryInfo,
           assetFiles,
-          context,
+          context: {
+            ...context,
+            normalizedConfig: serializableConfig(context.normalizedConfig),
+          },
           sourceMaps,
           setupEntries,
           updateSnapshot,

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -5,6 +5,7 @@ import type {
   WorkerState,
 } from '../../types';
 import { globalApis } from '../../utils/constants';
+import { deserializeConfig } from '../../utils/helper';
 import { formatTestError } from '../util';
 import { loadModule } from './loadModule';
 import { createForksRpcOptions, createRuntimeRpc } from './rpc';
@@ -27,6 +28,8 @@ const runInPool = async ({
   updateSnapshot,
   context,
 }: RunWorkerOptions['options']): Promise<TestFileResult> => {
+  context.normalizedConfig = deserializeConfig(context.normalizedConfig);
+
   const { rpc } = createRuntimeRpc(createForksRpcOptions());
   const codeContent = assetFiles[filePath]!;
   const {

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -84,14 +84,14 @@ export const getTaskNameWithPrefix = (
 
 const REGEXP_FLAG_PREFIX = 'RSTEST_REGEXP:';
 
-const wrapRegexp = (value: RegExp): string =>
+const wrapRegex = (value: RegExp): string =>
   `${REGEXP_FLAG_PREFIX}${value.toString()}`;
 
-const unwrapRegexp = (value: string): RegExp | string => {
+const unwrapRegex = (value: string): RegExp | string => {
   if (value.startsWith(REGEXP_FLAG_PREFIX)) {
-    const regexpStr = value.slice(REGEXP_FLAG_PREFIX.length);
+    const regexStr = value.slice(REGEXP_FLAG_PREFIX.length);
 
-    const matches = regexpStr.match(/^\/(.+)\/([gimuy]*)$/);
+    const matches = regexStr.match(/^\/(.+)\/([gimuy]*)$/);
     if (matches) {
       const [, pattern, flags] = matches;
       return new RegExp(pattern!, flags);
@@ -104,7 +104,7 @@ const unwrapRegexp = (value: string): RegExp | string => {
  * Serialize configuration for special types that do not support passing into the pool
  * eg. RegExp
  */
-export const serializableConfig = (
+export const serializeConfig = (
   normalizedConfig: NormalizedConfig,
 ): NormalizedConfig => {
   const { testNamePattern } = normalizedConfig;
@@ -112,7 +112,7 @@ export const serializableConfig = (
     ...normalizedConfig,
     testNamePattern:
       testNamePattern && typeof testNamePattern !== 'string'
-        ? wrapRegexp(testNamePattern)
+        ? wrapRegex(testNamePattern)
         : testNamePattern,
   };
 };
@@ -125,7 +125,7 @@ export const deserializeConfig = (
     ...normalizedConfig,
     testNamePattern:
       testNamePattern && typeof testNamePattern === 'string'
-        ? unwrapRegexp(testNamePattern)
+        ? unwrapRegex(testNamePattern)
         : testNamePattern,
   };
 };

--- a/tests/filter/fixtures/testNamePattern.config.ts
+++ b/tests/filter/fixtures/testNamePattern.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testNamePattern: /B/,
+});

--- a/tests/filter/testNamePattern.test.ts
+++ b/tests/filter/testNamePattern.test.ts
@@ -80,6 +80,34 @@ describe('test testNamePattern', () => {
     `);
   });
 
+  it('should filter test suite name success use regex', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        'fixtures/testNamePattern.test.ts',
+        '-c=fixtures/testNamePattern.config.ts',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[test] in level-B-A",
+        "[test] in level-B-C-A",
+      ]
+    `);
+  });
+
   it('should not run tests when filter test skipped', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',


### PR DESCRIPTION
## Summary

Some special types that do not support passing into the pool, eg. RegExp. we need serialize them when passing into the pool.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
