### PR TITLE
docs: add `setupFiles` configuration

### DIFF
--- a/website/docs/en/config/test/_meta.json
+++ b/website/docs/en/config/test/_meta.json
@@ -1,1 +1,1 @@
-["include", "exclude", "includeSource", "globals"]
+["include", "exclude", "includeSource", "globals", "setupFiles"]

--- a/website/docs/en/config/test/setupFiles.mdx
+++ b/website/docs/en/config/test/setupFiles.mdx
@@ -1,0 +1,14 @@
+# setupFiles
+
+- **Type:** `string[]`
+- **Default:** `[]`
+
+A list of paths to modules that run some code to configure or set up the testing environment, they will be run before each test file.
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  setupFiles: ['./scripts/rstest.setup.ts'],
+});
+```

--- a/website/docs/zh/config/test/_meta.json
+++ b/website/docs/zh/config/test/_meta.json
@@ -1,1 +1,1 @@
-["include", "exclude", "includeSource", "globals"]
+["include", "exclude", "includeSource", "globals", "setupFiles"]

--- a/website/docs/zh/config/test/setupFiles.mdx
+++ b/website/docs/zh/config/test/setupFiles.mdx
@@ -1,0 +1,14 @@
+# setupFiles
+
+- **类型：** `string[]`
+- **默认值：** `[]`
+
+一组 setup 文件列表，通常用于配置或设置测试环境，它们将在每个测试文件执行前运行。
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  setupFiles: ['./scripts/rstest.setup.ts'],
+});
+```


### PR DESCRIPTION
## Summary

docs: add `setupFiles` configuration.
`setupFiles` is a list of paths to modules that run some code to configure or set up the testing environment, they will be run before each test file.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
