### PR TITLE
fix: unexpected rebuild when using rsdoctor

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,6 +9,7 @@ import type { NormalizedConfig, RstestConfig } from './types';
 import {
   DEFAULT_CONFIG_EXTENSIONS,
   DEFAULT_CONFIG_NAME,
+  TEMP_RSTEST_OUTPUT_DIR_GLOB,
   color,
   logger,
 } from './utils';
@@ -110,7 +111,9 @@ export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {
 
   // The following configurations need overrides
   merged.include = config.include || merged.include;
-  merged.exclude = config.exclude || merged.exclude;
+  merged.exclude = (config.exclude || merged.exclude || []).concat([
+    TEMP_RSTEST_OUTPUT_DIR_GLOB,
+  ]);
   merged.reporters = config.reporters ?? merged.reporters;
   merged.pool =
     typeof config.pool === 'string'

--- a/packages/core/src/core/plugins/entry.ts
+++ b/packages/core/src/core/plugins/entry.ts
@@ -1,4 +1,5 @@
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+import { TEMP_RSTEST_OUTPUT_DIR_GLOB, castArray } from '../../utils';
 
 class TestFileWatchPlugin {
   private contextToWatch: string | null = null;
@@ -41,6 +42,22 @@ export const pluginEntryWatch: (params: {
             ...setupFiles,
           };
         };
+
+        config.watchOptions ??= {};
+        // TODO: rspack should support `(string | RegExp)[]` type
+        // https://github.com/web-infra-dev/rspack/issues/10596
+        config.watchOptions.ignored = castArray(
+          config.watchOptions.ignored || [],
+        ) as string[];
+
+        if (config.watchOptions.ignored.length === 0) {
+          config.watchOptions.ignored.push(
+            // apply default ignored patterns
+            ...['**/.git', '**/node_modules'],
+          );
+        }
+
+        config.watchOptions.ignored.push(TEMP_RSTEST_OUTPUT_DIR_GLOB);
       } else {
         const sourceEntries = await globTestSourceEntries();
         config.entry = {

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -9,7 +9,7 @@ import {
 } from '@rsbuild/core';
 import path from 'pathe';
 import type { EntryInfo, RstestContext, SourceMapInput } from '../types';
-import { isDebug } from '../utils';
+import { TEMP_RSTEST_OUTPUT_DIR, isDebug } from '../utils';
 import { pluginEntryWatch } from './plugins/entry';
 import { pluginIgnoreResolveError } from './plugins/ignoreResolveError';
 
@@ -115,7 +115,7 @@ export const prepareRsbuild = async (
               js: 'source-map',
             },
             distPath: {
-              root: 'dist/.test',
+              root: TEMP_RSTEST_OUTPUT_DIR,
             },
             externals: [
               {

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -6,6 +6,10 @@ export const TEST_DELIMITER = '>';
 
 export const ROOT_SUITE_NAME = 'Rstest:_internal_root_suite';
 
+export const TEMP_RSTEST_OUTPUT_DIR = 'dist/.rstest-temp';
+
+export const TEMP_RSTEST_OUTPUT_DIR_GLOB = '**/dist/.rstest-temp';
+
 export const DEFAULT_CONFIG_EXTENSIONS = [
   '.js',
   '.ts',

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -356,7 +356,7 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
     "library": {
       "type": "commonjs2",
     },
-    "path": "<WORKSPACE>/dist/.test",
+    "path": "<WORKSPACE>/dist/.rstest-temp",
     "pathinfo": false,
     "publicPath": "/",
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",

--- a/tests/externals/index.test.ts
+++ b/tests/externals/index.test.ts
@@ -23,7 +23,10 @@ describe('test externals', () => {
     await cli.exec;
     expect(cli.exec.process?.exitCode).toBe(0);
 
-    const outputPath = join(__dirname, 'dist/.test/fixtures/index.test.ts.js');
+    const outputPath = join(
+      __dirname,
+      'dist/.rstest-temp/fixtures/index.test.ts.js',
+    );
 
     expect(fs.existsSync(outputPath)).toBeTruthy();
     const content = fs.readFileSync(outputPath, 'utf-8');


### PR DESCRIPTION
## Summary

Fix unexpected rebuild when using rsdoctor. Should ignore watching rstest's output directory as some debug information will be output there.

<img width="938" alt="image" src="https://github.com/user-attachments/assets/cc156d29-3ec4-43dd-8236-68fdbd51e492" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
