### PR TITLE
refactor: only print file result when onTestFileResult hook called

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -154,6 +154,11 @@ export const createPool = async ({
         reporters.map((reporter) => reporter.onTestFileStart?.(test)),
       );
     },
+    onTestFileResult: async (test: TestFileResult) => {
+      await Promise.all(
+        reporters.map((reporter) => reporter.onTestFileResult?.(test)),
+      );
+    },
   };
 
   return {

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -269,7 +269,7 @@ const stackIgnores: (RegExp | string)[] = [
   /node:\w+/,
 ];
 
-function parseErrorStacktrace({
+async function parseErrorStacktrace({
   stack,
   getSourcemap,
 }: {

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -40,13 +40,17 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
         const tests = await runtime.instance.getTests();
         traverseUpdateTest(tests, testNamePattern);
 
-        return testRunner.runTests({
+        const results = await testRunner.runTests({
           tests,
           testPath,
           state: workerState,
           hooks,
           api,
         });
+
+        hooks.onTestFileResult?.(results);
+
+        return results;
       },
       collectTests: async () => {
         const tests = await runtime.instance.getTests();

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -155,6 +155,9 @@ const runInPool = async (
         onTestFileStart: async (test) => {
           await rpc.onTestFileStart(test);
         },
+        onTestFileResult: async (test) => {
+          await rpc.onTestFileResult(test);
+        },
         onTestCaseResult: async (result) => {
           await rpc.onTestCaseResult(result);
         },

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -45,6 +45,10 @@ export interface Reporter {
    */
   onTestFileStart?: (test: TestFileInfo) => void;
   /**
+   * Called when the test file has finished running.
+   */
+  onTestFileResult?: (test: TestFileResult) => void;
+  /**
    * Called when the test has finished running or was just skipped.
    */
   onTestCaseResult?: (result: TestResult) => void;

--- a/packages/core/src/types/runner.ts
+++ b/packages/core/src/types/runner.ts
@@ -1,10 +1,14 @@
-import type { TestFileInfo, TestResult } from './testSuite';
+import type { TestFileInfo, TestFileResult, TestResult } from './testSuite';
 
 export type RunnerHooks = {
   /**
    * Called before test file run.
    */
   onTestFileStart?: (test: TestFileInfo) => Promise<void>;
+  /**
+   * Called after the test file is finished running.
+   */
+  onTestFileResult: (test: TestFileResult) => Promise<void>;
   /**
    * Called after the test is finished running.
    */

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -2,7 +2,12 @@ import type { SnapshotUpdateState } from '@vitest/snapshot';
 import type { SnapshotEnvironment } from '@vitest/snapshot/environment';
 import type { RstestContext } from './core';
 import type { SourceMapInput } from './reporter';
-import type { TestFileInfo, TestResult, UserConsoleLog } from './testSuite';
+import type {
+  TestFileInfo,
+  TestFileResult,
+  TestResult,
+  UserConsoleLog,
+} from './testSuite';
 import type { DistPath, TestPath } from './utils';
 
 export type EntryInfo = {
@@ -17,6 +22,7 @@ export type ServerRPC = {};
 /** Runtime to Server */
 export type RuntimeRPC = {
   onTestFileStart: (test: TestFileInfo) => Promise<void>;
+  onTestFileResult: (test: TestFileResult) => Promise<void>;
   onTestCaseResult: (result: TestResult) => Promise<void>;
   onConsoleLog: (log: UserConsoleLog) => void;
 };

--- a/tests/lifecycle/index.test.ts
+++ b/tests/lifecycle/index.test.ts
@@ -27,14 +27,6 @@ describe('afterAll', () => {
       '[afterAll] in level A',
       '[afterAll] root',
     ]);
-
-    // test log print
-    expect(
-      logs.find((log) => log.includes('✓ level A > it in level A')),
-    ).toBeTruthy();
-    expect(
-      logs.find((log) => log.includes('_internal_root_suite')),
-    ).toBeFalsy();
   });
 });
 

--- a/tests/runner/test/async.test.ts
+++ b/tests/runner/test/async.test.ts
@@ -36,25 +36,5 @@ describe('Test Async Suite', () => {
         "run 3-0",
       ]
     `);
-
-    // test suite reference
-    expect(
-      logs
-        .filter((log) => log.includes('Test Async Suite'))
-        // slice `✓ Test Async Suite > 2 > 2-0 > 2-0-0 (0 ms)` to `> 2 > 2-0 > 2-0-0`
-        .map((log) => getTestName(log, 'Test Async Suite')),
-    ).toMatchInlineSnapshot(`
-      [
-        "> 0 > 0-0",
-        "> 0 > 0-1 > 0-1-0",
-        "> 0 > 0-1 > 0-1-1 > 0-1-1-0",
-        "> 0 > 0-2 > 0-2-0",
-        "> 0 > 0-3",
-        "> 1",
-        "> 2 > 2-0 > 2-0-0",
-        "> 2 > 2-1",
-        "> 3",
-      ]
-    `);
   });
 });

--- a/tests/test-api/each.test.ts
+++ b/tests/test-api/each.test.ts
@@ -21,21 +21,6 @@ it('Test Each API', async () => {
 
   const logs = cli.stdout.split('\n').filter(Boolean);
 
-  expect(
-    logs
-      .filter((log) => log.includes('add'))
-      .map((log) => getTestName(log, '✓')),
-  ).toMatchInlineSnapshot(`
-    [
-      "add(1, 1) -> 2",
-      "add(1, 2) -> 3",
-      "add(2, 1) -> 3",
-      "case-0 add(2, 1) -> 3",
-      "case-1 add(2, 2) -> 4",
-      "case-2 add(3, 1) -> 4",
-    ]
-  `);
-
   expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
 });
 
@@ -56,21 +41,6 @@ it('Test For API', async () => {
   expect(cli.exec.process?.exitCode).toBe(0);
 
   const logs = cli.stdout.split('\n').filter(Boolean);
-
-  expect(
-    logs
-      .filter((log) => log.includes('add'))
-      .map((log) => getTestName(log, '✓')),
-  ).toMatchInlineSnapshot(`
-    [
-      "add(1, 1) -> 2",
-      "add(1, 2) -> 3",
-      "add(2, 1) -> 3",
-      "case-0 add(2, 1) -> 3",
-      "case-1 add(2, 2) -> 4",
-      "case-2 add(3, 1) -> 4",
-    ]
-  `);
 
   expect(logs.find((log) => log.includes('Tests 6 passed'))).toBeTruthy();
 });

--- a/tests/watch/index.test.ts
+++ b/tests/watch/index.test.ts
@@ -25,7 +25,6 @@ describe('watch', () => {
     // initial
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 1 passed');
-    expect(cli.stdout).toMatch('index > should test source code correctly');
 
     // create
     cli.resetStd();
@@ -41,8 +40,6 @@ describe('watch', () => {
 
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 2 passed');
-    expect(cli.stdout).toMatch('bar > bar should be to bar');
-    expect(cli.stdout).toMatch('index > should test source code correctly');
 
     // update
     cli.resetStd();
@@ -52,7 +49,6 @@ describe('watch', () => {
 
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Test Files 1 failed | 1 passed');
-    expect(cli.stdout).toMatch('✓ index > should test source code correctly');
     expect(cli.stdout).toMatch('✗ bar > bar should be to bar');
 
     // delete
@@ -60,7 +56,6 @@ describe('watch', () => {
     fs.delete('./fixtures-test/bar.test.ts');
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Test Files 1 passed');
-    expect(cli.stdout).toMatch('✓ index > should test source code correctly');
 
     cli.exec.kill();
   });


### PR DESCRIPTION
## Summary

only print file result when `onTestFileResult` hook called, instead of print test case result when `onTestCaseResult` hook called.

todo:
- support update test status 

before:
> the test file starts and test case results are printed separately and unrelated.

<img width="795" alt="image" src="https://github.com/user-attachments/assets/2792646e-5fff-4805-a0da-5e780d60ec63" />




after:
<img width="609" alt="image" src="https://github.com/user-attachments/assets/ffcdc968-81ed-4da8-81ce-6158d5c2b6de" />



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
