### PR TITLE
feat: support run tests in parallel

### DIFF
--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -223,7 +223,14 @@ export const printSummaryErrorLogs = async ({
 };
 
 async function printCodeFrame(frame: StackFrame) {
-  const source = fs.readFileSync(frame.file!, 'utf-8');
+  const filePath = frame.file?.startsWith('file')
+    ? new URL(frame.file!)
+    : frame.file;
+
+  if (!filePath) {
+    return;
+  }
+  const source = fs.readFileSync(filePath!, 'utf-8');
   const { codeFrameColumns } = await import('@babel/code-frame');
   const result = codeFrameColumns(
     source,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -51,6 +51,7 @@ export type TestAPI = TestBaseAPI & {
   runIf: (condition: boolean) => TestBaseAPI;
   skipIf: (condition: boolean) => TestBaseAPI;
   todo: TestFn;
+  concurrent: TestBaseAPI;
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -30,6 +30,7 @@ export type TestCase = {
   timeout?: number;
   fails?: boolean;
   each?: boolean;
+  concurrent?: boolean;
   inTestEach?: boolean;
   // TODO
   only?: boolean;
@@ -65,6 +66,7 @@ export type TestSuite = {
   runMode: TestRunMode;
   each?: boolean;
   inTestEach?: boolean;
+  concurrent?: boolean;
   // TODO
   filepath?: string;
   /** nested cases and suite could in a suite */

--- a/tests/test-api/concurrent.test.ts
+++ b/tests/test-api/concurrent.test.ts
@@ -1,0 +1,149 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+describe('Test Concurrent', () => {
+  it('should run concurrent cases correctly', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/concurrent.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.includes('[log]'))).toMatchInlineSnapshot(`
+      [
+        "[log] serial test",
+        "[log] serial test 0 - 1",
+        "[log] concurrent test 1",
+        "[log] concurrent test 2",
+        "[log] concurrent test 2 - 1",
+        "[log] concurrent test 1 - 1",
+        "[log] concurrent test 3",
+        "[log] concurrent test 3 - 1",
+        "[log] concurrent test B 1",
+        "[log] concurrent test B 1 - 1",
+        "[log] serial test B 1",
+        "[log] concurrent test B 2",
+        "[log] concurrent test B 2 - 1",
+      ]
+    `);
+  });
+
+  it('should run concurrent cases correctly with nested', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/concurrentNested.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.includes('[log]'))).toMatchInlineSnapshot(`
+      [
+        "[log] serial test",
+        "[log] serial test 0 - 1",
+        "[log] concurrent test 1",
+        "[log] concurrent test 2",
+        "[log] concurrent test 2 - 1",
+        "[log] concurrent test 1 - 1",
+        "[log] concurrent test 3",
+        "[log] concurrent test 4",
+        "[log] concurrent test 3 - 1",
+        "[log] concurrent test 4 - 1",
+        "[log] concurrent test 5",
+        "[log] concurrent test 5 - 1",
+      ]
+    `);
+  });
+
+  it('should run concurrent cases isolated in different suites', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/concurrentIsolated.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.includes('[log]'))).toMatchInlineSnapshot(`
+      [
+        "[log] concurrent test 1",
+        "[log] concurrent test 2",
+        "[log] concurrent test 2 - 1",
+        "[log] concurrent test 1 - 1",
+        "[log] concurrent test B 1",
+        "[log] concurrent test B 2",
+        "[log] concurrent test B 2 - 1",
+        "[log] concurrent test B 1 - 1",
+      ]
+    `);
+  });
+
+  it('should run concurrent cases correctly with limit', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/concurrentLimit.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.includes('[log]'))).toMatchInlineSnapshot(`
+      [
+        "[log] concurrent test 1",
+        "[log] concurrent test 2",
+        "[log] concurrent test 3",
+        "[log] concurrent test 4",
+        "[log] concurrent test 5",
+        "[log] concurrent test 2 - 1",
+        "[log] concurrent test 6",
+        "[log] concurrent test 3 - 1",
+        "[log] concurrent test 7",
+        "[log] concurrent test 4 - 1",
+        "[log] concurrent test 5 - 1",
+        "[log] concurrent test 1 - 1",
+        "[log] concurrent test 6 - 1",
+        "[log] concurrent test 7 - 1",
+      ]
+    `);
+  });
+});

