### PR TITLE
feat: support `testTimeout` configuration

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -15,27 +15,28 @@ type CommonOptions = {
   passWithNoTests?: boolean;
   update?: boolean;
   testNamePattern?: RegExp | string;
+  testTimeout?: number;
 };
 
 const applyCommonOptions = (cli: CAC) => {
   cli
     .option(
       '-c, --config <config>',
-      'specify the configuration file, can be a relative or absolute path',
+      'Specify the configuration file, can be a relative or absolute path',
     )
     .option(
       '--config-loader <loader>',
-      'specify the loader to load the config file, can be `jiti` or `native`',
+      'Specify the loader to load the config file, can be `jiti` or `native`',
       {
         default: 'jiti',
       },
     )
     .option(
       '-r, --root <root>',
-      'specify the project root directory, can be an absolute path or a path relative to cwd',
+      'Specify the project root directory, can be an absolute path or a path relative to cwd',
     )
-    .option('--globals', 'provide global APIs')
-    .option('-u, --update', 'update snapshot files')
+    .option('--globals', 'Provide global APIs')
+    .option('-u, --update', 'Update snapshot files')
     .option(
       '--passWithNoTests',
       'Allows the test suite to pass when no files are found.',
@@ -43,7 +44,8 @@ const applyCommonOptions = (cli: CAC) => {
     .option(
       '-t, --testNamePattern <testNamePattern>',
       'Run only tests with a name that matches the regex.',
-    );
+    )
+    .option('--testTimeout <testTimeout>', 'Timeout of a test in milliseconds');
 };
 
 export async function initCli(options: CommonOptions): Promise<{
@@ -65,6 +67,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'passWithNoTests',
     'update',
     'testNamePattern',
+    'testTimeout',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -89,6 +89,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   globals: false,
   passWithNoTests: false,
   update: false,
+  testTimeout: 5_000,
   reporters: ['default'],
 });
 

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -20,7 +20,14 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
     getCurrentTest: TestRunner['getCurrentTest'];
   };
 } {
-  const runtimeAPI: RunnerRuntime = new RunnerRuntime(workerState.sourcePath);
+  const {
+    sourcePath,
+    normalizedConfig: { testTimeout },
+  } = workerState;
+  const runtimeAPI: RunnerRuntime = new RunnerRuntime({
+    sourcePath,
+    testTimeout,
+  });
   const testRunner: TestRunner = new TestRunner();
 
   const it = ((name, fn, timeout) =>

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -95,10 +95,17 @@ export class RunnerRuntime {
   private collectStatus: CollectStatus = 'lazy';
   private currentCollectList: Array<() => MaybePromise<void>> = [];
   private defaultHookTimeout = 5_000;
-  private defaultTestTimeout = 5_000;
+  private defaultTestTimeout;
 
-  constructor(sourcePath: string) {
+  constructor({
+    sourcePath,
+    testTimeout,
+  }: {
+    testTimeout: number;
+    sourcePath: string;
+  }) {
     this.sourcePath = sourcePath;
+    this.defaultTestTimeout = testTimeout;
   }
 
   afterAll(

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -82,6 +82,12 @@ export interface RstestConfig {
    * Run only tests with a name that matches the regex.
    */
   testNamePattern?: string | RegExp;
+
+  /**
+   * Timeout of a test in milliseconds.
+   * @default 5000
+   */
+  testTimeout?: number;
 }
 
 export type NormalizedConfig = Required<

--- a/tests/expect/test/index.test.ts
+++ b/tests/expect/test/index.test.ts
@@ -155,4 +155,35 @@ describe('Expect API', () => {
     ).toBeTruthy();
     expect(logs.find((log) => log.includes('Tests 2 failed'))).toBeTruthy();
   }, 10000);
+
+  it('should not throw timeout error when update timeout time via testTimeout configuration', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'timeout.test', '--testTimeout=10000'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    // The timeout set by the API is higher than the global configuration item
+    expect(
+      logs.find((log) => log.includes('Error: test hook timed out in 50ms')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('timeout.test.ts:5:5')),
+    ).toBeTruthy();
+
+    expect(
+      logs.find((log) => log.includes('Error: test hook timed out in 5000ms')),
+    ).toBeFalsy();
+    expect(
+      logs.find((log) => log.includes('Tests 1 failed | 1 passed')),
+    ).toBeTruthy();
+  }, 12000);
 });


### PR DESCRIPTION
## Summary

`testTimeout` configuration is used to set default timeout of a test.

```ts
import { defineConfig } from '@rstest/core';

export default defineConfig({
    testTimeout: 10_000,
});

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
