### PR TITLE
fix: unexpected rpc error about result.expected

### DIFF
--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -21,6 +21,17 @@ export const formatTestError = (err: any): TestError[] => {
     ) {
       errObj.diff = diff(err.actual, err.expected)!;
     }
+
+    for (const key of ['actual', 'expected'] as const) {
+      if (typeof err[key] !== 'string') {
+        (errObj as Record<string, any>)[key] = JSON.stringify(
+          err[key],
+          null,
+          10,
+        );
+      }
+    }
+
     return errObj;
   });
 };

--- a/tests/expect/test/edgeCase.test.ts
+++ b/tests/expect/test/edgeCase.test.ts
@@ -1,0 +1,27 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../../scripts';
+
+describe('Expect edge cases', () => {
+  it('no unexpected rpc error about result.expected', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/error.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.find((log) => log.includes('Error: Symbol('))).toBeFalsy();
+  });
+});

--- a/tests/expect/test/fixtures/error.test.ts
+++ b/tests/expect/test/fixtures/error.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from '@rstest/core';
+
+it('test asymmetricMatcher error', () => {
+  expect({
+    text: 'hello world',
+  }).toEqual({
+    text: expect.stringMatching('hhh'),
+  });
+});

--- a/tests/expect/test/index.test.ts
+++ b/tests/expect/test/index.test.ts
@@ -186,4 +186,25 @@ describe('Expect API', () => {
       logs.find((log) => log.includes('Tests 1 failed | 1 passed')),
     ).toBeTruthy();
   }, 12000);
+
+  it('no unexpected rpc error about result.expected', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/error.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.find((log) => log.includes('Error: Symbol('))).toBeFalsy();
+  });
 });

--- a/tests/expect/test/index.test.ts
+++ b/tests/expect/test/index.test.ts
@@ -186,25 +186,4 @@ describe('Expect API', () => {
       logs.find((log) => log.includes('Tests 1 failed | 1 passed')),
     ).toBeTruthy();
   }, 12000);
-
-  it('no unexpected rpc error about result.expected', async () => {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
-
-    const { cli } = await runRstestCli({
-      command: 'rstest',
-      args: ['run', 'fixtures/error.test.ts'],
-      options: {
-        nodeOptions: {
-          cwd: __dirname,
-        },
-      },
-    });
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(1);
-
-    const logs = cli.stdout.split('\n').filter(Boolean);
-
-    expect(logs.find((log) => log.includes('Error: Symbol('))).toBeFalsy();
-  });
 });


### PR DESCRIPTION
## Summary

unexpected rpc error about `result.expected`
![image](https://github.com/user-attachments/assets/b329e5d2-9cc2-4e4f-b12e-ae1bfa3b81bb)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
