### PR TITLE
feat: support object type params in name template

### DIFF
--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -326,7 +326,7 @@ export class RunnerRuntime {
         // TODO: template string table.
         const param = cases[i]!;
         const params = castArray(param) as Parameters<typeof fn>;
-        // TODO: support test name template
+
         this.describe(
           formatName(name, param, i),
           () => fn?.(...params),
@@ -343,7 +343,7 @@ export class RunnerRuntime {
         // TODO: template string table.
         const param = cases[i]!;
         const params = castArray(param) as Parameters<typeof fn>;
-        // TODO: support test name template
+
         this.it(
           formatName(name, param, i),
           () => fn?.(...params),

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -3,7 +3,10 @@ import type { TestSuite } from '../../src/types';
 
 describe('RunnerRuntime', () => {
   it('should add test correctly', async () => {
-    const runtime = new RunnerRuntime(__filename);
+    const runtime = new RunnerRuntime({
+      sourcePath: __filename,
+      testTimeout: 100,
+    });
 
     runtime.describe('suite - 0', () => {
       runtime.it('test - 0', () => {});
@@ -41,7 +44,10 @@ describe('RunnerRuntime', () => {
   });
 
   it('should add test correctly when describe fn undefined', async () => {
-    const runtime = new RunnerRuntime(__filename);
+    const runtime = new RunnerRuntime({
+      sourcePath: __filename,
+      testTimeout: 100,
+    });
 
     runtime.describe('suite - 0');
 

--- a/packages/core/tests/runner/util.test.ts
+++ b/packages/core/tests/runner/util.test.ts
@@ -1,0 +1,15 @@
+import { formatName } from '../../src/runtime/util';
+
+it('test formatName', () => {
+  expect(formatName('test index %#', [1, 2, 3], 1)).toBe('test index 1');
+
+  expect(formatName('test %i + %i -> %i', [1, 2, 3], 0)).toBe(
+    'test 1 + 2 -> 3',
+  );
+
+  expect(formatName('test $a', { a: 1 }, 0)).toBe('test 1');
+
+  expect(formatName('test $a.b', { a: { b: 1 } }, 0)).toBe('test 1');
+
+  expect(formatName('test $c', { a: { b: 1 } }, 0)).toBe('test undefined');
+});

--- a/tests/test-api/each.test.ts
+++ b/tests/test-api/each.test.ts
@@ -27,9 +27,9 @@ it('Test Each API', async () => {
       .map((log) => getTestName(log, '✓')),
   ).toMatchInlineSnapshot(`
     [
-      "add($a, $b) -> $expected",
-      "add($a, $b) -> $expected",
-      "add($a, $b) -> $expected",
+      "add(1, 1) -> 2",
+      "add(1, 2) -> 3",
+      "add(2, 1) -> 3",
       "case-0 add(2, 1) -> 3",
       "case-1 add(2, 2) -> 4",
       "case-2 add(3, 1) -> 4",


### PR DESCRIPTION
## Summary

```ts
it.each([
  { a: 1, b: 1, expected: 2 },
  { a: 1, b: 2, expected: 3 },
  { a: 2, b: 1, expected: 3 },
])('add($a, $b) -> $expected', ({ a, b, expected }) => {
  expect(a + b).toBe(expected);
});

```

<img width="391" alt="image" src="https://github.com/user-attachments/assets/0de0ff22-336f-4a46-b105-2b402f961da2" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
