### PR TITLE
feat: support array type cases in test `each` API

### DIFF
--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -1,8 +1,10 @@
 import type {
   DescribeAPI,
+  DescribeEachFn,
   RunnerAPI,
   RunnerHooks,
   TestAPI,
+  TestEachFn,
   TestFileResult,
   WorkerState,
 } from '../../types';
@@ -36,13 +38,13 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   it.todo = (name, fn, timeout) => runtimeAPI.it(name, fn, timeout, 'todo');
   it.skip = (name, fn, timeout) => runtimeAPI.it(name, fn, timeout, 'skip');
   it.only = (name, fn, timeout) => runtimeAPI.it(name, fn, timeout, 'only');
-  it.each = runtimeAPI.each.bind(runtimeAPI);
+  it.each = runtimeAPI.each.bind(runtimeAPI) as TestEachFn;
 
   const describe = ((name, fn) => runtimeAPI.describe(name, fn)) as DescribeAPI;
   describe.only = (name, fn) => runtimeAPI.describe(name, fn, 'only');
   describe.todo = (name, fn) => runtimeAPI.describe(name, fn, 'todo');
   describe.skip = (name, fn) => runtimeAPI.describe(name, fn, 'skip');
-  describe.each = runtimeAPI.describeEach.bind(runtimeAPI);
+  describe.each = runtimeAPI.describeEach.bind(runtimeAPI) as DescribeEachFn;
 
   return {
     api: {

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -13,6 +13,7 @@ import type {
   TestSuiteListeners,
 } from '../../types';
 import { ROOT_SUITE_NAME, castArray } from '../../utils';
+import { formatTitle } from '../util';
 
 type ListenersKey<T extends TestSuiteListeners> =
   T extends `${infer U}Listeners` ? U : never;
@@ -326,7 +327,12 @@ export class RunnerRuntime {
         const param = cases[i]!;
         const params = castArray(param) as Parameters<typeof fn>;
         // TODO: support test name template
-        this.describe(name, () => fn?.(...params), 'run', true);
+        this.describe(
+          formatTitle(name, param, i),
+          () => fn?.(...params),
+          'run',
+          true,
+        );
       }
     };
   }
@@ -338,7 +344,13 @@ export class RunnerRuntime {
         const param = cases[i]!;
         const params = castArray(param) as Parameters<typeof fn>;
         // TODO: support test name template
-        this.it(name, () => fn?.(...params), timeout, 'run', true);
+        this.it(
+          formatTitle(name, param, i),
+          () => fn?.(...params),
+          timeout,
+          'run',
+          true,
+        );
       }
     };
   }

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -12,7 +12,7 @@ import type {
   TestSuite,
   TestSuiteListeners,
 } from '../../types';
-import { ROOT_SUITE_NAME } from '../../utils';
+import { ROOT_SUITE_NAME, castArray } from '../../utils';
 
 type ListenersKey<T extends TestSuiteListeners> =
   T extends `${infer U}Listeners` ? U : never;
@@ -317,30 +317,28 @@ export class RunnerRuntime {
     });
   }
 