--- a/tests/test-api/fixtures/concurrent.test.ts
+++ b/tests/test-api/fixtures/concurrent.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from '@rstest/core';
+
+describe('suite', () => {
+  it('serial test', async () => {
+    console.log('[log] serial test');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    console.log('[log] serial test 0 - 1');
+  });
+  it.concurrent('concurrent test 1', async () => {
+    console.log('[log] concurrent test 1');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    console.log('[log] concurrent test 1 - 1');
+  });
+
+  it.concurrent('concurrent test 2', async () => {
+    console.log('[log] concurrent test 2');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test 2 - 1');
+  });
+
+  it.skip('serial test 1', async () => {
+    console.log('[log] serial test 1');
+  });
+
+  it.concurrent('concurrent test 3', async () => {
+    console.log('[log] concurrent test 3');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test 3 - 1');
+  });
+});
+
+describe('suite B', () => {
+  it.concurrent('concurrent test B 1', async () => {
+    console.log('[log] concurrent test B 1');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    console.log('[log] concurrent test B 1 - 1');
+  });
+
+  it('serial test B 1', async () => {
+    console.log('[log] serial test B 1');
+  });
+
+  it.concurrent('concurrent test B 2', async () => {
+    console.log('[log] concurrent test B 2');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test B 2 - 1');
+  });
+});

--- a/tests/test-api/fixtures/concurrentIsolated.test.ts
+++ b/tests/test-api/fixtures/concurrentIsolated.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from '@rstest/core';
+
+describe('suite', () => {
+  it.concurrent('concurrent test 1', async () => {
+    console.log('[log] concurrent test 1');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    console.log('[log] concurrent test 1 - 1');
+  });
+
+  it.concurrent('concurrent test 2', async () => {
+    console.log('[log] concurrent test 2');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test 2 - 1');
+  });
+});
+
+describe('suite B', () => {
+  it.concurrent('concurrent test B 1', async () => {
+    console.log('[log] concurrent test B 1');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    console.log('[log] concurrent test B 1 - 1');
+  });
+
+  it.concurrent('concurrent test B 2', async () => {
+    console.log('[log] concurrent test B 2');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test B 2 - 1');
+  });
+});

--- a/tests/test-api/fixtures/concurrentLimit.test.ts
+++ b/tests/test-api/fixtures/concurrentLimit.test.ts
@@ -1,0 +1,42 @@
+import { it } from '@rstest/core';
+
+it.concurrent('concurrent test 1', async () => {
+  console.log('[log] concurrent test 1');
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  console.log('[log] concurrent test 1 - 1');
+});
+
+it.concurrent('concurrent test 2', async () => {
+  console.log('[log] concurrent test 2');
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  console.log('[log] concurrent test 2 - 1');
+});
+it.concurrent('concurrent test 3', async () => {
+  console.log('[log] concurrent test 3');
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  console.log('[log] concurrent test 3 - 1');
+});
+
+it.concurrent('concurrent test 4', async () => {
+  console.log('[log] concurrent test 4');
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  console.log('[log] concurrent test 4 - 1');
+});
+
+it.concurrent('concurrent test 5', async () => {
+  console.log('[log] concurrent test 5');
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  console.log('[log] concurrent test 5 - 1');
+});
+
+it.concurrent('concurrent test 6', async () => {
+  console.log('[log] concurrent test 6');
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  console.log('[log] concurrent test 6 - 1');
+});
+
+it.concurrent('concurrent test 7', async () => {
+  console.log('[log] concurrent test 7');
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  console.log('[log] concurrent test 7 - 1');
+});

--- a/tests/test-api/fixtures/concurrentNested.test.ts
+++ b/tests/test-api/fixtures/concurrentNested.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from '@rstest/core';
+
+describe('suite', () => {
+  it('serial test', async () => {
+    console.log('[log] serial test');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    console.log('[log] serial test 0 - 1');
+  });
+  it.concurrent('concurrent test 1', async () => {
+    console.log('[log] concurrent test 1');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    console.log('[log] concurrent test 1 - 1');
+  });
+
+  it.concurrent('concurrent test 2', async () => {
+    console.log('[log] concurrent test 2');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test 2 - 1');
+  });
+
+  describe('suite 1', () => {
+    it.concurrent('concurrent test 3', async () => {
+      console.log('[log] concurrent test 3');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      console.log('[log] concurrent test 3 - 1');
+    });
+
+    it.concurrent('concurrent test 4', async () => {
+      console.log('[log] concurrent test 4');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      console.log('[log] concurrent test 4 - 1');
+    });
+  });
+
+  it.concurrent('concurrent test 5', async () => {
+    console.log('[log] concurrent test 5');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test 5 - 1');
+  });
+});


### PR DESCRIPTION
## Summary

support run tests in parallel via `test.concurrent` API.

```ts
// The two tests marked with concurrent will be started in parallel
describe('suite', () => {
  it('serial test', async () => { /* ... */ })
  it.concurrent('concurrent test 1', async ({ expect }) => { /* ... */ })
  it.concurrent('concurrent test 2', async ({ expect }) => { /* ... */ })
})
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
