### PR TITLE
feat: support `rstest.isMockFunction`

### DIFF
--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -225,3 +225,6 @@ export const spyOn = <T extends Record<string, any>, K extends keyof T>(
 
   return wrapSpy(obj, method as string);
 };
+
+export const isMockFunction = (fn: any): fn is MockInstance =>
+  typeof fn === 'function' && '_isMockFunction' in fn && fn._isMockFunction;

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -1,9 +1,10 @@
 import type { RstestUtilities } from '../../types';
-import { fn, mocks, spyOn } from './spy';
+import { fn, isMockFunction, mocks, spyOn } from './spy';
 
 export const rstest: RstestUtilities = {
   fn,
   spyOn,
+  isMockFunction,
   clearAllMocks: () => {
     for (const mock of mocks) {
       mock.mockClear();

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -128,6 +128,11 @@ export type RstestUtilities = {
   ) => MockInstance<T[K]>;
 
   /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction: (fn: any) => fn is MockInstance;
+
+  /**
    * Calls `.mockClear()` on all spies.
    */
   clearAllMocks: () => RstestUtilities;

--- a/tests/spy/index.test.ts
+++ b/tests/spy/index.test.ts
@@ -90,6 +90,12 @@ describe('test spy', () => {
     expect(sayHi).toHaveBeenCalledTimes(4);
   });
 
+  it('isMockFunction', () => {
+    const sayHi = rstest.fn();
+    expect(rstest.isMockFunction(sayHi)).toBeTruthy();
+    expect(rstest.isMockFunction(() => {})).toBeFalsy();
+  });
+
   it('rstest.fn -> mock clear / reset / restore', () => {
     const sayHi = rstest.fn(function sayHiFn(name: string) {
       return `hi ${name}`;

--- a/tests/spy/spyOn.test.ts
+++ b/tests/spy/spyOn.test.ts
@@ -26,4 +26,17 @@ describe('test spyOn', () => {
 
     expect(hi.sayHi()).toBe('hi');
   });
+
+  it('isMockFunction', () => {
+    const hi = {
+      sayHi: () => 'hi',
+    };
+    const spy = rstest.spyOn(hi, 'sayHi');
+
+    expect(rstest.isMockFunction(spy)).toBeTruthy();
+    expect(rstest.isMockFunction(hi.sayHi)).toBeTruthy();
+
+    spy.mockRestore();
+    expect(rstest.isMockFunction(hi.sayHi)).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Summary

- `isMockFunction`: Determines if the given function is a mocked function.

```ts
    const sayHi = rstest.fn();
    expect(rstest.isMockFunction(sayHi)).toBeTruthy();
    expect(rstest.isMockFunction(() => {})).toBeFalsy();
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
