### PR TITLE
chore: remvoe licensePlugin  in rslib watch mode

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from '@rslib/core';
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import type { LicenseIdentifiedModule } from 'license-webpack-plugin/dist/LicenseIdentifiedModule';
 
+const isBuildWatch = process.argv.includes('--watch');
+
 export default defineConfig({
   lib: [
     {
@@ -54,7 +56,8 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
-      plugins: [licensePlugin()],
+      // fix licensePlugin watch error: ResourceData has been dropped by Rust.
+      plugins: isBuildWatch ? [] : [licensePlugin()],
       watchOptions: {
         ignored: /\.git/,
       },


### PR DESCRIPTION
## Summary

remove licensePlugin in rslib watch mode, temporarily fix licensePlugin watch error.

![image](https://github.com/user-attachments/assets/e9025617-c635-463b-b58d-a2a8f8da3278)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
