### PR TITLE
feat: support clearAllMocks / resetAllMocks / restoreAllMocks

### DIFF
--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -9,6 +9,8 @@ import type {
 
 let callOrder = 0;
 
+export const mocks: Set<MockInstance> = new Set();
+
 const wrapSpy = <T extends FunctionLike>(
   obj: Record<string, any>,
   methodName: string,
@@ -189,6 +191,8 @@ const wrapSpy = <T extends FunctionLike>(
     spyState.restore();
     mockName = mockFn?.name;
   };
+
+  mocks.add(spyFn);
 
   return spyFn;
 };

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -1,7 +1,25 @@
 import type { RstestUtilities } from '../../types';
-import { fn, spyOn } from './spy';
+import { fn, mocks, spyOn } from './spy';
 
 export const rstest: RstestUtilities = {
   fn,
   spyOn,
+  clearAllMocks: () => {
+    for (const mock of mocks) {
+      mock.mockClear();
+    }
+    return rstest;
+  },
+  resetAllMocks: () => {
+    for (const mock of mocks) {
+      mock.mockReset();
+    }
+    return rstest;
+  },
+  restoreAllMocks: () => {
+    for (const mock of mocks) {
+      mock.mockRestore();
+    }
+    return rstest;
+  },
 };

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -126,4 +126,17 @@ export type RstestUtilities = {
     methodName: K,
     accessType?: 'get' | 'set',
   ) => MockInstance<T[K]>;
+
+  /**
+   * Calls .mockClear() on all spies.
+   */
+  clearAllMocks: () => RstestUtilities;
+  /**
+   * Calls .mockReset() on all spies.
+   */
+  resetAllMocks: () => RstestUtilities;
+  /**
+   * Calls .mockReset() on all spies.
+   */
+  restoreAllMocks: () => RstestUtilities;
 };

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -128,15 +128,15 @@ export type RstestUtilities = {
   ) => MockInstance<T[K]>;
 
   /**
-   * Calls .mockClear() on all spies.
+   * Calls `.mockClear()` on all spies.
    */
   clearAllMocks: () => RstestUtilities;
   /**
-   * Calls .mockReset() on all spies.
+   * Calls `.mockReset()` on all spies.
    */
   resetAllMocks: () => RstestUtilities;
   /**
-   * Calls .mockReset() on all spies.
+   * Calls `.mockReset()` on all spies.
    */
   restoreAllMocks: () => RstestUtilities;
 };

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -136,7 +136,7 @@ export type RstestUtilities = {
    */
   resetAllMocks: () => RstestUtilities;
   /**
-   * Calls `.mockReset()` on all spies.
+   * Calls `.mockRestore()` on all spies.
    */
   restoreAllMocks: () => RstestUtilities;
 };

--- a/tests/spy/clearAllMocks.test.ts
+++ b/tests/spy/clearAllMocks.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, rstest } from '@rstest/core';
+
+describe('clearAllMocks', () => {
+  const sayHi = rstest.fn();
+
+  afterEach(() => {
+    rstest.clearAllMocks();
+  });
+  it('spy', () => {
+    sayHi.mockImplementation(() => 'hi');
+
+    expect(sayHi('bob')).toBe('hi');
+
+    expect(sayHi).toHaveBeenCalledTimes(1);
+  });
+
+  it('spy - 1', () => {
+    sayHi.mockImplementation(() => 'hello');
+
+    expect(sayHi('bob')).toBe('hello');
+
+    expect(sayHi).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `clearAllMocks`: Calls `.mockClear()` on all spies.
- `resetAllMocks`: Calls `.mockReset()` on all spies.
- `restoreAllMocks`: Calls `.mockRestore()` on all spies.

```ts
describe('clearAllMocks', () => {
  const sayHi = rstest.fn();

  afterEach(() => {
    rstest.clearAllMocks();
  });

  it('spy', () => {
    sayHi.mockImplementation(() => 'hi');

    expect(sayHi('bob')).toBe('hi');

    expect(sayHi).toHaveBeenCalledTimes(1);
  });

  it('spy - 1', () => {
    sayHi.mockImplementation(() => 'hello');

    expect(sayHi('bob')).toBe('hello');

    expect(sayHi).toHaveBeenCalledTimes(1);
  });
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
