### PR TITLE
feat: support maxConcurrency option

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -22,6 +22,7 @@ type CommonOptions = {
   unstubGlobals?: boolean;
   unstubEnvs?: boolean;
   retry?: number;
+  maxConcurrency?: number;
 };
 
 const applyCommonOptions = (cli: CAC) => {
@@ -53,6 +54,10 @@ const applyCommonOptions = (cli: CAC) => {
     )
     .option('--testTimeout <testTimeout>', 'Timeout of a test in milliseconds')
     .option('--retry <retry>', 'Number of times to retry a test if it fails.')
+    .option(
+      '--maxConcurrency <maxConcurrency>',
+      'Maximum number of concurrent tests.',
+    )
     .option(
       '--clearMocks',
       'Automatically clear mock calls, instances, contexts and results before every test.',
@@ -98,6 +103,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'unstubEnvs',
     'unstubGlobals',
     'retry',
+    'maxConcurrency',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -97,6 +97,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   restoreMocks: false,
   unstubGlobals: false,
   unstubEnvs: false,
+  maxConcurrency: 5,
 });
 
 export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -105,6 +105,7 @@ export const runInPool = async ({
     restoreMocks,
     unstubEnvs,
     unstubGlobals,
+    maxConcurrency,
   } = context.normalizedConfig;
 
   const runtimeConfig = {
@@ -118,6 +119,7 @@ export const runInPool = async ({
     restoreMocks,
     unstubEnvs,
     unstubGlobals,
+    maxConcurrency,
   };
 
   const results = await Promise.all(

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -42,7 +42,12 @@ export class TestRunner {
     api: Rstest;
   }): Promise<TestFileResult> {
     const {
-      runtimeConfig: { passWithNoTests, testNamePattern, retry },
+      runtimeConfig: {
+        passWithNoTests,
+        testNamePattern,
+        retry,
+        maxConcurrency,
+      },
       snapshotOptions,
     } = state;
     const results: TestResult[] = [];
@@ -168,7 +173,7 @@ export class TestRunner {
       return result;
     };
 
-    const limitMaxConcurrency = limitConcurrency(5);
+    const limitMaxConcurrency = limitConcurrency(maxConcurrency);
 
     const runTests = async (
       allTest: Test[],

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -123,6 +123,12 @@ export interface RstestConfig {
    */
   unstubEnvs?: boolean;
 
+  /**
+   * Maximum number of concurrent tests
+   * @default 5
+   */
+  maxConcurrency?: number;
+
   // Rsbuild configs
 
   plugins?: RsbuildConfig['plugins'];

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -31,6 +31,7 @@ export type RuntimeConfig = Pick<
   | 'restoreMocks'
   | 'unstubEnvs'
   | 'unstubGlobals'
+  | 'maxConcurrency'
 >;
 
 export type WorkerContext = {

--- a/tests/test-api/concurrent.test.ts
+++ b/tests/test-api/concurrent.test.ts
@@ -115,7 +115,7 @@ describe('Test Concurrent', () => {
 
     const { cli } = await runRstestCli({
       command: 'rstest',
-      args: ['run', 'fixtures/concurrentLimit.test.ts'],
+      args: ['run', 'fixtures/concurrentLimit.test.ts', '--maxConcurrency=4'],
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -133,14 +133,14 @@ describe('Test Concurrent', () => {
         "[log] concurrent test 2",
         "[log] concurrent test 3",
         "[log] concurrent test 4",
-        "[log] concurrent test 5",
         "[log] concurrent test 2 - 1",
-        "[log] concurrent test 6",
+        "[log] concurrent test 5",
         "[log] concurrent test 3 - 1",
-        "[log] concurrent test 7",
+        "[log] concurrent test 6",
         "[log] concurrent test 4 - 1",
-        "[log] concurrent test 5 - 1",
+        "[log] concurrent test 7",
         "[log] concurrent test 1 - 1",
+        "[log] concurrent test 5 - 1",
         "[log] concurrent test 6 - 1",
         "[log] concurrent test 7 - 1",
       ]


### PR DESCRIPTION
## Summary

- `maxConcurrency`: Maximum number of concurrent tests that are allowed to run at the same time in a test file (default: 5)
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
