### PR TITLE
feat: support `mockImplementation`

### DIFF
--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -80,15 +80,15 @@ export type MockContext<T extends FunctionLike = FunctionLike> = {
 
 export interface MockInstance<T extends FunctionLike = FunctionLike> {
   _isMockFunction: true;
-  // getMockImplementation(): T | undefined;
   getMockName(): string;
   mockName(name: string): this;
   mock: MockContext<T>;
   // mockClear(): this;
   // mockReset(): this;
   // mockRestore(): void;
-  // mockImplementation(fn: T): this;
-  // mockImplementationOnce(fn: T): this;
+  getMockImplementation(): T | undefined;
+  mockImplementation(fn: T): this;
+  mockImplementationOnce(fn: T): this;
   // withImplementation<T2>(
   //   fn: T,
   //   callback: () => T2,

--- a/tests/spy/index.test.ts
+++ b/tests/spy/index.test.ts
@@ -33,4 +33,28 @@ describe('test spy', () => {
     expect(sayHi).toHaveBeenLastCalledWith('Tom');
     expect(sayHi).toHaveBeenCalledTimes(2);
   });
+
+  it('rstest.fn -> mockImplementation', () => {
+    const sayHi = rstest.fn();
+
+    expect(sayHi.getMockImplementation()).toBeUndefined();
+
+    const res = sayHi('bob');
+
+    expect(res).toBeUndefined();
+
+    const sayHiImpl = (name: string) => `hi ${name}`;
+
+    sayHi.mockImplementation(sayHiImpl).mockImplementationOnce(() => 'hi');
+
+    expect(sayHi('bob')).toBe('hi');
+
+    expect(sayHi('bob')).toBe('hi bob');
+
+    expect(sayHi.getMockImplementation()).toEqual(sayHiImpl);
+
+    expect(sayHi('tom')).toBe('hi tom');
+
+    expect(sayHi).toHaveBeenCalledTimes(4);
+  });
 });


### PR DESCRIPTION
## Summary

support `mockImplementation`.
- `mockImplementation`: Accepts a function that should be used as the implementation of the mock. 
- `mockImplementationOnce`: Accepts a function that will be used as an implementation of the mock for one call to the mocked function. 
- `getMockImplementation`: Returns current mock implementation.

```ts
 const sayHi = rstest.fn().mockImplementation((name: string) => `hi ${name}`;).mockImplementationOnce(() => 'hi')

 expect(sayHi('bob')).toBe('hi');

 expect(sayHi('bob')).toBe('hi bob');
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
