### PR TITLE
feat: in-source testing

### DIFF
--- a/packages/core/importMeta.d.ts
+++ b/packages/core/importMeta.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly rstest?: typeof import('@rstest/core');
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,9 @@
     },
     "./globals": {
       "types": "./globals.d.ts"
+    },
+    "./importMeta": {
+      "types": "./importMeta.d.ts"
     }
   },
   "files": [

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -82,6 +82,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   name: 'rstest',
   include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   exclude: ['**/node_modules/**', '**/dist/**'],
+  includeSource: [],
   pool: {
     type: 'forks',
   },

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -16,7 +16,14 @@ export async function listTests(
   { filesOnly, json }: ListCommandOptions,
 ): Promise<void> {
   const {
-    normalizedConfig: { include, exclude, root, name, setupFiles: setups },
+    normalizedConfig: {
+      include,
+      exclude,
+      root,
+      name,
+      setupFiles: setups,
+      includeSource,
+    },
     rootPath,
   } = context;
 
@@ -25,6 +32,7 @@ export async function listTests(
     exclude,
     root,
     fileFilters,
+    includeSource,
   });
 
   const globTestSourceEntries = async (): Promise<Record<string, string>> => {

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -98,6 +98,11 @@ export const prepareRsbuild = async (
           dev: {
             writeToDisk,
           },
+          source: {
+            define: {
+              'import.meta.rstest': "global['@rstest/core']",
+            },
+          },
           output: {
             sourceMap: {
               js: 'source-map',

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -8,7 +8,14 @@ export async function runTests(
   fileFilters: string[],
 ): Promise<void> {
   const {
-    normalizedConfig: { include, exclude, root, name, setupFiles: setups },
+    normalizedConfig: {
+      include,
+      exclude,
+      root,
+      name,
+      setupFiles: setups,
+      includeSource,
+    },
     rootPath,
     reporters,
     snapshotManager,
@@ -19,6 +26,7 @@ export async function runTests(
     const entries = await getTestEntries({
       include,
       exclude,
+      includeSource,
       root,
       fileFilters,
     });

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -44,6 +44,12 @@ export interface RstestConfig {
    */
   exclude?: string[];
   /**
+   * A list of glob patterns that match your in-source test files
+   *
+   * @default []
+   */
+  includeSource?: string[];
+  /**
    * Path to setup files. They will be run before each test file.
    */
   setupFiles?: string[] | string;

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -365,6 +365,7 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
           "import.meta.env.DEV": false,
           "import.meta.env.MODE": "\\"none\\"",
           "import.meta.env.PROD": false,
+          "import.meta.rstest": "global['@rstest/core']",
           "process.env.ASSET_PREFIX": "\\"\\"",
           "process.env.BASE_URL": "\\"/\\"",
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@rsbuild/core':
         specifier: ^1.3.20
         version: 1.3.20
+      '@rslib/core':
+        specifier: 0.7.1
+        version: 0.7.1(typescript@5.8.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../packages/core

--- a/tests/in-source/fixtures/rslib.config.ts
+++ b/tests/in-source/fixtures/rslib.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      bundle: false,
+      format: 'esm',
+    },
+  ],
+  source: {
+    define: {
+      'import.meta.rstest': undefined,
+    },
+  },
+});

--- a/tests/in-source/fixtures/rstest.config.ts
+++ b/tests/in-source/fixtures/rstest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  includeSource: ['src/**/*.{js,ts}'],
+});

--- a/tests/in-source/fixtures/src/a.ts
+++ b/tests/in-source/fixtures/src/a.ts
@@ -1,0 +1,1 @@
+export const a = '1';

--- a/tests/in-source/fixtures/src/index.ts
+++ b/tests/in-source/fixtures/src/index.ts
@@ -1,0 +1,8 @@
+export const sayHi = () => 'hi';
+
+if (import.meta.rstest) {
+  const { it, expect } = import.meta.rstest;
+  it('should test source code correctly', () => {
+    expect(sayHi()).toBe('hi');
+  });
+}

--- a/tests/in-source/fixtures/tsconfig.json
+++ b/tests/in-source/fixtures/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
+    "types": ["@rstest/core/importMeta"]
+  },
+  "include": ["src"]
+}

--- a/tests/in-source/index.test.ts
+++ b/tests/in-source/index.test.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+describe('In-Source testing', () => {
+  it('should run in-source testing correctly', async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('Test Files 1 passed')),
+    ).toBeTruthy();
+  });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^1.3.20",
+    "@rslib/core": "0.7.1",
     "@rstest/core": "workspace:*",
     "jest-image-snapshot": "^6.5.0",
     "strip-ansi": "^7.1.0",


### PR DESCRIPTION
## Summary

Support run tests within source code, similar to [Rust's module tests](https://doc.rust-lang.org/book/ch11-03-test-organization.html#the-tests-module-and-cfgtest).


When `includeSource` defined, Rstest will run all matched files with `import.meta.rstest` inside.


```diff
import { defineConfig } from '@rstest/core'

export default defineConfig({
  test: {
+    includeSource: ['src/**/*.{js,ts}'], 
  },
})
```


```ts title=src/index.ts
export const sayHi = () => 'hi';

if (import.meta.rstest) {
  const { it, expect } = import.meta.rstest;
  it('should test source code correctly', () => {
    expect(sayHi()).toBe('hi');
  });
}

```

To get TypeScript support for `import.meta.rstest`, you should add `@rstest/core/importMeta` to your tsconfig.json:

```diff
{
  "compilerOptions": {
    "types": [
+      "@rstest/core/importMeta"
    ]
  }
}
```


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
