### PR TITLE
docs: use Open Sans as the default font

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,10 +257,6 @@ importers:
         version: link:../../packages/core
 
   website:
-    dependencies:
-      rspress:
-        specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(@types/react@19.1.4)(acorn@8.14.1)
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: ^1.3.1
@@ -286,6 +282,12 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      rspress:
+        specifier: ^2.0.0-beta.6
+        version: 2.0.0-beta.6(@types/react@19.1.4)(acorn@8.14.1)
+      rspress-plugin-font-open-sans:
+        specifier: ^1.0.0
+        version: 1.0.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2677,6 +2679,9 @@ packages:
 
   rspack-plugin-virtual-module@1.0.0:
     resolution: {integrity: sha512-v5MDtNEcDwV36gsHf5iIYyH1rYuC2TP3D+xE1Z+pqIWjFR9dpQ4DF4OzGtrBQSPKVhOyL0VW5UyeIbfdFxELmw==}
+
+  rspress-plugin-font-open-sans@1.0.0:
+    resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
 
   rspress@2.0.0-beta.6:
     resolution: {integrity: sha512-YM+4pMHr4yYUMQzlszRYOM4lgfQVmsd+BWTJcPmtJgsHPtpLPiiX25AgcmQDNNtiwVF+d/endH5mB+p7uTbadQ==}
@@ -6208,6 +6213,8 @@ snapshots:
   rspack-plugin-virtual-module@1.0.0:
     dependencies:
       fs-extra: 11.3.0
+
+  rspress-plugin-font-open-sans@1.0.0: {}
 
   rspress@2.0.0-beta.6(@types/react@19.1.4)(acorn@8.14.1):
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -8,9 +8,6 @@
     "dev": "rspress dev",
     "preview": "rspress preview"
   },
-  "dependencies": {
-    "rspress": "^2.0.0-beta.6"
-  },
   "devDependencies": {
     "@rsbuild/plugin-sass": "^1.3.1",
     "@rstack-dev/doc-ui": "1.10.2",
@@ -20,6 +17,8 @@
     "@types/react-dom": "^19.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "rspress": "^2.0.0-beta.6",
+    "rspress-plugin-font-open-sans": "^1.0.0",
     "typescript": "^5.8.3"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
+import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
@@ -64,6 +65,7 @@ export default defineConfig({
       },
     ],
   },
+  plugins: [pluginFontOpenSans()],
   builderConfig: {
     plugins: [pluginSass()],
   },


### PR DESCRIPTION
## Summary

use Open Sans as the default font in Rstest website.

https://www.npmjs.com/package/rspress-plugin-font-open-sans
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
