### PR TITLE
docs: update URLs to use the new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <picture>
-  <img alt="Rstest Banner" src="https://assets.rspack.dev/rstest/rstest-banner.png">
+  <img alt="Rstest Banner" src="https://assets.rspack.rs/rstest/rstest-banner.png">
 </picture>
 
 # Rstest

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,5 @@
 <picture>
-  <img alt="Rstest Banner" src="https://assets.rspack.dev/rstest/rstest-banner.png">
+  <img alt="Rstest Banner" src="https://assets.rspack.rs/rstest/rstest-banner.png">
 </picture>
 
 # Rstest

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Rstest website
 
-This website is built with [Rspress](https://github.com/web-infra-dev/rspress), the document content can be written using markdown or mdx syntax. You can refer to the [Rspress Website](https://rspress.dev/) for detailed usage.
+This website is built with [Rspress](https://github.com/web-infra-dev/rspress), the document content can be written using markdown or mdx syntax. You can refer to the [Rspress Website](https://rspress.rs/) for detailed usage.
 
 ## Contributing
 
@@ -14,4 +14,4 @@ The same as Rspack: [Writing style guide](https://github.com/web-infra-dev/rspac
 
 For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
 
-After you upload the images there, they will be automatically deployed under the <https://assets.rspack.dev/>.
+After you upload the images there, they will be automatically deployed under the <https://assets.rspack.rs/>.

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -21,7 +21,7 @@ More details can be found on [Rstest Roadmap](https://github.com/web-infra-dev/r
 Rstack is a unified JavaScript toolchain built around Rspack, with high performance and consistent architecture.
 
 <img
-  src="https://assets.rspack.dev/rstack/rstack-overview.png"
+  src="https://assets.rspack.rs/rstack/rstack-overview.png"
   alt="Rstack"
   width="820"
 />

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -21,7 +21,7 @@ Rstest 目前正处于积极开发阶段，目前尚无已发布的 npm 包。
 Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优秀的性能和一致的架构。
 
 <img
-  src="https://assets.rspack.dev/rstack/rstack-overview.png"
+  src="https://assets.rspack.rs/rstack/rstack-overview.png"
   alt="Rstack"
   width="820"
 />

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -7,8 +7,8 @@ import { defineConfig } from 'rspress/config';
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
   title: 'Rstest',
-  icon: 'https://assets.rspack.dev/rstest/rstest-logo.svg',
-  logo: 'https://assets.rspack.dev/rstest/rstest-logo.svg',
+  icon: 'https://assets.rspack.rs/rstest/rstest-logo.svg',
+  logo: 'https://assets.rspack.rs/rstest/rstest-logo.svg',
   logoText: 'Rstest',
   markdown: {
     checkDeadLinks: true,

--- a/website/theme/components/Hero.tsx
+++ b/website/theme/components/Hero.tsx
@@ -17,7 +17,7 @@ export function Hero() {
       title="Rstest"
       subTitle={t('subtitle')}
       description={t('slogan')}
-      logoUrl="https://assets.rspack.dev/rstest/rstest-logo.svg"
+      logoUrl="https://assets.rspack.rs/rstest/rstest-logo.svg"
       getStartedButtonText={t('quickStart')}
       githubURL="https://github.com/web-infra-dev/rstest"
     />

--- a/website/theme/components/RsbuildDocBadge.tsx
+++ b/website/theme/components/RsbuildDocBadge.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export function RsbuildDocBadge({ path, text, alt }: Props) {
   const langPrefix = useLang() === 'en' ? '' : '/zh';
-  const href = `https://rsbuild.dev${langPrefix}${path}`;
+  const href = `https://rsbuild.rs${langPrefix}${path}`;
 
   return (
     <Link
@@ -25,7 +25,7 @@ export function RsbuildDocBadge({ path, text, alt }: Props) {
         <img
           alt={alt || text}
           style={{ height: '18px', display: 'inline', pointerEvents: 'none' }}
-          src="https://assets.rspack.dev/rsbuild/rsbuild-logo.svg"
+          src="https://assets.rspack.rs/rsbuild/rsbuild-logo.svg"
         />
         {text}
       </Badge>


### PR DESCRIPTION
## Summary

Update URLs to use the new `.rs` domain.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
