### PR TITLE
feat: support only list the test files

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -188,12 +188,20 @@ export function setupCommands(): void {
       'list [...filters]',
       'lists all test files that Rstest will run given the arguments',
     )
-    .action(async (filters: string[], options: CommonOptions) => {
-      const { config } = await initCli(options);
-      const { createRstest } = await import('../core');
-      const rstest = createRstest(config, 'list', filters.map(normalize));
-      await rstest.listTests();
-    });
+    .option('--filesOnly', 'only list the test files')
+    .action(
+      async (
+        filters: string[],
+        options: CommonOptions & {
+          filesOnly?: boolean;
+        },
+      ) => {
+        const { config } = await initCli(options);
+        const { createRstest } = await import('../core');
+        const rstest = createRstest(config, 'list', filters.map(normalize));
+        await rstest.listTests({ filesOnly: options.filesOnly });
+      },
+    );
 
   cli.parse();
 }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1,4 +1,9 @@
-import type { RstestCommand, RstestConfig, RstestInstance } from '../types';
+import type {
+  ListCommandOptions,
+  RstestCommand,
+  RstestConfig,
+  RstestInstance,
+} from '../types';
 import { createContext } from './context';
 
 export function createRstest(
@@ -13,9 +18,9 @@ export function createRstest(
     await runTests(context, fileFilters);
   };
 
-  const listTests = async (): Promise<void> => {
+  const listTests = async (options: ListCommandOptions): Promise<void> => {
     const { listTests } = await import('./listTests');
-    await listTests(context, fileFilters);
+    await listTests(context, fileFilters, options);
   };
 
   return {

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -1,6 +1,6 @@
 import { relative } from 'node:path';
 import { createPool } from '../pool';
-import type { RstestContext, Test } from '../types';
+import type { ListCommandOptions, RstestContext, Test } from '../types';
 import {
   getSetupFiles,
   getTaskNameWithPrefix,
@@ -12,6 +12,7 @@ import { createRsbuildServer, prepareRsbuild } from './rsbuild';
 export async function listTests(
   context: RstestContext,
   fileFilters: string[],
+  { filesOnly }: ListCommandOptions,
 ): Promise<void> {
   const {
     normalizedConfig: { include, exclude, root, name, setupFiles: setups },
@@ -76,8 +77,12 @@ export async function listTests(
     }
   };
 
-  for (const files of list) {
-    for (const test of files) {
+  for (const file of list) {
+    if (filesOnly) {
+      logger.log(relative(rootPath, file.testPath));
+      continue;
+    }
+    for (const test of file.tests) {
       printTest(test);
     }
   }

--- a/packages/core/src/pool/forks.ts
+++ b/packages/core/src/pool/forks.ts
@@ -52,7 +52,10 @@ export const createForksPool = (poolOptions: {
 }): {
   name: string;
   runTest: (options: RunWorkerOptions) => Promise<TestFileResult>;
-  collectTests: (options: RunWorkerOptions) => Promise<Test[]>;
+  collectTests: (options: RunWorkerOptions) => Promise<{
+    tests: Test[];
+    testPath: string;
+  }>;
   close: () => Promise<void>;
 } => {
   const {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -49,7 +49,12 @@ export const createPool = async ({
     results: TestFileResult[];
     testResults: TestResult[];
   }>;
-  collectTests: () => Promise<Test[][]>;
+  collectTests: () => Promise<
+    Array<{
+      tests: Test[];
+      testPath: string;
+    }>
+  >;
   close: () => Promise<void>;
 }> => {
   // Some options may crash worker, e.g. --prof, --title.

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -91,7 +91,13 @@ const preparePool = async ({
 
 const runInPool = async (
   options: RunWorkerOptions['options'],
-): Promise<Test[] | TestFileResult> => {
+): Promise<
+  | {
+      tests: Test[];
+      testPath: string;
+    }
+  | TestFileResult
+> => {
   const {
     entryInfo: { distPath, testPath },
     setupEntries,
@@ -127,10 +133,17 @@ const runInPool = async (
   if (type === 'collect') {
     try {
       await loadFiles();
-      return runner.collectTests();
+      const tests = await runner.collectTests();
+      return {
+        testPath,
+        tests,
+      };
     } catch (err) {
       // TODO: log error
-      return [];
+      return {
+        testPath,
+        tests: [],
+      };
     }
   }
 

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -24,7 +24,11 @@ export type RstestContext = {
   snapshotManager: SnapshotManager;
 };
 
+export type ListCommandOptions = {
+  filesOnly?: boolean;
+};
+
 export type RstestInstance = {
   runTests: () => Promise<void>;
-  listTests: () => Promise<void>;
+  listTests: (options: ListCommandOptions) => Promise<void>;
 };

--- a/tests/list/index.test.ts
+++ b/tests/list/index.test.ts
@@ -80,4 +80,28 @@ describe('test list command', () => {
       ]
     `);
   });
+
+  it('should list test files correctly with --filesOnly', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['list', '--filesOnly'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout?.split('\n').filter(Boolean);
+
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        "a.test.ts",
+        "b.test.ts",
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
## Summary

Support only list the test files via `--filesOnly`

<img width="653" alt="image" src="https://github.com/user-attachments/assets/d0ced1a4-28fe-4c93-99a5-cc339dd6963d" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
