### PR TITLE
feat: support `output.cssModules` configuration

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -69,7 +69,7 @@ export const prepareRsbuild = async (
   setupFiles: Record<string, string>,
 ): Promise<RsbuildInstance> => {
   const {
-    normalizedConfig: { name, plugins, resolve, source },
+    normalizedConfig: { name, plugins, resolve, source, output },
   } = context;
 
   RsbuildLogger.level = isDebug() ? 'verbose' : 'error';
@@ -81,6 +81,7 @@ export const prepareRsbuild = async (
       plugins,
       resolve,
       source,
+      output,
       server: {
         printUrls: false,
         strictPort: false,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -94,7 +94,7 @@ export const runInPool = async ({
   });
 
   const { updateSnapshot } = context.snapshotManager.options;
-  const { plugins, resolve, source, ...runtimeConfig } =
+  const { plugins, resolve, source, output, ...runtimeConfig } =
     context.normalizedConfig;
 
   const results = await Promise.all(

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -132,13 +132,21 @@ export interface RstestConfig {
     'define' | 'tsconfigPath'
   >;
 
+  output?: Pick<NonNullable<RsbuildConfig['output']>, 'cssModules'>;
+
   resolve?: RsbuildConfig['resolve'];
 }
 
 export type NormalizedConfig = Required<
   Omit<
     RstestConfig,
-    'pool' | 'setupFiles' | 'testNamePattern' | 'plugins' | 'source' | 'resolve'
+    | 'pool'
+    | 'setupFiles'
+    | 'testNamePattern'
+    | 'plugins'
+    | 'source'
+    | 'resolve'
+    | 'output'
   >
 > & {
   pool: RstestPoolOptions;
@@ -147,4 +155,5 @@ export type NormalizedConfig = Required<
   plugins?: RstestConfig['plugins'];
   source?: RstestConfig['source'];
   resolve?: RstestConfig['resolve'];
+  output?: RstestConfig['output'];
 };

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -23,7 +23,7 @@ export type WorkerContext = {
   rootPath: RstestContext['rootPath'];
   runtimeConfig: Omit<
     RstestContext['normalizedConfig'],
-    'plugins' | 'source' | 'resolve'
+    'plugins' | 'source' | 'resolve' | 'output'
   >;
 };
 

--- a/tests/build/fixtures/cssModules/index.test.ts
+++ b/tests/build/fixtures/cssModules/index.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+import { style } from './src/index';
+
+it('css modules should work correctly', () => {
+  expect(style.titleClass).toBe('index-module__title-class');
+});

--- a/tests/build/fixtures/cssModules/rstest.config.ts
+++ b/tests/build/fixtures/cssModules/rstest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  name: 'node',
+  output: {
+    cssModules: {
+      localIdentName: '[name]__[local]',
+    },
+  },
+});

--- a/tests/build/fixtures/cssModules/src/env.d.ts
+++ b/tests/build/fixtures/cssModules/src/env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/tests/build/fixtures/cssModules/src/index.module.css
+++ b/tests/build/fixtures/cssModules/src/index.module.css
@@ -1,0 +1,3 @@
+.title-class {
+  font-size: 14px;
+}

--- a/tests/build/fixtures/cssModules/src/index.ts
+++ b/tests/build/fixtures/cssModules/src/index.ts
@@ -1,0 +1,3 @@
+import style from './index.module.css';
+
+export { style };


### PR DESCRIPTION
## Summary

`output.cssModules` configuration is used to setup css modules.

https://rsbuild.dev/config/output/css-modules

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
