### PR TITLE
fix: shorten CLI option names

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -59,23 +59,20 @@ const applyCommonOptions = (cli: CAC) => {
     )
     .option('--disableConsoleIntercept', 'Disable console intercept')
     .option(
-      '--slowTestThreshold <slowTestThreshold>',
+      '--slowTestThreshold <value>',
       'The number of milliseconds after which a test or suite is considered slow',
     )
     .option(
-      '-t, --testNamePattern <testNamePattern>',
+      '-t, --testNamePattern <value>',
       'Run only tests with a name that matches the regex',
     )
     .option(
-      '--testEnvironment <testEnvironment>',
+      '--testEnvironment <name>',
       'The environment that will be used for testing',
     )
-    .option('--testTimeout <testTimeout>', 'Timeout of a test in milliseconds')
+    .option('--testTimeout <value>', 'Timeout of a test in milliseconds')
     .option('--retry <retry>', 'Number of times to retry a test if it fails')
-    .option(
-      '--maxConcurrency <maxConcurrency>',
-      'Maximum number of concurrent tests',
-    )
+    .option('--maxConcurrency <value>', 'Maximum number of concurrent tests')
     .option(
       '--clearMocks',
       'Automatically clear mock calls, instances, contexts and results before every test',


### PR DESCRIPTION
## Summary

Improve CLI help message readability by replacing specific parameter names with the generic term `<value>`.

This will better display the help messages on small screens.

- before:

<img width="957" alt="Screenshot 2025-06-09 at 15 31 09" src="https://github.com/user-attachments/assets/544f54f7-3aa0-4ebf-b00c-2df935ebb28e" />

- after:

<img width="950" alt="Screenshot 2025-06-09 at 15 31 16" src="https://github.com/user-attachments/assets/645b2ee1-bd3c-4f03-b104-bb1a32461ee1" />


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
