### PR TITLE
feat: support `unstubEnvs` & `unstubGlobals` configs

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -19,6 +19,8 @@ type CommonOptions = {
   clearMocks?: boolean;
   resetMocks?: boolean;
   restoreMocks?: boolean;
+  unstubGlobals?: boolean;
+  unstubEnvs?: boolean;
 };
 
 const applyCommonOptions = (cli: CAC) => {
@@ -57,6 +59,14 @@ const applyCommonOptions = (cli: CAC) => {
     .option(
       '--restoreMocks',
       'Automatically restore mock state and implementation before every test.',
+    )
+    .option(
+      '--unstubGlobals',
+      'Restores all global variables that were changed with `rstest.stubGlobal` before every test.',
+    )
+    .option(
+      '--unstubEnvs',
+      'Restores all `process.env` values that were changed with `rstest.stubEnv` before every test.',
     );
 };
 
@@ -83,6 +93,8 @@ export async function initCli(options: CommonOptions): Promise<{
     'clearMocks',
     'resetMocks',
     'restoreMocks',
+    'unstubEnvs',
+    'unstubGlobals',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -94,6 +94,8 @@ const createDefaultConfig = (): NormalizedConfig => ({
   clearMocks: false,
   resetMocks: false,
   restoreMocks: false,
+  unstubGlobals: false,
+  unstubEnvs: false,
 });
 
 export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -323,19 +323,31 @@ export class TestRunner {
 
   private beforeEach(test: TestCase, state: WorkerState, api: Rstest) {
     const {
-      normalizedConfig: { clearMocks, resetMocks, restoreMocks },
+      normalizedConfig: {
+        clearMocks,
+        resetMocks,
+        restoreMocks,
+        unstubEnvs,
+        unstubGlobals,
+      },
     } = state;
 
     this.setCurrentTest(test);
 
-    if (clearMocks) {
-      api.rstest.clearAllMocks();
-    }
-    if (resetMocks) {
-      api.rstest.resetAllMocks();
-    }
     if (restoreMocks) {
       api.rstest.restoreAllMocks();
+    } else if (resetMocks) {
+      api.rstest.resetAllMocks();
+    } else if (clearMocks) {
+      api.rstest.clearAllMocks();
+    }
+
+    if (unstubEnvs) {
+      api.rstest.unstubAllEnvs();
+    }
+
+    if (unstubGlobals) {
+      api.rstest.unstubAllGlobals();
     }
   }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -104,6 +104,16 @@ export interface RstestConfig {
    * @default false
    */
   restoreMocks?: boolean;
+  /**
+   * Restores all global variables that were changed with `rstest.stubGlobal` before every test.
+   * @default false
+   */
+  unstubGlobals?: boolean;
+  /**
+   * Restores all `process.env` values that were changed with `rstest.stubEnv` before every test.
+   * @default false
+   */
+  unstubEnvs?: boolean;
 }
 
 export type NormalizedConfig = Required<


### PR DESCRIPTION
## Summary

-  `unstubEnvs`: Restores all `process.env` values that were changed with `rstest.stubEnv` before every test.
-  `unstubGlobals`: Restores all global variables that were changed with `rstest.stubGlobal` before every test.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
