### PR TITLE
perf: disable useless watching when rstest only run once

### DIFF
--- a/packages/core/src/core/plugins/entry.ts
+++ b/packages/core/src/core/plugins/entry.ts
@@ -42,29 +42,34 @@ export const pluginEntryWatch: (params: {
             ...setupFiles,
           };
         };
+
+        config.watchOptions ??= {};
+        // TODO: rspack should support `(string | RegExp)[]` type
+        // https://github.com/web-infra-dev/rspack/issues/10596
+        config.watchOptions.ignored = castArray(
+          config.watchOptions.ignored || [],
+        ) as string[];
+
+        if (config.watchOptions.ignored.length === 0) {
+          config.watchOptions.ignored.push(
+            // apply default ignored patterns
+            ...['**/.git', '**/node_modules'],
+          );
+        }
+
+        config.watchOptions.ignored.push(TEMP_RSTEST_OUTPUT_DIR_GLOB);
       } else {
+        // watch false seems not effect when rspack.watch()
+        config.watch = false;
+        config.watchOptions ??= {};
+        config.watchOptions.ignored = '**/**';
+
         const sourceEntries = await globTestSourceEntries();
         config.entry = {
           ...sourceEntries,
           ...setupFiles,
         };
       }
-
-      config.watchOptions ??= {};
-      // TODO: rspack should support `(string | RegExp)[]` type
-      // https://github.com/web-infra-dev/rspack/issues/10596
-      config.watchOptions.ignored = castArray(
-        config.watchOptions.ignored || [],
-      ) as string[];
-
-      if (config.watchOptions.ignored.length === 0) {
-        config.watchOptions.ignored.push(
-          // apply default ignored patterns
-          ...['**/.git', '**/node_modules'],
-        );
-      }
-
-      config.watchOptions.ignored.push(TEMP_RSTEST_OUTPUT_DIR_GLOB);
     });
   },
 });

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -441,13 +441,10 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
     ],
   },
   "target": "node",
+  "watch": false,
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": [
-      "**/.git",
-      "**/node_modules",
-      "**/dist/.rstest-temp",
-    ],
+    "ignored": "**/**",
   },
 }
 `;


### PR DESCRIPTION
## Summary

disable useless watching when rstest only run once.

before:
![image](https://github.com/user-attachments/assets/ddb6d0ad-34ea-48b1-a771-79443e4bc93d)


after:
![image](https://github.com/user-attachments/assets/4fc5d0b1-7efd-4a03-95d1-5bb587fd8fec)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
