### PR TITLE
test(e2e): support throw error logs when test failed

### DIFF
--- a/tests/build/index.test.ts
+++ b/tests/build/index.test.ts
@@ -14,7 +14,7 @@ describe('test build config', () => {
     { name: 'tools/rspack' },
     { name: 'decorators' },
   ])('$name config should work correctly', async ({ name }) => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: [
         'run',
@@ -29,7 +29,6 @@ describe('test build config', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
   });
 });

--- a/tests/cli/index.test.ts
+++ b/tests/cli/index.test.ts
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 describe.concurrent('test exit code', () => {
   it('should return code 0 when test succeed', async () => {
-    const { cli } = await runRstestCli({
+    const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'success.test.ts'],
       options: {
@@ -19,8 +19,7 @@ describe.concurrent('test exit code', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
   });
 
   it('should return code 1 when test failed', async () => {

--- a/tests/externals/index.test.ts
+++ b/tests/externals/index.test.ts
@@ -10,7 +10,7 @@ const __dirname = dirname(__filename);
 describe('test externals', () => {
   it('should external node_modules by default', async () => {
     process.env.DEBUG_RSTEST_OUTPUTS = 'true';
-    const { cli } = await runRstestCli({
+    const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', './fixtures/index.test.ts'],
       options: {
@@ -20,8 +20,7 @@ describe('test externals', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const outputPath = join(
       __dirname,

--- a/tests/filter/default.test.ts
+++ b/tests/filter/default.test.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 it('should run success without filter', async () => {
-  const { cli } = await runRstestCli({
+  const { cli, expectExecSuccess } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'fixtures/testNamePattern.test.ts'],
     options: {
@@ -17,8 +17,7 @@ it('should run success without filter', async () => {
     },
   });
 
-  await cli.exec;
-  expect(cli.exec.process?.exitCode).toBe(0);
+  await expectExecSuccess();
 
   const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/filter/regex.test.ts
+++ b/tests/filter/regex.test.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 it('should filter test suite name success use regex', async () => {
-  const { cli } = await runRstestCli({
+  const { cli, expectExecSuccess } = await runRstestCli({
     command: 'rstest',
     args: [
       'run',
@@ -21,8 +21,7 @@ it('should filter test suite name success use regex', async () => {
     },
   });
 
-  await cli.exec;
-  expect(cli.exec.process?.exitCode).toBe(0);
+  await expectExecSuccess();
 
   const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/filter/testNamePattern.test.ts
+++ b/tests/filter/testNamePattern.test.ts
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 
 describe('test testNamePattern', () => {
   it('should filter test case name success', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/testNamePattern.test.ts', '-t=level-B-A'],
       options: {
@@ -18,8 +18,7 @@ describe('test testNamePattern', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 
@@ -31,7 +30,7 @@ describe('test testNamePattern', () => {
   });
 
   it('should filter test suite name success', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/testNamePattern.test.ts', '-t=level-B'],
       options: {
@@ -41,8 +40,7 @@ describe('test testNamePattern', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 
@@ -55,7 +53,7 @@ describe('test testNamePattern', () => {
   });
 
   it('should not run tests when filter test skipped', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/testNamePattern.test.ts', '-t=level-B-B'],
       options: {
@@ -65,8 +63,7 @@ describe('test testNamePattern', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/globals/index.test.ts
+++ b/tests/globals/index.test.ts
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 
 describe('test global APIs', () => {
   it('should run with global API succeed', async () => {
-    const { cli } = await runRstestCli({
+    const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/index.test.ts', '--globals'],
       options: {
@@ -18,7 +18,6 @@ describe('test global APIs', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
   });
 });

--- a/tests/in-source/index.test.ts
+++ b/tests/in-source/index.test.ts
@@ -8,7 +8,7 @@ describe('In-Source testing', () => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run'],
       options: {
@@ -17,8 +17,7 @@ describe('In-Source testing', () => {
         },
       },
     });
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/jsdom/handledError.test.ts
+++ b/tests/jsdom/handledError.test.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 it('should handle error correctly', async () => {
-  const { cli } = await runRstestCli({
+  const { cli, expectExecSuccess } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'test/handledError'],
     options: {
@@ -19,5 +19,5 @@ it('should handle error correctly', async () => {
 
   await cli.exec;
 
-  expect(cli.exec.process?.exitCode).toBe(0);
+  await expectExecSuccess();
 });

--- a/tests/jsdom/index.test.ts
+++ b/tests/jsdom/index.test.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 it('should run jsdom test correctly', async () => {
-  const { cli } = await runRstestCli({
+  const { expectExecSuccess } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'test/App'],
     options: {
@@ -17,7 +17,5 @@ it('should run jsdom test correctly', async () => {
     },
   });
 
-  await cli.exec;
-
-  expect(cli.exec.process?.exitCode).toBe(0);
+  await expectExecSuccess();
 });

--- a/tests/list/index.test.ts
+++ b/tests/list/index.test.ts
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 describe('test list command', () => {
   it('should list tests correctly', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['list'],
       options: {
@@ -19,8 +19,7 @@ describe('test list command', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout?.split('\n').filter(Boolean);
 
@@ -35,7 +34,7 @@ describe('test list command', () => {
   });
 
   it('should list tests correctly with file filter', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['list', 'a.test'],
       options: {
@@ -46,7 +45,7 @@ describe('test list command', () => {
     });
 
     await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout?.split('\n').filter(Boolean);
 
@@ -59,7 +58,7 @@ describe('test list command', () => {
   });
 
   it('should list tests correctly with test name filter', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['list', '-t', 'a'],
       options: {
@@ -69,8 +68,7 @@ describe('test list command', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout?.split('\n').filter(Boolean);
 
@@ -83,7 +81,7 @@ describe('test list command', () => {
   });
 
   it('should list test files correctly with --filesOnly', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['list', '--filesOnly'],
       options: {
@@ -94,7 +92,7 @@ describe('test list command', () => {
     });
 
     await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout?.split('\n').filter(Boolean);
 

--- a/tests/list/json.test.ts
+++ b/tests/list/json.test.ts
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 describe('test list command with --json', () => {
   it('should list tests json correctly', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['list', '--json'],
       options: {
@@ -19,8 +19,7 @@ describe('test list command with --json', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout?.split('\n').filter(Boolean);
 
@@ -49,7 +48,7 @@ describe('test list command with --json', () => {
   });
 
   it('should list test files json correctly', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['list', '--filesOnly', '--json'],
       options: {
@@ -59,8 +58,7 @@ describe('test list command with --json', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout?.split('\n').filter(Boolean);
 
@@ -83,7 +81,7 @@ describe('test list command with --json', () => {
 
     fs.rmSync(outputPath, { force: true });
 
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['list', '--json', 'output.json'],
       options: {
@@ -93,8 +91,7 @@ describe('test list command with --json', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     expect(fs.existsSync(outputPath)).toBeTruthy();
 

--- a/tests/noTests/index.test.ts
+++ b/tests/noTests/index.test.ts
@@ -31,7 +31,7 @@ describe('no tests', () => {
   });
 
   it('should passWithNoTests with passWithNoTests flag', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/', '--passWithNoTests'],
       options: {
@@ -43,7 +43,7 @@ describe('no tests', () => {
 
     await cli.exec;
 
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/scripts/index.ts
+++ b/tests/scripts/index.ts
@@ -76,7 +76,19 @@ export async function runRstestCli({
 }: { command: string; options?: Partial<Options>; args?: string[] }) {
   const process = x(command, args, options as Options);
   const cli = new Cli(process);
-  return { cli };
+
+  const expectExecSuccess = async () => {
+    await cli.exec;
+    const exitCode = cli.exec.process?.exitCode;
+    if (exitCode !== 0) {
+      const logs = cli.stdout.split('\n').filter(Boolean);
+      throw new Error(
+        `Test failed with exit code ${exitCode}. Logs: ${logs.join('\n')}`,
+      );
+    }
+  };
+
+  return { cli, expectExecSuccess };
 }
 
 export async function prepareFixtures({

--- a/tests/setup/index.test.ts
+++ b/tests/setup/index.test.ts
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 
 describe('test setup file', async () => {
   it('should run setup file correctly', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run'],
       options: {
@@ -22,7 +22,7 @@ describe('test setup file', async () => {
     const logs = cli.stdout
       .split('\n')
       .filter((log) => log.startsWith('[afterAll]'));
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
     expect(logs).toEqual(['[afterAll] setup']);
   });
 

--- a/tests/snapshot/obsolete.test.ts
+++ b/tests/snapshot/obsolete.test.ts
@@ -10,7 +10,7 @@ const __dirname = dirname(__filename);
 
 describe('test snapshot', () => {
   it('should mark snapshot obsolete ', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/obsolete.test.ts'],
       options: {
@@ -20,8 +20,7 @@ describe('test snapshot', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 
@@ -29,7 +28,7 @@ describe('test snapshot', () => {
   });
 
   it('should not mark snapshot obsolete when case skipped', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/skip.test.ts'],
       options: {
@@ -39,8 +38,7 @@ describe('test snapshot', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/spy/config.test.ts
+++ b/tests/spy/config.test.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 it('test clearMocks config', async () => {
-  const { cli } = await runRstestCli({
+  const { expectExecSuccess } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'fixtures/clearMocks.test', '--clearMocks'],
     options: {
@@ -17,12 +17,11 @@ it('test clearMocks config', async () => {
     },
   });
 
-  await cli.exec;
-  expect(cli.exec.process?.exitCode).toBe(0);
+  await expectExecSuccess();
 });
 
 it('test restoreMocks config', async () => {
-  const { cli } = await runRstestCli({
+  const { expectExecSuccess } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'fixtures/restoreMocks.test', '--restoreMocks'],
     options: {
@@ -32,6 +31,5 @@ it('test restoreMocks config', async () => {
     },
   });
 
-  await cli.exec;
-  expect(cli.exec.process?.exitCode).toBe(0);
+  await expectExecSuccess();
 });

--- a/tests/ssr/index.test.ts
+++ b/tests/ssr/index.test.ts
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 
 describe('test ssr', () => {
   it('should run ssr test succeed', async () => {
-    const { cli } = await runRstestCli({
+    const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'test/index.test.ts'],
       options: {
@@ -18,10 +18,6 @@ describe('test ssr', () => {
       },
     });
 
-    await cli.exec;
-
-    const logs = cli.stdout.split('\n').filter(Boolean);
-
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
   });
 });

--- a/tests/test-api/concurrentLimit.test.ts
+++ b/tests/test-api/concurrentLimit.test.ts
@@ -7,7 +7,7 @@ it('should run concurrent cases correctly with limit', async () => {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = dirname(__filename);
 
-  const { cli } = await runRstestCli({
+  const { cli, expectExecSuccess } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'fixtures/concurrentLimit.test.ts', '--maxConcurrency=4'],
     options: {
@@ -16,8 +16,7 @@ it('should run concurrent cases correctly with limit', async () => {
       },
     },
   });
-  await cli.exec;
-  expect(cli.exec.process?.exitCode).toBe(0);
+  await expectExecSuccess();
 
   const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/test-api/edgeCase.test.ts
+++ b/tests/test-api/edgeCase.test.ts
@@ -27,7 +27,7 @@ describe('Test Edge Cases', () => {
 
   it('test module not found', async () => {
     // Module not found errors should be silent at build time, and throw errors at runtime
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/moduleNotFound.test.ts'],
       options: {
@@ -36,8 +36,7 @@ describe('Test Edge Cases', () => {
         },
       },
     });
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
     expect(logs.find((log) => log.includes('Build error'))).toBeFalsy();
@@ -46,7 +45,7 @@ describe('Test Edge Cases', () => {
   });
 
   it('only in skip suite', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/onlyInSkip.test.ts'],
       options: {
@@ -56,7 +55,7 @@ describe('Test Edge Cases', () => {
       },
     });
     await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
 
     const logs = cli.stdout.split('\n').filter(Boolean);
 

--- a/tests/test-api/retry.test.ts
+++ b/tests/test-api/retry.test.ts
@@ -8,7 +8,7 @@ describe('Test Retry', () => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 
-    const { cli } = await runRstestCli({
+    const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/retry.test.ts', '--retry=4'],
       options: {
@@ -17,8 +17,7 @@ describe('Test Retry', () => {
         },
       },
     });
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
   });
 
   it('should error when retry times exhausted', async () => {


### PR DESCRIPTION
## Summary

support throw error logs when test failed:
![image](https://github.com/user-attachments/assets/7d1d2bf9-9af4-409c-9389-f3757df358b0)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
