### PR TITLE
feat: support `rstest.spyOn`

### DIFF
--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -1,6 +1,7 @@
 import type { RstestUtilities } from '../../types';
-import { fn } from './spy';
+import { fn, spyOn } from './spy';
 
 export const rstest: RstestUtilities = {
   fn,
+  spyOn,
 };

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -114,5 +114,16 @@ export interface Mock<T extends FunctionLike = FunctionLike>
 export type MockFn = <T extends FunctionLike = FunctionLike>(fn?: T) => Mock<T>;
 
 export type RstestUtilities = {
+  /**
+   * Creates a spy on a function.
+   */
   fn: MockFn;
+  /**
+   * Creates a spy on a method of an object
+   */
+  spyOn: <T extends Record<string, any>, K extends keyof T>(
+    obj: T,
+    methodName: K,
+    accessType?: 'get' | 'set',
+  ) => MockInstance<T[K]>;
 };

--- a/tests/spy/spyOn.test.ts
+++ b/tests/spy/spyOn.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, rstest } from '@rstest/core';
+
+describe('test spyOn', () => {
+  it('spyOn', () => {
+    const sayHi = () => 'hi';
+    const hi = {
+      sayHi,
+    };
+    const spy = rstest.spyOn(hi, 'sayHi');
+
+    expect(hi.sayHi()).toBe('hi');
+
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockImplementation(() => 'hello');
+
+    expect(hi.sayHi()).toBe('hello');
+
+    spy.mockRestore();
+
+    expect(hi.sayHi()).toBe('hi');
+
+    expect(hi.sayHi).toEqual(sayHi);
+
+    spy.mockImplementation(() => 'mocked');
+
+    expect(hi.sayHi()).toBe('hi');
+  });
+});


### PR DESCRIPTION
## Summary

Support create a spy on a method of an object via   `rstest.spyOn`.

```ts
    const hi = {
      sayHi:  () => 'hi',
    };
    const spy = rstest.spyOn(hi, 'sayHi');

    spy.mockImplementation(() => 'hello');

    expect(hi.sayHi()).toBe('hello');

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
