### PR TITLE
feat: support read mock context

### DIFF
--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -19,7 +19,7 @@ export const formatTestError = (err: any): TestError[] => {
         error.expected !== undefined &&
         error.actual !== undefined)
     ) {
-      errObj.diff = diff(err.actual, err.expected)!;
+      errObj.diff = diff(err.expected, err.actual)!;
     }
 
     for (const key of ['actual', 'expected'] as const) {

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -18,30 +18,33 @@ interface MockResultThrow {
    */
   value: any;
 }
-// interface MockSettledResultFulfilled<T> {
-//   type: 'fulfilled';
-//   value: T;
-// }
-// interface MockSettledResultRejected {
-//   type: 'rejected';
-//   value: any;
-// }
 
-// interface MockSettledResultFulfilled<T> {
-//   type: 'fulfilled';
-//   value: T;
-// }
-// interface MockSettledResultRejected {
-//   type: 'rejected';
-//   value: any;
-// }
 type MockResult<T> =
   | MockResultReturn<T>
   | MockResultThrow
   | MockResultIncomplete;
-// type MockSettledResult<T> =
-//   | MockSettledResultFulfilled<T>
-//   | MockSettledResultRejected;
+
+interface MockSettledResultFulfilled<T> {
+  type: 'fulfilled';
+  value: T;
+}
+interface MockSettledResultRejected {
+  type: 'rejected';
+  value: any;
+}
+
+interface MockSettledResultFulfilled<T> {
+  type: 'fulfilled';
+  value: T;
+}
+interface MockSettledResultRejected {
+  type: 'rejected';
+  value: any;
+}
+
+type MockSettledResult<T> =
+  | MockSettledResultFulfilled<T>
+  | MockSettledResultRejected;
 
 export type MockContext<T extends FunctionLike = FunctionLike> = {
   /**
@@ -51,21 +54,22 @@ export type MockContext<T extends FunctionLike = FunctionLike> = {
   /**
    * List of all the object instances that have been instantiated from the mock.
    */
-  // instances: Array<ReturnType<T>>;
+  instances: Array<ReturnType<T>>;
   /**
    * List of all the function contexts that have been applied to calls to the mock.
    */
-  // contexts: Array<ThisParameterType<T>>;
+  contexts: Array<ThisParameterType<T>>;
   /**
-   * List of the call order indexes of the mock. Jest is indexing the order of
-   * invocations of all mocks in a test file. The index is starting with `1`.
+   * The order of mock's execution.
+   * This returns an array of numbers which are shared between all defined mocks.
+   * The index is starting with `1`.
    */
-  // invocationCallOrder: Array<number>;
+  invocationCallOrder: Array<number>;
   /**
    * List of the call arguments of the last call that was made to the mock.
    * If the function was not called, it will return `undefined`.
    */
-  // lastCall?: Parameters<T>;
+  lastCall: Parameters<T> | undefined;
   /**
    * List of the results of all calls that have been made to the mock.
    */
@@ -74,7 +78,7 @@ export type MockContext<T extends FunctionLike = FunctionLike> = {
   /**
    * List of the results of all values that were `resolved` or `rejected` from the function.
    */
-  // settledResults: MockSettledResult<Awaited<ReturnType<T>>>[];
+  settledResults: MockSettledResult<Awaited<ReturnType<T>>>[];
 };
 
 export interface MockInstance<T extends FunctionLike = FunctionLike> {

--- a/tests/diff/index.test.ts
+++ b/tests/diff/index.test.ts
@@ -27,13 +27,13 @@ describe('diff', () => {
       .filter(Boolean);
 
     // should diff object correctly
-    expect(logs.find((log) => log.includes('-"b":2,'))).toBeDefined();
-    expect(logs.find((log) => log.includes('+"b":3,'))).toBeDefined();
-    expect(logs.find((log) => log.includes('-"cA":1,'))).toBeDefined();
-    expect(logs.find((log) => log.includes('+"cA":3,'))).toBeDefined();
+    expect(logs.find((log) => log.includes('-"b":3,'))).toBeDefined();
+    expect(logs.find((log) => log.includes('+"b":2,'))).toBeDefined();
+    expect(logs.find((log) => log.includes('-"cA":3,'))).toBeDefined();
+    expect(logs.find((log) => log.includes('+"cA":1,'))).toBeDefined();
 
     // should diff string correctly
-    expect(logs.find((log) => log.includes('-hi'))).toBeDefined();
-    expect(logs.find((log) => log.includes('+hii'))).toBeDefined();
+    expect(logs.find((log) => log.includes('-hii'))).toBeDefined();
+    expect(logs.find((log) => log.includes('+hi'))).toBeDefined();
   });
 });

--- a/tests/spy/index.test.ts
+++ b/tests/spy/index.test.ts
@@ -15,7 +15,7 @@ describe('test spy', () => {
     expect(sayHi.getMockName()).toBe('sayHi');
   });
 
-  it('rstest.fn -> mock context', () => {
+  it('rstest.fn -> mock properties', () => {
     const sayHi = rstest.fn((name: string) => `hi ${name}`);
     const sayHello = rstest.fn((name: string) => `hello ${name}`);
 
@@ -24,6 +24,8 @@ describe('test spy', () => {
     expect(res).toBe('hi bob');
 
     expect(sayHi.mock.calls).toEqual([['bob']]);
+    expect(sayHi.mock.lastCall).toEqual(['bob']);
+
     expect(sayHi.mock.results).toEqual([
       {
         type: 'return',
@@ -38,6 +40,30 @@ describe('test spy', () => {
     sayHi('Tom');
     expect(sayHi).toHaveBeenLastCalledWith('Tom');
     expect(sayHi).toHaveBeenCalledTimes(2);
+  });
+
+  it('rstest.fn -> mock.instance', () => {
+    const MyClass = rstest.fn();
+    const a = new MyClass();
+    const b = new MyClass();
+    expect(MyClass.mock.instances).toEqual([a, b]);
+  });
+
+  it('rstest.fn -> mock.contexts', () => {
+    const sayHi = rstest.fn(function mockFn(this: any) {
+      return `hi ${this?.name || ''}`;
+    });
+
+    expect(sayHi()).toBe('hi ');
+    expect(sayHi.call({ name: 'bob' })).toBe('hi bob');
+
+    expect(sayHi.call({ name: 'tom' })).toBe('hi tom');
+
+    expect(sayHi.mock.contexts).toEqual([
+      undefined,
+      { name: 'bob' },
+      { name: 'tom' },
+    ]);
   });
 
   it('rstest.fn -> mockImplementation', () => {

--- a/tests/spy/invocationCallOrder.test.ts
+++ b/tests/spy/invocationCallOrder.test.ts
@@ -1,0 +1,13 @@
+import { expect, it, rstest } from '@rstest/core';
+
+it('rstest.fn -> mock.invocationCallOrder', () => {
+  const sayHi = rstest.fn();
+  const sayHello = rstest.fn();
+
+  sayHi();
+  sayHello();
+  sayHi();
+
+  expect(sayHi.mock.invocationCallOrder).toEqual([1, 3]);
+  expect(sayHello.mock.invocationCallOrder).toEqual([2]);
+});


### PR DESCRIPTION
## Summary

* Added `lastCall`, `instances`, `contexts`, `settledResults` and `invocationCallOrder` properties to track detailed mock call information.
* Fixed the order of arguments in the `diff` function for error formatting, ensuring correct expected/actual comparison.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
