### PR TITLE
feat: support retry failed test

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -21,6 +21,7 @@ type CommonOptions = {
   restoreMocks?: boolean;
   unstubGlobals?: boolean;
   unstubEnvs?: boolean;
+  retry?: number;
 };
 
 const applyCommonOptions = (cli: CAC) => {
@@ -51,6 +52,7 @@ const applyCommonOptions = (cli: CAC) => {
       'Run only tests with a name that matches the regex.',
     )
     .option('--testTimeout <testTimeout>', 'Timeout of a test in milliseconds')
+    .option('--retry <retry>', 'Number of times to retry a test if it fails.')
     .option(
       '--clearMocks',
       'Automatically clear mock calls, instances, contexts and results before every test.',
@@ -95,6 +97,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'restoreMocks',
     'unstubEnvs',
     'unstubGlobals',
+    'retry',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -90,6 +90,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   passWithNoTests: false,
   update: false,
   testTimeout: 5_000,
+  retry: 0,
   reporters: ['default'],
   clearMocks: false,
   resetMocks: false,

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -41,7 +41,7 @@ export class TestRunner {
     api: Rstest;
   }): Promise<TestFileResult> {
     const {
-      normalizedConfig: { passWithNoTests, testNamePattern },
+      normalizedConfig: { passWithNoTests, testNamePattern, retry },
       snapshotOptions,
     } = state;
     const results: TestResult[] = [];
@@ -52,6 +52,120 @@ export class TestRunner {
     const snapshotClient = getSnapshotClient();
 
     await snapshotClient.setup(testPath, snapshotOptions);
+
+    const runTestsCase = async (
+      test: TestCase,
+      parentHooks: {
+        beforeEachListeners: BeforeEachListener[];
+        afterEachListeners: AfterEachListener[];
+      },
+    ): Promise<TestResult> => {
+      if (test.runMode === 'skip') {
+        const result = {
+          status: 'skip' as const,
+          parentNames: test.parentNames,
+          name: test.name,
+          testPath,
+        };
+        return result;
+      }
+      if (test.runMode === 'todo') {
+        const result = {
+          status: 'todo' as const,
+          parentNames: test.parentNames,
+          name: test.name,
+          testPath,
+        };
+        return result;
+      }
+
+      let result: TestResult | undefined = undefined;
+
+      this.beforeEach(test, state, api);
+
+      const cleanups: AfterEachListener[] = [];
+
+      try {
+        for (const fn of parentHooks.beforeEachListeners) {
+          const cleanupFn = await fn();
+          cleanupFn && cleanups.push(cleanupFn);
+        }
+      } catch (error) {
+        result = {
+          status: 'fail' as const,
+          parentNames: test.parentNames,
+          name: test.name,
+          errors: formatTestError(error),
+          testPath,
+        };
+      }
+
+      if (result?.status !== 'fail') {
+        if (test.fails) {
+          try {
+            this.beforeRunTest(test, snapshotClient.getSnapshotState(testPath));
+            await test.fn?.();
+            this.afterRunTest(test);
+
+            result = {
+              status: 'fail' as const,
+              parentNames: test.parentNames,
+              name: test.name,
+              testPath,
+              errors: [
+                {
+                  message: 'Expect test to fail',
+                },
+              ],
+            };
+          } catch (error) {
+            result = {
+              status: 'pass' as const,
+              parentNames: test.parentNames,
+              name: test.name,
+              testPath,
+            };
+          }
+        } else {
+          try {
+            this.beforeRunTest(test, snapshotClient.getSnapshotState(testPath));
+            await test.fn?.();
+            this.afterRunTest(test);
+            result = {
+              parentNames: test.parentNames,
+              name: test.name,
+              status: 'pass' as const,
+              testPath,
+            };
+          } catch (error) {
+            result = {
+              status: 'fail' as const,
+              parentNames: test.parentNames,
+              name: test.name,
+              errors: formatTestError(error),
+              testPath,
+            };
+          }
+        }
+      }
+
+      const afterEachFns = [...(parentHooks.afterEachListeners || [])]
+        .reverse()
+        .concat(cleanups);
+      try {
+        for (const fn of afterEachFns) {
+          await fn();
+        }
+      } catch (error) {
+        result.status = 'fail';
+        result.errors ??= [];
+        result.errors.push(...formatTestError(error));
+      }
+
+      this.resetCurrentTest();
+
+      return result;
+    };
 
     const runTest = async (
       test: Test,
@@ -138,124 +252,25 @@ export class TestRunner {
         }
       } else {
         const start = Date.now();
-        if (test.runMode === 'skip') {
-          const result = {
-            status: 'skip' as const,
-            parentNames: test.parentNames,
-            name: test.name,
-            testPath,
-          };
-          hooks.onTestCaseResult?.(result);
-          results.push(result);
-          return;
-        }
-        if (test.runMode === 'todo') {
-          const result = {
-            status: 'todo' as const,
-            parentNames: test.parentNames,
-            name: test.name,
-            testPath,
-          };
-          hooks.onTestCaseResult?.(result);
-          results.push(result);
-          return;
-        }
-
         let result: TestResult | undefined = undefined;
+        let retryCount = 0;
 
-        this.beforeEach(test, state, api);
+        do {
+          const currentResult = await runTestsCase(test, parentHooks);
 
-        const cleanups: AfterEachListener[] = [];
-
-        try {
-          for (const fn of parentHooks.beforeEachListeners) {
-            const cleanupFn = await fn();
-            cleanupFn && cleanups.push(cleanupFn);
-          }
-        } catch (error) {
           result = {
-            status: 'fail' as const,
-            parentNames: test.parentNames,
-            name: test.name,
-            errors: formatTestError(error),
-            testPath,
-            duration: Date.now() - start,
+            ...currentResult,
+            errors:
+              currentResult.status === 'fail' && result && result!.errors
+                ? result.errors.concat(...(currentResult.errors || []))
+                : currentResult.errors,
           };
-        }
 
-        if (result?.status !== 'fail') {
-          if (test.fails) {
-            try {
-              this.beforeRunTest(
-                test,
-                snapshotClient.getSnapshotState(testPath),
-              );
-              await test.fn?.();
-              this.afterRunTest(test);
-
-              result = {
-                status: 'fail' as const,
-                parentNames: test.parentNames,
-                name: test.name,
-                testPath,
-                errors: [
-                  {
-                    message: 'Expect test to fail',
-                  },
-                ],
-              };
-            } catch (error) {
-              result = {
-                status: 'pass' as const,
-                parentNames: test.parentNames,
-                name: test.name,
-                testPath,
-              };
-            }
-          } else {
-            try {
-              this.beforeRunTest(
-                test,
-                snapshotClient.getSnapshotState(testPath),
-              );
-              await test.fn?.();
-              this.afterRunTest(test);
-              result = {
-                parentNames: test.parentNames,
-                name: test.name,
-                status: 'pass' as const,
-                testPath,
-              };
-            } catch (error) {
-              result = {
-                status: 'fail' as const,
-                parentNames: test.parentNames,
-                name: test.name,
-                errors: formatTestError(error),
-                testPath,
-              };
-            }
-          }
-        }
-
-        const afterEachFns = [...(parentHooks.afterEachListeners || [])]
-          .reverse()
-          .concat(cleanups);
-        try {
-          for (const fn of afterEachFns) {
-            await fn();
-          }
-        } catch (error) {
-          result.status = 'fail';
-          result.errors ??= [];
-          result.errors.push(...formatTestError(error));
-        }
-
-        this.resetCurrentTest();
+          retryCount++;
+        } while (retryCount <= retry && result.status === 'fail');
 
         result.duration = Date.now() - start;
         hooks.onTestCaseResult?.(result);
-
         results.push(result);
       }
     };

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -42,6 +42,12 @@ export interface RstestConfig {
    * Path to setup files. They will be run before each test file.
    */
   setupFiles?: string[] | string;
+
+  /**
+   * Retry the test specific number of times if it fails.
+   * @default 0
+   */
+  retry?: number;
   /**
    * Allows the test suite to pass when no files are found.
    *

--- a/tests/test-api/fixtures/retry.test.ts
+++ b/tests/test-api/fixtures/retry.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+let count = 1;
+it('should run success with retry', () => {
+  expect(count++).toBe(5);
+});

--- a/tests/test-api/retry.test.ts
+++ b/tests/test-api/retry.test.ts
@@ -1,0 +1,47 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+describe('Test Retry', () => {
+  it('should run success with retry', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/retry.test.ts', '--retry=4'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+  });
+
+  it('should error when retry times exhausted', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/retry.test.ts', '--retry=3'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('Test Files 1 failed')),
+    ).toBeTruthy();
+    expect(logs.find((log) => log.includes('Tests 1 failed'))).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Support retry the test specific number of times if it fails via `retry` config.

```ts
import { defineConfig } from '@rstest/core';

export default defineConfig({
   retry: 2,
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
