### PR TITLE
feat: support get expect from test context

### DIFF
--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -11,6 +11,7 @@ import type {
   Test,
   TestAPI,
   TestBaseAPI,
+  TestCallbackFn,
   TestCase,
   TestEachFn,
   TestRunMode,
@@ -217,12 +218,13 @@ export class RunnerRuntime {
     return this.tests;
   }
 
-  addTestCase(test: Omit<TestCase, 'filePath'>): void {
+  addTestCase(test: Omit<TestCase, 'filePath' | 'context'>): void {
     if (this.collectStatus === 'lazy') {
       this.currentCollectList.push(() => {
         this.addTest({
           ...test,
           filePath: this.sourcePath,
+          context: undefined!,
         });
         this.resetCurrentTest();
       });
@@ -230,6 +232,7 @@ export class RunnerRuntime {
       this.addTest({
         ...test,
         filePath: this.sourcePath,
+        context: undefined!,
       });
       this.resetCurrentTest();
     }
@@ -255,7 +258,7 @@ export class RunnerRuntime {
     concurrent = false,
   }: {
     name: string;
-    fn?: () => void | Promise<void>;
+    fn?: TestCallbackFn;
     timeout?: number;
     runMode?: TestRunMode;
     each?: boolean;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -8,9 +8,15 @@ import type {
 } from './testSuite';
 import type { MaybePromise } from './utils';
 
+export type TestContext = {
+  expect: RstestExpect;
+};
+
+export type TestCallbackFn = (context: TestContext) => MaybePromise<void>;
+
 type TestFn = (
   description: string,
-  fn?: () => MaybePromise<void>,
+  fn?: TestCallbackFn,
   timeout?: number,
 ) => void;
 

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,4 +1,5 @@
 import type { SnapshotResult } from '@vitest/snapshot';
+import type { TestContext } from './api';
 
 // TODO: Unify filePath、testPath、originPath、sourcePath
 import type { MaybePromise } from './utils';
@@ -25,13 +26,14 @@ export interface TaskResult {
 export type TestCase = {
   filePath: string;
   name: string;
-  fn?: () => void | Promise<void>;
+  fn?: (context: TestContext) => void | Promise<void>;
   runMode: TestRunMode;
   timeout?: number;
   fails?: boolean;
   each?: boolean;
   concurrent?: boolean;
   inTestEach?: boolean;
+  context: TestContext;
   // TODO
   only?: boolean;
   // TODO

--- a/tests/test-api/__snapshots__/concurrentContext.test.ts.snap
+++ b/tests/test-api/__snapshots__/concurrentContext.test.ts.snap
@@ -1,0 +1,3 @@
+// Snapshot v1
+
+exports[`concurrent test 2 1`] = `"hello world"`;

--- a/tests/test-api/concurrentContext.test.ts
+++ b/tests/test-api/concurrentContext.test.ts
@@ -1,0 +1,19 @@
+import { it } from '@rstest/core';
+
+it.concurrent('concurrent test 1', async ({ expect }) => {
+  expect.assertions(1);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  expect(1 + 1).toBe(2);
+});
+
+it.concurrent('concurrent test 2', async ({ expect }) => {
+  expect(1 + 1).toBe(2);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect('hello world').toMatchSnapshot();
+});
+it.concurrent('concurrent test 3', async ({ expect }) => {
+  expect.assertions(2);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(1 + 1).toBe(2);
+  expect(1 + 2).toBe(3);
+});


### PR DESCRIPTION
## Summary

Support get expect from test context. This API is useful for running snapshot and assertion tests concurrently because global expect cannot track them: 

```ts
it.concurrent('concurrent test 1', async ({ expect }) => {
  await new Promise((resolve) => setTimeout(resolve, 100));
  expect('hello world').toMatchSnapshot();
});

it.concurrent('concurrent test 2', async ({ expect }) => {
  expect.assertions(2);
  await new Promise((resolve) => setTimeout(resolve, 100));
  expect(1 + 1).toBe(2);
  expect(1 + 2).toBe(3);
});

```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
