### PR TITLE
fix(workflows): node cache version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,11 @@ jobs:
               - "!**/_meta.json"
               - "!**/dictionary.txt"
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install Dependencies
@@ -95,11 +95,11 @@ jobs:
               - "!**/_meta.json"
               - "!**/dictionary.txt"
 
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
               - "!**/_meta.json"
               - "!**/dictionary.txt"
 
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:


### PR DESCRIPTION
## Summary

Expect use Node.js 18, but matched Node.js 22 cache 😢 
![image](https://github.com/user-attachments/assets/b265d442-2afe-4260-b9cf-649efc0e772a)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
