### PR TITLE
chore: init mock api

### DIFF
--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -4,4 +4,7 @@ import { fn, spyOn } from './spy';
 export const rstest: RstestUtilities = {
   fn,
   spyOn,
+  mock: () => {
+    // TODO
+  },
 };

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -126,4 +126,9 @@ export type RstestUtilities = {
     methodName: K,
     accessType?: 'get' | 'set',
   ) => MockInstance<T[K]>;
+
+  /**
+   * WIP: Mock a module
+   */
+  mock: <T = unknown>(moduleName: string, moduleFactory?: () => T) => void;
 };

--- a/tests/mock/src/b.ts
+++ b/tests/mock/src/b.ts
@@ -1,0 +1,1 @@
+export const b = 2;

--- a/tests/mock/src/index.ts
+++ b/tests/mock/src/index.ts
@@ -1,0 +1,2 @@
+export { b } from './b';
+export const a = 1;

--- a/tests/mock/tests/index.test.ts
+++ b/tests/mock/tests/index.test.ts
@@ -1,0 +1,12 @@
+import { expect, it, rstest } from '@rstest/core';
+
+rstest.mock('../src/b', () => {
+  return {
+    b: 3,
+  };
+});
+
+it.todo('should mock relative path module correctly', async () => {
+  const { b } = await import('../src/index');
+  expect(b).toBe(3);
+});


### PR DESCRIPTION
## Summary

This PR is used to initialize the mock API and does not include the implementation of the mock API.

```ts
rstest.mock('../src/b', () => {
  return {
    b: 3,
  };
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
