### PR TITLE
fix: should interopDefault in node test environment by default

### DIFF
--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -53,7 +53,7 @@ const preparePool = async ({
     });
   }
 
-  const interopDefault = testEnvironment === 'jsdom';
+  const interopDefault = true;
 
   const workerState: WorkerState = {
     ...context,

--- a/tests/externals/interop.test.ts
+++ b/tests/externals/interop.test.ts
@@ -17,7 +17,7 @@ describe('test interop', () => {
   });
 
   it('should interopDefault correctly in jsdom test environment', async () => {
-    const { cli } = await runRstestCli({
+    const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', './fixtures/interop', '--testEnvironment=jsdom'],
       options: {
@@ -27,12 +27,11 @@ describe('test interop', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(0);
+    await expectExecSuccess();
   });
 
-  it('should not interopDefault in node test environment', async () => {
-    const { cli } = await runRstestCli({
+  it('should interopDefault correctly in node test environment', async () => {
+    const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', './fixtures/interop', '--testEnvironment=node'],
       options: {
@@ -42,7 +41,6 @@ describe('test interop', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(1);
+    await expectExecSuccess();
   });
 });


### PR DESCRIPTION
## Summary

fix `lodash` import error in node test environment. should interopDefault in node test environment by default.

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/453b2af7-e472-4c41-86da-52b883ff6a6e" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
