### PR TITLE
fix: should keep dynamic import expressions

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -130,6 +130,13 @@ export const prepareRsbuild = async (
               config.output.devtoolModuleFilenameTemplate =
                 '[absolute-resource-path]';
 
+              // Keep dynamic import expressions
+              config.module.parser ??= {};
+              config.module.parser.javascript = {
+                importDynamic: false,
+                ...(config.module.parser.javascript || {}),
+              };
+
               config.optimization = {
                 ...(config.optimization || {}),
                 moduleIds: 'named',

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -29,6 +29,7 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "importDynamic": false,
       },
     },
     "rules": [

--- a/tests/build/runtimeImport/a.js
+++ b/tests/build/runtimeImport/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/tests/build/runtimeImport/b.ts
+++ b/tests/build/runtimeImport/b.ts
@@ -1,0 +1,1 @@
+export const b = 1;

--- a/tests/build/runtimeImport/index.test.ts
+++ b/tests/build/runtimeImport/index.test.ts
@@ -1,0 +1,16 @@
+import { join } from 'node:path';
+import { expect, it } from '@rstest/core';
+
+const customImport = async (name: string) => {
+  return import(join(__dirname, name));
+};
+
+it('should load runtime deps correctly', async () => {
+  const res = await customImport('./a.js');
+  expect(res.a).toBe(1);
+});
+
+it('should load compile-time deps correctly', async () => {
+  const res = await import('./b.ts');
+  expect(res.b).toBe(1);
+});

--- a/tests/build/runtimeImport/package.json
+++ b/tests/build/runtimeImport/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@rstest/tests-runtime-import",
+  "type": "module",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

should keep dynamic import expressions.

before:
<img width="961" alt="image" src="https://github.com/user-attachments/assets/509123d7-869f-407b-abac-b117529ac037" />

after:
<img width="606" alt="image" src="https://github.com/user-attachments/assets/e519f4cb-59b3-43ca-a625-a37b4d622651" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
