### PR TITLE
feat: support get test file path via `beforeAll` context

### DIFF
--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -25,6 +25,7 @@ export type TestCase = {
 };
 
 export type SuiteContext = {
+  /** The test file path */
   filepath: string;
 };
 

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -24,8 +24,14 @@ export type TestCase = {
   promises?: Promise<any>[];
 };
 
-export type AfterAllListener = () => MaybePromise<void>;
-export type BeforeAllListener = () => MaybePromise<void | AfterAllListener>;
+export type SuiteContext = {
+  filepath: string;
+};
+
+export type AfterAllListener = (ctx: SuiteContext) => MaybePromise<void>;
+export type BeforeAllListener = (
+  ctx: SuiteContext,
+) => MaybePromise<void | AfterAllListener>;
 export type AfterEachListener = () => MaybePromise<void>;
 export type BeforeEachListener = () => MaybePromise<void | AfterEachListener>;
 

--- a/tests/lifecycle/fixtures/beforeAll.test.ts
+++ b/tests/lifecycle/fixtures/beforeAll.test.ts
@@ -1,8 +1,9 @@
 import { beforeAll, describe, expect, it } from '@rstest/core';
 import { sleep } from '../../scripts';
 
-beforeAll(() => {
+beforeAll((ctx) => {
   console.log('[beforeAll] root');
+  expect(ctx.filepath).toBe(__filename);
 });
 
 beforeAll(async () => {

--- a/tests/setup/fixtures/basic/rstest.setup.ts
+++ b/tests/setup/fixtures/basic/rstest.setup.ts
@@ -1,8 +1,13 @@
 import path from 'node:path';
-import { afterAll, expect } from '@rstest/core';
+import { afterAll, beforeAll, expect } from '@rstest/core';
 import { createSnapshotSerializer } from 'path-serializer';
 
 process.env.RETEST_SETUP_FLAG = '1';
+
+beforeAll((ctx) => {
+  console.log('[beforeAll] root');
+  expect(ctx.filepath).toContain('index.test.ts');
+});
 
 expect.addSnapshotSerializer(
   createSnapshotSerializer({


### PR DESCRIPTION
## Summary

support get test file path via `beforeAll` / `afterAll` context.

```ts
beforeAll((ctx) => {
  console.log('ctx', ctx.filepath);
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
