### PR TITLE
fix: should throw error when use `toMatchInlineSnapshot` in `test.each`

### DIFF
--- a/packages/core/src/runtime/api/snapshot.ts
+++ b/packages/core/src/runtime/api/snapshot.ts
@@ -224,13 +224,14 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
         throw new Error('toMatchInlineSnapshot cannot be used with "not"');
       }
       const test = getTest('toMatchInlineSnapshot', this);
-      // TODO
-      //   const isInsideEach = test.each || test.suite?.each;
-      //   if (isInsideEach) {
-      //     throw new Error(
-      //       'InlineSnapshot cannot be used inside of test.each or describe.each',
-      //     );
-      //   }
+
+      const isInsideEach = test.each || test.inTestEach;
+      if (isInsideEach) {
+        throw new Error(
+          'InlineSnapshot cannot be used inside of test.each or describe.each',
+        );
+      }
+
       const expected = utils.flag(this, 'object');
       const error = utils.flag(this, 'error');
       if (typeof properties === 'string') {

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -190,12 +190,14 @@ export class RunnerRuntime {
     name: string,
     fn?: () => MaybePromise<void>,
     runMode: TestRunMode = 'run',
+    each = false,
   ): void {
     const currentSuite: TestSuite = {
       name,
       runMode,
       tests: [],
       type: 'suite',
+      each,
     };
 
     if (!fn) {
@@ -228,6 +230,10 @@ export class RunnerRuntime {
       this.tests.push(test);
     } else {
       const current = this._currentTest[this._currentTest.length - 1]!;
+
+      if (current.each || current.inTestEach) {
+        test.inTestEach = true;
+      }
 
       if (current.type === 'case') {
         throw new Error(
@@ -291,6 +297,7 @@ export class RunnerRuntime {
     fn?: () => void | Promise<void>,
     timeout: number = this.defaultTestTimeout,
     runMode: TestRunMode = 'run',
+    each = false,
   ): void {
     this.addTestCase({
       name,
@@ -305,6 +312,7 @@ export class RunnerRuntime {
       runMode,
       type: 'case',
       timeout,
+      each,
     });
   }
 
@@ -319,7 +327,7 @@ export class RunnerRuntime {
         const param = cases[i]!;
         // TODO: support test name template
         // TODO: support param array ([[a, b, expected, actual]])
-        this.it(name, () => fn?.(param), timeout, 'run');
+        this.it(name, () => fn?.(param), timeout, 'run', true);
       }
     };
   }

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -29,6 +29,8 @@ export type TestCase = {
   runMode: TestRunMode;
   timeout?: number;
   fails?: boolean;
+  each?: boolean;
+  inTestEach?: boolean;
   // TODO
   only?: boolean;
   // TODO
@@ -61,6 +63,8 @@ export type TestSuite = {
   name: string;
   parentNames?: string[];
   runMode: TestRunMode;
+  each?: boolean;
+  inTestEach?: boolean;
   // TODO
   filepath?: string;
   /** nested cases and suite could in a suite */

--- a/tests/snapshot/fixtures/inlineSnapshot.each.test.ts
+++ b/tests/snapshot/fixtures/inlineSnapshot.each.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('test ineSnapshot in each', () => {
+  it.each([
+    { a: 1, b: 1 },
+    { a: 1, b: 2 },
+    { a: 2, b: 1 },
+  ])('add two numbers correctly', ({ a, b }) => {
+    expect(a + b).toMatchInlineSnapshot();
+  });
+});

--- a/tests/snapshot/fixtures/inlineSnapshot.each.test.ts
+++ b/tests/snapshot/fixtures/inlineSnapshot.each.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 
-describe('test ineSnapshot in each', () => {
+describe('test inlineSnapshot in each', () => {
   it.each([
     { a: 1, b: 1 },
     { a: 1, b: 2 },

--- a/tests/snapshot/index.test.ts
+++ b/tests/snapshot/index.test.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
 import { createSnapshotSerializer } from 'path-serializer';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 describe('test snapshot', () => {
   it('test toMatchInlineSnapshot API', () => {
@@ -22,5 +28,32 @@ describe('test snapshot', () => {
     expect(__filename).toMatchInlineSnapshot(
       `"<WORKSPACE>/snapshot/index.test.ts"`,
     );
+  });
+
+  it('should failed when use inline snapshot in each', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/inlineSnapshot.each.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) =>
+        log.includes(
+          'InlineSnapshot cannot be used inside of test.each or describe.each',
+        ),
+      ),
+    ).toBeTruthy();
+
+    expect(logs.find((log) => log.includes('Tests 3 failed'))).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

should throw error when use `toMatchInlineSnapshot` in `test.each`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
