### PR TITLE
feat: init testEnvironment configuration

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -19,6 +19,7 @@ type CommonOptions = {
   update?: boolean;
   testNamePattern?: RegExp | string;
   testTimeout?: number;
+  testEnvironment?: string;
   clearMocks?: boolean;
   resetMocks?: boolean;
   restoreMocks?: boolean;
@@ -50,43 +51,47 @@ const applyCommonOptions = (cli: CAC) => {
     .option('-u, --update', 'Update snapshot files')
     .option(
       '--passWithNoTests',
-      'Allows the test suite to pass when no files are found.',
+      'Allows the test suite to pass when no files are found',
     )
     .option(
       '--printConsoleTrace',
-      'Print console traces when calling any console method.',
+      'Print console traces when calling any console method',
     )
-    .option('--disableConsoleIntercept', 'Disable console intercept.')
+    .option('--disableConsoleIntercept', 'Disable console intercept')
     .option(
       '--slowTestThreshold <slowTestThreshold>',
       'The number of milliseconds after which a test or suite is considered slow',
     )
     .option(
       '-t, --testNamePattern <testNamePattern>',
-      'Run only tests with a name that matches the regex.',
+      'Run only tests with a name that matches the regex',
+    )
+    .option(
+      '--testEnvironment <testEnvironment>',
+      'The environment that will be used for testing',
     )
     .option('--testTimeout <testTimeout>', 'Timeout of a test in milliseconds')
-    .option('--retry <retry>', 'Number of times to retry a test if it fails.')
+    .option('--retry <retry>', 'Number of times to retry a test if it fails')
     .option(
       '--maxConcurrency <maxConcurrency>',
-      'Maximum number of concurrent tests.',
+      'Maximum number of concurrent tests',
     )
     .option(
       '--clearMocks',
-      'Automatically clear mock calls, instances, contexts and results before every test.',
+      'Automatically clear mock calls, instances, contexts and results before every test',
     )
-    .option('--resetMocks', 'Automatically reset mock state before every test.')
+    .option('--resetMocks', 'Automatically reset mock state before every test')
     .option(
       '--restoreMocks',
-      'Automatically restore mock state and implementation before every test.',
+      'Automatically restore mock state and implementation before every test',
     )
     .option(
       '--unstubGlobals',
-      'Restores all global variables that were changed with `rstest.stubGlobal` before every test.',
+      'Restores all global variables that were changed with `rstest.stubGlobal` before every test',
     )
     .option(
       '--unstubEnvs',
-      'Restores all `process.env` values that were changed with `rstest.stubEnv` before every test.',
+      'Restores all `process.env` values that were changed with `rstest.stubEnv` before every test',
     );
 };
 
@@ -120,6 +125,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'maxConcurrency',
     'printConsoleTrace',
     'disableConsoleIntercept',
+    'testEnvironment',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -91,6 +91,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   passWithNoTests: false,
   update: false,
   testTimeout: 5_000,
+  testEnvironment: 'node',
   retry: 0,
   reporters: ['default'],
   clearMocks: false,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -129,6 +129,7 @@ export const createPool = async ({
     maxConcurrency,
     printConsoleTrace,
     disableConsoleIntercept,
+    testEnvironment,
   } = context.normalizedConfig;
 
   const runtimeConfig = {
@@ -145,6 +146,7 @@ export const createPool = async ({
     maxConcurrency,
     printConsoleTrace,
     disableConsoleIntercept,
+    testEnvironment,
   };
 
   const rpcMethods = {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -83,6 +83,14 @@ export interface RstestConfig {
   globals?: boolean;
 
   /**
+   * The environment that will be used for testing
+   *
+   * TODO: support more test environments
+   * @default 'node'
+   */
+  testEnvironment?: 'node';
+
+  /**
    * print console traces when calling any console method.
    *
    * @default false

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -43,6 +43,7 @@ export type RuntimeConfig = Pick<
   | 'maxConcurrency'
   | 'printConsoleTrace'
   | 'disableConsoleIntercept'
+  | 'testEnvironment'
 >;
 
 export type WorkerContext = {


### PR DESCRIPTION
## Summary

The `testEnvironment` configuration can be used to specify the environment to use for testing.

```ts
import { defineConfig } from '@rstest/core';

export default defineConfig({
   testEnvironment: 'node',
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
