### PR TITLE
docs: add banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<picture>
+  <img alt="Rstest Banner" src="https://assets.rspack.dev/rstest/rstest-banner.png">
+</picture>
+
 # Rstest
 
 <p>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,1 +1,11 @@
+<picture>
+  <img alt="Rstest Banner" src="https://assets.rspack.dev/rstest/rstest-banner.png">
+</picture>
+
 # Rstest
+
+Rstest is a testing framework powered by Rspack.
+
+## 📖 License
+
+Rstest is licensed under the [MIT License](https://github.com/web-infra-dev/rstest/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Add the Rstest banner image to README files:

![image](https://github.com/user-attachments/assets/4fa01900-7e13-49a9-9694-61755b5d9698)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
