### PR TITLE
enhance: optimize snapshot output

### DIFF
--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -104,7 +104,7 @@ export async function listTests(
 
       if (file.errors?.length) {
         for (const error of file.errors) {
-          await printError(error, getSourcemap);
+          await printError(error, getSourcemap, rootPath);
         }
       }
     }

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -103,9 +103,10 @@ export class DefaultReporter implements Reporter {
       if (!showAllCases && result.status !== 'fail' && !isSlowCase) {
         continue;
       }
-      const icon = isSlowCase
-        ? color.yellow(statusStr[result.status])
-        : statusColorfulStr[result.status];
+      const icon =
+        isSlowCase && result.status === 'pass'
+          ? color.yellow(statusStr[result.status])
+          : statusColorfulStr[result.status];
       const nameStr = getTaskNameWithPrefix(result);
       const duration =
         typeof result.duration !== 'undefined'

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -74,18 +74,14 @@ export const printSnapshotSummaryLog = (
       );
     }
   }
-  const F_DOWN_RIGHT = '↳';
+  const POINTER = '➜';
 
   if (snapshots.filesRemovedList?.length) {
     const [head, ...tail] = snapshots.filesRemovedList;
-    summary.push(
-      `${color.gray(F_DOWN_RIGHT)} ${formatTestPath(rootDir, head!)}`,
-    );
+    summary.push(`${color.gray(POINTER)} ${formatTestPath(rootDir, head!)}`);
 
     for (const key of tail) {
-      summary.push(
-        `  ${color.gray(F_DOWN_RIGHT)} ${formatTestPath(rootDir, key)}`,
-      );
+      summary.push(`  ${formatTestPath(rootDir, key)}`);
     }
   }
 
@@ -98,10 +94,10 @@ export const printSnapshotSummaryLog = (
 
     for (const uncheckedFile of snapshots.uncheckedKeysByFile) {
       summary.push(
-        `${color.gray(F_DOWN_RIGHT)} ${formatTestPath(rootDir, uncheckedFile.filePath)}`,
+        `${color.gray(POINTER)} ${formatTestPath(rootDir, uncheckedFile.filePath)}`,
       );
       for (const key of uncheckedFile.keys) {
-        summary.push(`  ${color.gray(F_DOWN_RIGHT)} ${key}`);
+        summary.push(`  ${key}`);
       }
     }
   }
@@ -176,7 +172,7 @@ export const printSummaryErrorLogs = async ({
     if (test.errors) {
       const { printError } = await import('../utils/error');
       for (const error of test.errors) {
-        await printError(error, getSourcemap);
+        await printError(error, getSourcemap, rootPath);
       }
     }
   }

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -114,7 +114,7 @@ export const prettyTestPath = (testPath: string): string => {
 
 export const formatTestPath = (root: string, testFilePath: string): string => {
   let testPath = testFilePath;
-  if (path.isAbsolute(testPath)) {
+  if (path.isAbsolute(testPath) && testPath.includes(root)) {
     testPath = path.relative(root, testPath);
   }
 

--- a/tests/setup/index.test.ts
+++ b/tests/setup/index.test.ts
@@ -43,9 +43,7 @@ describe('test setup file', async () => {
     // test error log
     expect(logs.find((log) => log.includes('Rstest setup error'))).toBeTruthy();
     expect(
-      logs.find((log) =>
-        log.includes(['error', 'rstest.setup.ts:1:7'].join(sep)),
-      ),
+      logs.find((log) => log.includes('rstest.setup.ts:1:7')),
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- update snapshot prefix pointer
- shorten the error trace path
- ignore vitest/snapshot in trace

before:
![image](https://github.com/user-attachments/assets/8ad2e693-c926-4104-a223-b31290c764f3)

after:
![image](https://github.com/user-attachments/assets/1f6115cf-59e3-45c7-99bf-0b125da513bd)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
