### PR TITLE
feat: support mock `withImplementation`

### DIFF
--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -35,6 +35,34 @@ const wrapSpy = <T extends FunctionLike>(
       : implementation;
   };
 
+  function withImplementation(fn: T, cb: () => void): void;
+  function withImplementation(fn: T, cb: () => Promise<void>): Promise<void>;
+  function withImplementation(
+    fn: T,
+    cb: () => void | Promise<void>,
+  ): void | Promise<void> {
+    const originalImplementation = implementation;
+
+    implementation = fn;
+    spyState.willCall(willCall);
+
+    const reset = () => {
+      implementation = originalImplementation;
+    };
+
+    const result = cb();
+
+    if (result instanceof Promise) {
+      return result.then(() => {
+        reset();
+      });
+    }
+
+    reset();
+  }
+
+  spyFn.withImplementation = withImplementation;
+
   spyFn.mockImplementation = (fn) => {
     implementation = fn;
     return spyFn;

--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -42,12 +42,15 @@ const wrapSpy = <T extends FunctionLike>(
     cb: () => void | Promise<void>,
   ): void | Promise<void> {
     const originalImplementation = implementation;
+    const originalMockImplementationOnce = mockImplementationOnce;
 
     implementation = fn;
+    mockImplementationOnce = [];
     spyState.willCall(willCall);
 
     const reset = () => {
       implementation = originalImplementation;
+      mockImplementationOnce = originalMockImplementationOnce;
     };
 
     const result = cb();

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -89,10 +89,10 @@ export interface MockInstance<T extends FunctionLike = FunctionLike> {
   getMockImplementation(): T | undefined;
   mockImplementation(fn: T): this;
   mockImplementationOnce(fn: T): this;
-  // withImplementation<T2>(
-  //   fn: T,
-  //   callback: () => T2,
-  // ): T2 extends Promise<unknown> ? Promise<void> : void;
+  withImplementation<T2>(
+    fn: T,
+    callback: () => T2,
+  ): T2 extends Promise<unknown> ? Promise<void> : void;
   // mockReturnThis(): this;
   // mockReturnValue(value: ReturnType<T>): this;
   // mockReturnValueOnce(value: ReturnType<T>): this;

--- a/tests/spy/fixtures/withImplementation.test.ts
+++ b/tests/spy/fixtures/withImplementation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, rstest } from '@rstest/core';
+
+describe('test withImplementation', () => {
+  it('withImplementation', () => {
+    let isMockCalled = false;
+    const mockFn = () => {
+      isMockCalled = true;
+      console.log('[call original]');
+      return 'original';
+    };
+    const myMockFn = rstest.fn(mockFn);
+
+    myMockFn.withImplementation(
+      () => {
+        console.log('[call temp]');
+        return 'temp';
+      },
+      () => {
+        console.log('[call callback]');
+        const res = myMockFn();
+        console.log('[callback res]', res);
+      },
+    );
+
+    expect(myMockFn.getMockImplementation()).toBe(mockFn);
+    expect(isMockCalled).toBe(false);
+
+    console.log('[call myMockFn]');
+    expect(myMockFn()).toBe('original');
+    expect(isMockCalled).toBe(true);
+
+    console.log('[call myMockFn - 1]');
+
+    expect(myMockFn()).toBe('original');
+  });
+
+  it('withImplementation async', async () => {
+    const myMockFn = rstest.fn(() => {
+      console.log('[1 - call original]');
+      return 'original';
+    });
+
+    await myMockFn.withImplementation(
+      () => {
+        console.log('[1 - call temp]');
+        return 'temp';
+      },
+      async () => {
+        console.log('[1 - call callback]');
+        const res = myMockFn();
+        console.log('[1 - callback res]', res);
+      },
+    );
+
+    console.log('[1 - call myMockFn]');
+
+    expect(myMockFn()).toBe('original');
+
+    console.log('[1 - call myMockFn - 1]');
+    expect(myMockFn()).toBe('original');
+  });
+});

--- a/tests/spy/fixtures/withImplementation.test.ts
+++ b/tests/spy/fixtures/withImplementation.test.ts
@@ -10,6 +10,14 @@ describe('test withImplementation', () => {
     };
     const myMockFn = rstest.fn(mockFn);
 
+    const mockFn1 = () => {
+      isMockCalled = true;
+      console.log('[call original - 1]');
+      return 'original - 1';
+    };
+
+    myMockFn.mockImplementationOnce(mockFn1);
+
     myMockFn.withImplementation(
       () => {
         console.log('[call temp]');
@@ -18,20 +26,22 @@ describe('test withImplementation', () => {
       () => {
         console.log('[call callback]');
         const res = myMockFn();
-        console.log('[callback res]', res);
+        const res1 = myMockFn();
+        console.log('[callback res]', res, res1);
       },
     );
 
-    expect(myMockFn.getMockImplementation()).toBe(mockFn);
+    expect(myMockFn.getMockImplementation()).toBe(mockFn1);
     expect(isMockCalled).toBe(false);
 
     console.log('[call myMockFn]');
-    expect(myMockFn()).toBe('original');
+    expect(myMockFn()).toBe('original - 1');
     expect(isMockCalled).toBe(true);
 
     console.log('[call myMockFn - 1]');
 
     expect(myMockFn()).toBe('original');
+    expect(myMockFn).toHaveBeenCalledTimes(4);
   });
 
   it('withImplementation async', async () => {

--- a/tests/spy/withImplementation.test.ts
+++ b/tests/spy/withImplementation.test.ts
@@ -1,0 +1,42 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+it('test withImplementation', async () => {
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/withImplementation.test'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(0);
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+    [
+      "[call callback]",
+      "[call temp]",
+      "[callback res] temp",
+      "[call myMockFn]",
+      "[call original]",
+      "[call myMockFn - 1]",
+      "[call original]",
+      "[1 - call callback]",
+      "[1 - call temp]",
+      "[1 - callback res] temp",
+      "[1 - call myMockFn]",
+      "[1 - call original]",
+      "[1 - call myMockFn - 1]",
+      "[1 - call original]",
+    ]
+  `);
+});

--- a/tests/spy/withImplementation.test.ts
+++ b/tests/spy/withImplementation.test.ts
@@ -25,9 +25,10 @@ it('test withImplementation', async () => {
     [
       "[call callback]",
       "[call temp]",
-      "[callback res] temp",
+      "[call temp]",
+      "[callback res] temp temp",
       "[call myMockFn]",
-      "[call original]",
+      "[call original - 1]",
       "[call myMockFn - 1]",
       "[call original]",
       "[1 - call callback]",


### PR DESCRIPTION
## Summary

- `withImplementation`: Accepts a function which should be temporarily used as the implementation of the mock while the callback is being executed.

```ts
test('test', () => {
  const mock = rstest.fn(() => 'outside callback');

  mock.withImplementation(
    () => 'inside callback',
    () => {
      mock(); // 'inside callback'
    },
  );

  mock(); // 'outside callback'
});
```


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
