### PR TITLE
fix: should keep dynamic require expressions

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -133,10 +133,15 @@ export const prepareRsbuild = async (
               config.output.devtoolModuleFilenameTemplate =
                 '[absolute-resource-path]';
 
-              // Keep dynamic import expressions
               config.module.parser ??= {};
               config.module.parser.javascript = {
+                // Keep dynamic import expressions.
+                // eg. (modulePath) => import(modulePath)
                 importDynamic: false,
+                // Keep dynamic require expressions.
+                // eg. (modulePath) => require(modulePath)
+                requireDynamic: false,
+                requireAsExpression: false,
                 ...(config.module.parser.javascript || {}),
               };
 

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -114,8 +114,11 @@ async function parseErrorStacktrace({
       .filter(
         (frame) =>
           frame.file && !stackIgnores.some((entry) => frame.file?.match(entry)),
+        // &&
+        // frame.methodName !== 'webpackEmptyContext',
       )
       .map(async (frame) => {
+        // console.log('frame', frame);
         const sourcemap = getSourcemap(frame.file!);
         if (sourcemap) {
           const traceMap = new TraceMap(sourcemap);
@@ -128,7 +131,7 @@ async function parseErrorStacktrace({
             // some Rspack runtime wrapper code, should filter them out
             return null;
           }
-
+          console.log('frame', source);
           return {
             ...frame,
             file: source,

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -1,4 +1,4 @@
-// Snapshot v1
+// Rstest Snapshot v1
 
 exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
 {
@@ -30,6 +30,8 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
       "javascript": {
         "exportsPresence": "error",
         "importDynamic": false,
+        "requireAsExpression": false,
+        "requireDynamic": false,
       },
     },
     "rules": [

--- a/tests/build/runtimeRequire/a.js
+++ b/tests/build/runtimeRequire/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/tests/build/runtimeRequire/b.ts
+++ b/tests/build/runtimeRequire/b.ts
@@ -1,0 +1,1 @@
+export const b = 1;

--- a/tests/build/runtimeRequire/index.test.ts
+++ b/tests/build/runtimeRequire/index.test.ts
@@ -1,0 +1,16 @@
+import { join } from 'node:path';
+import { expect, it } from '@rstest/core';
+
+const customRequire = (name: string) => {
+  return require(join(__dirname, name));
+};
+
+it('should load runtime deps correctly', async () => {
+  const res = require('./a.js');
+  expect(res.a).toBe(1);
+});
+
+it('should load compile-time deps correctly', async () => {
+  const res = customRequire('./b.ts');
+  expect(res.b).toBe(1);
+});

--- a/tests/build/runtimeRequire/package.json
+++ b/tests/build/runtimeRequire/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@rstest/tests-runtime-import",
+  "type": "module",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

should keep dynamic require expressions.

before:
![image](https://github.com/user-attachments/assets/7df41c07-a26c-4de1-a45d-9e2c4d5deac1)


after:
![image](https://github.com/user-attachments/assets/4628fee2-b6a5-47fd-835b-5b5d775e356f)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
