### PR TITLE
fix: always ignore watching rstest temporary output dir

### DIFF
--- a/packages/core/src/core/plugins/entry.ts
+++ b/packages/core/src/core/plugins/entry.ts
@@ -42,22 +42,6 @@ export const pluginEntryWatch: (params: {
             ...setupFiles,
           };
         };
-
-        config.watchOptions ??= {};
-        // TODO: rspack should support `(string | RegExp)[]` type
-        // https://github.com/web-infra-dev/rspack/issues/10596
-        config.watchOptions.ignored = castArray(
-          config.watchOptions.ignored || [],
-        ) as string[];
-
-        if (config.watchOptions.ignored.length === 0) {
-          config.watchOptions.ignored.push(
-            // apply default ignored patterns
-            ...['**/.git', '**/node_modules'],
-          );
-        }
-
-        config.watchOptions.ignored.push(TEMP_RSTEST_OUTPUT_DIR_GLOB);
       } else {
         const sourceEntries = await globTestSourceEntries();
         config.entry = {
@@ -65,6 +49,22 @@ export const pluginEntryWatch: (params: {
           ...setupFiles,
         };
       }
+
+      config.watchOptions ??= {};
+      // TODO: rspack should support `(string | RegExp)[]` type
+      // https://github.com/web-infra-dev/rspack/issues/10596
+      config.watchOptions.ignored = castArray(
+        config.watchOptions.ignored || [],
+      ) as string[];
+
+      if (config.watchOptions.ignored.length === 0) {
+        config.watchOptions.ignored.push(
+          // apply default ignored patterns
+          ...['**/.git', '**/node_modules'],
+        );
+      }
+
+      config.watchOptions.ignored.push(TEMP_RSTEST_OUTPUT_DIR_GLOB);
     });
   },
 });

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -437,6 +437,11 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
   "target": "node",
   "watchOptions": {
     "aggregateTimeout": 0,
+    "ignored": [
+      "**/.git",
+      "**/node_modules",
+      "**/dist/.rstest-temp",
+    ],
   },
 }
 `;


### PR DESCRIPTION
## Summary

Always ignore watching rstest temporary output directory, regardless of watch mode. Because rstest is always built via rsbuild's dev mode (rspack.watch).

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
