### PR TITLE
test: enable module not found case

### DIFF
--- a/tests/test-api/edgeCase.test.ts
+++ b/tests/test-api/edgeCase.test.ts
@@ -25,8 +25,7 @@ describe('Test Edge Cases', () => {
     expect(logs.find((log) => log.includes('Error: Symbol('))).toBeFalsy();
   });
 
-  // TODO: should be fixed in rspack next version (1.3.12)
-  it.todo('test module not found', async () => {
+  it('test module not found', async () => {
     // Module not found errors should be silent at build time, and throw errors at runtime
     const { cli } = await runRstestCli({
       command: 'rstest',


### PR DESCRIPTION
## Summary
enable module not found case since rspack 1.3.12.

https://github.com/web-infra-dev/rspack/releases/tag/v1.3.12

https://github.com/web-infra-dev/rspack/pull/10439

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
