### PR TITLE
feat: make all test API chainable

### DIFF
--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -424,7 +424,7 @@ export const createRuntimeAPI = ({
     return testFn;
   };
 
-  const it = createTestAPI() as TestAPI;
+  const it = createTestAPI();
 
   const createDescribeAPI = (
     options: {
@@ -481,7 +481,7 @@ export const createRuntimeAPI = ({
     return describeFn;
   };
 
-  const describe = createDescribeAPI() as DescribeAPI;
+  const describe = createDescribeAPI();
 
   return {
     api: {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -46,33 +46,27 @@ export interface DescribeEachFn {
   ): (description: string, fn: (...args: [...T]) => MaybePromise<void>) => void;
 }
 
-export type TestBaseAPI = TestFn & {
+export type TestAPI = TestFn & {
   each: TestEachFn;
-  fails: TestFn;
-};
-
-export type TestAPI = TestBaseAPI & {
-  only: TestBaseAPI;
-  skip: TestBaseAPI;
-  runIf: (condition: boolean) => TestBaseAPI;
-  skipIf: (condition: boolean) => TestBaseAPI;
-  todo: TestFn;
-  concurrent: TestBaseAPI;
+  fails: TestAPI;
+  concurrent: TestAPI;
+  only: TestAPI;
+  skip: TestAPI;
+  todo: TestAPI;
+  runIf: (condition: boolean) => TestAPI;
+  skipIf: (condition: boolean) => TestAPI;
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;
 
-export type DescribeBaseAPI = DescribeFn & {
+export type DescribeAPI = DescribeFn & {
   each: DescribeEachFn;
-};
-
-export type DescribeAPI = DescribeBaseAPI & {
-  only: DescribeBaseAPI;
-  skip: DescribeBaseAPI;
-  runIf: (condition: boolean) => DescribeBaseAPI;
-  skipIf: (condition: boolean) => DescribeBaseAPI;
+  only: DescribeAPI;
+  skip: DescribeAPI;
+  runIf: (condition: boolean) => DescribeAPI;
+  skipIf: (condition: boolean) => DescribeAPI;
   todo: DescribeFn;
-  concurrent: DescribeBaseAPI;
+  concurrent: DescribeAPI;
 };
 
 export type RunnerAPI = {

--- a/tests/describe/chain.test.ts
+++ b/tests/describe/chain.test.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { expect, it } from '@rstest/core';
+import { describe, expect, it } from '@rstest/core';
 import { runRstestCli } from '../scripts';
 
 it('Describe only.each API', async () => {
@@ -47,4 +47,29 @@ it('Describe skip.each API', async () => {
   expect(
     logs.find((log) => log.includes('Tests 2 passed | 3 skipped')),
   ).toBeTruthy();
+});
+
+it('Describe chain API enumerable', async () => {
+  expect(Object.keys(describe)).toMatchInlineSnapshot(`
+    [
+      "only",
+      "todo",
+      "skip",
+      "concurrent",
+      "skipIf",
+      "runIf",
+      "each",
+    ]
+  `);
+  expect(Object.keys(describe.only)).toMatchInlineSnapshot(`
+    [
+      "only",
+      "todo",
+      "skip",
+      "concurrent",
+      "skipIf",
+      "runIf",
+      "each",
+    ]
+  `);
 });

--- a/tests/test-api/chain.test.ts
+++ b/tests/test-api/chain.test.ts
@@ -7,6 +7,33 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('Test Chain', () => {
+  it('chain API enumerable', async () => {
+    expect(Object.keys(it)).toMatchInlineSnapshot(`
+      [
+        "fails",
+        "concurrent",
+        "skip",
+        "todo",
+        "only",
+        "runIf",
+        "skipIf",
+        "each",
+      ]
+    `);
+    expect(Object.keys(it.only)).toMatchInlineSnapshot(`
+      [
+        "fails",
+        "concurrent",
+        "skip",
+        "todo",
+        "only",
+        "runIf",
+        "skipIf",
+        "each",
+      ]
+    `);
+  });
+
   it('Support only.each', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',


### PR DESCRIPTION
## Summary

make all test API chainable (expect test.each & describe.each).

```ts
export type TestAPI = TestFn & {
  fails: TestAPI;
  concurrent: TestAPI;
  only: TestAPI;
  skip: TestAPI;
  todo: TestAPI;
  runIf: (condition: boolean) => TestAPI;
  skipIf: (condition: boolean) => TestAPI;
  each: TestEachFn;
};

export type DescribeAPI = DescribeFn & {
  only: DescribeAPI;
  skip: DescribeAPI;
  runIf: (condition: boolean) => DescribeAPI;
  skipIf: (condition: boolean) => DescribeAPI;
  todo: DescribeFn;
  concurrent: DescribeAPI;
  each: DescribeEachFn;
};
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
