### PR TITLE
feat: init mock API type declaration

### DIFF
--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -33,6 +33,28 @@ export const createRstestUtilities: () => RstestUtilities = () => {
     mock: () => {
       // TODO
     },
+    doMock: () => {
+      // TODO
+    },
+    unMock: () => {
+      // TODO
+    },
+    doUnMock: () => {
+      // TODO
+    },
+    importMock: async () => {
+      // TODO
+      return {} as any;
+    },
+    importActual: async () => {
+      // TODO
+      return {} as any;
+    },
+    resetModules: () => {
+      // TODO
+      return rstest;
+    },
+
     stubEnv: (name: string, value: string | undefined): RstestUtilities => {
       if (!originalEnvValues.has(name)) {
         originalEnvValues.set(name, process.env[name]);

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -194,9 +194,46 @@ export type RstestUtilities = {
   restoreAllMocks: () => RstestUtilities;
 
   /**
-   * WIP: Mock a module
+   * @todo
+   * Mock a module
    */
   mock: <T = unknown>(moduleName: string, moduleFactory?: () => T) => void;
+
+  /**
+   * @todo
+   * Mock a module, not hoisted.
+   */
+  doMock: <T = unknown>(moduleName: string, moduleFactory?: () => T) => void;
+
+  /**
+   * @todo
+   * Removes module from the mocked registry.
+   */
+  unMock: (path: string) => void;
+
+  /**
+   * @todo
+   * Removes module from the mocked registry, not hoisted.
+   */
+  doUnMock: (path: string) => void;
+
+  /**
+   * @todo
+   * Imports a module with all of its properties (including nested properties) mocked.
+   */
+  importMock: <T = Record<string, unknown>>(path: string) => Promise<T>;
+
+  /**
+   * @todo
+   * Returns the actual module instead of a mock, bypassing all checks on whether the module should receive a mock implementation or not.
+   */
+  importActual: <T = Record<string, unknown>>(path: string) => Promise<T>;
+
+  /**
+   * @todo
+   * Resets modules registry by clearing the cache of all modules.
+   */
+  resetModules: () => RstestUtilities;
 
   /**
    * Changes the value of environmental variable on `process.env`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
 
+  tests/mock:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      strip-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
+
   tests/reporter:
     devDependencies:
       '@rstest/core':

--- a/tests/mock/package.json
+++ b/tests/mock/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "@rstest/test-mock",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*",
+    "picocolors": "^1.1.1",
+    "strip-ansi": "^7.1.0"
+  }
+}

--- a/tests/mock/tests/external.test.ts
+++ b/tests/mock/tests/external.test.ts
@@ -1,0 +1,14 @@
+import { expect, it, rstest } from '@rstest/core';
+
+rstest.mock('picocolors', () => {
+  return {
+    sayHi: () => 'hi',
+  };
+});
+
+it.todo('should mock external module correctly', async () => {
+  // @ts-expect-error
+  const { sayHi } = await import('picocolors');
+
+  expect(sayHi?.()).toBe('hi');
+});


### PR DESCRIPTION
## Summary

This PR is used to initialize the mock API and does not include specific implementations.

- `rstest.doMock`: Mock a module, not hoisted.
- `rstest.unMock`: Removes module from the mocked registry.
- `rstest.doUnMock`: Removes module from the mocked registry, not hoisted.
- `rstest.importMock`: Imports a module with all of its properties (including nested properties) mocked.
- `rstest.importActual`: Returns the actual module instead of a mock, bypassing all checks on whether the module should receive a mock implementation or not.
- `rstest.resetModules`: Resets modules registry by clearing the cache of all modules.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
