### PR TITLE
feat: support tools rspack / swc / bundlerChain configs

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -69,7 +69,7 @@ export const prepareRsbuild = async (
   setupFiles: Record<string, string>,
 ): Promise<RsbuildInstance> => {
   const {
-    normalizedConfig: { name, plugins, resolve, source, output },
+    normalizedConfig: { name, plugins, resolve, source, output, tools },
   } = context;
 
   RsbuildLogger.level = isDebug() ? 'verbose' : 'error';
@@ -78,6 +78,7 @@ export const prepareRsbuild = async (
 
   const rsbuildInstance = await createRsbuild({
     rsbuildConfig: {
+      tools,
       plugins,
       resolve,
       source,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -94,8 +94,31 @@ export const runInPool = async ({
   });
 
   const { updateSnapshot } = context.snapshotManager.options;
-  const { plugins, resolve, source, output, ...runtimeConfig } =
-    context.normalizedConfig;
+  const {
+    testNamePattern,
+    testTimeout,
+    passWithNoTests,
+    retry,
+    globals,
+    clearMocks,
+    resetMocks,
+    restoreMocks,
+    unstubEnvs,
+    unstubGlobals,
+  } = context.normalizedConfig;
+
+  const runtimeConfig = {
+    testNamePattern,
+    testTimeout,
+    passWithNoTests,
+    retry,
+    globals,
+    clearMocks,
+    resetMocks,
+    restoreMocks,
+    unstubEnvs,
+    unstubGlobals,
+  };
 
   const results = await Promise.all(
     entries.map((entryInfo) =>

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -135,6 +135,11 @@ export interface RstestConfig {
   output?: Pick<NonNullable<RsbuildConfig['output']>, 'cssModules'>;
 
   resolve?: RsbuildConfig['resolve'];
+
+  tools?: Pick<
+    NonNullable<RsbuildConfig['tools']>,
+    'rspack' | 'swc' | 'bundlerChain'
+  >;
 }
 
 export type NormalizedConfig = Required<
@@ -147,6 +152,7 @@ export type NormalizedConfig = Required<
     | 'source'
     | 'resolve'
     | 'output'
+    | 'tools'
   >
 > & {
   pool: RstestPoolOptions;
@@ -156,4 +162,5 @@ export type NormalizedConfig = Required<
   source?: RstestConfig['source'];
   resolve?: RstestConfig['resolve'];
   output?: RstestConfig['output'];
+  tools?: RstestConfig['tools'];
 };

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -19,12 +19,23 @@ export type RuntimeRPC = {
   onTestCaseResult: (result: TestResult) => Promise<void>;
 };
 
+export type RuntimeConfig = Pick<
+  RstestContext['normalizedConfig'],
+  | 'testTimeout'
+  | 'testNamePattern'
+  | 'globals'
+  | 'passWithNoTests'
+  | 'retry'
+  | 'clearMocks'
+  | 'resetMocks'
+  | 'restoreMocks'
+  | 'unstubEnvs'
+  | 'unstubGlobals'
+>;
+
 export type WorkerContext = {
   rootPath: RstestContext['rootPath'];
-  runtimeConfig: Omit<
-    RstestContext['normalizedConfig'],
-    'plugins' | 'source' | 'resolve' | 'output'
-  >;
+  runtimeConfig: RuntimeConfig;
 };
 
 export type RunWorkerOptions = {

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -1,6 +1,6 @@
 import { isAbsolute, join, parse, sep } from 'pathe';
 import color from 'picocolors';
-import type { NormalizedConfig, TestResult } from '../types';
+import type { RuntimeConfig, TestResult } from '../types';
 import { TEST_DELIMITER } from './constants';
 
 export function getAbsolutePath(base: string, filepath: string): string {
@@ -105,8 +105,8 @@ const unwrapRegex = (value: string): RegExp | string => {
  * eg. RegExp
  */
 export const serializableConfig = (
-  normalizedConfig: NormalizedConfig,
-): NormalizedConfig => {
+  normalizedConfig: RuntimeConfig,
+): RuntimeConfig => {
   const { testNamePattern } = normalizedConfig;
   return {
     ...normalizedConfig,
@@ -118,8 +118,8 @@ export const serializableConfig = (
 };
 
 export const undoSerializableConfig = (
-  normalizedConfig: NormalizedConfig,
-): NormalizedConfig => {
+  normalizedConfig: RuntimeConfig,
+): RuntimeConfig => {
   const { testNamePattern } = normalizedConfig;
   return {
     ...normalizedConfig,

--- a/tests/build/fixtures/tools/rspack/index.test.ts
+++ b/tests/build/fixtures/tools/rspack/index.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+import { count } from './src/index';
+
+it('tools.rspack config should work correctly', () => {
+  expect(count).toBe(2);
+});

--- a/tests/build/fixtures/tools/rspack/rstest.config.ts
+++ b/tests/build/fixtures/tools/rspack/rstest.config.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  name: 'node',
+  tools: {
+    rspack: {
+      resolve: {
+        alias: {
+          './a': path.join(__dirname, './src/b'),
+        },
+      },
+    },
+  },
+});

--- a/tests/build/fixtures/tools/rspack/src/a.ts
+++ b/tests/build/fixtures/tools/rspack/src/a.ts
@@ -1,0 +1,1 @@
+export const count = 1;

--- a/tests/build/fixtures/tools/rspack/src/b.ts
+++ b/tests/build/fixtures/tools/rspack/src/b.ts
@@ -1,0 +1,1 @@
+export const count = 2;

--- a/tests/build/fixtures/tools/rspack/src/index.ts
+++ b/tests/build/fixtures/tools/rspack/src/index.ts
@@ -1,0 +1,1 @@
+export { count } from './a';

--- a/tests/build/index.test.ts
+++ b/tests/build/index.test.ts
@@ -7,26 +7,28 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('test build config', () => {
-  it.each([{ name: 'define' }, { name: 'alias' }, { name: 'plugin' }])(
-    '$name config should work correctly',
-    async ({ name }) => {
-      const { cli } = await runRstestCli({
-        command: 'rstest',
-        args: [
-          'run',
-          `fixtures/${name}/index.test.ts`,
-          '-c',
-          `fixtures/${name}/rstest.config.ts`,
-        ],
-        options: {
-          nodeOptions: {
-            cwd: __dirname,
-          },
+  it.each([
+    { name: 'define' },
+    { name: 'alias' },
+    { name: 'plugin' },
+    { name: 'tools/rspack' },
+  ])('$name config should work correctly', async ({ name }) => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        `fixtures/${name}/index.test.ts`,
+        '-c',
+        `fixtures/${name}/rstest.config.ts`,
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
         },
-      });
+      },
+    });
 
-      await cli.exec;
-      expect(cli.exec.process?.exitCode).toBe(0);
-    },
-  );
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

support `tools.rspack` / `tools.swc` / `tools.bundlerChain` configs.

```ts
import path from 'node:path';
import { defineConfig } from '@rstest/core';

export default defineConfig({
  name: 'node',
  tools: {
    rspack: {
      resolve: {
        alias: {
          './a': path.join(__dirname, './src/b'),
        },
      },
    },
  },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
