### PR TITLE
fix(extend): support define an option

### DIFF
--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -458,13 +458,19 @@ export class TestRunner {
     const cleanups: Array<() => Promise<void>> = [];
 
     if (test.fixtures) {
-      for (const [key, fn] of Object.entries(test.fixtures)) {
+      for (const [key, fixtureValue] of Object.entries(test.fixtures)) {
+        if (typeof fixtureValue !== 'function') {
+          // @ts-expect-error extra context
+          context[key] = fixtureValue;
+          continue;
+        }
+
         // This API behavior follows vitest & playwright
         // but why not return cleanup function?
         await new Promise<void>((fixtureResolve) => {
           let useDone: (() => void) | undefined;
           // TODO: call fixture on demand
-          const block = fn(context, async (value: any) => {
+          const block = fixtureValue(context, async (value: any) => {
             // @ts-expect-error extra context
             context[key] = value;
 

--- a/tests/test-api/extend.test.ts
+++ b/tests/test-api/extend.test.ts
@@ -4,6 +4,7 @@ const todos: number[] = [];
 
 const myTest = test.extend<{
   todos: number[];
+  archive: number[];
 }>({
   todos: async (_, use) => {
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -12,6 +13,7 @@ const myTest = test.extend<{
     // cleanup after each test function
     todos.length = 0;
   },
+  archive: [],
 });
 
 myTest('add todo 1', ({ todos }) => {
@@ -33,4 +35,11 @@ myTest.fails('add todo 3 - failed', ({ todos }) => {
 
   todos.push(4, 5);
   expect(todos.length).toBe(6);
+});
+
+myTest('add archive', ({ archive }) => {
+  expect(archive.length).toBe(0);
+
+  archive.push(1, 2);
+  expect(archive.length).toBe(2);
 });


### PR DESCRIPTION
## Summary

Test extend support define an option and provide a default value.

```ts
import { expect, test } from '@rstest/core';

const todos: number[] = [];

const myTest = test.extend<{
  todos: number[];
  archive: number[];
}>({
  // Define an option and provide a default value.
  archive: [],
  // Define a fixture.
  todos: async (_, use) => {
    todos.push(1, 2, 3);
    await use(todos);
    // cleanup after each test function
    todos.length = 0;
  },
});

myTest('add archive', ({ archive }) => {
  expect(archive.length).toBe(0);

  archive.push(1, 2);
  expect(archive.length).toBe(2);
});


```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
