### PR TITLE
feat: support `clearMocks` / `resetMocks` / `restoreMocks` configs

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -16,6 +16,9 @@ type CommonOptions = {
   update?: boolean;
   testNamePattern?: RegExp | string;
   testTimeout?: number;
+  clearMocks?: boolean;
+  resetMocks?: boolean;
+  restoreMocks?: boolean;
 };
 
 const applyCommonOptions = (cli: CAC) => {
@@ -45,7 +48,16 @@ const applyCommonOptions = (cli: CAC) => {
       '-t, --testNamePattern <testNamePattern>',
       'Run only tests with a name that matches the regex.',
     )
-    .option('--testTimeout <testTimeout>', 'Timeout of a test in milliseconds');
+    .option('--testTimeout <testTimeout>', 'Timeout of a test in milliseconds')
+    .option(
+      '--clearMocks',
+      'Automatically clear mock calls, instances, contexts and results before every test.',
+    )
+    .option('--resetMocks', 'Automatically reset mock state before every test.')
+    .option(
+      '--restoreMocks',
+      'Automatically restore mock state and implementation before every test.',
+    );
 };
 
 export async function initCli(options: CommonOptions): Promise<{
@@ -68,6 +80,9 @@ export async function initCli(options: CommonOptions): Promise<{
     'update',
     'testNamePattern',
     'testTimeout',
+    'clearMocks',
+    'resetMocks',
+    'restoreMocks',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -91,6 +91,9 @@ const createDefaultConfig = (): NormalizedConfig => ({
   update: false,
   testTimeout: 5_000,
   reporters: ['default'],
+  clearMocks: false,
+  resetMocks: false,
+  restoreMocks: false,
 });
 
 export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {

--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -14,7 +14,11 @@ export const createRstestRuntime = (
   workerState: WorkerState,
 ): {
   runner: {
-    runTest: (testPath: string, hooks: RunnerHooks) => Promise<TestFileResult>;
+    runTest: (
+      testPath: string,
+      hooks: RunnerHooks,
+      api: Rstest,
+    ) => Promise<TestFileResult>;
     getCurrentTest: () => TestCase | undefined;
   };
   api: Rstest;

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -1,6 +1,7 @@
 import type {
   DescribeAPI,
   DescribeEachFn,
+  Rstest,
   RunnerAPI,
   RunnerHooks,
   TestAPI,
@@ -18,6 +19,7 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
     runTest: (
       testFilePath: string,
       hooks: RunnerHooks,
+      api: Rstest,
     ) => Promise<TestFileResult>;
     getCurrentTest: TestRunner['getCurrentTest'];
   };
@@ -57,9 +59,15 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
       beforeEach: runtimeAPI.beforeEach.bind(runtimeAPI),
     },
     runner: {
-      runTest: async (testFilePath: string, hooks: RunnerHooks) => {
+      runTest: async (testPath: string, hooks: RunnerHooks, api: Rstest) => {
         const tests = await runtimeAPI.getTests();
-        return testRunner.runTests(tests, testFilePath, workerState, hooks);
+        return testRunner.runTests({
+          tests,
+          testPath,
+          state: workerState,
+          hooks,
+          api,
+        });
       },
       getCurrentTest: () => testRunner.getCurrentTest(),
     },

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -81,14 +81,18 @@ const runInPool = async ({
       assetFiles,
     });
 
-    const results = await runner.runTest(originPath, {
-      onTestFileStart: async (test) => {
-        await rpc.onTestFileStart(test);
+    const results = await runner.runTest(
+      originPath,
+      {
+        onTestFileStart: async (test) => {
+          await rpc.onTestFileStart(test);
+        },
+        onTestCaseResult: async (result) => {
+          await rpc.onTestCaseResult(result);
+        },
       },
-      onTestCaseResult: async (result) => {
-        await rpc.onTestCaseResult(result);
-      },
-    });
+      api,
+    );
 
     return results;
   } catch (err) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -88,6 +88,22 @@ export interface RstestConfig {
    * @default 5000
    */
   testTimeout?: number;
+
+  /**
+   * Automatically clear mock calls, instances, contexts and results before every test.
+   * @default false
+   */
+  clearMocks?: boolean;
+  /**
+   * Automatically reset mock state before every test.
+   * @default false
+   */
+  resetMocks?: boolean;
+  /**
+   * Automatically restore mock state and implementation before every test.
+   * @default false
+   */
+  restoreMocks?: boolean;
 }
 
 export type NormalizedConfig = Required<

--- a/tests/spy/config.test.ts
+++ b/tests/spy/config.test.ts
@@ -1,0 +1,37 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+it('test clearMocks config', async () => {
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/clearMocks.test', '--clearMocks'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(0);
+});
+
+it('test restoreMocks config', async () => {
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/restoreMocks.test', '--restoreMocks'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(0);
+});

--- a/tests/spy/fixtures/clearMocks.test.ts
+++ b/tests/spy/fixtures/clearMocks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, rstest } from '@rstest/core';
+
+describe('auto clearMocks', () => {
+  const sayHi = rstest.fn();
+
+  it('spy', () => {
+    sayHi.mockImplementation(() => 'hi');
+
+    expect(sayHi('bob')).toBe('hi');
+
+    expect(sayHi).toHaveBeenCalledTimes(1);
+  });
+
+  it('spy - 1', () => {
+    sayHi.mockImplementation(() => 'hello');
+
+    expect(sayHi('bob')).toBe('hello');
+
+    expect(sayHi).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/spy/fixtures/restoreMocks.test.ts
+++ b/tests/spy/fixtures/restoreMocks.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, rstest } from '@rstest/core';
+
+describe('auto restoreMocks', () => {
+  const hi = {
+    sayHi: () => 'hi',
+  };
+
+  it('spy', () => {
+    const spy = rstest.spyOn(hi, 'sayHi');
+
+    spy.mockImplementation(() => 'hello');
+
+    expect(hi.sayHi()).toBe('hello');
+  });
+
+  it('spy - 1', () => {
+    expect(hi.sayHi()).toBe('hi');
+    expect(rstest.isMockFunction(hi.sayHi)).toBeFalsy();
+  });
+});

--- a/tests/spy/withImplementation.test.ts
+++ b/tests/spy/withImplementation.test.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from '@rstest/core';
+import { expect, it } from '@rstest/core';
 import { runRstestCli } from '../scripts';
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Summary

- `clearMocks`: Automatically clear mock calls, instances, contexts and results before every test.
- `resetMocks`: Automatically reset mock state before every test.
- `restoreMocks`: Automatically restore mock state and implementation before every test.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
