### PR TITLE
feat: support `stubEnv` & `unstubAllEnvs` API

### DIFF
--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../types';
 import { createRunner } from '../runner';
 import { GLOBAL_EXPECT, createExpect } from './expect';
-import { rstest } from './utilities';
+import { createRstestUtilities } from './utilities';
 
 export const createRstestRuntime = (
   workerState: WorkerState,
@@ -37,7 +37,7 @@ export const createRstestRuntime = (
     api: {
       ...runnerAPI,
       expect,
-      rstest,
+      rstest: createRstestUtilities(),
     },
   };
 };

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -1,29 +1,63 @@
 import type { RstestUtilities } from '../../types';
 import { fn, isMockFunction, mocks, spyOn } from './spy';
 
-export const rstest: RstestUtilities = {
-  fn,
-  spyOn,
-  isMockFunction,
-  clearAllMocks: () => {
-    for (const mock of mocks) {
-      mock.mockClear();
-    }
-    return rstest;
-  },
-  resetAllMocks: () => {
-    for (const mock of mocks) {
-      mock.mockReset();
-    }
-    return rstest;
-  },
-  restoreAllMocks: () => {
-    for (const mock of mocks) {
-      mock.mockRestore();
-    }
-    return rstest;
-  },
-  mock: () => {
-    // TODO
-  },
+export const createRstestUtilities: () => RstestUtilities = () => {
+  const originalEnvValues = new Map<string, string | undefined>();
+
+  const rstest: RstestUtilities = {
+    fn,
+    spyOn,
+    isMockFunction,
+    clearAllMocks: () => {
+      for (const mock of mocks) {
+        mock.mockClear();
+      }
+      return rstest;
+    },
+    resetAllMocks: () => {
+      for (const mock of mocks) {
+        mock.mockReset();
+      }
+      return rstest;
+    },
+    restoreAllMocks: () => {
+      for (const mock of mocks) {
+        mock.mockRestore();
+      }
+      return rstest;
+    },
+    mock: () => {
+      // TODO
+    },
+    stubEnv: (name: string, value: string | undefined): RstestUtilities => {
+      if (!originalEnvValues.has(name)) {
+        originalEnvValues.set(name, process.env[name]);
+      }
+
+      // update process.env
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+
+      return rstest;
+    },
+    unstubAllEnvs: (): RstestUtilities => {
+      // restore process.env
+      for (const [name, value] of originalEnvValues) {
+        if (value === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = value;
+        }
+      }
+
+      originalEnvValues.clear();
+
+      return rstest;
+    },
+  };
+
+  return rstest;
 };

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -197,4 +197,14 @@ export type RstestUtilities = {
    * WIP: Mock a module
    */
   mock: <T = unknown>(moduleName: string, moduleFactory?: () => T) => void;
+
+  /**
+   * Changes the value of environmental variable on `process.env`.
+   */
+  stubEnv: (name: string, value: string | undefined) => RstestUtilities;
+
+  /**
+   * Restores all `process.env` values that were changed with `rstest.stubEnv`.
+   */
+  unstubAllEnvs: () => RstestUtilities;
 };

--- a/tests/spy/stubEnv.test.ts
+++ b/tests/spy/stubEnv.test.ts
@@ -1,0 +1,21 @@
+import { expect, it, rstest } from '@rstest/core';
+
+it('test stubEnv & unstubAllEnvs', () => {
+  const env = process.env.NODE_ENV;
+  const mockEnv = env === 'production' ? 'development' : 'production';
+  rstest.stubEnv('NODE_ENV', mockEnv);
+
+  rstest.stubEnv('TEST_111', '111');
+
+  expect(process.env.NODE_ENV).toBe(mockEnv);
+
+  expect(process.env.TEST_111).toBe('111');
+
+  rstest.stubEnv('NODE_ENV', undefined);
+  expect(process.env.NODE_ENV).toBeUndefined();
+
+  rstest.unstubAllEnvs();
+
+  expect(process.env.NODE_ENV).toBe(env);
+  expect(process.env.TEST_111).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
support `stubEnv` & `unstubAllEnvs` API.
- `stubEnv`: Changes the value of environmental variable on `process.env`.
- `unstubAllEnvs`: Restores all `process.env` values that were changed with `rstest.stubEnv`.

```ts
rstest.stubEnv('NODE_ENV', 'development');

// do something in development
// ...

rstest.unstubAllEnvs();
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
