### PR TITLE
fix:remove inaccurate external path matching

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -47,9 +47,6 @@ const autoExternalNodeModules: (
       dependencyType === 'commonjs' ? 'commonjs' : 'module-import',
     );
   };
-  if (/node_modules/.test(request)) {
-    return doExternal();
-  }
 
   const resolver = getResolve?.();
 


### PR DESCRIPTION
## Summary

remove inaccurate external path matching:
- expect matched: `node_modules/aaa`
- unexpected matched: `./index.vue.ts?vue&type=script&setup=true&lang=ts!=!../../node_modules/...`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
