### PR TITLE
fix: `module not found` errors should be silent at build

### DIFF
--- a/packages/core/src/core/plugins/ignoreResolveError.ts
+++ b/packages/core/src/core/plugins/ignoreResolveError.ts
@@ -1,0 +1,28 @@
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+
+class IgnoreModuleNotFoundErrorPlugin {
+  apply(compiler: Rspack.Compiler) {
+    compiler.hooks.done.tap('Rstest:IgnoreModuleNotFoundPlugin', (stats) => {
+      stats.compilation.errors = stats.compilation.errors.filter((error) => {
+        if (/Module not found/.test(error.message)) {
+          return false;
+        }
+        return true;
+      });
+    });
+  }
+}
+
+/**
+ * Module not found errors should be silent at build, and throw errors at runtime
+ */
+export const pluginIgnoreResolveError: RsbuildPlugin = {
+  name: 'rstest:ignore-resolve-error',
+  setup: (api) => {
+    api.modifyRspackConfig(async (config) => {
+      config.plugins!.push(new IgnoreModuleNotFoundErrorPlugin());
+      config.optimization ??= {};
+      config.optimization.emitOnErrors = true;
+    });
+  },
+};

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -9,6 +9,7 @@ import {
 import path from 'pathe';
 import type { EntryInfo, SourceMapInput } from '../types';
 import { isDebug } from '../utils';
+import { pluginIgnoreResolveError } from './plugins/ignoreResolveError';
 
 const isMultiCompiler = <
   C extends Rspack.Compiler = Rspack.Compiler,
@@ -93,6 +94,7 @@ export const prepareRsbuild = async (
               };
             },
           },
+          plugins: [pluginIgnoreResolveError],
         },
       },
     },

--- a/tests/expect/test/edgeCase.test.ts
+++ b/tests/expect/test/edgeCase.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
 import { runRstestCli } from '../../scripts';
 
-describe('Expect edge cases', () => {
+describe('Expect Edge Cases', () => {
   it('no unexpected rpc error about result.expected', async () => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
@@ -23,5 +23,28 @@ describe('Expect edge cases', () => {
     const logs = cli.stdout.split('\n').filter(Boolean);
 
     expect(logs.find((log) => log.includes('Error: Symbol('))).toBeFalsy();
+  });
+
+  it('test module not found', async () => {
+    // Module not found errors should be silent at build time, and throw errors at runtime
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/moduleNotFound.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+    expect(logs.find((log) => log.includes('Build error'))).toBeFalsy();
+    expect(logs.find((log) => log.includes('Module not found'))).toBeFalsy();
+    expect(logs.find((log) => log.includes('Tests 2 passed'))).toBeTruthy();
   });
 });

--- a/tests/expect/test/fixtures/moduleNotFound.test.ts
+++ b/tests/expect/test/fixtures/moduleNotFound.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from '@rstest/core';
+
+const expectNotFound = async () => {
+  try {
+    // @ts-expect-error
+    const res = await import('404');
+    return res;
+  } catch (err) {
+    return null;
+  }
+};
+
+const unexpectNotFound = async () => {
+  // @ts-expect-error
+  return import('aaa');
+};
+
+it('test expectNotFound error', async () => {
+  await expect(expectNotFound()).resolves.toBeNull();
+});
+
+it('test expectNotFound error', async () => {
+  await expect(unexpectNotFound()).rejects.toThrowError(
+    /Cannot find module \'aaa\'/,
+  );
+});


### PR DESCRIPTION
## Summary

Some `module not found` errors are as expected, so we need to ignore these errors at build time and throw errors at runtime if necessary.

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/29b19914-2c38-4316-a60c-2816c7d012ba" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
