### PR TITLE
feat: init `test.each` API

### DIFF
--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -36,6 +36,7 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   it.todo = (name, fn, timeout) => runtimeAPI.it(name, fn, timeout, 'todo');
   it.skip = (name, fn, timeout) => runtimeAPI.it(name, fn, timeout, 'skip');
   it.only = (name, fn, timeout) => runtimeAPI.it(name, fn, timeout, 'only');
+  it.each = runtimeAPI.each.bind(runtimeAPI);
 
   const describe = ((name, fn) => runtimeAPI.describe(name, fn)) as DescribeAPI;
   describe.only = (name, fn) => runtimeAPI.describe(name, fn, 'only');

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -6,6 +6,7 @@ import type {
   BeforeEachListener,
   Test,
   TestCase,
+  TestEachFn,
   TestRunMode,
   TestSuite,
   TestSuiteListeners,
@@ -305,6 +306,22 @@ export class RunnerRuntime {
       type: 'case',
       timeout,
     });
+  }
+
+  each<T>(cases: T[]): TestEachFn<T> {
+    return (
+      name: string,
+      fn?: (param: T) => void | Promise<void>,
+      timeout: number = this.defaultTestTimeout,
+    ) => {
+      for (let i = 0; i < cases.length; i++) {
+        // TODO: template string table.
+        const param = cases[i]!;
+        // TODO: support test name template
+        // TODO: support param array ([[a, b, expected, actual]])
+        this.it(name, () => fn?.(param), timeout, 'run');
+      }
+    };
   }
 
   fails(

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -13,11 +13,18 @@ type TestFn = (
   timeout?: number,
 ) => void;
 
+export type TestEachFn<T> = (
+  description: string,
+  fn?: (param: T) => MaybePromise<void>,
+  timeout?: number,
+) => void;
+
 export type TestAPI = TestFn & {
   fails: TestFn;
   only: TestFn;
   todo: TestFn;
   skip: TestFn;
+  each: <T>(cases: T[]) => TestEachFn<T>;
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;

--- a/tests/test-api/each.test.ts
+++ b/tests/test-api/each.test.ts
@@ -1,0 +1,33 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+it('Test Each API', async () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/each.test.ts'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(0);
+
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+    [
+      "[beforeEach] root",
+      "[beforeEach] root",
+      "[beforeEach] root",
+    ]
+  `);
+
+  expect(logs.find((log) => log.includes('Tests 3 passed'))).toBeTruthy();
+});

--- a/tests/test-api/fixtures/each.test.ts
+++ b/tests/test-api/fixtures/each.test.ts
@@ -1,0 +1,13 @@
+import { beforeEach, expect, it } from '@rstest/core';
+
+beforeEach(() => {
+  console.log('[beforeEach] root');
+});
+
+it.each([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('add two numbers correctly', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected);
+});


### PR DESCRIPTION
## Summary

init `test.each` API.

```ts
it.each([
  { a: 1, b: 1, expected: 2 },
  { a: 1, b: 2, expected: 3 },
  { a: 2, b: 1, expected: 3 },
])('add two numbers correctly', ({ a, b, expected }) => {
  expect(a + b).toBe(expected);
});
```

TODO:
- support template string table.
- support test name template
- support params array

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
