### PR TITLE
fix: update global api

### DIFF
--- a/packages/core/globals.d.ts
+++ b/packages/core/globals.d.ts
@@ -3,5 +3,10 @@ declare global {
   const describe: typeof import('@rstest/core')['describe'];
   const it: typeof import('@rstest/core')['it'];
   const expect: typeof import('@rstest/core')['expect'];
+  const beforeAll: typeof import('@rstest/core')['beforeAll'];
+  const afterAll: typeof import('@rstest/core')['afterAll'];
+  const beforeEach: typeof import('@rstest/core')['beforeEach'];
+  const afterEach: typeof import('@rstest/core')['afterEach'];
+  const rstest: typeof import('@rstest/core')['rstest'];
 }
 export {};

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -24,4 +24,5 @@ export const globalApis: (keyof Rstest)[] = [
   'afterEach',
   'beforeAll',
   'beforeEach',
+  'rstest',
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,15 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
 
+  tests/globals/fixtures:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@rstest/tsconfig':
+        specifier: workspace:*
+        version: link:../../../scripts/tsconfig
+
   tests/lifecycle:
     devDependencies:
       '@rstest/core':

--- a/tests/globals/fixtures/index.test.ts
+++ b/tests/globals/fixtures/index.test.ts
@@ -1,0 +1,22 @@
+beforeAll(() => {
+  console.log('[beforeAll]');
+});
+
+afterAll(() => {
+  console.log('[afterAll]');
+});
+
+beforeEach(() => {
+  console.log('[beforeEach]');
+});
+
+afterEach(() => {
+  console.log('[afterEach]');
+});
+
+describe('Index', () => {
+  it('should add two numbers correctly', () => {
+    expect(1 + 1).toBe(2);
+    expect(rstest.fn).toBeDefined();
+  });
+});

--- a/tests/globals/fixtures/package.json
+++ b/tests/globals/fixtures/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@rstest/tests-global-fixtures",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*",
+    "@rstest/tsconfig": "workspace:*"
+  }
+}

--- a/tests/globals/fixtures/tsconfig.json
+++ b/tests/globals/fixtures/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@rstest/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "types": ["@rstest/core/globals"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/tests/globals/index.test.ts
+++ b/tests/globals/index.test.ts
@@ -1,0 +1,24 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test global APIs', () => {
+  it('should run with global API succeed', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/index.test.ts', '--globals'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary


* Added `rstest` to global API
* Added `rstest` / `beforeAll` / `afterAll`  / `beforeEach`  / `afterEach` to global type


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
