### PR TITLE
feat: add hooks to global API

### DIFF
--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -20,4 +20,8 @@ export const globalApis: (keyof Rstest)[] = [
   'describe',
   'it',
   'expect',
+  'afterAll',
+  'afterEach',
+  'beforeAll',
+  'beforeEach',
 ];


### PR DESCRIPTION
## Summary

Support use the hook APIs globally without import `@rstest/core`.

```diff
- import { beforeAll, beforeEach, afterAll, afterEach } from '@rstest/core';

beforeAll(() => {
  console.log('run beforeAll');
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
