### PR TITLE
fix: correctly display build error messages

### DIFF
--- a/packages/core/src/core/plugins/ignoreResolveError.ts
+++ b/packages/core/src/core/plugins/ignoreResolveError.ts
@@ -3,12 +3,15 @@ import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 class IgnoreModuleNotFoundErrorPlugin {
   apply(compiler: Rspack.Compiler) {
     compiler.hooks.done.tap('Rstest:IgnoreModuleNotFoundPlugin', (stats) => {
-      stats.compilation.errors = stats.compilation.errors.filter((error) => {
-        if (/Module not found/.test(error.message)) {
-          return false;
+      if (stats.compilation.errors.length === 0) {
+        return;
+      }
+      for (let i = stats.compilation.errors.length - 1; i >= 0; i--) {
+        if (/Module not found/.test(stats.compilation.errors[i]!.message)) {
+          // Use `splice` instead of `filter` & `reassign` to avoid communication problems with Rust -> JS -> Rust
+          stats.compilation.errors.splice(i, 1);
         }
-        return true;
-      });
+      }
     });
   }
 }

--- a/packages/core/src/core/plugins/ignoreResolveError.ts
+++ b/packages/core/src/core/plugins/ignoreResolveError.ts
@@ -3,9 +3,6 @@ import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 class IgnoreModuleNotFoundErrorPlugin {
   apply(compiler: Rspack.Compiler) {
     compiler.hooks.done.tap('Rstest:IgnoreModuleNotFoundPlugin', (stats) => {
-      if (stats.compilation.errors.length === 0) {
-        return;
-      }
       for (let i = stats.compilation.errors.length - 1; i >= 0; i--) {
         if (/Module not found/.test(stats.compilation.errors[i]!.message)) {
           // Use `splice` instead of `filter` & `reassign` to avoid communication problems with Rust -> JS -> Rust

--- a/tests/test-api/edgeCase.test.ts
+++ b/tests/test-api/edgeCase.test.ts
@@ -44,6 +44,29 @@ describe('Test Edge Cases', () => {
     expect(logs.find((log) => log.includes('Tests 2 passed'))).toBeTruthy();
   });
 
+  it('should log build error message correctly', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/lessError.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    // no `× [object Object]`
+    expect(logs.find((log) => log.includes('[object Object]'))).toBeFalsy();
+    expect(
+      logs.find((log) => log.includes('To enable support for Less')),
+    ).toBeTruthy();
+  });
+
   it('only in skip suite', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/tests/test-api/fixtures/index.module.less
+++ b/tests/test-api/fixtures/index.module.less
@@ -1,0 +1,3 @@
+.page {
+  display: flex;
+}

--- a/tests/test-api/fixtures/lessError.test.ts
+++ b/tests/test-api/fixtures/lessError.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from '@rstest/core';
+// @ts-expect-error
+import style from './index.module.less';
+
+it('test', () => {
+  expect(style).toBeDefined();
+});


### PR DESCRIPTION
## Summary

Use `stats.compilation.errors.splice` instead of `filter` & `reassign` to avoid communication problems with `Rust -> JS -> Rust`. 

 This is actually a bug in rspack and is not easy to fix at the moment.


now:
![image](https://github.com/user-attachments/assets/cf135dd3-0c5d-4145-a914-ee787c33e5ef)


expect:
![image](https://github.com/user-attachments/assets/c418d5bc-70c8-4c67-99f6-3236e0ae7325)



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
