### PR TITLE
docs: add Samply profiling guide

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -110,6 +110,7 @@ rspack
 rspress
 rstack
 rstest
+Samply
 selfsign
 selfsigned
 sirv

--- a/website/docs/en/guide/advanced/profiling.mdx
+++ b/website/docs/en/guide/advanced/profiling.mdx
@@ -40,3 +40,25 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 ```
 
 After running the above commands, Rstest will automatically register the Rsdoctor plugin, and after the build is completed, it will open the build analysis page. For complete features, please refer to [Rsdoctor document](https://rsdoctor.rs/).
+
+![rsdoctor-rstest-outputs](https://assets.rspack.rs/rstest/assets/rsdoctor-rstest-outputs.png)
+
+## CPU profiling
+
+### Samply
+
+> Note: In order to be able to profiling the node.js side code in macos, node 22.16+ is required.
+
+[Samply](https://github.com/mstange/samply) supports performance analysis for both Rstest main process and test process simultaneously. You can perform a complete performance analysis through the following steps:
+
+Run the following command to start performance analysis:：
+
+```bash
+samply record -- node --perf-prof --perf-basic-prof --interpreted-frames-native-stack {your_node_modules_folder}/@rstest/core/bin/rstest.js
+```
+
+After the command execution, the analysis results will automatically open in the [Firefox Profiler](https://profiler.firefox.com/).
+
+Rstest’s JavaScript typically runs in the Node.js thread. Select the Node.js thread to view the time distribution on the Node.js side.
+
+![rstest-samply-profiling](https://assets.rspack.rs/rstest/assets/rstest-samply-profiling.png)

--- a/website/docs/en/guide/advanced/profiling.mdx
+++ b/website/docs/en/guide/advanced/profiling.mdx
@@ -47,7 +47,7 @@ After running the above commands, Rstest will automatically register the Rsdocto
 
 ### Samply
 
-> Note: In order to be able to profiling the node.js side code in macos, node 22.16+ is required.
+> Note: In order to be able to profiling the Node.js side code in macOS, Node.js v22.16+ is required.
 
 [Samply](https://github.com/mstange/samply) supports performance analysis for both Rstest main process and test process simultaneously. You can perform a complete performance analysis through the following steps:
 

--- a/website/docs/zh/guide/advanced/profiling.mdx
+++ b/website/docs/zh/guide/advanced/profiling.mdx
@@ -40,3 +40,25 @@ import { PackageManagerTabs } from '@theme';
 ```
 
 在项目内执行上述命令后，Rstest 会自动注册 Rsdoctor 的插件，并在构建完成后打开本次构建的分析页面，请参考 [Rsdoctor 文档](https://rsdoctor.rs/) 来了解完整功能。
+
+![rsdoctor-rstest-outputs](https://assets.rspack.rs/rstest/assets/rsdoctor-rstest-outputs.png)
+
+## CPU profiling
+
+### Samply
+
+> 注意：为了能在 macos 中对 node.js 侧代码进行 profiling 需要 node 22.16+ 版本。
+
+[Samply](https://github.com/mstange/samply) 支持同时对 Rstest 主进程和测试进程进行性能分析，可通过如下步骤进行完整的性能分析:
+
+运行以下命令启动性能分析：
+
+```bash
+samply record -- node --perf-prof --perf-basic-prof --interpreted-frames-native-stack {your_node_modules_folder}/@rstest/core/bin/rstest.js
+```
+
+命令执行完毕后会自动打开分析结果。
+
+Rstest 的 JavaScript 代码通常执行在 Node.js 线程里，选择 Node.js 线程查看 Node.js 侧的耗时分布。
+
+![rstest-samply-profiling](https://assets.rspack.rs/rstest/assets/rstest-samply-profiling.png)

--- a/website/docs/zh/guide/advanced/profiling.mdx
+++ b/website/docs/zh/guide/advanced/profiling.mdx
@@ -47,7 +47,7 @@ import { PackageManagerTabs } from '@theme';
 
 ### Samply
 
-> 注意：为了能在 macos 中对 node.js 侧代码进行 profiling 需要 node 22.16+ 版本。
+> 注意：为了能在 macOS 中对 Node.js 侧代码进行 profiling 需要 22.16+ 版本。
 
 [Samply](https://github.com/mstange/samply) 支持同时对 Rstest 主进程和测试进程进行性能分析，可通过如下步骤进行完整的性能分析:
 


### PR DESCRIPTION
## Summary

[Samply](https://github.com/mstange/samply) supports performance analysis for both Rstest main process and test process simultaneously.

![image](https://github.com/user-attachments/assets/7e2e6bf6-9508-4bd5-8a1c-b3a33ce0aa80)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
