### PR TITLE
fix: support printf-like string when format with object param

### DIFF
--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -36,7 +36,7 @@ export const formatTestError = (err: any): TestError[] => {
     return errObj;
   });
 };
-
+// cspell:ignore sdjifo
 const formatRegExp = /%[sdjifoOc%]/;
 
 export const formatName = (

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -37,6 +37,8 @@ export const formatTestError = (err: any): TestError[] => {
   });
 };
 
+const formatRegExp = /%[sdjifoOc%]/;
+
 export const formatName = (
   template: string,
   param: any[] | Record<string, any>,
@@ -58,10 +60,13 @@ export const formatName = (
   if (Array.isArray(param)) {
     // format printf-like string
     // https://nodejs.org/api/util.html#util_util_format_format_args
-    // Need a more standard check for valid format specifiers
-    return templateStr.includes('%')
+    return formatRegExp.test(templateStr)
       ? format(templateStr, ...param)
       : templateStr;
+  }
+
+  if (formatRegExp.test(templateStr)) {
+    templateStr = format(templateStr, param);
   }
 
   return templateStr.replace(/\$([$\w.]+)/g, (_, key: string) => {

--- a/packages/core/tests/runner/util.test.ts
+++ b/packages/core/tests/runner/util.test.ts
@@ -12,4 +12,6 @@ it('test formatName', () => {
   expect(formatName('test $a.b', { a: { b: 1 } }, 0)).toBe('test 1');
 
   expect(formatName('test $c', { a: { b: 1 } }, 0)).toBe('test undefined');
+
+  expect(formatName('%j', { a: { b: 1 } }, 0)).toBe('{"a":{"b":1}}');
 });


### PR DESCRIPTION
## Summary

<img width="900" alt="image" src="https://github.com/user-attachments/assets/436f73cb-7b67-45c2-8122-072267b45dbc" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
