### PR TITLE
feat: support custom handler for console log in tests

### DIFF
--- a/packages/core/src/core/context.ts
+++ b/packages/core/src/core/context.ts
@@ -52,7 +52,10 @@ export function createContext(
     : cwd;
 
   const rstestConfig = withDefaultConfig(userConfig);
-  const reporters = createReporters(rstestConfig.reporters, { rootPath });
+  const reporters = createReporters(rstestConfig.reporters, {
+    rootPath,
+    config: rstestConfig,
+  });
   const snapshotManager = new SnapshotManager({
     updateSnapshot: rstestConfig.update ? 'all' : isCI ? 'none' : 'new',
   });

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -142,6 +142,11 @@ export const runInPool = async ({
               reporters.map((reporter) => reporter.onTestCaseResult?.(result)),
             );
           },
+          onConsoleLog: async (log) => {
+            await Promise.all(
+              reporters.map((reporter) => reporter.onConsoleLog?.(log)),
+            );
+          },
           onTestFileStart: async (test) => {
             await Promise.all(
               reporters.map((reporter) => reporter.onTestFileStart?.(test)),

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -4,6 +4,7 @@ import type {
   Duration,
   GetSourcemap,
   Reporter,
+  RstestConfig,
   SnapshotSummary,
   TestFileInfo,
   TestFileResult,
@@ -20,13 +21,20 @@ import { printSummaryErrorLogs, printSummaryLog } from './summary';
 
 export class DefaultReporter implements Reporter {
   private rootPath: string;
+  private config: RstestConfig;
   private options: DefaultReporterOptions = {};
 
   constructor({
     rootPath,
     options,
-  }: { rootPath: string; options: DefaultReporterOptions }) {
+    config,
+  }: {
+    rootPath: string;
+    config: RstestConfig;
+    options: DefaultReporterOptions;
+  }) {
     this.rootPath = rootPath;
+    this.config = config;
     this.options = options;
   }
 
@@ -65,6 +73,16 @@ export class DefaultReporter implements Reporter {
         console.error(color.red(`    ${error.message}`));
       }
     }
+  }
+
+  onConsoleLog(log: { content: string }): void {
+    const shouldLog = this.config.onConsoleLog?.(log.content) ?? true;
+
+    if (!shouldLog) {
+      return;
+    }
+
+    console.log(log.content);
   }
 
   async onTestRunEnd({

--- a/packages/core/src/runtime/worker/console.ts
+++ b/packages/core/src/runtime/worker/console.ts
@@ -1,0 +1,13 @@
+import { Console } from 'node:console';
+import { format } from 'node:util';
+import type { WorkerRPC } from './rpc';
+
+export function createCustomConsole(rpc: WorkerRPC): Console {
+  class CustomConsole extends Console {
+    override log(firstArg: unknown, ...args: Array<unknown>) {
+      rpc.onConsoleLog({ content: format(firstArg, ...args) });
+    }
+  }
+
+  return new CustomConsole(process.stdout, process.stderr);
+}

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -50,12 +50,15 @@ const runInPool = async ({
   };
 
   const { createRstestRuntime } = await import('../api');
+  const { createCustomConsole } = await import('./console');
+
   const { api, runner } = createRstestRuntime(workerState);
 
   const rstestContext = {
     global: {
       '@rstest/core': api,
     },
+    console: createCustomConsole(rpc),
     ...(globals ? getGlobalApi(api) : {}),
   };
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -138,6 +138,11 @@ export interface RstestConfig {
    */
   maxConcurrency?: number;
 
+  /**
+   * Custom handler for console log in tests
+   */
+  onConsoleLog?: (content: string) => boolean | void;
+
   // Rsbuild configs
 
   plugins?: RsbuildConfig['plugins'];
@@ -168,11 +173,13 @@ export type NormalizedConfig = Required<
     | 'resolve'
     | 'output'
     | 'tools'
+    | 'onConsoleLog'
   >
 > & {
   pool: RstestPoolOptions;
   setupFiles?: string[] | string;
   testNamePattern?: RstestConfig['testNamePattern'];
+  onConsoleLog?: RstestConfig['onConsoleLog'];
   plugins?: RstestConfig['plugins'];
   source?: RstestConfig['source'];
   resolve?: RstestConfig['resolve'];

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -1,7 +1,12 @@
 import type { SourceMapInput } from '@jridgewell/trace-mapping';
 import type { SnapshotSummary } from '@vitest/snapshot';
 import type { BuiltInReporterNames } from '../core/context';
-import type { TestFileInfo, TestFileResult, TestResult } from './testSuite';
+import type {
+  TestFileInfo,
+  TestFileResult,
+  TestResult,
+  UserConsoleLog,
+} from './testSuite';
 import type { MaybePromise } from './utils';
 
 export type Duration = {
@@ -59,4 +64,9 @@ export interface Reporter {
     getSourcemap: GetSourcemap;
     snapshotSummary: SnapshotSummary;
   }) => MaybePromise<void>;
+
+  /**
+   * Called when console log is calling.
+   */
+  onConsoleLog?: (log: UserConsoleLog) => void;
 }

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -116,3 +116,7 @@ export type TestFileResult = TestResult & {
   results: TestResult[];
   snapshotResult?: SnapshotResult;
 };
+
+export interface UserConsoleLog {
+  content: string;
+}

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -2,7 +2,7 @@ import type { SnapshotUpdateState } from '@vitest/snapshot';
 import type { SnapshotEnvironment } from '@vitest/snapshot/environment';
 import type { RstestContext } from './core';
 import type { SourceMapInput } from './reporter';
-import type { TestFileInfo, TestResult } from './testSuite';
+import type { TestFileInfo, TestResult, UserConsoleLog } from './testSuite';
 
 export type EntryInfo = {
   filePath: string;
@@ -17,6 +17,7 @@ export type ServerRPC = {};
 export type RuntimeRPC = {
   onTestFileStart: (test: TestFileInfo) => Promise<void>;
   onTestCaseResult: (result: TestResult) => Promise<void>;
+  onConsoleLog: (log: UserConsoleLog) => void;
 };
 
 export type RuntimeConfig = Pick<

--- a/tests/log/fixtures/consoleLogFalse.config.ts
+++ b/tests/log/fixtures/consoleLogFalse.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  onConsoleLog: () => false,
+});

--- a/tests/log/fixtures/log.test.ts
+++ b/tests/log/fixtures/log.test.ts
@@ -1,0 +1,5 @@
+import { test } from '@rstest/core';
+
+test('log output', () => {
+  console.log("I'm log");
+});

--- a/tests/log/index.test.ts
+++ b/tests/log/index.test.ts
@@ -1,0 +1,26 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('console log', () => {
+  it('should not console log when onConsoleLog return false', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'log.test', '-c', 'consoleLogFalse.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('I'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

support custom handler for console log in tests via `onConsoleLog` config.

```ts
export default defineConfig({
  onConsoleLog: () => false,
});

```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
