### PR TITLE
docs: redirect rstest.dev to rstest.rs

### DIFF
--- a/website/docs/public/_redirects
+++ b/website/docs/public/_redirects
@@ -1,0 +1,2 @@
+# Redirect rstest.dev to rstest.rs
+https://rstest.dev/* https://rstest.rs/:splat 301!


### PR DESCRIPTION
## Summary

Redirect rstest.dev to rstest.rs to ensure that users access the same domain name.

## Related Links

See: https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
