### PR TITLE
feat: support `describe.concurrent`

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -66,6 +66,7 @@ export type DescribeAPI = DescribeBaseAPI & {
   runIf: (condition: boolean) => DescribeBaseAPI;
   skipIf: (condition: boolean) => DescribeBaseAPI;
   todo: DescribeFn;
+  concurrent: DescribeBaseAPI;
 };
 
 export type RunnerAPI = {

--- a/tests/describe/concurrent.test.ts
+++ b/tests/describe/concurrent.test.ts
@@ -1,0 +1,42 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+describe('Test Concurrent', () => {
+  it('should run concurrent cases correctly', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/concurrent.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.includes('[log]'))).toMatchInlineSnapshot(`
+      [
+        "[log] concurrent test 1",
+        "[log] concurrent test 2",
+        "[log] concurrent test 3",
+        "[log] concurrent test 4",
+        "[log] concurrent test 5",
+        "[log] concurrent test 2 - 1",
+        "[log] concurrent test B 1",
+        "[log] concurrent test 3 - 1",
+        "[log] concurrent test 4 - 1",
+        "[log] concurrent test 5 - 1",
+        "[log] concurrent test 1 - 1",
+        "[log] concurrent test B 1 - 1",
+      ]
+    `);
+  });
+});

--- a/tests/describe/fixtures/concurrent.test.ts
+++ b/tests/describe/fixtures/concurrent.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from '@rstest/core';
+
+describe.concurrent('suite', () => {
+  it('test 1', async () => {
+    console.log('[log] concurrent test 1');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    console.log('[log] concurrent test 1 - 1');
+  });
+
+  it('test 2', async () => {
+    console.log('[log] concurrent test 2');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test 2 - 1');
+  });
+
+  describe('suite 1', () => {
+    it('test 3', async () => {
+      console.log('[log] concurrent test 3');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      console.log('[log] concurrent test 3 - 1');
+    });
+
+    it('test 4', async () => {
+      console.log('[log] concurrent test 4');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      console.log('[log] concurrent test 4 - 1');
+    });
+  });
+
+  it('test 5', async () => {
+    console.log('[log] concurrent test 5');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    console.log('[log] concurrent test 5 - 1');
+  });
+});
+
+describe.concurrent('suite B', () => {
+  it('test B 1', async () => {
+    console.log('[log] concurrent test B 1');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    console.log('[log] concurrent test B 1 - 1');
+  });
+});


### PR DESCRIPTION
## Summary

If you use `.concurrent` on a suite, every test in it will be started in parallel.

```ts
// All tests within this suite will be started in parallel
describe.concurrent('suite', () => {
  it('concurrent test 1', async () => { /* ... */ })
  it('concurrent test 2', async () => { /* ... */ })
  it('concurrent test 3', async () => { /* ... */ })
})
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
