### PR TITLE
fix: should throw error when setup file not found

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -294,7 +294,7 @@ export const createRsbuildServer = async ({
     const entries: EntryInfo[] = [];
     const setupEntries: EntryInfo[] = [];
     const sourceEntries = await globTestSourceEntries();
-    // TODO: check compile error, such as setupFiles not found
+
     for (const entry of Object.keys(entrypoints!)) {
       const e = entrypoints![entry]!;
 

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import pathe from 'pathe';
 import { glob } from 'tinyglobby';
@@ -100,6 +101,14 @@ export const getSetupFiles = (
   return Object.fromEntries(
     castArray(setups).map((setupFile) => {
       const setupFilePath = getAbsolutePath(rootPath, setupFile);
+
+      if (!existsSync(setupFilePath)) {
+        let errorMessage = `Setup file ${color.red(setupFile)} not found`;
+        if (setupFilePath !== setupFile) {
+          errorMessage += color.gray(` (resolved path: ${setupFilePath})`);
+        }
+        throw errorMessage;
+      }
       const name = pathe.relative(rootPath, setupFilePath);
       return [name, setupFilePath];
     }),


### PR DESCRIPTION
## Summary

should throw error when setup file not found.
![image](https://github.com/user-attachments/assets/7019e874-b7e9-4a78-a1b4-f641fb5f47a4)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
