### PR TITLE
feat: support mock clear / reset / restore

### DIFF
--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -10,12 +10,14 @@ const wrapSpy = <T extends FunctionLike>(
 
   const spyFn = spyImpl as unknown as Mock<T>;
 
-  const mockImplementationOnce: T[] = [];
+  let mockImplementationOnce: T[] = [];
   let implementation = mockFn;
 
-  const mockState = {
+  const initMockState = () => ({
     mockName: mockFn?.name,
-  };
+  });
+
+  let mockState = initMockState();
 
   const spyState = getInternalState(spyImpl);
 
@@ -60,6 +62,26 @@ const wrapSpy = <T extends FunctionLike>(
       },
     }),
   });
+
+  spyFn.mockClear = () => {
+    spyState.reset();
+
+    return spyFn;
+  };
+
+  spyFn.mockReset = () => {
+    spyFn.mockClear();
+    implementation = mockFn;
+    mockImplementationOnce = [];
+
+    return spyFn;
+  };
+
+  spyFn.mockRestore = () => {
+    spyFn.mockReset();
+    spyState.restore();
+    mockState = initMockState();
+  };
 
   return spyFn;
 };

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -83,9 +83,9 @@ export interface MockInstance<T extends FunctionLike = FunctionLike> {
   getMockName(): string;
   mockName(name: string): this;
   mock: MockContext<T>;
-  // mockClear(): this;
-  // mockReset(): this;
-  // mockRestore(): void;
+  mockClear(): this;
+  mockReset(): this;
+  mockRestore(): void;
   getMockImplementation(): T | undefined;
   mockImplementation(fn: T): this;
   mockImplementationOnce(fn: T): this;

--- a/tests/spy/index.test.ts
+++ b/tests/spy/index.test.ts
@@ -57,4 +57,51 @@ describe('test spy', () => {
 
     expect(sayHi).toHaveBeenCalledTimes(4);
   });
+
+  it('rstest.fn -> mock clear / reset / restore', () => {
+    const sayHi = rstest.fn(function sayHiFn(name: string) {
+      return `hi ${name}`;
+    });
+    const sayHello = rstest.fn();
+
+    expect(sayHi.getMockName()).toBe('sayHiFn');
+    sayHi.mockImplementation(() => 'hi');
+    sayHello.mockImplementation(() => 'hello');
+
+    expect(sayHi('bob')).toBe('hi');
+    expect(sayHello('bob')).toBe('hello');
+
+    sayHi.mockName('sayHi');
+    expect(sayHi.getMockName()).toBe('sayHi');
+
+    expect(sayHi.mock.calls).toEqual([['bob']]);
+
+    sayHi.mockClear();
+    sayHello.mockClear();
+
+    expect(sayHi.getMockName()).toBe('sayHi');
+
+    expect(sayHi.mock.calls).toEqual([]);
+
+    expect(sayHi).toHaveBeenCalledTimes(0);
+
+    expect(sayHi('bob')).toBe('hi');
+    expect(sayHello()).toBe('hello');
+
+    sayHi.mockReset();
+    sayHello.mockReset();
+
+    expect(sayHi.getMockName()).toBe('sayHi');
+
+    expect(sayHi.mock.calls).toEqual([]);
+
+    expect(sayHi('bob')).toBe('hi bob');
+    expect(sayHello()).toBeUndefined();
+
+    sayHi.mockRestore();
+    sayHello.mockRestore();
+
+    expect(sayHi.getMockName()).toBe('sayHiFn');
+    expect(sayHello.getMockName()).toBe('rstest.fn()');
+  });
 });


### PR DESCRIPTION
## Summary

- `mockClear`:  Clears all information about every call.
- `mockReset`: Does what `mockClear` does and resets inner implementation to the original function.
- `mockRestore`: Does what `mockReset` does and restores original descriptors of spied-on objects.

```ts
    const sayHi = rstest.fn(function sayHiFn(name: string) {
      return `hi ${name}`;
    });
    const sayHello = rstest.fn();

    expect(sayHi.getMockName()).toBe('sayHiFn');
    sayHi.mockImplementation(() => 'hi');
    sayHello.mockImplementation(() => 'hello');

    expect(sayHi('bob')).toBe('hi');
    expect(sayHello('bob')).toBe('hello');

    sayHi.mockName('sayHi');
    expect(sayHi.getMockName()).toBe('sayHi');

    expect(sayHi.mock.calls).toEqual([['bob']]);
 
   // test mockClear
    sayHi.mockClear();
    sayHello.mockClear();

    expect(sayHi.getMockName()).toBe('sayHi');

    expect(sayHi.mock.calls).toEqual([]);

    expect(sayHi).toHaveBeenCalledTimes(0);

    expect(sayHi('bob')).toBe('hi');
    expect(sayHello()).toBe('hello');

     // test mockReset
    sayHi.mockReset();
    sayHello.mockReset();

    expect(sayHi.getMockName()).toBe('sayHi');

    expect(sayHi.mock.calls).toEqual([]);

    expect(sayHi('bob')).toBe('hi bob');
    expect(sayHello()).toBeUndefined();

    // test mockRestore
    sayHi.mockRestore();
    sayHello.mockRestore();

    expect(sayHi.getMockName()).toBe('sayHiFn');
    expect(sayHello.getMockName()).toBe('rstest.fn()');
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
