### PR TITLE
feat(list): support output test json to file

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -189,7 +189,7 @@ export function setupCommands(): void {
       'lists all test files that Rstest will run given the arguments',
     )
     .option('--filesOnly', 'only list the test files')
-    .option('--json', 'print tests as JSON')
+    .option('--json [boolean/path]', 'print tests as JSON')
     .action(
       async (
         filters: string[],

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -189,7 +189,7 @@ export function setupCommands(): void {
       'lists all test files that Rstest will run given the arguments',
     )
     .option('--filesOnly', 'only list the test files')
-    .option('--json [boolean/path]', 'print tests as JSON')
+    .option('--json [boolean/path]', 'print tests as JSON or write to a file')
     .action(
       async (
         filters: string[],

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -26,7 +26,7 @@ export type RstestContext = {
 
 export type ListCommandOptions = {
   filesOnly?: boolean;
-  json?: boolean;
+  json?: boolean | string;
 };
 
 export type RstestInstance = {

--- a/tests/list/index.test.ts
+++ b/tests/list/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
@@ -173,5 +174,28 @@ describe('test list command', () => {
         "]",
       ]
     `);
+  });
+
+  it('should output test json file correctly', async () => {
+    const outputPath = join(__dirname, 'fixtures', 'output.json');
+
+    fs.rmSync(outputPath, { force: true });
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['list', '--json', 'output.json'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    expect(fs.existsSync(outputPath)).toBeTruthy();
+
+    fs.rmSync(outputPath, { force: true });
   });
 });


### PR DESCRIPTION
## Summary

support output test json to file via `--json <filePath>`

```bash
$ rstest list --json output.json
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
