### PR TITLE
feat: support print console traces when calling console method

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -13,6 +13,7 @@ type CommonOptions = {
   configLoader?: LoadConfigOptions['loader'];
   globals?: boolean;
   passWithNoTests?: boolean;
+  printConsoleTrace?: boolean;
   update?: boolean;
   testNamePattern?: RegExp | string;
   testTimeout?: number;
@@ -47,6 +48,10 @@ const applyCommonOptions = (cli: CAC) => {
     .option(
       '--passWithNoTests',
       'Allows the test suite to pass when no files are found.',
+    )
+    .option(
+      '--printConsoleTrace',
+      'Print console traces when calling any console method.',
     )
     .option(
       '-t, --testNamePattern <testNamePattern>',
@@ -104,6 +109,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'unstubGlobals',
     'retry',
     'maxConcurrency',
+    'printConsoleTrace',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -98,6 +98,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   unstubGlobals: false,
   unstubEnvs: false,
   maxConcurrency: 5,
+  printConsoleTrace: false,
 });
 
 export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -106,6 +106,7 @@ export const runInPool = async ({
     unstubEnvs,
     unstubGlobals,
     maxConcurrency,
+    printConsoleTrace,
   } = context.normalizedConfig;
 
   const runtimeConfig = {
@@ -120,6 +121,7 @@ export const runInPool = async ({
     unstubEnvs,
     unstubGlobals,
     maxConcurrency,
+    printConsoleTrace,
   };
 
   const results = await Promise.all(

--- a/packages/core/src/runtime/worker/console.ts
+++ b/packages/core/src/runtime/worker/console.ts
@@ -1,12 +1,40 @@
 import { Console } from 'node:console';
 import { format } from 'node:util';
+import { color } from '../../utils';
 import type { WorkerRPC } from './rpc';
 
-export function createCustomConsole(rpc: WorkerRPC): Console {
+export function createCustomConsole({
+  rpc,
+  testPath,
+  printConsoleTrace,
+}: { rpc: WorkerRPC; testPath: string; printConsoleTrace: boolean }): Console {
+  const getConsoleTrace = () => {
+    const limit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 3;
+    const stack = new Error('STACK_TRACE').stack;
+    const trace = stack?.split('\n').slice(3).join('\n');
+    Error.stackTraceLimit = limit;
+
+    return trace;
+  };
   class CustomConsole extends Console {
     override log(firstArg: unknown, ...args: Array<unknown>) {
-      rpc.onConsoleLog({ content: format(firstArg, ...args) });
+      rpc.onConsoleLog({
+        content: format(firstArg, ...args),
+        trace: printConsoleTrace ? getConsoleTrace() : undefined,
+        name: color.gray(color.bold('log')),
+        testPath,
+      });
     }
+    override warn(firstArg: unknown, ...args: Array<unknown>) {
+      rpc.onConsoleLog({
+        content: format(firstArg, ...args),
+        trace: printConsoleTrace ? getConsoleTrace() : undefined,
+        name: color.yellow(color.bold('warn')),
+        testPath,
+      });
+    }
+    // todo: find a better way to override error, trace, info, debug, etc.
   }
 
   return new CustomConsole(process.stdout, process.stderr);

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -33,7 +33,7 @@ const runInPool = async ({
   const { rpc } = createRuntimeRpc(createForksRpcOptions());
   const codeContent = assetFiles[filePath]!;
   const {
-    runtimeConfig: { globals },
+    runtimeConfig: { globals, printConsoleTrace },
   } = context;
 
   const workerState: WorkerState = {
@@ -72,7 +72,11 @@ const runInPool = async ({
     global: {
       '@rstest/core': api,
     },
-    console: createCustomConsole(rpc),
+    console: createCustomConsole({
+      rpc,
+      testPath: originPath,
+      printConsoleTrace,
+    }),
     Error,
     ...(globals ? getGlobalApi(api) : {}),
   };

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -75,6 +75,13 @@ export interface RstestConfig {
    * @default false
    */
   globals?: boolean;
+
+  /**
+   * print console traces when calling any console method.
+   *
+   * @default false
+   */
+  printConsoleTrace?: boolean;
   /**
    * Update snapshot files. Will update all changed snapshots and delete obsolete ones.
    *
@@ -162,27 +169,20 @@ export interface RstestConfig {
   >;
 }
 
+type OptionalKeys =
+  | 'setupFiles'
+  | 'testNamePattern'
+  | 'plugins'
+  | 'source'
+  | 'resolve'
+  | 'output'
+  | 'tools'
+  | 'onConsoleLog';
+
 export type NormalizedConfig = Required<
-  Omit<
-    RstestConfig,
-    | 'pool'
-    | 'setupFiles'
-    | 'testNamePattern'
-    | 'plugins'
-    | 'source'
-    | 'resolve'
-    | 'output'
-    | 'tools'
-    | 'onConsoleLog'
-  >
+  Omit<RstestConfig, OptionalKeys | 'pool'>
 > & {
+  [key in OptionalKeys]?: RstestConfig[key];
+} & {
   pool: RstestPoolOptions;
-  setupFiles?: string[] | string;
-  testNamePattern?: RstestConfig['testNamePattern'];
-  onConsoleLog?: RstestConfig['onConsoleLog'];
-  plugins?: RstestConfig['plugins'];
-  source?: RstestConfig['source'];
-  resolve?: RstestConfig['resolve'];
-  output?: RstestConfig['output'];
-  tools?: RstestConfig['tools'];
 };

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -119,4 +119,7 @@ export type TestFileResult = TestResult & {
 
 export interface UserConsoleLog {
   content: string;
+  name: string;
+  trace?: string;
+  testPath: string;
 }

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -33,6 +33,7 @@ export type RuntimeConfig = Pick<
   | 'unstubEnvs'
   | 'unstubGlobals'
   | 'maxConcurrency'
+  | 'printConsoleTrace'
 >;
 
 export type WorkerContext = {

--- a/tests/log/index.test.ts
+++ b/tests/log/index.test.ts
@@ -24,6 +24,24 @@ describe('console log', () => {
     expect(logs.filter((log) => log.startsWith('I'))).toEqual([]);
   });
 
+  it('should console log trace when printConsoleTrace enabled', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'log.test', '--printConsoleTrace'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('I'))).toEqual(["I'm log"]);
+    expect(logs.some((log) => log.includes('log.test.ts:4:11'))).toBeTruthy;
+  });
+
   it('should console trace correctly', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',


### PR DESCRIPTION
## Summary

support print console traces when calling console method via enabling `printConsoleTrace` configuration.

<img width="911" alt="image" src="https://github.com/user-attachments/assets/90f14168-14dd-4ae8-89c7-1e2eeb1085e6" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
