### PR TITLE
fix: `--cpu-prof` not working in child_process

### DIFF
--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -5,6 +5,7 @@ import type {
   TestFileResult,
   WorkerState,
 } from '../../types';
+import './setup';
 import { globalApis } from '../../utils/constants';
 import { undoSerializableConfig } from '../../utils/helper';
 import { formatTestError } from '../util';

--- a/packages/core/src/runtime/worker/setup.ts
+++ b/packages/core/src/runtime/worker/setup.ts
@@ -1,0 +1,15 @@
+const gracefulExit: boolean = process.execArgv.some(
+  (execArg) =>
+    execArg.startsWith('--prof') ||
+    execArg.startsWith('--cpu-prof') ||
+    execArg.startsWith('--heap-prof') ||
+    execArg.startsWith('--diagnostic-dir'),
+);
+
+if (gracefulExit) {
+  // gracefully handle SIGTERM to generate CPU profile
+  // https://github.com/nodejs/node/issues/55094
+  process.on('SIGTERM', () => {
+    process.exit();
+  });
+}


### PR DESCRIPTION
## Summary

fix `--cpu-prof` not working in child_process. Gracefully handle SIGTERM to generate CPU profile.

https://github.com/nodejs/node/issues/55094

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
