### PR TITLE
feat: support fixtures on-demand & `auto` option

### DIFF
--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -267,6 +267,7 @@ const stackIgnores: (RegExp | string)[] = [
   /node_modules\/tinypool/,
   /node_modules\/chai/,
   /node:\w+/,
+  '<anonymous>',
 ];
 
 async function parseErrorStacktrace({

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -1,0 +1,216 @@
+import type {
+  Fixtures,
+  NormalizedFixture,
+  NormalizedFixtures,
+  TestCase,
+} from '../../types';
+import { isObject } from '../../utils';
+
+export const normalizeFixtures = (
+  fixtures: Fixtures = {},
+  extendFixtures: NormalizedFixtures = {},
+): NormalizedFixtures => {
+  const result: NormalizedFixtures = {};
+  for (const key in fixtures) {
+    const fixtureOptionKeys = ['auto'];
+    // @ts-expect-error
+    const value = fixtures[key]!;
+    if (Array.isArray(value)) {
+      if (value.length === 1 && typeof value[0] === 'function') {
+        result[key] = {
+          isFn: true,
+          value: value[0],
+        };
+        continue;
+      }
+      if (
+        isObject(value[1]) &&
+        Object.keys(value[1]).some((key) => fixtureOptionKeys.includes(key))
+      ) {
+        result[key] = {
+          isFn: typeof value[0] === 'function',
+          value: value[0],
+          options: value[1],
+        };
+        continue;
+      }
+    }
+    result[key] = {
+      isFn: typeof value === 'function',
+      value,
+    };
+  }
+  const formattedResult = Object.fromEntries(
+    Object.entries(result).map(([key, value]) => {
+      if (value.isFn) {
+        const usedProps = getFixtureUsedProps(value.value);
+        value.deps = usedProps.filter(
+          (p) => p in result || p in extendFixtures,
+        );
+      }
+      return [key, value];
+    }),
+  );
+
+  return {
+    ...extendFixtures,
+    ...formattedResult,
+  };
+};
+
+export const handleFixtures = async (
+  test: TestCase,
+  context: Record<string, any>,
+): Promise<{
+  cleanups: (() => Promise<void>)[];
+}> => {
+  const cleanups: (() => Promise<void>)[] = [];
+
+  if (!test.fixtures) {
+    return { cleanups };
+  }
+
+  const doneMap = new Set<string>();
+  const pendingMap = new Set<string>();
+
+  const usedKeys: string[] = test.originalFn
+    ? getFixtureUsedProps(test.originalFn)
+    : [];
+
+  const useFixture = async (
+    name: string,
+    NormalizedFixture: NormalizedFixture,
+  ) => {
+    if (doneMap.has(name)) {
+      return;
+    }
+    if (pendingMap.has(name)) {
+      throw new Error(`Circular fixture dependency: ${name}`);
+    }
+
+    const { isFn, deps, value: fixtureValue } = NormalizedFixture;
+    if (!isFn) {
+      context[name] = fixtureValue;
+      doneMap.add(name);
+      return;
+    }
+
+    pendingMap.add(name);
+
+    if (deps?.length) {
+      for (const dep of deps) {
+        await useFixture(dep, test.fixtures![dep] as NormalizedFixture);
+      }
+    }
+
+    // This API behavior follows vitest & playwright
+    // but why not return cleanup function?
+    await new Promise<void>((fixtureResolve) => {
+      let useDone: (() => void) | undefined;
+      const block = fixtureValue(context, async (value: any) => {
+        context[name] = value;
+        fixtureResolve();
+        return new Promise<void>((useFnResolve) => {
+          useDone = useFnResolve;
+        });
+      });
+
+      cleanups.unshift(() => {
+        useDone?.();
+        return block;
+      });
+    });
+
+    doneMap.add(name);
+    pendingMap.delete(name);
+  };
+
+  for (const [name, params] of Object.entries(test.fixtures)) {
+    // call fixture on demand
+    const shouldAdd = params.options?.auto || usedKeys.includes(name);
+    if (!shouldAdd) {
+      continue;
+    }
+
+    await useFixture(name, params);
+  }
+
+  return { cleanups };
+};
+
+function splitByComma(s: string) {
+  const result: string[] = [];
+  const stack: string[] = [];
+  let start = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '{' || s[i] === '[') {
+      stack.push(s[i] === '{' ? '}' : ']');
+    } else if (s[i] === stack[stack.length - 1]) {
+      stack.pop();
+    } else if (!stack.length && s[i] === ',') {
+      const token = s.substring(start, i).trim();
+      if (token) result.push(token);
+      start = i + 1;
+    }
+  }
+  const lastToken = s.substring(start).trim();
+  if (lastToken) result.push(lastToken);
+  return result;
+}
+
+function filterOutComments(s: string): string {
+  const result: string[] = [];
+  let commentState: 'none' | 'singleline' | 'multiline' = 'none';
+  for (let i = 0; i < s.length; ++i) {
+    if (commentState === 'singleline') {
+      if (s[i] === '\n') commentState = 'none';
+    } else if (commentState === 'multiline') {
+      if (s[i - 1] === '*' && s[i] === '/') commentState = 'none';
+    } else if (commentState === 'none') {
+      if (s[i] === '/' && s[i + 1] === '/') {
+        commentState = 'singleline';
+      } else if (s[i] === '/' && s[i + 1] === '*') {
+        commentState = 'multiline';
+        i += 2;
+      } else {
+        result.push(s[i]!);
+      }
+    }
+  }
+  return result.join('');
+}
+
+/**
+ * This method is modified based on source found in
+ * https://github.com/microsoft/playwright/blob/3584e722237488c07dd23bbf12966f5509bf25c6/packages/playwright/src/common/fixtures.ts#L272
+ */
+// biome-ignore lint/complexity/noBannedTypes: Function type
+export function getFixtureUsedProps(fn: Function): string[] {
+  const text = filterOutComments(fn.toString());
+  const match = text.match(/(?:async)?(?:\s+function)?[^(]*\(([^)]*)/);
+  if (!match) return [];
+  const trimmedParams = match[1]!.trim();
+  if (!trimmedParams) return [];
+  const [firstParam] = splitByComma(trimmedParams);
+  if (firstParam?.[0] !== '{' || firstParam[firstParam.length - 1] !== '}') {
+    if (firstParam?.startsWith('_')) {
+      return [];
+    }
+    throw new Error(
+      `First argument must use the object destructuring pattern: ${firstParam}`,
+    );
+  }
+  const props = splitByComma(
+    firstParam.substring(1, firstParam.length - 1),
+  ).map((prop) => {
+    const colon = prop.indexOf(':');
+    return colon === -1 ? prop.trim() : prop.substring(0, colon).trim();
+  });
+  const restProperty = props.find((prop) => prop.startsWith('...'));
+  if (restProperty) {
+    throw new Error(
+      `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
+    );
+  }
+  return props;
+}

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -92,10 +92,6 @@ interface FixtureOptions {
    * Whether to automatically set up current fixture, even though it's not being used in tests.
    */
   auto?: boolean;
-  //   /**
-  //    * Indicated if the injected value from the config should be preferred over the fixture value
-  //    */
-  //   injected?: boolean;
 }
 
 type Use<T> = (value: T) => Promise<void>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -88,16 +88,16 @@ export type DescribeAPI = DescribeFn & {
 };
 
 // TODO: support fixture options
-// interface FixtureOptions {
-//   /**
-//    * Whether to automatically set up current fixture, even though it's not being used in tests.
-//    */
-//   auto?: boolean;
-//   /**
-//    * Indicated if the injected value from the config should be preferred over the fixture value
-//    */
-//   injected?: boolean;
-// }
+interface FixtureOptions {
+  /**
+   * Whether to automatically set up current fixture, even though it's not being used in tests.
+   */
+  auto?: boolean;
+  //   /**
+  //    * Indicated if the injected value from the config should be preferred over the fixture value
+  //    */
+  //   injected?: boolean;
+}
 
 type Use<T> = (value: T) => Promise<void>;
 
@@ -117,13 +117,24 @@ type Fixture<T, K extends keyof T, ExtraContext = object> = ((
       | (T[K] extends any
           ? FixtureFn<T, K, Omit<ExtraContext, Exclude<keyof T, K>>>
           : never);
+
 export type Fixtures<
   T extends Record<string, any> = object,
   ExtraContext = object,
 > = {
-  [K in keyof T]: Fixture<T, K, ExtraContext & TestContext>;
-  // | [Fixture<T, K, ExtraContext & TestContext>, FixtureOptions?];
+  [K in keyof T]:
+    | Fixture<T, K, ExtraContext & TestContext>
+    | [Fixture<T, K, ExtraContext & TestContext>, FixtureOptions?];
 };
+
+export type NormalizedFixture = {
+  isFn: boolean;
+  deps?: string[];
+  value: FixtureFn<any, any, any> | any;
+  options?: FixtureOptions;
+};
+
+export type NormalizedFixtures = Record<string, NormalizedFixture>;
 
 export type TestAPIs<ExtraContext = object> = TestAPI<ExtraContext> & {
   extend: <T extends Record<string, any> = object>(

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -87,7 +87,6 @@ export type DescribeAPI = DescribeFn & {
   sequential: DescribeAPI;
 };
 
-// TODO: support fixture options
 interface FixtureOptions {
   /**
    * Whether to automatically set up current fixture, even though it's not being used in tests.

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,5 +1,5 @@
 import type { SnapshotResult } from '@vitest/snapshot';
-import type { Fixtures, TestContext } from './api';
+import type { NormalizedFixtures, TestContext } from './api';
 import type { TestPath } from './utils';
 
 import type { MaybePromise } from './utils';
@@ -26,12 +26,13 @@ export interface TaskResult {
 export type TestCase = {
   testPath: TestPath;
   name: string;
+  originalFn?: (context: TestContext) => void | Promise<void>;
   fn?: (context: TestContext) => void | Promise<void>;
   runMode: TestRunMode;
   timeout?: number;
   fails?: boolean;
   each?: boolean;
-  fixtures?: Fixtures;
+  fixtures?: NormalizedFixtures;
   concurrent?: boolean;
   sequential?: boolean;
   inTestEach?: boolean;

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -20,6 +20,9 @@ export function slash(path: string): string {
   return path.replace(/\\/g, '/');
 }
 
+export const isObject = (obj: unknown): obj is Record<string, any> =>
+  Object.prototype.toString.call(obj) === '[object Object]';
+
 export const castArray = <T>(arr?: T | T[]): T[] => {
   if (arr === undefined) {
     return [];

--- a/tests/test-api/extend.auto.test.ts
+++ b/tests/test-api/extend.auto.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, expect, test } from '@rstest/core';
+
+const logs: string[] = [];
+
+afterAll(() => {
+  // should init on demand
+  expect(logs.length).toBe(4);
+});
+
+const todos: number[] = [];
+const archive: number[] = [];
+
+const myTest = test.extend<{
+  todos: number[];
+  archive: number[];
+}>({
+  todos: [
+    async (_, use) => {
+      logs.push('init todos');
+      todos.push(1, 2, 3);
+      await use(todos);
+      // cleanup after each test function
+      todos.length = 0;
+    },
+    {
+      auto: true,
+    },
+  ],
+  archive: [
+    async (_, use) => {
+      logs.push('init archive');
+      await use(archive);
+      // cleanup after each test function
+      archive.length = 0;
+    },
+    {
+      auto: true,
+    },
+  ],
+});
+
+myTest('add todo', ({ todos }) => {
+  expect(todos.length).toBe(3);
+
+  todos.push(4);
+  expect(todos.length).toBe(4);
+});
+
+myTest('add archive', ({ archive }) => {
+  expect(archive.length).toBe(0);
+
+  archive.push(1, 2);
+  expect(archive.length).toBe(2);
+});

--- a/tests/test-api/extend.extend.test.ts
+++ b/tests/test-api/extend.extend.test.ts
@@ -33,7 +33,7 @@ myTest1('add todo', ({ todos }) => {
   expect(todos.length).toBe(4);
 });
 
-myTest1('add archive', ({ todos }) => {
+myTest1('add archive', ({ archive }) => {
   expect(archive.length).toBe(3);
 
   archive.push(4, 5);

--- a/tests/test-api/extend.onDemand.test.ts
+++ b/tests/test-api/extend.onDemand.test.ts
@@ -1,4 +1,11 @@
-import { expect, test } from '@rstest/core';
+import { afterAll, expect, test } from '@rstest/core';
+
+const logs: string[] = [];
+
+afterAll(() => {
+  // should init on demand
+  expect(logs.length).toBe(3);
+});
 
 const todos: number[] = [];
 
@@ -7,6 +14,7 @@ const myTest = test.extend<{
   archive: number[];
 }>({
   todos: async (_, use) => {
+    logs.push('init todos');
     await new Promise((resolve) => setTimeout(resolve, 10));
     todos.push(1, 2, 3);
     await use(todos);


### PR DESCRIPTION
## Summary

Support fixtures on-demand & `auto` option.

Rstest will setup fixtures  on-demand (only the ones needed by your test and nothing else). 
You can use `auto: true` to explicitly initialize a fixture, even if it's not being used in tests.

```ts
const myTest = test.extend<{
  todos: number[];
  archive: number[];
}>({
  todos: [
    async ({}, use) => {  // Will always be executed, although not used
      todos.push(1, 2, 3);
      await use(todos);
      todos.length = 0;
    },
    {
      auto: true,  
    },
  ],
  archive: async ({}, use) => {  // Will be executed when used
      logs.push('init archive');
      await use(archive);
      archive.length = 0;
    },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
