### PR TITLE
feat: add requireActual function declaration

### DIFF
--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -43,11 +43,14 @@ export const createRstestUtilities: () => RstestUtilities = () => {
       // TODO
     },
     importMock: async () => {
-      // TODO
       return {} as any;
     },
     importActual: async () => {
-      // TODO
+      // The real implementation is handled by Rstest built-in plugin.
+      return {} as any;
+    },
+    requireActual: () => {
+      // The real implementation is handled by Rstest built-in plugin.
       return {} as any;
     },
     resetModules: () => {

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -225,9 +225,15 @@ export type RstestUtilities = {
 
   /**
    * @todo
-   * Returns the actual module instead of a mock, bypassing all checks on whether the module should receive a mock implementation or not.
+   * Import and return the actual module instead of a mock, bypassing all checks on whether the module should receive a mock implementation or not.
    */
   importActual: <T = Record<string, unknown>>(path: string) => Promise<T>;
+
+  /**
+   * @todo
+   * Require and return the actual module instead of a mock, bypassing all checks on whether the module should receive a mock implementation or not.
+   */
+  requireActual: <T = Record<string, unknown>>(path: string) => T;
 
   /**
    * @todo


### PR DESCRIPTION
## Summary

`requireActual` and `importActual` are fully handled by Retest built-in plugin, no runtime is dependent on `@rstest/core`. Just leave a noop function here.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
