### PR TITLE
fix: only print failed files when test error

### DIFF
--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -99,10 +99,10 @@ export async function listTests(
     for (const file of list) {
       const relativePath = relative(rootPath, file.testPath);
 
-      //  FAIL  tests/index.test.ts
-      logger.log(`${color.bgRed(' FAIL ')} ${relativePath}`);
-
       if (file.errors?.length) {
+        //  FAIL  tests/index.test.ts
+        logger.log(`${color.bgRed(' FAIL ')} ${relativePath}`);
+
         for (const error of file.errors) {
           await printError(error, getSourcemap, rootPath);
         }


### PR DESCRIPTION
## Summary

expect:
<img width="674" alt="image" src="https://github.com/user-attachments/assets/c2c48eb1-d64f-4500-8720-2f3fa95ae95d" />


actual:
<img width="708" alt="image" src="https://github.com/user-attachments/assets/acb5e135-9454-464d-a23d-7a5133b2423a" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
