### PR TITLE
chore: optimize build config

### DIFF
--- a/packages/core/src/core/plugins/ignoreResolveError.ts
+++ b/packages/core/src/core/plugins/ignoreResolveError.ts
@@ -23,6 +23,9 @@ export const pluginIgnoreResolveError: RsbuildPlugin = {
       config.plugins!.push(new IgnoreModuleNotFoundErrorPlugin());
       config.optimization ??= {};
       config.optimization.emitOnErrors = true;
+
+      config.ignoreWarnings ??= [];
+      config.ignoreWarnings.push(/Module not found/);
     });
   },
 };

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -74,6 +74,7 @@ export const prepareRsbuild = async (
   setupFiles: Record<string, string>,
 ): Promise<RsbuildInstance> => {
   const {
+    command,
     normalizedConfig: { name, plugins, resolve, source, output, tools },
   } = context;
 
@@ -135,7 +136,11 @@ export const prepareRsbuild = async (
           },
           plugins: [
             pluginIgnoreResolveError,
-            pluginEntryWatch({ globTestSourceEntries, setupFiles }),
+            pluginEntryWatch({
+              globTestSourceEntries,
+              setupFiles,
+              isWatch: command === 'watch',
+            }),
           ],
         },
       },

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -4,7 +4,7 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
 {
   "context": "<WORKSPACE>",
   "devtool": "source-map",
-  "entry": [Function],
+  "entry": {},
   "experiments": {
     "asyncWebAssembly": true,
     "incremental": true,
@@ -18,6 +18,9 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
   "externalsPresets": {
     "node": true,
   },
+  "ignoreWarnings": [
+    /Module not found/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -374,9 +377,6 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
       "name": "DefinePlugin",
     },
     IgnoreModuleNotFoundErrorPlugin {},
-    TestFileWatchPlugin {
-      "contextToWatch": "<WORKSPACE>",
-    },
   ],
   "resolve": {
     "alias": {


### PR DESCRIPTION
## Summary

- only enable TestFileWatchPlugin in watch mode.
- ignore `Module not found` warning. reference https://github.com/web-infra-dev/rspack/pull/10377
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
