### PR TITLE
feat: add vitest import tip when import vitest failed

### DIFF
--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -11,6 +11,17 @@ export async function printError(
 ): Promise<void> {
   const errorName = error.name || 'Unknown Error';
 
+  if (error.message.includes('Vitest failed to access its internal state')) {
+    const tips = [
+      'Error: not support import `vitest` in Rstest test environment.\n',
+      'Solution:',
+      `  - Update your code to use imports from "${color.yellow('@rstest/core')}" instead of "${color.yellow('vitest')}".`,
+      '  - Enable `globals` configuration and use global API.',
+    ];
+
+    logger.log(`${color.red(tips.join('\n'))}\n`);
+    return;
+  }
   logger.log(
     `${color.red(color.bold(errorName))}${color.red(`: ${error.message}`)}\n`,
   );
@@ -77,7 +88,7 @@ function printStack(stackFrames: StackFrame[], rootPath: string) {
         : `at ${formatTestPath(rootPath, frame.file!)}:${frame.lineNumber}:${frame.column}`;
     logger.log(color.gray(`        ${msg}`));
   }
-  logger.log();
+  stackFrames.length && logger.log();
 }
 
 const stackIgnores: (RegExp | string)[] = [


### PR DESCRIPTION
## Summary

add vitest import tip when import vitest failed.

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/04ab2db0-278f-452f-8ed9-50e7a0780e9a" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
