### PR TITLE
feat: support mock returns

### DIFF
--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -1,12 +1,15 @@
-import { getInternalState, internalSpyOn } from 'tinyspy';
-import type { FunctionLike, Mock, MockFn } from '../../types';
+import { type SpyInternalImpl, getInternalState, internalSpyOn } from 'tinyspy';
+import type { FunctionLike, Mock, MockContext, MockFn } from '../../types';
 
 const wrapSpy = <T extends FunctionLike>(
   obj: Record<string, any>,
   methodName: string,
   mockFn?: T,
 ): Mock<T> => {
-  const spyImpl = internalSpyOn(obj, methodName, mockFn);
+  const spyImpl = internalSpyOn(obj, methodName, mockFn) as SpyInternalImpl<
+    Parameters<T>,
+    ReturnType<T>
+  >;
 
   const spyFn = spyImpl as unknown as Mock<T>;
 
@@ -76,6 +79,14 @@ const wrapSpy = <T extends FunctionLike>(
     return spyFn;
   };
 
+  spyFn.mockReturnValue = (value) => {
+    return spyFn.mockImplementation((() => value) as T);
+  };
+
+  spyFn.mockReturnValueOnce = (value) => {
+    return spyFn.mockImplementationOnce((() => value) as T);
+  };
+
   function willCall(this: unknown, ...args: any) {
     let impl = implementation;
     if (mockImplementationOnce.length) {
@@ -87,9 +98,16 @@ const wrapSpy = <T extends FunctionLike>(
   spyState.willCall(willCall);
 
   Object.defineProperty(spyFn, 'mock', {
-    get: () => ({
+    get: (): MockContext<T> => ({
       get calls() {
         return spyState.calls;
+      },
+      get results() {
+        return spyState.results.map(([resultType, value]) => {
+          const type =
+            resultType === 'error' ? ('throw' as const) : ('return' as const);
+          return { type: type, value };
+        });
       },
     }),
   });

--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -87,6 +87,22 @@ const wrapSpy = <T extends FunctionLike>(
     return spyFn.mockImplementationOnce((() => value) as T);
   };
 
+  spyFn.mockResolvedValue = (value) => {
+    return spyFn.mockImplementation((() => Promise.resolve(value)) as T);
+  };
+
+  spyFn.mockResolvedValueOnce = (value) => {
+    return spyFn.mockImplementationOnce((() => Promise.resolve(value)) as T);
+  };
+
+  spyFn.mockRejectedValue = (value) => {
+    return spyFn.mockImplementation((() => Promise.reject(value)) as T);
+  };
+
+  spyFn.mockRejectedValueOnce = (value) => {
+    return spyFn.mockImplementationOnce((() => Promise.reject(value)) as T);
+  };
+
   function willCall(this: unknown, ...args: any) {
     let impl = implementation;
     if (mockImplementationOnce.length) {

--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -103,6 +103,12 @@ const wrapSpy = <T extends FunctionLike>(
     return spyFn.mockImplementationOnce((() => Promise.reject(value)) as T);
   };
 
+  spyFn.mockReturnThis = () => {
+    return spyFn.mockImplementation(function (this: ReturnType<T>) {
+      return this;
+    } as T);
+  };
+
   function willCall(this: unknown, ...args: any) {
     let impl = implementation;
     if (mockImplementationOnce.length) {

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -1,24 +1,23 @@
 import type { FunctionLike } from './utils';
 
-// TODO
-// interface MockResultReturn<T> {
-//   type: 'return';
-//   /**
-//    * The value that was returned from the function. If function returned a Promise, then this will be a resolved value.
-//    */
-//   value: T;
-// }
-// interface MockResultIncomplete {
-//   type: 'incomplete';
-//   value: undefined;
-// }
-// interface MockResultThrow {
-//   type: 'throw';
-//   /**
-//    * An error that was thrown during function execution.
-//    */
-//   value: any;
-// }
+interface MockResultReturn<T> {
+  type: 'return';
+  /**
+   * The value that was returned from the function. If function returned a Promise, then this will be a resolved value.
+   */
+  value: T;
+}
+interface MockResultIncomplete {
+  type: 'incomplete';
+  value: undefined;
+}
+interface MockResultThrow {
+  type: 'throw';
+  /**
+   * An error that was thrown during function execution.
+   */
+  value: any;
+}
 // interface MockSettledResultFulfilled<T> {
 //   type: 'fulfilled';
 //   value: T;
@@ -36,10 +35,10 @@ import type { FunctionLike } from './utils';
 //   type: 'rejected';
 //   value: any;
 // }
-// type MockResult<T> =
-//   | MockResultReturn<T>
-//   | MockResultThrow
-//   | MockResultIncomplete;
+type MockResult<T> =
+  | MockResultReturn<T>
+  | MockResultThrow
+  | MockResultIncomplete;
 // type MockSettledResult<T> =
 //   | MockSettledResultFulfilled<T>
 //   | MockSettledResultRejected;
@@ -70,7 +69,7 @@ export type MockContext<T extends FunctionLike = FunctionLike> = {
   /**
    * List of the results of all calls that have been made to the mock.
    */
-  // results: Array<MockResult<ReturnType<T>>>;
+  results: Array<MockResult<ReturnType<T>>>;
 
   /**
    * List of the results of all values that were `resolved` or `rejected` from the function.
@@ -94,8 +93,8 @@ export interface MockInstance<T extends FunctionLike = FunctionLike> {
     callback: () => T2,
   ): T2 extends Promise<unknown> ? Promise<void> : void;
   // mockReturnThis(): this;
-  // mockReturnValue(value: ReturnType<T>): this;
-  // mockReturnValueOnce(value: ReturnType<T>): this;
+  mockReturnValue(value: ReturnType<T>): this;
+  mockReturnValueOnce(value: ReturnType<T>): this;
   // mockResolvedValue(value: Awaited<ReturnType<T>>): this;
   // mockResolvedValueOnce(value: Awaited<ReturnType<T>>): this;
   // mockRejectedValue(error: unknown): this;

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -92,7 +92,7 @@ export interface MockInstance<T extends FunctionLike = FunctionLike> {
     fn: T,
     callback: () => T2,
   ): T2 extends Promise<unknown> ? Promise<void> : void;
-  // mockReturnThis(): this;
+  mockReturnThis(): this;
   mockReturnValue(value: ReturnType<T>): this;
   mockReturnValueOnce(value: ReturnType<T>): this;
   mockResolvedValue(value: Awaited<ReturnType<T>>): this;

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -95,10 +95,10 @@ export interface MockInstance<T extends FunctionLike = FunctionLike> {
   // mockReturnThis(): this;
   mockReturnValue(value: ReturnType<T>): this;
   mockReturnValueOnce(value: ReturnType<T>): this;
-  // mockResolvedValue(value: Awaited<ReturnType<T>>): this;
-  // mockResolvedValueOnce(value: Awaited<ReturnType<T>>): this;
-  // mockRejectedValue(error: unknown): this;
-  // mockRejectedValueOnce(error: unknown): this;
+  mockResolvedValue(value: Awaited<ReturnType<T>>): this;
+  mockResolvedValueOnce(value: Awaited<ReturnType<T>>): this;
+  mockRejectedValue(error: unknown): this;
+  mockRejectedValueOnce(error: unknown): this;
 }
 
 export interface Mock<T extends FunctionLike = FunctionLike>

--- a/tests/spy/index.test.ts
+++ b/tests/spy/index.test.ts
@@ -157,4 +157,15 @@ describe('test spy', () => {
     await expect(sayHi()).rejects.toThrowError('hello');
     await expect(sayHi()).rejects.toThrowError('hi');
   });
+
+  it('rstest.fn -> mock return this', () => {
+    const sayHi = rstest.fn(function mockFn(this: any) {
+      return `hi ${this?.name}`;
+    });
+
+    expect(sayHi.call({ name: 'bob' })).toBe('hi bob');
+
+    sayHi.mockReturnThis();
+    expect(sayHi.call({ name: 'bob' })).toEqual({ name: 'bob' });
+  });
 });

--- a/tests/spy/index.test.ts
+++ b/tests/spy/index.test.ts
@@ -138,4 +138,23 @@ describe('test spy', () => {
 
     expect(sayHi()).toBeUndefined();
   });
+
+  it('rstest.fn -> mock async returns', async () => {
+    const sayHi = rstest.fn(() => Promise.resolve(''));
+
+    await expect(sayHi()).resolves.toBe('');
+
+    sayHi.mockResolvedValue('hi').mockResolvedValueOnce('hello');
+
+    await expect(sayHi()).resolves.toBe('hello');
+
+    await expect(sayHi()).resolves.toBe('hi');
+
+    sayHi
+      .mockRejectedValue(new Error('hi'))
+      .mockRejectedValueOnce(new Error('hello'));
+
+    await expect(sayHi()).rejects.toThrowError('hello');
+    await expect(sayHi()).rejects.toThrowError('hi');
+  });
 });

--- a/tests/spy/index.test.ts
+++ b/tests/spy/index.test.ts
@@ -24,6 +24,12 @@ describe('test spy', () => {
     expect(res).toBe('hi bob');
 
     expect(sayHi.mock.calls).toEqual([['bob']]);
+    expect(sayHi.mock.results).toEqual([
+      {
+        type: 'return',
+        value: 'hi bob',
+      },
+    ]);
 
     expect(sayHi).toHaveBeenCalledTimes(1);
     expect(sayHi).toHaveBeenCalledWith('bob');
@@ -103,5 +109,33 @@ describe('test spy', () => {
 
     expect(sayHi.getMockName()).toBe('sayHiFn');
     expect(sayHello.getMockName()).toBe('rstest.fn()');
+  });
+
+  it('rstest.fn -> mock returns', () => {
+    const sayHi = rstest.fn();
+
+    const res = sayHi('bob');
+
+    expect(res).toBeUndefined();
+
+    expect(sayHi).toHaveReturned();
+
+    expect(sayHi.getMockImplementation()).toBeUndefined();
+
+    sayHi.mockReturnValue('hi').mockReturnValueOnce('hello');
+
+    expect(sayHi.getMockImplementation()).toBeDefined();
+
+    expect(sayHi()).toBe('hello');
+
+    expect(sayHi()).toBe('hi');
+
+    expect(sayHi()).toBe('hi');
+
+    expect(sayHi).toHaveBeenCalledTimes(4);
+
+    sayHi.mockReset();
+
+    expect(sayHi()).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- `mockReturnValue`: Accepts a value that will be returned whenever the mock function is called.
- `mockReturnValueOnce`: Accepts a value that will be returned for one call to the mock function. 
- `mockResolvedValue`: Accepts a value that will be resolved when the async function is called. 
- `mockResolvedValueOnce`: Accepts a value that will be resolved during the next function call. 
- `mockRejectedValue`: Accepts an error that will be rejected when async function is called.
- `mockRejectedValueOnce`: Accepts a value that will be rejected during the next function call. 
- `mockReturnThis`: Accepts a value that will be returned whenever the mock function is called.

```ts
   const sayHi = rstest.fn();

    sayHi.mockReturnValue('hi').mockReturnValueOnce('hello');

    expect(sayHi()).toBe('hello');

    expect(sayHi()).toBe('hi');

    expect(sayHi()).toBe('hi');

```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
