### PR TITLE
fix: should not mark snapshot obsolete when case skipped

### DIFF
--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -62,6 +62,7 @@ export class TestRunner {
       },
     ): Promise<TestResult> => {
       if (test.runMode === 'skip') {
+        snapshotClient.skipTest(testPath, getTaskNameWithPrefix(test));
         const result = {
           status: 'skip' as const,
           parentNames: test.parentNames,

--- a/tests/snapshot/fixtures/__snapshots__/obsolete.test.ts.snap
+++ b/tests/snapshot/fixtures/__snapshots__/obsolete.test.ts.snap
@@ -1,0 +1,3 @@
+// Snapshot v1
+
+exports[`test snapshot obsolete > test snapshot generate 1`] = `"hello world"`;

--- a/tests/snapshot/fixtures/__snapshots__/skip.test.ts.snap
+++ b/tests/snapshot/fixtures/__snapshots__/skip.test.ts.snap
@@ -1,0 +1,3 @@
+// Snapshot v1
+
+exports[`test snapshot obsolete > test snapshot generate 1`] = `"hello world"`;

--- a/tests/snapshot/fixtures/obsolete.test.ts
+++ b/tests/snapshot/fixtures/obsolete.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('test snapshot obsolete', () => {
+  it('test snapshot generate', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/tests/snapshot/fixtures/skip.test.ts
+++ b/tests/snapshot/fixtures/skip.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('test snapshot obsolete', () => {
+  it.skip('test snapshot generate', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/tests/snapshot/obsolete.test.ts
+++ b/tests/snapshot/obsolete.test.ts
@@ -1,0 +1,49 @@
+import path from 'node:path';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { createSnapshotSerializer } from 'path-serializer';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test snapshot', () => {
+  it('should mark snapshot obsolete ', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/obsolete.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.find((log) => log.includes('1 obsolete'))).toBeTruthy();
+  });
+
+  it('should not mark snapshot obsolete when case skipped', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/skip.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.find((log) => log.includes('1 obsolete'))).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

should not mark snapshot obsolete when case skipped.

expect:
<img width="875" alt="image" src="https://github.com/user-attachments/assets/dab75578-a2e6-4cdf-bbd3-544e918a4b6d" />


actual:
<img width="771" alt="image" src="https://github.com/user-attachments/assets/6b9a035c-8ec5-4ab0-96fe-a377106faadb" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