-  describeEach<T>(cases: T[]): DescribeEachFn<T> {
-    return (name: string, fn?: (param: T) => void | Promise<void>) => {
+  describeEach(
+    cases: Parameters<DescribeEachFn>[0],
+  ): ReturnType<DescribeEachFn> {
+    return (name: string, fn) => {
       for (let i = 0; i < cases.length; i++) {
         // TODO: template string table.
         const param = cases[i]!;
+        const params = castArray(param) as Parameters<typeof fn>;
         // TODO: support test name template
-        // TODO: support param array ([[a, b, expected, actual]])
-        this.describe(name, () => fn?.(param), 'run', true);
+        this.describe(name, () => fn?.(...params), 'run', true);
       }
     };
   }
 
-  each<T>(cases: T[]): TestEachFn<T> {
-    return (
-      name: string,
-      fn?: (param: T) => void | Promise<void>,
-      timeout: number = this.defaultTestTimeout,
-    ) => {
+  each(cases: Parameters<TestEachFn>[0]): ReturnType<TestEachFn> {
+    return (name, fn, timeout = this.defaultTestTimeout) => {
       for (let i = 0; i < cases.length; i++) {
         // TODO: template string table.
         const param = cases[i]!;
+        const params = castArray(param) as Parameters<typeof fn>;
         // TODO: support test name template
-        // TODO: support param array ([[a, b, expected, actual]])
-        this.it(name, () => fn?.(param), timeout, 'run', true);
+        this.it(name, () => fn?.(...params), timeout, 'run', true);
       }
     };
   }

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -13,7 +13,7 @@ import type {
   TestSuiteListeners,
 } from '../../types';
 import { ROOT_SUITE_NAME, castArray } from '../../utils';
-import { formatTitle } from '../util';
+import { formatName } from '../util';
 
 type ListenersKey<T extends TestSuiteListeners> =
   T extends `${infer U}Listeners` ? U : never;
@@ -328,7 +328,7 @@ export class RunnerRuntime {
         const params = castArray(param) as Parameters<typeof fn>;
         // TODO: support test name template
         this.describe(
-          formatTitle(name, param, i),
+          formatName(name, param, i),
           () => fn?.(...params),
           'run',
           true,
@@ -345,7 +345,7 @@ export class RunnerRuntime {
         const params = castArray(param) as Parameters<typeof fn>;
         // TODO: support test name template
         this.it(
-          formatTitle(name, param, i),
+          formatName(name, param, i),
           () => fn?.(...params),
           timeout,
           'run',

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -61,7 +61,6 @@ export const formatName = (
     return format(templateStr, ...param);
   }
 
+  // TODO: support object param
   return templateStr;
-
-  // return template.replace(/%s/g, () => String(param[Object.keys(param)[index]] ?? ''));
 };

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -1,3 +1,4 @@
+import { format } from 'node:util';
 import { diff } from 'jest-diff';
 import type { TestError } from '../types';
 
@@ -34,4 +35,33 @@ export const formatTestError = (err: any): TestError[] => {
 
     return errObj;
   });
+};
+
+export const formatTitle = (
+  template: string,
+  param: any[] | Record<string, any>,
+  index: number,
+): string => {
+  let templateStr = template;
+
+  if (['%%', '%#', '%$'].some((flag) => templateStr.includes(flag))) {
+    // '%%' single percent sign ('%')
+    // '%#' match index (0 based) of the test case
+    // '%$' match index (1 based) of the test case
+    templateStr = templateStr
+      .replace(/%%/g, '__rstest_escaped_%__')
+      .replace(/%#/g, `${index}`)
+      .replace(/%\$/g, `${index + 1}`)
+      .replace(/__rstest_escaped_%__/g, '%%');
+  }
+
+  if (Array.isArray(param)) {
+    // format printf-like string
+    // https://nodejs.org/api/util.html#util_util_format_format_args
+    return format(templateStr, ...param);
+  }
+
+  return templateStr;
+
+  // return template.replace(/%s/g, () => String(param[Object.keys(param)[index]] ?? ''));
 };

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -37,7 +37,7 @@ export const formatTestError = (err: any): TestError[] => {
   });
 };
 
-export const formatTitle = (
+export const formatName = (
   template: string,
   param: any[] | Record<string, any>,
   index: number,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -14,31 +14,47 @@ type TestFn = (
   timeout?: number,
 ) => void;
 
-export type TestEachFn<T> = (
-  description: string,
-  fn?: (param: T) => MaybePromise<void>,
-  timeout?: number,
-) => void;
+export interface TestEachFn {
+  <T extends Record<string, unknown>>(
+    cases: ReadonlyArray<T>,
+  ): (
+    description: string,
+    fn?: (param: T) => MaybePromise<void>,
+    timeout?: number,
+  ) => void;
+  <T extends readonly [unknown, ...Array<unknown>]>(
+    cases: ReadonlyArray<T>,
+  ): (
+    description: string,
+    fn: (...args: [...T]) => MaybePromise<void>,
+    timeout?: number,
+  ) => void;
+}
+
+export interface DescribeEachFn {
+  <T extends Record<string, unknown>>(
+    cases: ReadonlyArray<T>,
+  ): (description: string, fn?: (param: T) => MaybePromise<void>) => void;
+  <T extends readonly [unknown, ...Array<unknown>]>(
+    cases: ReadonlyArray<T>,
+  ): (description: string, fn: (...args: [...T]) => MaybePromise<void>) => void;
+}
 
 export type TestAPI = TestFn & {
   fails: TestFn;
   only: TestFn;
   todo: TestFn;
   skip: TestFn;
-  each: <T>(cases: T[]) => TestEachFn<T>;
+  each: TestEachFn;
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;
-export type DescribeEachFn<T> = (
-  description: string,
-  fn?: (param: T) => void,
-) => void;
 
 export type DescribeAPI = DescribeFn & {
   only: DescribeFn;
   todo: DescribeFn;
   skip: DescribeFn;
-  each: <T>(cases: T[]) => DescribeEachFn<T>;
+  each: DescribeEachFn;
 };
 
 export type RunnerAPI = {

--- a/tests/describe/each.test.ts
+++ b/tests/describe/each.test.ts
@@ -21,5 +21,5 @@ it('Describe Each API', async () => {
 
   const logs = cli.stdout.split('\n').filter(Boolean);
 
-  expect(logs.find((log) => log.includes('Tests 3 passed'))).toBeTruthy();
+  expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
 });

--- a/tests/describe/fixtures/each.test.ts
+++ b/tests/describe/fixtures/each.test.ts
@@ -9,3 +9,13 @@ describe.each([
     expect(a + b).toBe(expected);
   });
 });
+
+describe.each([
+  [2, 1, 3],
+  [2, 2, 4],
+  [3, 1, 4],
+])('add two numbers correctly', (a, b, expected) => {
+  it(`should return ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});

--- a/tests/runner/test/async.test.ts
+++ b/tests/runner/test/async.test.ts
@@ -1,7 +1,7 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
-import { runRstestCli } from '../../scripts';
+import { getTestName, runRstestCli } from '../../scripts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -42,18 +42,18 @@ describe('Test Async Suite', () => {
       logs
         .filter((log) => log.includes('Test Async Suite'))
         // slice `✓ Test Async Suite > 2 > 2-0 > 2-0-0 (0 ms)` to `> 2 > 2-0 > 2-0-0`
-        .map((log) => log.split('Test Async Suite')[1].split('(')[0]),
+        .map((log) => getTestName(log, 'Test Async Suite')),
     ).toMatchInlineSnapshot(`
       [
-        " > 0 > 0-0 ",
-        " > 0 > 0-1 > 0-1-0 ",
-        " > 0 > 0-1 > 0-1-1 > 0-1-1-0 ",
-        " > 0 > 0-2 > 0-2-0 ",
-        " > 0 > 0-3 ",
-        " > 1 ",
-        " > 2 > 2-0 > 2-0-0 ",
-        " > 2 > 2-1 ",
-        " > 3 ",
+        "> 0 > 0-0",
+        "> 0 > 0-1 > 0-1-0",
+        "> 0 > 0-1 > 0-1-1 > 0-1-1-0",
+        "> 0 > 0-2 > 0-2-0",
+        "> 0 > 0-3",
+        "> 1",
+        "> 2 > 2-0 > 2-0-0",
+        "> 2 > 2-1",
+        "> 3",
       ]
     `);
   });

--- a/tests/scripts/utils.ts
+++ b/tests/scripts/utils.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 import { expect } from '@rstest/core';
 
+export const getTestName = (log: string, prefix: string) =>
+  log.slice(0, log.lastIndexOf('(')).split(prefix)[1].trim();
+
 export const expectFile = (filePath: string, timeout = 3000) =>
   expect
     .poll(() => fs.existsSync(filePath), {

--- a/tests/test-api/each.test.ts
+++ b/tests/test-api/each.test.ts
@@ -1,7 +1,7 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { expect, it } from '@rstest/core';
-import { runRstestCli } from '../scripts';
+import { getTestName, runRstestCli } from '../scripts';
 
 it('Test Each API', async () => {
   const __filename = fileURLToPath(import.meta.url);
@@ -21,13 +21,20 @@ it('Test Each API', async () => {
 
   const logs = cli.stdout.split('\n').filter(Boolean);
 
-  expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+  expect(
+    logs
+      .filter((log) => log.includes('add'))
+      .map((log) => getTestName(log, '✓')),
+  ).toMatchInlineSnapshot(`
     [
-      "[beforeEach] root",
-      "[beforeEach] root",
-      "[beforeEach] root",
+      "add(%i, %i) -> %i",
+      "add(%i, %i) -> %i",
+      "add(%i, %i) -> %i",
+      "add(%i, %i) -> %i",
+      "add(%i, %i) -> %i",
+      "add(%i, %i) -> %i",
     ]
   `);
 
-  expect(logs.find((log) => log.includes('Tests 3 passed'))).toBeTruthy();
+  expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
 });

--- a/tests/test-api/each.test.ts
+++ b/tests/test-api/each.test.ts
@@ -27,12 +27,12 @@ it('Test Each API', async () => {
       .map((log) => getTestName(log, '✓')),
   ).toMatchInlineSnapshot(`
     [
-      "add(%i, %i) -> %i",
-      "add(%i, %i) -> %i",
-      "add(%i, %i) -> %i",
-      "add(%i, %i) -> %i",
-      "add(%i, %i) -> %i",
-      "add(%i, %i) -> %i",
+      "add($a, $b) -> $expected",
+      "add($a, $b) -> $expected",
+      "add($a, $b) -> $expected",
+      "case-0 add(2, 1) -> 3",
+      "case-1 add(2, 2) -> 4",
+      "case-2 add(3, 1) -> 4",
     ]
   `);
 

--- a/tests/test-api/fixtures/each.test.ts
+++ b/tests/test-api/fixtures/each.test.ts
@@ -1,13 +1,17 @@
-import { beforeEach, expect, it } from '@rstest/core';
-
-beforeEach(() => {
-  console.log('[beforeEach] root');
-});
+import { expect, it } from '@rstest/core';
 
 it.each([
   { a: 1, b: 1, expected: 2 },
   { a: 1, b: 2, expected: 3 },
   { a: 2, b: 1, expected: 3 },
-])('add two numbers correctly', ({ a, b, expected }) => {
+])('add(%i, %i) -> %i', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected);
+});
+
+it.each([
+  [2, 1, 3],
+  [2, 2, 4],
+  [3, 1, 4],
+])('add(%i, %i) -> %i', (a, b, expected) => {
   expect(a + b).toBe(expected);
 });

--- a/tests/test-api/fixtures/each.test.ts
+++ b/tests/test-api/fixtures/each.test.ts
@@ -4,7 +4,7 @@ it.each([
   { a: 1, b: 1, expected: 2 },
   { a: 1, b: 2, expected: 3 },
   { a: 2, b: 1, expected: 3 },
-])('add(%i, %i) -> %i', ({ a, b, expected }) => {
+])('add($a, $b) -> $expected', ({ a, b, expected }) => {
   expect(a + b).toBe(expected);
 });
 
@@ -12,6 +12,6 @@ it.each([
   [2, 1, 3],
   [2, 2, 4],
   [3, 1, 4],
-])('add(%i, %i) -> %i', (a, b, expected) => {
+])('case-%# add(%i, %i) -> %i', (a, b, expected) => {
   expect(a + b).toBe(expected);
 });


### PR DESCRIPTION
## Summary

Support array type cases in  test `each` API.

```ts
it.each([
  [2, 1, 3],
  [2, 2, 4],
  [3, 1, 4],
])('add(%i, %i) -> %i', (a, b, expected) => {
  expect(a + b).toBe(expected);
});

```

<img width="331" alt="image" src="https://github.com/user-attachments/assets/738d9e22-4643-4b87-8b44-8330321e48ac" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
