### PR TITLE
feat: support `describe.each` API

### DIFF
--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -42,6 +42,7 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   describe.only = (name, fn) => runtimeAPI.describe(name, fn, 'only');
   describe.todo = (name, fn) => runtimeAPI.describe(name, fn, 'todo');
   describe.skip = (name, fn) => runtimeAPI.describe(name, fn, 'skip');
+  describe.each = runtimeAPI.describeEach.bind(runtimeAPI);
 
   return {
     api: {

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -324,7 +324,7 @@ export class RunnerRuntime {
         const param = cases[i]!;
         // TODO: support test name template
         // TODO: support param array ([[a, b, expected, actual]])
-        this.describe(name, () => fn?.(param));
+        this.describe(name, () => fn?.(param), 'run', true);
       }
     };
   }

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -4,6 +4,7 @@ import type {
   AfterEachListener,
   BeforeAllListener,
   BeforeEachListener,
+  DescribeEachFn,
   Test,
   TestCase,
   TestEachFn,
@@ -306,6 +307,18 @@ export class RunnerRuntime {
       type: 'case',
       timeout,
     });
+  }
+
+  describeEach<T>(cases: T[]): DescribeEachFn<T> {
+    return (name: string, fn?: (param: T) => void | Promise<void>) => {
+      for (let i = 0; i < cases.length; i++) {
+        // TODO: template string table.
+        const param = cases[i]!;
+        // TODO: support test name template
+        // TODO: support param array ([[a, b, expected, actual]])
+        this.describe(name, () => fn?.(param));
+      }
+    };
   }
 
   each<T>(cases: T[]): TestEachFn<T> {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -29,11 +29,16 @@ export type TestAPI = TestFn & {
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;
+export type DescribeEachFn<T> = (
+  description: string,
+  fn?: (param: T) => void,
+) => void;
 
 export type DescribeAPI = DescribeFn & {
   only: DescribeFn;
   todo: DescribeFn;
   skip: DescribeFn;
+  each: <T>(cases: T[]) => DescribeEachFn<T>;
 };
 
 export type RunnerAPI = {

--- a/tests/describe/each.test.ts
+++ b/tests/describe/each.test.ts
@@ -1,0 +1,25 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+it('Describe Each API', async () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/each.test.ts'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(0);
+
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expect(logs.find((log) => log.includes('Tests 3 passed'))).toBeTruthy();
+});

--- a/tests/describe/fixtures/each.test.ts
+++ b/tests/describe/fixtures/each.test.ts
@@ -1,21 +1,11 @@
 import { describe, expect, it } from '@rstest/core';
 
-describe('test inlineSnapshot in each', () => {
-  it.each([
-    { a: 1, b: 1 },
-    { a: 1, b: 2 },
-    { a: 2, b: 1 },
-  ])('add two numbers correctly', ({ a, b }) => {
-    expect(a + b).toMatchInlineSnapshot();
-  });
-});
-
 describe.each([
   { a: 1, b: 1, expected: 2 },
   { a: 1, b: 2, expected: 3 },
   { a: 2, b: 1, expected: 3 },
 ])('add two numbers correctly', ({ a, b, expected }) => {
   it(`should return ${expected}`, () => {
-    expect(a + b).toMatchInlineSnapshot();
+    expect(a + b).toBe(expected);
   });
 });

--- a/tests/snapshot/index.test.ts
+++ b/tests/snapshot/index.test.ts
@@ -54,6 +54,6 @@ describe('test snapshot', () => {
       ),
     ).toBeTruthy();
 
-    expect(logs.find((log) => log.includes('Tests 3 failed'))).toBeTruthy();
+    expect(logs.find((log) => log.includes('Tests 6 failed'))).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Support `describe.each` API:

```ts
describe.each([
  { a: 1, b: 1, expected: 2 },
  { a: 1, b: 2, expected: 3 },
  { a: 2, b: 1, expected: 3 },
])('add two numbers correctly', ({ a, b, expected }) => {
  it(`should return ${expected}`, () => {
    expect(a + b).toBe(expected);
  });
});

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
