### PR TITLE
feat: init `test.extend` API

### DIFF
--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -7,12 +7,14 @@ import type {
   DescribeAPI,
   DescribeEachFn,
   DescribeForFn,
+  Fixtures,
   RunnerAPI,
   Test,
   TestAPI,
   TestCallbackFn,
   TestCase,
   TestEachFn,
+  TestExtend,
   TestForFn,
   TestRunMode,
   TestSuite,
@@ -260,6 +262,7 @@ export class RunnerRuntime {
   it({
     name,
     fn,
+    fixtures,
     timeout = this.defaultTestTimeout,
     runMode = 'run',
     fails = false,
@@ -268,6 +271,7 @@ export class RunnerRuntime {
     sequential,
   }: {
     name: string;
+    fixtures?: Fixtures;
     fn?: TestCallbackFn;
     timeout?: number;
     runMode?: TestRunMode;
@@ -289,6 +293,7 @@ export class RunnerRuntime {
       runMode,
       type: 'case',
       timeout,
+      fixtures,
       concurrent,
       sequential,
       each,
@@ -429,6 +434,7 @@ export const createRuntimeAPI = ({
       concurrent?: boolean;
       sequential?: boolean;
       fails?: boolean;
+      fixtures?: Fixtures;
       runMode?: 'skip' | 'only' | 'todo';
     } = {},
   ): TestAPI => {
@@ -501,7 +507,13 @@ export const createRuntimeAPI = ({
     return testFn;
   };
 
-  const it = createTestAPI();
+  const it = createTestAPI() as TestAPI & {
+    extend: TestExtend;
+  };
+
+  it.extend = ((fixtures: Fixtures): TestAPI => {
+    return createTestAPI({ fixtures });
+  }) as TestExtend;
 
   const createDescribeAPI = (
     options: {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -12,11 +12,13 @@ export type TestContext = {
   expect: RstestExpect;
 };
 
-export type TestCallbackFn = (context: TestContext) => MaybePromise<void>;
+export type TestCallbackFn<ExtraContext = object> = (
+  context: TestContext & ExtraContext,
+) => MaybePromise<void>;
 
-type TestFn = (
+type TestFn<ExtraContext = object> = (
   description: string,
-  fn?: TestCallbackFn,
+  fn?: TestCallbackFn<ExtraContext>,
   timeout?: number,
 ) => void;
 
@@ -37,11 +39,11 @@ export interface TestEachFn {
   ) => void;
 }
 
-export type TestForFn = <T>(
+export type TestForFn<ExtraContext = object> = <T>(
   cases: ReadonlyArray<T>,
 ) => (
   description: string,
-  fn?: (param: T, context: TestContext) => MaybePromise<void>,
+  fn?: (param: T, context: TestContext & ExtraContext) => MaybePromise<void>,
   timeout?: number,
 ) => void;
 
@@ -58,17 +60,17 @@ export type DescribeForFn = <T>(
   cases: ReadonlyArray<T>,
 ) => (description: string, fn?: (param: T) => MaybePromise<void>) => void;
 
-export type TestAPI = TestFn & {
+export type TestAPI<ExtraContext = object> = TestFn<ExtraContext> & {
   each: TestEachFn;
-  for: TestForFn;
-  fails: TestAPI;
-  concurrent: TestAPI;
-  sequential: TestAPI;
-  only: TestAPI;
-  skip: TestAPI;
-  todo: TestAPI;
-  runIf: (condition: boolean) => TestAPI;
-  skipIf: (condition: boolean) => TestAPI;
+  for: TestForFn<ExtraContext>;
+  fails: TestAPI<ExtraContext>;
+  concurrent: TestAPI<ExtraContext>;
+  sequential: TestAPI<ExtraContext>;
+  only: TestAPI<ExtraContext>;
+  skip: TestAPI<ExtraContext>;
+  todo: TestAPI<ExtraContext>;
+  runIf: (condition: boolean) => TestAPI<ExtraContext>;
+  skipIf: (condition: boolean) => TestAPI<ExtraContext>;
 };
 
 type DescribeFn = (description: string, fn?: () => void) => void;
@@ -85,10 +87,65 @@ export type DescribeAPI = DescribeFn & {
   sequential: DescribeAPI;
 };
 
+// TODO: support fixture options
+// interface FixtureOptions {
+//   /**
+//    * Whether to automatically set up current fixture, even though it's not being used in tests.
+//    */
+//   auto?: boolean;
+//   /**
+//    * Indicated if the injected value from the config should be preferred over the fixture value
+//    */
+//   injected?: boolean;
+// }
+
+type Use<T> = (value: T) => Promise<void>;
+
+type FixtureFn<T, K extends keyof T, ExtraContext> = (
+  context: Omit<T, K> & ExtraContext,
+  use: Use<T[K]>,
+) => Promise<void>;
+
+type Fixture<T, K extends keyof T, ExtraContext = object> = ((
+  ...args: any
+) => any) extends T[K]
+  ? T[K] extends any
+    ? FixtureFn<T, K, Omit<ExtraContext, Exclude<keyof T, K>>>
+    : never
+  :
+      | T[K]
+      | (T[K] extends any
+          ? FixtureFn<T, K, Omit<ExtraContext, Exclude<keyof T, K>>>
+          : never);
+export type Fixtures<
+  T extends Record<string, any> = object,
+  ExtraContext = object,
+> = {
+  [K in keyof T]: Fixture<T, K, ExtraContext & TestContext>;
+  // | [Fixture<T, K, ExtraContext & TestContext>, FixtureOptions?];
+};
+
+export type TestExtend = <
+  T extends Record<string, any> = object,
+  ExtraContext = object,
+>(
+  fixtures: Fixtures<T, ExtraContext>,
+) => TestAPI<{
+  [K in keyof T | keyof ExtraContext]: K extends keyof T
+    ? T[K]
+    : K extends keyof ExtraContext
+      ? ExtraContext[K]
+      : never;
+}>;
+
 export type RunnerAPI = {
   describe: DescribeAPI;
-  it: TestAPI;
-  test: TestAPI;
+  it: TestAPI & {
+    extend: TestExtend;
+  };
+  test: TestAPI & {
+    extend: TestExtend;
+  };
   beforeAll: (fn: BeforeAllListener, timeout?: number) => MaybePromise<void>;
   afterAll: (fn: AfterAllListener, timeout?: number) => MaybePromise<void>;
   beforeEach: (fn: BeforeEachListener, timeout?: number) => MaybePromise<void>;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,5 +1,5 @@
 import type { SnapshotResult } from '@vitest/snapshot';
-import type { TestContext } from './api';
+import type { Fixtures, TestContext } from './api';
 import type { TestPath } from './utils';
 
 import type { MaybePromise } from './utils';
@@ -31,6 +31,7 @@ export type TestCase = {
   timeout?: number;
   fails?: boolean;
   each?: boolean;
+  fixtures?: Fixtures;
   concurrent?: boolean;
   sequential?: boolean;
   inTestEach?: boolean;

--- a/tests/test-api/chain.test.ts
+++ b/tests/test-api/chain.test.ts
@@ -35,7 +35,6 @@ describe('Test Chain', () => {
         "skipIf",
         "each",
         "for",
-        "extend",
       ]
     `);
   });

--- a/tests/test-api/chain.test.ts
+++ b/tests/test-api/chain.test.ts
@@ -20,6 +20,7 @@ describe('Test Chain', () => {
         "skipIf",
         "each",
         "for",
+        "extend",
       ]
     `);
     expect(Object.keys(it.only)).toMatchInlineSnapshot(`
@@ -34,6 +35,7 @@ describe('Test Chain', () => {
         "skipIf",
         "each",
         "for",
+        "extend",
       ]
     `);
   });

--- a/tests/test-api/extend.test.ts
+++ b/tests/test-api/extend.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@rstest/core';
+
+const todos: number[] = [];
+
+const myTest = test.extend<{
+  todos: number[];
+}>({
+  todos: async (_, use) => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    todos.push(1, 2, 3);
+    await use(todos);
+    // cleanup after each test function
+    todos.length = 0;
+  },
+});
+
+myTest('add todo 1', ({ todos }) => {
+  console.log('run');
+  expect(todos.length).toBe(3);
+
+  todos.push(4);
+  expect(todos.length).toBe(4);
+});
+
+myTest('add todo 2', ({ todos }) => {
+  expect(todos.length).toBe(3);
+
+  todos.push(4, 5);
+  expect(todos.length).toBe(5);
+});
+
+myTest.fails('add todo 3 - failed', ({ todos }) => {
+  expect(todos.length).toBe(3);
+
+  todos.push(4, 5);
+  expect(todos.length).toBe(6);
+});

--- a/tests/test-api/extend.test.ts
+++ b/tests/test-api/extend.test.ts
@@ -15,7 +15,6 @@ const myTest = test.extend<{
 });
 
 myTest('add todo 1', ({ todos }) => {
-  console.log('run');
   expect(todos.length).toBe(3);
 
   todos.push(4);


### PR DESCRIPTION
## Summary

Init `test.extend` API, support use it to define your own test API with custom fixtures and reuse it anywhere.

Like [Playwright#test-extend](https://playwright.dev/docs/api/class-test#test-extend).

```ts
import { expect, test } from '@rstest/core';

const todos: number[] = [];

const myTest = test.extend<{
  todos: number[];
}>({
  todos: async (_, use) => {
    todos.push(1, 2, 3);
    await use(todos);
    // cleanup after each test function
    todos.length = 0;
  },
});

myTest('add todo', ({ todos }) => {
  expect(todos.length).toBe(3);

  todos.push(4);
  expect(todos.length).toBe(4);
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
