### PR TITLE
chore: unify testPath & distPath

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -224,20 +224,20 @@ export const createRsbuildServer = async ({
     for (const entry of Object.keys(entrypoints!)) {
       const e = entrypoints![entry]!;
 
-      const filePath = path.join(
+      const distPath = path.join(
         outputPath!,
         e.assets![e.assets!.length - 1]!.name,
       );
 
       if (setupFiles[entry]) {
         setupEntries.push({
-          filePath,
-          originPath: setupFiles[entry],
+          distPath,
+          testPath: setupFiles[entry],
         });
       } else if (sourceEntries[entry]) {
         entries.push({
-          filePath,
-          originPath: sourceEntries[entry],
+          distPath,
+          testPath: sourceEntries[entry],
         });
       }
     }

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -43,7 +43,7 @@ export class DefaultReporter implements Reporter {
 
   onTestFileStart(test: TestFileInfo): void {
     const { rootPath } = this;
-    const relativePath = relative(rootPath, test.filePath);
+    const relativePath = relative(rootPath, test.testPath);
     const { dir, base } = parsePosix(relativePath);
 
     console.log('');

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -62,7 +62,7 @@ export function createExpect({
       expectedAssertionsNumber: null,
       expectedAssertionsNumberErrorGen: null,
       get testPath() {
-        return workerState.filePath;
+        return workerState.testPath;
       },
     },
     expect,

--- a/packages/core/src/runtime/api/snapshot.ts
+++ b/packages/core/src/runtime/api/snapshot.ts
@@ -125,7 +125,7 @@ function getError(expected: () => void | Error, promise: string | undefined) {
 
 function getTestNames(test: TestCase) {
   return {
-    filepath: test.filePath,
+    filepath: test.testPath,
     name: getTaskNameWithPrefix(test),
     // testId: test.id,
   };

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -21,11 +21,11 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   };
 } {
   const {
-    sourcePath,
+    testPath,
     runtimeConfig: { testTimeout },
   } = workerState;
   const runtime = createRuntimeAPI({
-    sourcePath,
+    testPath,
     testTimeout,
   });
   const testRunner: TestRunner = new TestRunner();

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -59,7 +59,7 @@ export class TestRunner {
     const errors: TestError[] = [];
     let defaultStatus: TestResultStatus = 'pass';
 
-    hooks.onTestFileStart?.({ filePath: testPath });
+    hooks.onTestFileStart?.({ testPath });
     const snapshotClient = getSnapshotClient();
 
     await snapshotClient.setup(testPath, snapshotOptions);
@@ -447,7 +447,7 @@ export class TestRunner {
         isExpectingAssertionsError: null,
         expectedAssertionsNumber: null,
         expectedAssertionsNumberErrorGen: null,
-        testPath: test.filePath,
+        testPath: test.testPath,
         snapshotState,
         currentTestName: getTaskNameWithPrefix(test),
       },

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -26,7 +26,7 @@ export class RunnerRuntime {
   private tests: Test[] = [];
   /** a calling stack of the current test suites and case */
   private _currentTest: Test[] = [];
-  private sourcePath: string;
+  private testPath: string;
 
   /**
    * Collect test status:
@@ -39,13 +39,13 @@ export class RunnerRuntime {
   private defaultTestTimeout;
 
   constructor({
-    sourcePath,
+    testPath,
     testTimeout,
   }: {
     testTimeout: number;
-    sourcePath: string;
+    testPath: string;
   }) {
-    this.sourcePath = sourcePath;
+    this.testPath = testPath;
     this.defaultTestTimeout = testTimeout;
   }
 
@@ -120,6 +120,7 @@ export class RunnerRuntime {
   private getDefaultRootSuite(): TestSuite {
     return {
       runMode: 'run',
+      testPath: this.testPath,
       name: ROOT_SUITE_NAME,
       tests: [],
       type: 'suite',
@@ -145,6 +146,7 @@ export class RunnerRuntime {
       tests: [],
       type: 'suite',
       each,
+      testPath: this.testPath,
       concurrent,
     };
 
@@ -216,12 +218,12 @@ export class RunnerRuntime {
     return this.tests;
   }
 
-  addTestCase(test: Omit<TestCase, 'filePath' | 'context'>): void {
+  addTestCase(test: Omit<TestCase, 'testPath' | 'context'>): void {
     if (this.collectStatus === 'lazy') {
       this.currentCollectList.push(() => {
         this.addTest({
           ...test,
-          filePath: this.sourcePath,
+          testPath: this.testPath,
           context: undefined!,
         });
         this.resetCurrentTest();
@@ -229,7 +231,7 @@ export class RunnerRuntime {
     } else {
       this.addTest({
         ...test,
-        filePath: this.sourcePath,
+        testPath: this.testPath,
         context: undefined!,
       });
       this.resetCurrentTest();
@@ -350,14 +352,14 @@ export class RunnerRuntime {
 }
 
 export const createRuntimeAPI = ({
-  sourcePath,
+  testPath,
   testTimeout,
-}: { sourcePath: string; testTimeout: number }): {
+}: { testPath: string; testTimeout: number }): {
   api: RunnerAPI;
   instance: RunnerRuntime;
 } => {
   const runtimeInstance: RunnerRuntime = new RunnerRuntime({
-    sourcePath,
+    testPath,
     testTimeout,
   });
 

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -27,7 +27,7 @@ const createRequire = (
       try {
         return loadModule({
           codeContent: content,
-          originPath: joinedPath,
+          testPath: joinedPath,
           distPath: joinedPath,
           rstestContext,
           assetFiles,
@@ -50,23 +50,23 @@ const createRequire = (
 export const loadModule = ({
   codeContent,
   distPath,
-  originPath,
+  testPath,
   rstestContext,
   assetFiles,
 }: {
   codeContent: string;
   distPath: string;
-  originPath: string;
+  testPath: string;
   rstestContext: Record<string, any>;
   assetFiles: Record<string, string>;
 }): any => {
-  const fileDir = path.dirname(originPath);
+  const fileDir = path.dirname(testPath);
 
   const localModule = {
     children: [],
     exports: {},
-    filename: originPath,
-    id: originPath,
+    filename: testPath,
+    id: testPath,
     isPreloading: false,
     loaded: false,
     path: fileDir,
@@ -75,9 +75,9 @@ export const loadModule = ({
   const context = {
     module: localModule,
     exports: localModule.exports,
-    require: createRequire(originPath, distPath, rstestContext, assetFiles),
+    require: createRequire(testPath, distPath, rstestContext, assetFiles),
     __dirname: fileDir,
-    __filename: originPath,
+    __filename: testPath,
     ...rstestContext,
   };
 
@@ -100,7 +100,7 @@ export const loadModule = ({
       }
       const dependencyAsset = await import.meta.resolve(
         specifier,
-        pathToFileURL(originPath),
+        pathToFileURL(testPath),
       );
 
       // @ts-expect-error

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,7 +1,7 @@
 import type { SnapshotResult } from '@vitest/snapshot';
 import type { TestContext } from './api';
+import type { TestPath } from './utils';
 
-// TODO: Unify filePath、testPath、originPath、sourcePath
 import type { MaybePromise } from './utils';
 
 export type TestRunMode = 'run' | 'skip' | 'todo' | 'only';
@@ -24,7 +24,7 @@ export interface TaskResult {
 }
 
 export type TestCase = {
-  filePath: string;
+  testPath: TestPath;
   name: string;
   fn?: (context: TestContext) => void | Promise<void>;
   runMode: TestRunMode;
@@ -34,7 +34,6 @@ export type TestCase = {
   concurrent?: boolean;
   inTestEach?: boolean;
   context: TestContext;
-  // TODO
   only?: boolean;
   // TODO
   onFinished?: any[];
@@ -51,8 +50,7 @@ export type TestCase = {
 };
 
 export type SuiteContext = {
-  /** The test file path */
-  filepath: string;
+  filepath: TestPath;
 };
 
 export type AfterAllListener = (ctx: SuiteContext) => MaybePromise<void>;
@@ -69,8 +67,7 @@ export type TestSuite = {
   each?: boolean;
   inTestEach?: boolean;
   concurrent?: boolean;
-  // TODO
-  filepath?: string;
+  testPath: TestPath;
   /** nested cases and suite could in a suite */
   tests: Array<TestSuite | TestCase>;
   type: 'suite';
@@ -89,7 +86,7 @@ export type TestSuiteListeners = keyof Pick<
 >;
 
 export type TestFileInfo = {
-  filePath: string;
+  testPath: TestPath;
 };
 
 export type Test = TestSuite | TestCase;
@@ -106,7 +103,7 @@ export type TestError = {
 export type TestResult = {
   status: TestResultStatus;
   name: string;
-  testPath: string;
+  testPath: TestPath;
   parentNames?: string[];
   duration?: number;
   errors?: TestError[];
@@ -121,6 +118,6 @@ export interface UserConsoleLog {
   content: string;
   name: string;
   trace?: string;
-  testPath: string;
+  testPath: TestPath;
   type: 'stdout' | 'stderr';
 }

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -1,3 +1,8 @@
 export type MaybePromise<T> = T | Promise<T>;
 
 export type FunctionLike = (...args: any) => any;
+
+/** The test file output path */
+export type DistPath = string;
+/** The test original path */
+export type TestPath = string;

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -4,5 +4,5 @@ export type FunctionLike = (...args: any) => any;
 
 /** The test file output path */
 export type DistPath = string;
-/** The test original path */
+/** The test file original path */
 export type TestPath = string;

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -3,10 +3,11 @@ import type { SnapshotEnvironment } from '@vitest/snapshot/environment';
 import type { RstestContext } from './core';
 import type { SourceMapInput } from './reporter';
 import type { TestFileInfo, TestResult, UserConsoleLog } from './testSuite';
+import type { DistPath, TestPath } from './utils';
 
 export type EntryInfo = {
-  filePath: string;
-  originPath: string;
+  distPath: DistPath;
+  testPath: TestPath;
 };
 
 /** Server to Runtime */
@@ -56,10 +57,8 @@ export type RunWorkerOptions = {
 
 export type WorkerState = WorkerContext & {
   environment: string;
-  /** Test file source code path */
-  sourcePath: string;
-  /** Test file path (distPath) */
-  filePath: string;
+  testPath: TestPath;
+  distPath: DistPath;
   snapshotOptions: {
     updateSnapshot: SnapshotUpdateState;
     snapshotEnvironment: SnapshotEnvironment;


### PR DESCRIPTION
## Summary

Unify testPath & distPath usage in Rstest:
- testPath: the test file original path
- distPath: the test file output path
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
