### PR TITLE
feat: support disableConsoleIntercept

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -14,6 +14,7 @@ type CommonOptions = {
   globals?: boolean;
   passWithNoTests?: boolean;
   printConsoleTrace?: boolean;
+  disableConsoleIntercept?: boolean;
   update?: boolean;
   testNamePattern?: RegExp | string;
   testTimeout?: number;
@@ -53,6 +54,7 @@ const applyCommonOptions = (cli: CAC) => {
       '--printConsoleTrace',
       'Print console traces when calling any console method.',
     )
+    .option('--disableConsoleIntercept', 'Disable console intercept.')
     .option(
       '-t, --testNamePattern <testNamePattern>',
       'Run only tests with a name that matches the regex.',
@@ -110,6 +112,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'retry',
     'maxConcurrency',
     'printConsoleTrace',
+    'disableConsoleIntercept',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -99,6 +99,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   unstubEnvs: false,
   maxConcurrency: 5,
   printConsoleTrace: false,
+  disableConsoleIntercept: false,
 });
 
 export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -107,6 +107,7 @@ export const runInPool = async ({
     unstubGlobals,
     maxConcurrency,
     printConsoleTrace,
+    disableConsoleIntercept,
   } = context.normalizedConfig;
 
   const runtimeConfig = {
@@ -122,6 +123,7 @@ export const runInPool = async ({
     unstubGlobals,
     maxConcurrency,
     printConsoleTrace,
+    disableConsoleIntercept,
   };
 
   const results = await Promise.all(

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -33,7 +33,7 @@ const runInPool = async ({
   const { rpc } = createRuntimeRpc(createForksRpcOptions());
   const codeContent = assetFiles[filePath]!;
   const {
-    runtimeConfig: { globals, printConsoleTrace },
+    runtimeConfig: { globals, printConsoleTrace, disableConsoleIntercept },
   } = context;
 
   const workerState: WorkerState = {
@@ -72,11 +72,13 @@ const runInPool = async ({
     global: {
       '@rstest/core': api,
     },
-    console: createCustomConsole({
-      rpc,
-      testPath: originPath,
-      printConsoleTrace,
-    }),
+    console: disableConsoleIntercept
+      ? console
+      : createCustomConsole({
+          rpc,
+          testPath: originPath,
+          printConsoleTrace,
+        }),
     Error,
     ...(globals ? getGlobalApi(api) : {}),
   };

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -82,6 +82,14 @@ export interface RstestConfig {
    * @default false
    */
   printConsoleTrace?: boolean;
+
+  /**
+   * Disable console intercept. `onConsoleLog` & `printConsoleTrace` configuration will not take effect.
+   *
+   * @default false
+   */
+  disableConsoleIntercept?: boolean;
+
   /**
    * Update snapshot files. Will update all changed snapshots and delete obsolete ones.
    *

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -34,6 +34,7 @@ export type RuntimeConfig = Pick<
   | 'unstubGlobals'
   | 'maxConcurrency'
   | 'printConsoleTrace'
+  | 'disableConsoleIntercept'
 >;
 
 export type WorkerContext = {

--- a/tests/log/index.test.ts
+++ b/tests/log/index.test.ts
@@ -24,6 +24,30 @@ describe('console log', () => {
     expect(logs.filter((log) => log.startsWith('I'))).toEqual([]);
   });
 
+  it('should onConsoleLog will not take effect when disableConsoleIntercept', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        'log.test',
+        '-c',
+        'consoleLogFalse.config.ts',
+        '--disableConsoleIntercept',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.some((log) => log.startsWith('I'))).toBeTruthy();
+    expect(logs.some((log) => log.includes('log.test.ts:4:11'))).toBeFalsy();
+  });
+
   it('should console log trace when printConsoleTrace enabled', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',
@@ -46,7 +70,7 @@ describe('console log', () => {
         "I'm info",
       ]
     `);
-    expect(logs.some((log) => log.includes('log.test.ts:4:11'))).toBeTruthy;
+    expect(logs.some((log) => log.includes('log.test.ts:4:11'))).toBeTruthy();
   });
 
   it('should console trace correctly', async () => {


### PR DESCRIPTION
## Summary

Support disabling console interception through the `disableConsoleIntercept` configuration. In this case, the `onConsoleLog` and `printConsoleTrace` configurations will not take effect.

```ts
export default defineConfig({
  disableConsoleIntercept: true,
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
