### PR TITLE
feat: support slowTestThreshold option

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -26,6 +26,7 @@ type CommonOptions = {
   unstubEnvs?: boolean;
   retry?: number;
   maxConcurrency?: number;
+  slowTestThreshold?: number;
 };
 
 const applyCommonOptions = (cli: CAC) => {
@@ -56,6 +57,10 @@ const applyCommonOptions = (cli: CAC) => {
       'Print console traces when calling any console method.',
     )
     .option('--disableConsoleIntercept', 'Disable console intercept.')
+    .option(
+      '--slowTestThreshold <slowTestThreshold>',
+      'The number of milliseconds after which a test or suite is considered slow',
+    )
     .option(
       '-t, --testNamePattern <testNamePattern>',
       'Run only tests with a name that matches the regex.',
@@ -111,6 +116,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'unstubEnvs',
     'unstubGlobals',
     'retry',
+    'slowTestThreshold',
     'maxConcurrency',
     'printConsoleTrace',
     'disableConsoleIntercept',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -95,6 +95,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   clearMocks: false,
   resetMocks: false,
   restoreMocks: false,
+  slowTestThreshold: 300,
   unstubGlobals: false,
   unstubEnvs: false,
   maxConcurrency: 5,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -137,6 +137,12 @@ export interface RstestConfig {
   restoreMocks?: boolean;
 
   /**
+   * The number of milliseconds after which a test or suite is considered slow and reported as such in the results.
+   * @default 300
+   */
+  slowTestThreshold?: number;
+
+  /**
    * Restores all global variables that were changed with `rstest.stubGlobal` before every test.
    * @default false
    */

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   setupFiles: ['../scripts/rstest.setup.ts'],
   testTimeout: process.env.CI ? 10_000 : 5_000,
+  slowTestThreshold: 2_000,
   exclude: [
     '**/node_modules/**',
     '**/dist/**',


### PR DESCRIPTION
## Summary

- `slowTestThreshold`:  The number of milliseconds after which a test or suite is considered slow and reported as such in the results. Default: 300.

```bash
$ rstest run --slowTestThreshold 5000
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
