### PR TITLE
feat: support print tests as JSON

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -3,7 +3,7 @@ import cac, { type CAC } from 'cac';
 import { normalize } from 'pathe';
 import { isCI } from 'std-env';
 import { loadConfig } from '../config';
-import type { RstestConfig } from '../types';
+import type { ListCommandOptions, RstestConfig } from '../types';
 import { formatError, getAbsolutePath } from '../utils/helper';
 import { logger } from '../utils/logger';
 import { showRstest } from './prepare';
@@ -189,17 +189,19 @@ export function setupCommands(): void {
       'lists all test files that Rstest will run given the arguments',
     )
     .option('--filesOnly', 'only list the test files')
+    .option('--json', 'print tests as JSON')
     .action(
       async (
         filters: string[],
-        options: CommonOptions & {
-          filesOnly?: boolean;
-        },
+        options: CommonOptions & ListCommandOptions,
       ) => {
         const { config } = await initCli(options);
         const { createRstest } = await import('../core');
         const rstest = createRstest(config, 'list', filters.map(normalize));
-        await rstest.listTests({ filesOnly: options.filesOnly });
+        await rstest.listTests({
+          filesOnly: options.filesOnly,
+          json: options.json,
+        });
       },
     );
 

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -26,6 +26,7 @@ export type RstestContext = {
 
 export type ListCommandOptions = {
   filesOnly?: boolean;
+  json?: boolean;
 };
 
 export type RstestInstance = {

--- a/tests/list/index.test.ts
+++ b/tests/list/index.test.ts
@@ -104,4 +104,74 @@ describe('test list command', () => {
       ]
     `);
   });
+
+  it('should list tests json correctly', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['list', '--json'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout?.split('\n').filter(Boolean);
+
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        "[",
+        "  {",
+        "    \\"file\\": \\"<WORKSPACE>/tests/list/fixtures/a.test.ts\\",",
+        "    \\"name\\": \\"test a > test a-1\\"",
+        "  },",
+        "  {",
+        "    \\"file\\": \\"<WORKSPACE>/tests/list/fixtures/a.test.ts\\",",
+        "    \\"name\\": \\"test a-2\\"",
+        "  },",
+        "  {",
+        "    \\"file\\": \\"<WORKSPACE>/tests/list/fixtures/b.test.ts\\",",
+        "    \\"name\\": \\"test b > test b-1\\"",
+        "  },",
+        "  {",
+        "    \\"file\\": \\"<WORKSPACE>/tests/list/fixtures/b.test.ts\\",",
+        "    \\"name\\": \\"test b-2\\"",
+        "  }",
+        "]",
+      ]
+    `);
+  });
+
+  it('should list test files json correctly', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['list', '--filesOnly', '--json'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout?.split('\n').filter(Boolean);
+
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        "[",
+        "  {",
+        "    \\"file\\": \\"<WORKSPACE>/tests/list/fixtures/a.test.ts\\"",
+        "  },",
+        "  {",
+        "    \\"file\\": \\"<WORKSPACE>/tests/list/fixtures/b.test.ts\\"",
+        "  }",
+        "]",
+      ]
+    `);
+  });
 });

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  setupFiles: ['./rstest.setup.ts'],
+  setupFiles: ['../scripts/rstest.setup.ts'],
   testTimeout: process.env.CI ? 10_000 : 5_000,
   exclude: [
     '**/node_modules/**',


### PR DESCRIPTION
## Summary

Support print tests as JSON via `--json`.

<img width="941" alt="image" src="https://github.com/user-attachments/assets/1275e90c-c412-4eec-9c4d-9dd6d5cbb247" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
