### PR TITLE
perf: post assets to worker on demand

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -108,6 +108,8 @@ export const prepareRsbuild = async (
             },
           },
           output: {
+            // Pass resources to the worker on demand according to entry
+            manifest: true,
             sourceMap: {
               js: 'source-map',
             },
@@ -141,6 +143,11 @@ export const prepareRsbuild = async (
                 ...(config.optimization || {}),
                 moduleIds: 'named',
                 chunkIds: 'named',
+                splitChunks: {
+                  chunks: 'all',
+                  minSize: 0,
+                  maxInitialRequests: Number.POSITIVE_INFINITY,
+                },
               };
             },
           },
@@ -213,15 +220,20 @@ export const createRsbuildServer = async ({
   const getRsbuildStats = async () => {
     const stats = await devServer.environments[name]!.getStats();
 
+    const { manifest } = devServer.environments[name]!.context;
+
     const {
       entrypoints,
       outputPath,
       assets,
       time: buildTime,
     } = stats.toJson({
+      all: false,
       entrypoints: true,
       outputPath: true,
       assets: true,
+      relatedAssets: true,
+      cachedAssets: true,
       // get the compilation time
       timings: true,
     });
@@ -237,6 +249,21 @@ export const createRsbuildServer = async ({
       });
     };
 
+    const getEntryFiles = async () => {
+      const entryFiles: Record<string, string[]> = {};
+
+      const entries = Object.keys(manifest!.entries!);
+
+      for (const entry of entries) {
+        const data = manifest!.entries[entry];
+        entryFiles[entry] = (
+          (data.initial?.js || []).concat(data.async?.js || []) || []
+        ).map((file: string) => path.join(outputPath!, file));
+      }
+      return entryFiles;
+    };
+
+    const entryFiles = await getEntryFiles();
     const entries: EntryInfo[] = [];
     const setupEntries: EntryInfo[] = [];
     const sourceEntries = await globTestSourceEntries();
@@ -253,11 +280,13 @@ export const createRsbuildServer = async ({
         setupEntries.push({
           distPath,
           testPath: setupFiles[entry],
+          files: entryFiles[entry],
         });
       } else if (sourceEntries[entry]) {
         entries.push({
           distPath,
           testPath: sourceEntries[entry],
+          files: entryFiles[entry],
         });
       }
     }

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -163,11 +163,34 @@ export const createPool = async ({
     },
   };
 
+  const setupAssets = setupEntries.flatMap((entry) => entry.files);
+
+  const filterAssetsByEntry = (entryInfo: EntryInfo) => {
+    const neededFiles = entryInfo.files
+      ? Object.fromEntries(
+          Object.entries(assetFiles).filter(
+            ([key]) =>
+              entryInfo.files!.includes(key) || setupAssets.includes(key),
+          ),
+        )
+      : assetFiles;
+
+    const neededSourceMaps =
+      Object.keys(entries).length > 1
+        ? Object.fromEntries(
+            Object.entries(sourceMaps).filter(([key]) => neededFiles[key]),
+          )
+        : sourceMaps;
+
+    return { assetFiles: neededFiles, sourceMaps: neededSourceMaps };
+  };
   return {
     runTests: async () => {
       const results = await Promise.all(
-        entries.map((entryInfo) =>
-          pool.runTest({
+        entries.map((entryInfo) => {
+          const { assetFiles, sourceMaps } = filterAssetsByEntry(entryInfo);
+
+          return pool.runTest({
             options: {
               entryInfo,
               assetFiles,
@@ -181,8 +204,8 @@ export const createPool = async ({
               updateSnapshot,
             },
             rpcMethods,
-          }),
-        ),
+          });
+        }),
       );
 
       for (const result of results) {
@@ -197,8 +220,10 @@ export const createPool = async ({
     },
     collectTests: async () => {
       return Promise.all(
-        entries.map((entryInfo) =>
-          pool.collectTests({
+        entries.map((entryInfo) => {
+          const { assetFiles, sourceMaps } = filterAssetsByEntry(entryInfo);
+
+          return pool.collectTests({
             options: {
               entryInfo,
               assetFiles,
@@ -212,8 +237,8 @@ export const createPool = async ({
               updateSnapshot,
             },
             rpcMethods,
-          }),
-        ),
+          });
+        }),
       );
     },
     close: () => pool.close(),

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -13,6 +13,7 @@ import type { DistPath, TestPath } from './utils';
 export type EntryInfo = {
   distPath: DistPath;
   testPath: TestPath;
+  files?: string[];
 };
 
 /** Server to Runtime */


### PR DESCRIPTION
## Summary

Optimize worker options serialization performance, post assets to worker on demand.

before (test in rsbuild):
![image](https://github.com/user-attachments/assets/c426724d-9e30-4b31-9c0f-ae0009c4985a)

after:
![image](https://github.com/user-attachments/assets/baa0f61e-8f26-41aa-8cdb-1a17153861a1)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
