### PR TITLE
docs: add `Rsdoctor` guide

### DIFF
--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -8,5 +8,10 @@
     "type": "dir",
     "name": "basic",
     "label": "Basic"
+  },
+  {
+    "type": "dir",
+    "name": "advanced",
+    "label": "Advanced"
   }
 ]

--- a/website/docs/en/guide/advanced/_meta.json
+++ b/website/docs/en/guide/advanced/_meta.json
@@ -1,0 +1,1 @@
+["profiling"]

--- a/website/docs/en/guide/advanced/profiling.mdx
+++ b/website/docs/en/guide/advanced/profiling.mdx
@@ -1,0 +1,42 @@
+# Profiling
+
+## Using Rsdoctor
+
+Rsdoctor is a build analysis tool that can visually display the compilation time of each loaders and plugins.
+
+When you need to debug Rstest's build outputs or build processes, you can use Rsdoctor for troubleshooting.
+
+### Quick start
+
+In Rstest, you can enable Rsdoctor analysis as follows:
+
+1. Install the Rsdoctor plugin:
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add @rsdoctor/rspack-plugin -D" />
+
+2. Add `RSDOCTOR=true` env variable before the CLI command:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test:rsdoctor": "RSDOCTOR=true rstest run"
+  }
+}
+```
+
+As Windows does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test:rsdoctor": "cross-env RSDOCTOR=true rstest run"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.0"
+  }
+}
+```
+
+After running the above commands, Rstest will automatically register the Rsdoctor plugin, and after the build is completed, it will open the build analysis page. For complete features, please refer to [Rsdoctor document](https://rsdoctor.rs/).

--- a/website/docs/en/guide/advanced/profiling.mdx
+++ b/website/docs/en/guide/advanced/profiling.mdx
@@ -2,7 +2,7 @@
 
 ## Using Rsdoctor
 
-Rsdoctor is a build analysis tool that can visually display the compilation time of each loaders and plugins.
+[Rsdoctor](https://rsdoctor.rs/) is a build analysis tool that can visually display the compilation time of each loaders and plugins.
 
 When you need to debug Rstest's build outputs or build processes, you can use Rsdoctor for troubleshooting.
 

--- a/website/docs/zh/guide/_meta.json
+++ b/website/docs/zh/guide/_meta.json
@@ -8,5 +8,10 @@
     "type": "dir",
     "name": "basic",
     "label": "基础"
+  },
+  {
+    "type": "dir",
+    "name": "advanced",
+    "label": "进阶"
   }
 ]

--- a/website/docs/zh/guide/advanced/_meta.json
+++ b/website/docs/zh/guide/advanced/_meta.json
@@ -1,0 +1,1 @@
+["profiling"]

--- a/website/docs/zh/guide/advanced/profiling.mdx
+++ b/website/docs/zh/guide/advanced/profiling.mdx
@@ -1,0 +1,42 @@
+# 性能分析
+
+## 使用 Rsdoctor
+
+[Rsdoctor](https://rsdoctor.rs/) 是一款为 Rspack 生态量身打造的构建分析工具。
+
+当你需要调试 Rstest 的构建产物或构建过程时，可以借助 Rsdoctor 来提升排查问题的效率。
+
+### 快速上手
+
+在 Rstest 中，你可以通过以下步骤开启 Rsdoctor 分析：
+
+1. 安装 Rsdoctor 插件：
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add @rsdoctor/rspack-plugin -D" />
+
+2. 在 CLI 命令前添加 `RSDOCTOR=true` 环境变量：
+
+```json title="package.json"
+{
+  "scripts": {
+    "test:rsdoctor": "RSDOCTOR=true rstest run"
+  }
+}
+```
+
+由于 Windows 不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
+
+```json title="package.json"
+{
+  "scripts": {
+    "test:rsdoctor": "cross-env RSDOCTOR=true rstest run"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.0"
+  }
+}
+```
+
+在项目内执行上述命令后，Rstest 会自动注册 Rsdoctor 的插件，并在构建完成后打开本次构建的分析页面，请参考 [Rsdoctor 文档](https://rsdoctor.rs/) 来了解完整功能。


### PR DESCRIPTION
## Summary

[Rsdoctor](https://rsdoctor.rs/) is a build analysis tool that can visually display the compilation time of each loaders and plugins.

When you need to debug Rstest's build outputs or build processes, you can use Rsdoctor for troubleshooting.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
