### PR TITLE
test: skip module not found case temporary

### DIFF
--- a/tests/test-api/edgeCase.test.ts
+++ b/tests/test-api/edgeCase.test.ts
@@ -25,7 +25,8 @@ describe('Test Edge Cases', () => {
     expect(logs.find((log) => log.includes('Error: Symbol('))).toBeFalsy();
   });
 
-  it('test module not found', async () => {
+  // should be fixed in rspack next version (1.3.12)
+  it.todo('test module not found', async () => {
     // Module not found errors should be silent at build time, and throw errors at runtime
     const { cli } = await runRstestCli({
       command: 'rstest',


### PR DESCRIPTION
## Summary

skip module not found case temporary, it should be fixed in rspack next version (1.3.12)

https://github.com/web-infra-dev/rstest/actions/runs/15152644316/job/42602104483?pr=209
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
