### PR TITLE
feat: support disable the summary outputs by setting `summary` to `false`.

### DIFF
--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -1,5 +1,6 @@
 import { relative } from 'pathe';
 import type {
+  DefaultReporterOptions,
   Duration,
   GetSourcemap,
   Reporter,
@@ -19,9 +20,14 @@ import { printSummaryErrorLogs, printSummaryLog } from './summary';
 
 export class DefaultReporter implements Reporter {
   private rootPath: string;
+  private options: DefaultReporterOptions = {};
 
-  constructor({ rootPath }: { rootPath: string }) {
+  constructor({
+    rootPath,
+    options,
+  }: { rootPath: string; options: DefaultReporterOptions }) {
     this.rootPath = rootPath;
+    this.options = options;
   }
 
   onTestFileStart(test: TestFileInfo): void {
@@ -74,6 +80,9 @@ export class DefaultReporter implements Reporter {
     snapshotSummary: SnapshotSummary;
     getSourcemap: GetSourcemap;
   }): Promise<void> {
+    if (this.options.summary === false) {
+      return;
+    }
     await printSummaryErrorLogs({
       testResults,
       results,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,5 +1,9 @@
 import type { RsbuildConfig } from '@rsbuild/core';
-import type { BuiltInReporterNames, Reporter } from './reporter';
+import type {
+  BuiltInReporterNames,
+  Reporter,
+  ReporterWithOptions,
+} from './reporter';
 
 export type RstestPoolType = 'forks';
 
@@ -84,7 +88,12 @@ export interface RstestConfig {
   reporters?:
     | Reporter
     | BuiltInReporterNames
-    | (Reporter | BuiltInReporterNames)[];
+    | (
+        | Reporter
+        | BuiltInReporterNames
+        | [BuiltInReporterNames]
+        | ReporterWithOptions
+      )[];
   /**
    * Run only tests with a name that matches the regex.
    */

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -16,6 +16,24 @@ export type GetSourcemap = (sourcePath: string) => SourceMapInput | null;
 
 export type { BuiltInReporterNames };
 
+export type DefaultReporterOptions = {
+  /**
+   * prints out summary of all tests
+   * @default true
+   */
+  summary?: boolean;
+};
+
+type BuiltinReporterOptions = {
+  default: DefaultReporterOptions;
+};
+
+export type ReporterWithOptions<
+  Name extends BuiltInReporterNames = BuiltInReporterNames,
+> = Name extends keyof BuiltinReporterOptions
+  ? [Name, Partial<BuiltinReporterOptions[Name]>]
+  : [Name, Record<string, unknown>];
+
 export interface Reporter {
   /**
    * Called before test file run.


### PR DESCRIPTION
## Summary

Support disable the summary outputs by setting `summary` to `false`.

```ts
export default defineConfig({
  reporters: [['default', { summary: false}]],
});

```

before:
<img width="922" alt="image" src="https://github.com/user-attachments/assets/6c5b0438-3fdb-4587-87bd-15097ad15d1d" />


after:
<img width="872" alt="image" src="https://github.com/user-attachments/assets/a8af1d0a-72b1-45b9-a4e1-41a146b63f10" />



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
