### PR TITLE
feat: support `test.for`

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -37,6 +37,14 @@ export interface TestEachFn {
   ) => void;
 }
 
+export type TestForFn = <T>(
+  cases: ReadonlyArray<T>,
+) => (
+  description: string,
+  fn?: (param: T, context: TestContext) => MaybePromise<void>,
+  timeout?: number,
+) => void;
+
 export interface DescribeEachFn {
   <T extends Record<string, unknown>>(
     cases: ReadonlyArray<T>,
@@ -46,8 +54,13 @@ export interface DescribeEachFn {
   ): (description: string, fn: (...args: [...T]) => MaybePromise<void>) => void;
 }
 
+export type DescribeForFn = <T>(
+  cases: ReadonlyArray<T>,
+) => (description: string, fn?: (param: T) => MaybePromise<void>) => void;
+
 export type TestAPI = TestFn & {
   each: TestEachFn;
+  for: TestForFn;
   fails: TestAPI;
   concurrent: TestAPI;
   only: TestAPI;
@@ -61,6 +74,7 @@ type DescribeFn = (description: string, fn?: () => void) => void;
 
 export type DescribeAPI = DescribeFn & {
   each: DescribeEachFn;
+  for: DescribeForFn;
   only: DescribeAPI;
   skip: DescribeAPI;
   runIf: (condition: boolean) => DescribeAPI;

--- a/tests/describe/chain.test.ts
+++ b/tests/describe/chain.test.ts
@@ -59,6 +59,7 @@ it('Describe chain API enumerable', async () => {
       "skipIf",
       "runIf",
       "each",
+      "for",
     ]
   `);
   expect(Object.keys(describe.only)).toMatchInlineSnapshot(`
@@ -70,6 +71,7 @@ it('Describe chain API enumerable', async () => {
       "skipIf",
       "runIf",
       "each",
+      "for",
     ]
   `);
 });

--- a/tests/describe/each.test.ts
+++ b/tests/describe/each.test.ts
@@ -23,3 +23,24 @@ it('Describe Each API', async () => {
 
   expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
 });
+
+it('Describe For API', async () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/for.test.ts'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(0);
+
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
+});

--- a/tests/describe/fixtures/for.test.ts
+++ b/tests/describe/fixtures/for.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe.for([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('add two numbers correctly', ({ a, b, expected }) => {
+  it(`should return ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});
+
+describe.for([
+  [2, 1, 3],
+  [2, 2, 4],
+  [3, 1, 4],
+])('add two numbers correctly', ([a, b, expected]) => {
+  it(`should return ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});

--- a/tests/test-api/chain.test.ts
+++ b/tests/test-api/chain.test.ts
@@ -18,6 +18,7 @@ describe('Test Chain', () => {
         "runIf",
         "skipIf",
         "each",
+        "for",
       ]
     `);
     expect(Object.keys(it.only)).toMatchInlineSnapshot(`
@@ -30,6 +31,7 @@ describe('Test Chain', () => {
         "runIf",
         "skipIf",
         "each",
+        "for",
       ]
     `);
   });

--- a/tests/test-api/each.test.ts
+++ b/tests/test-api/each.test.ts
@@ -38,3 +38,39 @@ it('Test Each API', async () => {
 
   expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
 });
+
+it('Test For API', async () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/for.test.ts'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(0);
+
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expect(
+    logs
+      .filter((log) => log.includes('add'))
+      .map((log) => getTestName(log, '✓')),
+  ).toMatchInlineSnapshot(`
+    [
+      "add(1, 1) -> 2",
+      "add(1, 2) -> 3",
+      "add(2, 1) -> 3",
+      "case-0 add(2, 1) -> 3",
+      "case-1 add(2, 2) -> 4",
+      "case-2 add(3, 1) -> 4",
+    ]
+  `);
+
+  expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
+});

--- a/tests/test-api/fixtures/for.test.ts
+++ b/tests/test-api/fixtures/for.test.ts
@@ -1,0 +1,17 @@
+import { it } from '@rstest/core';
+
+it.for([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('add($a, $b) -> $expected', ({ a, b, expected }, { expect }) => {
+  expect(a + b).toBe(expected);
+});
+
+it.for([
+  [2, 1, 3],
+  [2, 2, 4],
+  [3, 1, 4],
+])('case-%# add(%i, %i) -> %i', ([a, b, expected], { expect }) => {
+  expect(a + b).toBe(expected);
+});


### PR DESCRIPTION
## Summary

`test.for` is alternative of `test.each` to provide TestContext.

```ts
it.for([
  [2, 1, 3],
  [2, 2, 4],
  [3, 1, 4],
])('add($i, $i) -> $i', ([a, b, expected], { expect }) => {
  expect(a + b).toBe(expected);
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
