### PR TITLE
feat: support `stubGlobal` & `unstubAllGlobals` API

### DIFF
--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -207,4 +207,17 @@ export type RstestUtilities = {
    * Restores all `process.env` values that were changed with `rstest.stubEnv`.
    */
   unstubAllEnvs: () => RstestUtilities;
+
+  /**
+   * Changes the value of global variable.
+   */
+  stubGlobal: (
+    name: string | number | symbol,
+    value: unknown,
+  ) => RstestUtilities;
+
+  /**
+   * Restores all global variables that were changed with `rstest.stubGlobal`.
+   */
+  unstubAllGlobals: () => RstestUtilities;
 };

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -143,7 +143,7 @@ unpatch
 unplugin
 unpredictibly
 unshift
-unstubAllEnvs
+unstub
 upath
 vitest
 vnode

--- a/tests/spy/stubGlobal.test.ts
+++ b/tests/spy/stubGlobal.test.ts
@@ -13,8 +13,6 @@ it('test stubGlobal & unstubAllGlobals', () => {
 
   checkGlobalThis();
 
-  globalThis.AbortController;
-
   expect(globalThis[testFlag]).toBeTruthy();
 
   rstest.unstubAllGlobals();

--- a/tests/spy/stubGlobal.test.ts
+++ b/tests/spy/stubGlobal.test.ts
@@ -1,0 +1,23 @@
+import { expect, it, rstest } from '@rstest/core';
+
+function checkGlobalThis() {
+  // @ts-expect-error
+  expect(__test_flag__).toBeTruthy();
+}
+
+it('test stubGlobal & unstubAllGlobals', () => {
+  const testFlag = '__test_flag__';
+  expect(globalThis[testFlag]).toBeUndefined();
+
+  rstest.stubGlobal(testFlag, true);
+
+  checkGlobalThis();
+
+  globalThis.AbortController;
+
+  expect(globalThis[testFlag]).toBeTruthy();
+
+  rstest.unstubAllGlobals();
+
+  expect(globalThis[testFlag]).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- `stubGlobal`: Changes the value of global variable.
- `unstubAllGlobals`: Restores all global variables that were changed with `rstest.stubGlobal`.

```ts
rstest.stubGlobal('__test_flag__', true);

__test_flag__ // true
globalThis.__test_flag__  // true

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
