### PR TITLE
test: use `expectFile` instead of `waitFile`

### DIFF
--- a/tests/scripts/utils.ts
+++ b/tests/scripts/utils.ts
@@ -1,20 +1,12 @@
 import fs from 'node:fs';
+import { expect } from '@rstest/core';
 
-export const waitFile = async (filePath: string, timeout = 3000) => {
-  return new Promise((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (fs.existsSync(filePath)) {
-        clearInterval(interval);
-        resolve(true);
-      }
-    }, 100);
-
-    setTimeout(() => {
-      clearInterval(interval);
-      reject(new Error(`File ${filePath} not found within ${timeout}ms`));
-    }, timeout);
-  });
-};
+export const expectFile = (filePath: string, timeout = 3000) =>
+  expect
+    .poll(() => fs.existsSync(filePath), {
+      timeout,
+    })
+    .toBeTruthy();
 
 export const sleep = (ms: number) => {
   return new Promise<void>((resolve) => {

--- a/tests/snapshot/file.test.ts
+++ b/tests/snapshot/file.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
-import { runRstestCli, waitFile } from '../scripts';
+import { expectFile, runRstestCli } from '../scripts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -28,7 +28,7 @@ describe('test snapshot', () => {
       },
     });
 
-    await waitFile(snapshotFilePath, 3000);
+    await expectFile(snapshotFilePath, 3000);
     expect(fs.existsSync(snapshotFilePath)).toBeTruthy();
 
     const content = fs.readFileSync(snapshotFilePath, 'utf-8');


### PR DESCRIPTION
## Summary

use `expectFile` instead of `waitFile`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
