### PR TITLE
chore: update test file display color

### DIFF
--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -142,7 +142,7 @@ export async function listTests(
       logger.log(
         test.name
           ? `${color.dim(`${shortPath} > `)}${test.name}`
-          : prettyTestPath(shortPath, false),
+          : prettyTestPath(shortPath),
       );
     }
   }

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -106,18 +106,10 @@ export const getSetupFiles = (
   );
 };
 
-export const prettyTestPath = (
-  testPath: string,
-  highlightFileName = true,
-): string => {
+export const prettyTestPath = (testPath: string): string => {
   const { dir, base } = parsePosix(testPath);
 
-  if (!highlightFileName) {
-    return `${dir !== '.' ? color.gray(`${dir}/`) : ''}${base}`;
-  }
-  const ext = base.match(/(\.(spec|test)\.[cm]?[tj]sx?)$/)?.[0] || '';
-  const name = base.replace(ext, '');
-  return `${dir !== '.' ? color.gray(`${dir}/`) : ''}${name}${ext ? color.gray(ext) : ''}`;
+  return `${dir !== '.' ? color.gray(`${dir}/`) : ''}${color.cyan(base)}`;
 };
 
 export const formatTestPath = (root: string, testFilePath: string): string => {


### PR DESCRIPTION
## Summary

- use cyan color
- no longer support only highlight fileName

<img width="661" alt="image" src="https://github.com/user-attachments/assets/585d07d0-94b3-4024-b6b7-60a64b76633a" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
