### PR TITLE
chore: merge runtime fails API

### DIFF
--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -1,19 +1,13 @@
 import type {
-  DescribeAPI,
-  DescribeBaseAPI,
-  DescribeEachFn,
   Rstest,
   RunnerAPI,
   RunnerHooks,
-  TestAPI,
-  TestBaseAPI,
-  TestEachFn,
   TestFileResult,
   WorkerState,
 } from '../../types';
 
 import { TestRunner } from './runner';
-import { RunnerRuntime } from './runtime';
+import { createRuntimeAPI } from './runtime';
 
 export function createRunner({ workerState }: { workerState: WorkerState }): {
   api: RunnerAPI;
@@ -30,69 +24,17 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
     sourcePath,
     runtimeConfig: { testTimeout },
   } = workerState;
-  const runtimeAPI: RunnerRuntime = new RunnerRuntime({
+  const runtime = createRuntimeAPI({
     sourcePath,
     testTimeout,
   });
   const testRunner: TestRunner = new TestRunner();
 
-  // TODO: optimize chainable API
-
-  const it = ((name, fn, timeout) =>
-    runtimeAPI.it({ name, fn, timeout })) as TestAPI;
-  it.fails = (name, fn, timeout) =>
-    runtimeAPI.it({ name, fn, timeout, fails: true });
-  it.each = runtimeAPI.each.bind(runtimeAPI) as TestEachFn;
-  it.todo = (name, fn, timeout) =>
-    runtimeAPI.it({ name, fn, timeout, runMode: 'todo' });
-
-  it.skip = ((name, fn, timeout) =>
-    runtimeAPI.it({ name, fn, timeout, runMode: 'skip' })) as TestBaseAPI;
-  it.skip.fails = (name, fn, timeout) =>
-    runtimeAPI.it({ name, fn, timeout, runMode: 'skip', fails: true });
-  it.skip.each = ((cases: any) => runtimeAPI.each(cases, 'skip')) as TestEachFn;
-
-  it.only = ((name, fn, timeout) =>
-    runtimeAPI.it({ name, fn, timeout, runMode: 'only' })) as TestBaseAPI;
-  it.only.fails = (name, fn, timeout) =>
-    runtimeAPI.it({ name, fn, timeout, runMode: 'only', fails: true });
-  it.only.each = ((cases: any) => runtimeAPI.each(cases, 'only')) as TestEachFn;
-
-  it.runIf = (condition: boolean) => (condition ? it : it.skip) as TestBaseAPI;
-  it.skipIf = (condition: boolean) => (condition ? it.skip : it) as TestBaseAPI;
-
-  const describe = ((name, fn) => runtimeAPI.describe(name, fn)) as DescribeAPI;
-
-  describe.only = ((name, fn) =>
-    runtimeAPI.describe(name, fn, 'only')) as DescribeBaseAPI;
-  describe.only.each = ((cases: any) =>
-    runtimeAPI.describeEach(cases, 'only')) as DescribeEachFn;
-  describe.todo = (name, fn) => runtimeAPI.describe(name, fn, 'todo');
-  describe.skip = ((name, fn) =>
-    runtimeAPI.describe(name, fn, 'skip')) as DescribeBaseAPI;
-  describe.skip.each = ((cases: any) =>
-    runtimeAPI.describeEach(cases, 'skip')) as DescribeEachFn;
-
-  describe.skipIf = (condition: boolean) =>
-    (condition ? describe.skip : describe) as DescribeBaseAPI;
-  describe.runIf = (condition: boolean) =>
-    (condition ? describe : describe.skip) as DescribeBaseAPI;
-
-  describe.each = runtimeAPI.describeEach.bind(runtimeAPI) as DescribeEachFn;
-
   return {
-    api: {
-      describe,
-      it,
-      test: it,
-      afterAll: runtimeAPI.afterAll.bind(runtimeAPI),
-      beforeAll: runtimeAPI.beforeAll.bind(runtimeAPI),
-      afterEach: runtimeAPI.afterEach.bind(runtimeAPI),
-      beforeEach: runtimeAPI.beforeEach.bind(runtimeAPI),
-    },
+    api: runtime.api,
     runner: {
       runTest: async (testPath: string, hooks: RunnerHooks, api: Rstest) => {
-        const tests = await runtimeAPI.getTests();
+        const tests = await runtime.instance.getTests();
         return testRunner.runTests({
           tests,
           testPath,

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -39,21 +39,23 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   // TODO: optimize chainable API
 
   const it = ((name, fn, timeout) =>
-    runtimeAPI.it(name, fn, timeout)) as TestAPI;
-  it.fails = runtimeAPI.fails.bind(runtimeAPI);
+    runtimeAPI.it({ name, fn, timeout })) as TestAPI;
+  it.fails = (name, fn, timeout) =>
+    runtimeAPI.it({ name, fn, timeout, fails: true });
   it.each = runtimeAPI.each.bind(runtimeAPI) as TestEachFn;
-  it.todo = (name, fn, timeout) => runtimeAPI.it(name, fn, timeout, 'todo');
+  it.todo = (name, fn, timeout) =>
+    runtimeAPI.it({ name, fn, timeout, runMode: 'todo' });
 
   it.skip = ((name, fn, timeout) =>
-    runtimeAPI.it(name, fn, timeout, 'skip')) as TestBaseAPI;
+    runtimeAPI.it({ name, fn, timeout, runMode: 'skip' })) as TestBaseAPI;
   it.skip.fails = (name, fn, timeout) =>
-    runtimeAPI.fails(name, fn, timeout, 'skip');
+    runtimeAPI.it({ name, fn, timeout, runMode: 'skip', fails: true });
   it.skip.each = ((cases: any) => runtimeAPI.each(cases, 'skip')) as TestEachFn;
 
   it.only = ((name, fn, timeout) =>
-    runtimeAPI.it(name, fn, timeout, 'only')) as TestBaseAPI;
+    runtimeAPI.it({ name, fn, timeout, runMode: 'only' })) as TestBaseAPI;
   it.only.fails = (name, fn, timeout) =>
-    runtimeAPI.fails(name, fn, timeout, 'only');
+    runtimeAPI.it({ name, fn, timeout, runMode: 'only', fails: true });
   it.only.each = ((cases: any) => runtimeAPI.each(cases, 'only')) as TestEachFn;
 
   it.runIf = (condition: boolean) => (condition ? it : it.skip) as TestBaseAPI;

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -4,8 +4,13 @@ import type {
   AfterEachListener,
   BeforeAllListener,
   BeforeEachListener,
+  DescribeAPI,
+  DescribeBaseAPI,
   DescribeEachFn,
+  RunnerAPI,
   Test,
+  TestAPI,
+  TestBaseAPI,
   TestCase,
   TestEachFn,
   TestRunMode,
@@ -315,3 +320,78 @@ export class RunnerRuntime {
     throw new Error('Expect to find a suite, but got undefined');
   }
 }
+
+export const createRuntimeAPI = ({
+  sourcePath,
+  testTimeout,
+}: { sourcePath: string; testTimeout: number }): {
+  api: RunnerAPI;
+  instance: RunnerRuntime;
+} => {
+  const runtimeInstance: RunnerRuntime = new RunnerRuntime({
+    sourcePath,
+    testTimeout,
+  });
+
+  // TODO: optimize chainable API
+
+  const it = ((name, fn, timeout) =>
+    runtimeInstance.it({ name, fn, timeout })) as TestAPI;
+  it.fails = (name, fn, timeout) =>
+    runtimeInstance.it({ name, fn, timeout, fails: true });
+  it.each = runtimeInstance.each.bind(runtimeInstance) as TestEachFn;
+  it.todo = (name, fn, timeout) =>
+    runtimeInstance.it({ name, fn, timeout, runMode: 'todo' });
+
+  it.skip = ((name, fn, timeout) =>
+    runtimeInstance.it({ name, fn, timeout, runMode: 'skip' })) as TestBaseAPI;
+  it.skip.fails = (name, fn, timeout) =>
+    runtimeInstance.it({ name, fn, timeout, runMode: 'skip', fails: true });
+  it.skip.each = ((cases: any) =>
+    runtimeInstance.each(cases, 'skip')) as TestEachFn;
+
+  it.only = ((name, fn, timeout) =>
+    runtimeInstance.it({ name, fn, timeout, runMode: 'only' })) as TestBaseAPI;
+  it.only.fails = (name, fn, timeout) =>
+    runtimeInstance.it({ name, fn, timeout, runMode: 'only', fails: true });
+  it.only.each = ((cases: any) =>
+    runtimeInstance.each(cases, 'only')) as TestEachFn;
+
+  it.runIf = (condition: boolean) => (condition ? it : it.skip) as TestBaseAPI;
+  it.skipIf = (condition: boolean) => (condition ? it.skip : it) as TestBaseAPI;
+
+  const describe = ((name, fn) =>
+    runtimeInstance.describe(name, fn)) as DescribeAPI;
+
+  describe.only = ((name, fn) =>
+    runtimeInstance.describe(name, fn, 'only')) as DescribeBaseAPI;
+  describe.only.each = ((cases: any) =>
+    runtimeInstance.describeEach(cases, 'only')) as DescribeEachFn;
+  describe.todo = (name, fn) => runtimeInstance.describe(name, fn, 'todo');
+  describe.skip = ((name, fn) =>
+    runtimeInstance.describe(name, fn, 'skip')) as DescribeBaseAPI;
+  describe.skip.each = ((cases: any) =>
+    runtimeInstance.describeEach(cases, 'skip')) as DescribeEachFn;
+
+  describe.skipIf = (condition: boolean) =>
+    (condition ? describe.skip : describe) as DescribeBaseAPI;
+  describe.runIf = (condition: boolean) =>
+    (condition ? describe : describe.skip) as DescribeBaseAPI;
+
+  describe.each = runtimeInstance.describeEach.bind(
+    runtimeInstance,
+  ) as DescribeEachFn;
+
+  return {
+    api: {
+      describe,
+      it,
+      test: it,
+      afterAll: runtimeInstance.afterAll.bind(runtimeInstance),
+      beforeAll: runtimeInstance.beforeAll.bind(runtimeInstance),
+      afterEach: runtimeInstance.afterEach.bind(runtimeInstance),
+      beforeEach: runtimeInstance.beforeEach.bind(runtimeInstance),
+    },
+    instance: runtimeInstance,
+  };
+};

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -228,13 +228,21 @@ export class RunnerRuntime {
     }
   }
 
-  it(
-    name: string,
-    fn?: () => void | Promise<void>,
-    timeout: number = this.defaultTestTimeout,
-    runMode: TestRunMode = 'run',
+  it({
+    name,
+    fn,
+    timeout = this.defaultTestTimeout,
+    runMode = 'run',
+    fails = false,
     each = false,
-  ): void {
+  }: {
+    name: string;
+    fn?: () => void | Promise<void>;
+    timeout?: number;
+    runMode?: TestRunMode;
+    each?: boolean;
+    fails?: boolean;
+  }): void {
     this.addTestCase({
       name,
       fn: fn
@@ -249,6 +257,7 @@ export class RunnerRuntime {
       type: 'case',
       timeout,
       each,
+      fails,
     });
   }
 
@@ -282,37 +291,15 @@ export class RunnerRuntime {
         const param = cases[i]!;
         const params = castArray(param) as Parameters<typeof fn>;
 
-        this.it(
-          formatName(name, param, i),
-          () => fn?.(...params),
+        this.it({
+          name: formatName(name, param, i),
+          fn: () => fn?.(...params),
           timeout,
           runMode,
-          true,
-        );
+          each: true,
+        });
       }
     };
-  }
-
-  fails(
-    name: string,
-    fn?: () => void | Promise<void>,
-    timeout: number = this.defaultTestTimeout,
-    runMode: TestRunMode = 'run',
-  ): void {
-    this.addTestCase({
-      name,
-      fn: fn
-        ? wrapTimeout({
-            name: 'test',
-            fn,
-            timeout,
-            stackTraceError: new Error('STACK_TRACE_ERROR'),
-          })
-        : fn,
-      fails: true,
-      runMode,
-      type: 'case',
-    });
   }
 
   private getCurrentSuite(): TestSuite {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -51,6 +51,7 @@ export type TestAPI = TestBaseAPI & {
   runIf: (condition: boolean) => TestBaseAPI;
   skipIf: (condition: boolean) => TestBaseAPI;
   todo: TestFn;
+  concurrent: TestBaseAPI;
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -51,7 +51,6 @@ export type TestAPI = TestBaseAPI & {
   runIf: (condition: boolean) => TestBaseAPI;
   skipIf: (condition: boolean) => TestBaseAPI;
   todo: TestFn;
-  concurrent: TestBaseAPI;
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -1,9 +1,9 @@
-import { RunnerRuntime } from '../../src/runtime/runner/runtime';
+import { createRuntimeAPI } from '../../src/runtime/runner/runtime';
 import type { TestSuite } from '../../src/types';
 
 describe('RunnerRuntime', () => {
   it('should add test correctly', async () => {
-    const runtime = new RunnerRuntime({
+    const { api: runtime, instance } = createRuntimeAPI({
       sourcePath: __filename,
       testTimeout: 100,
     });
@@ -23,7 +23,7 @@ describe('RunnerRuntime', () => {
     runtime.describe('suite - 1', () => {});
     runtime.it('test - 2', () => {});
 
-    const tests = await runtime.getTests();
+    const tests = await instance.getTests();
 
     expect(tests.map((test) => test.name)).toEqual([
       'suite - 0',
@@ -44,7 +44,7 @@ describe('RunnerRuntime', () => {
   });
 
   it('should add test correctly when describe fn undefined', async () => {
-    const runtime = new RunnerRuntime({
+    const { api: runtime, instance } = createRuntimeAPI({
       sourcePath: __filename,
       testTimeout: 100,
     });
@@ -64,7 +64,7 @@ describe('RunnerRuntime', () => {
     });
     runtime.it('test - 2', () => {});
 
-    const tests = await runtime.getTests();
+    const tests = await instance.getTests();
 
     expect(tests.map((test) => test.name)).toEqual([
       'suite - 0',


### PR DESCRIPTION
## Summary

* Removed the redundant `fails` method, as its functionality is now integrated into the refactored `it` method. 


<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
