### PR TITLE
docs: add Rstack links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ We plan to release a preview version for testing by June 2025, followed by the f
 
 More details can be found on [Rstest Roadmap](https://github.com/web-infra-dev/rstest/issues/85).
 
+## 🦀 Rstack
+
+Rstack is a unified JavaScript toolchain built around Rspack, with high performance and consistent architecture.
+
+| Name                                                  | Description              |
+| ----------------------------------------------------- | ------------------------ |
+| [Rspack](https://github.com/web-infra-dev/rspack)     | Bundler                  |
+| [Rsbuild](https://github.com/web-infra-dev/rsbuild)   | Build tool               |
+| [Rslib](https://github.com/web-infra-dev/rslib)       | Library development tool |
+| [Rspress](https://github.com/web-infra-dev/rspress)   | Static site generator    |
+| [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | Build analyzer           |
+| [Rstest](https://github.com/web-infra-dev/rstest)     | Testing framework        |
+
 ## 🙏 Credits
 
 Rstest has been inspired by several outstanding projects in the community. We would like to acknowledge and express our sincere gratitude to the following projects:


### PR DESCRIPTION
## Summary

This PR adds a new "Rstack" section to the README files , which details the projects of the Rstack toolchain and helps users to understand its concepts and goals.

Same as https://github.com/web-infra-dev/rspack/pull/10424

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
