### PR TITLE
docs: add `plugins` configuration

### DIFF
--- a/website/docs/en/api/rstest/_meta.json
+++ b/website/docs/en/api/rstest/_meta.json
@@ -1,0 +1,1 @@
+["mockFunctions", "fakeTimers"]

--- a/website/docs/en/config/_meta.json
+++ b/website/docs/en/config/_meta.json
@@ -8,5 +8,10 @@
     "type": "dir",
     "name": "test",
     "label": "Test Configurations"
+  },
+  {
+    "type": "dir",
+    "name": "build",
+    "label": "Build Configurations"
   }
 ]

--- a/website/docs/en/config/build/plugins.mdx
+++ b/website/docs/en/config/build/plugins.mdx
@@ -1,0 +1,98 @@
+---
+overviewHeaders: []
+---
+
+import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
+
+# plugins <RsbuildDocBadge path="/config/plugins" text="plugins" />
+
+`plugins` is used to register Rsbuild plugins.
+
+Rstest and Rsbuild share the same plugin system, so you can use Rsbuild plugins in Rstest.
+
+## Using plugins
+
+You can register Rsbuild plugins in `rstest.config.*` using the `plugins` option, see [Rsbuild - plugins](https://rsbuild.rs/config/plugins).
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+});
+```
+
+## Official plugins
+
+The following are official plugins that can be used in Rsbuild, and applicable to Rstest.
+
+### For React
+
+Plugins available for React:
+
+- [React Plugin](https://rsbuild.rs/plugins/list/plugin-react): Provides support for React.
+- [SVGR Plugin](https://rsbuild.rs/plugins/list/plugin-svgr): Support convert SVG to React components.
+- [Styled Components Plugin](https://github.com/rsbuild-contrib/rsbuild-plugin-styled-components): Provide compile-time support for styled-components.
+
+### For Vue
+
+Plugins available for Vue:
+
+- [Vue Plugin](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue): Based on [unplugin-vue](https://github.com/unplugin/unplugin-vue), provides support for Vue 3 SFC (Single File Components).
+- [Vue Plugin](https://rsbuild.rs/plugins/list/plugin-vue): Based on [vue-loader](https://github.com/vuejs/vue-loader), provides support for Vue 3 SFC (Single File Components) (Recommend using the implementation based on [unplugin-vue](https://github.com/unplugin/unplugin-vue), as vue-loader is no longer maintained).
+- [Vue JSX Plugin](https://github.com/rspack-contrib/rsbuild-plugin-vue-jsx): Provides support for Vue 3 JSX / TSX syntax.
+- [Vue2 Plugin](https://github.com/rspack-contrib/rsbuild-plugin-vue2): Provides support for Vue 2 SFC (Single File Components).
+- [Vue2 JSX Plugin](https://github.com/rspack-contrib/rsbuild-plugin-vue2-jsx): Provides support for Vue 2 JSX / TSX syntax.
+
+### For Preact
+
+Plugins available for Preact:
+
+- [Preact Plugin](https://rsbuild.rs/plugins/list/plugin-preact): Provides support for Preact.
+
+### For Svelte
+
+Plugins available for Svelte:
+
+- [Svelte Plugin](https://rsbuild.rs/plugins/list/plugin-svelte): Provides support for Svelte components (`.svelte` files).
+
+### For Solid
+
+Plugins available for Solid:
+
+- [Solid Plugin](https://rsbuild.rs/plugins/list/plugin-solid): Provides support for Solid.
+
+### Common
+
+The following are common framework-agnostic plugins:
+
+- [Babel Plugin](https://rsbuild.rs/plugins/list/plugin-babel): Provides support for Babel transpilation capabilities.
+- [Sass Plugin](https://rsbuild.rs/plugins/list/plugin-sass): Use Sass as the CSS preprocessor.
+- [Less Plugin](https://rsbuild.rs/plugins/list/plugin-less): Use Less as the CSS preprocessor.
+- [Stylus Plugin](https://rsbuild.rs/plugins/list/plugin-stylus): Use Stylus as the CSS preprocessor.
+- [ESLint Plugin](https://github.com/rspack-contrib/rsbuild-plugin-eslint): Run ESLint checks during the compilation.
+- [Type Check Plugin](https://github.com/rspack-contrib/rsbuild-plugin-type-check): Run TypeScript type checker on a separate process.
+- [publint Plugin](https://github.com/rspack-contrib/rsbuild-plugin-publint): Run `publint` to lint npm packages after the build.
+- [Image Compress Plugin](https://github.com/rspack-contrib/rsbuild-plugin-image-compress): Compress the image assets.
+- [MDX Plugin](https://github.com/rspack-contrib/rsbuild-plugin-mdx): Provide support for MDX.
+- [Node Polyfill Plugin](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill): Used to inject polyfills of Node core modules in the browser side.
+- [Source Build Plugin](https://github.com/rspack-contrib/rsbuild-plugin-source-build): This plugin is designed for the monorepo scenario. It supports referencing source code from other subdirectories and performs build and hot update.
+- [Check Syntax Plugin](https://github.com/rspack-contrib/rsbuild-plugin-check-syntax): Check the syntax compatibility of output files and determine if there are any advanced syntaxes that could cause compatibility issues.
+- [CSS Minimizer Plugin](https://github.com/rspack-contrib/rsbuild-plugin-css-minimizer): Used to customize CSS minimizer, switch to [cssnano](https://github.com/cssnano/cssnano) or other tools for CSS compression.
+- [Typed CSS Modules Plugin](https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules): Generate TypeScript declaration file for CSS Modules.
+- [Pug Plugin](https://github.com/rspack-contrib/rsbuild-plugin-pug): Provides support for the Pug template engine.
+- [Rem Plugin](https://github.com/rspack-contrib/rsbuild-plugin-rem): Implements the rem adaptive layout for mobile pages.
+- [UMD Plugin](https://github.com/rspack-contrib/rsbuild-plugin-umd): Generate outputs in UMD format.
+- [YAML Plugin](https://github.com/rspack-contrib/rsbuild-plugin-yaml): Import YAML files and convert them into JavaScript objects.
+- [TOML Plugin](https://github.com/rspack-contrib/rsbuild-plugin-toml): Import TOML files and convert them into JavaScript objects.
+
+:::tip
+You can find the source code of all official plugins in [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) and [rspack-contrib](https://github.com/rspack-contrib).
+:::
+
+## Community plugins
+
+You can check out the Rsbuild plugins provided by the community at [awesome-rspack - Rsbuild Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rsbuild-plugins).
+
+You can also discover more Rsbuild plugins on npm by searching for the keyword [rsbuild-plugin](https://www.npmjs.com/search?q=rsbuild-plugin&ranking=popularity).

--- a/website/docs/zh/api/rstest/_meta.json
+++ b/website/docs/zh/api/rstest/_meta.json
@@ -1,0 +1,1 @@
+["mockFunctions", "fakeTimers"]

--- a/website/docs/zh/config/_meta.json
+++ b/website/docs/zh/config/_meta.json
@@ -8,5 +8,10 @@
     "type": "dir",
     "name": "test",
     "label": "Test Configurations"
+  },
+  {
+    "type": "dir",
+    "name": "build",
+    "label": "Build Configurations"
   }
 ]

--- a/website/docs/zh/config/build/plugins.mdx
+++ b/website/docs/zh/config/build/plugins.mdx
@@ -1,0 +1,98 @@
+---
+overviewHeaders: []
+---
+
+import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
+
+# plugins <RsbuildDocBadge path="/config/plugins" text="plugins" />
+
+`plugins` 选项用于注册 Rsbuild 插件。
+
+Rstest 与 Rsbuild 共享同一套插件系统，因此你可以在 Rstest 中使用 Rsbuild 插件。
+
+## 使用插件
+
+你可以在 `rstest.config.*` 中通过 `plugins` 选项来注册 Rsbuild 插件，详见 [Rsbuild - plugins](https://rsbuild.rs/zh/config/plugins)。
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+});
+```
+
+## 官方插件
+
+下面是 Rsbuild 官方提供的插件，适用于 Rsbuild 和 Rstest。
+
+### React
+
+适用于 React 的插件有：
+
+- [React 插件](https://rsbuild.rs/zh/plugins/list/plugin-react)：提供对 React 的支持。
+- [SVGR 插件](https://rsbuild.rs/zh/plugins/list/plugin-svgr)：支持将 SVG 图片转换为一个 React 组件使用。
+- [Styled Components 插件](https://github.com/rspack-contrib/rsbuild-plugin-styled-components)：提供对 styled-components 的编译时支持。
+
+### Vue
+
+适用于 Vue 的插件有：
+
+- [Vue 插件](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue)：基于 [unplugin-vue](https://github.com/unplugin/unplugin-vue) 实现的为 Vue 3 SFC（单文件组件）提供支持的插件。
+- [Vue 插件](https://rsbuild.rs/zh/plugins/list/plugin-vue)：基于 [vue-loader](https://github.com/vuejs/vue-loader) 实现的为 Vue 3 SFC（单文件组件）提供支持的插件（推荐使用基于 [unplugin-vue](https://github.com/unplugin/unplugin-vue) 的实现，vue-loader 已不再维护）。
+- [Vue JSX 插件](https://github.com/rspack-contrib/rsbuild-plugin-vue-jsx)：提供对 Vue 3 JSX / TSX 语法的支持。
+- [Vue 2 插件](https://github.com/rspack-contrib/rsbuild-plugin-vue2)：提供对 Vue 2 SFC（单文件组件）的支持。
+- [Vue 2 JSX 插件](https://github.com/rspack-contrib/rsbuild-plugin-vue2-jsx)：提供对 Vue 2 JSX / TSX 语法的支持。
+
+### Preact
+
+适用于 Preact 的插件有：
+
+- [Preact 插件](https://rsbuild.rs/zh/plugins/list/plugin-preact)：提供对 Preact 的支持。
+
+### Svelte
+
+适用于 Svelte 的插件有：
+
+- [Svelte 插件](https://rsbuild.rs/zh/plugins/list/plugin-svelte)：提供对 Svelte 组件（`.svelte` 文件）的支持。
+
+### Solid
+
+适用于 Solid 的插件有：
+
+- [Solid 插件](https://rsbuild.rs/zh/plugins/list/plugin-solid)：提供对 Solid 的支持。
+
+### Common
+
+以下是与框架无关的通用插件：
+
+- [Babel 插件](https://rsbuild.rs/zh/plugins/list/plugin-babel)：提供对 Babel 转译能力的支持。
+- [Sass 插件](https://rsbuild.rs/zh/plugins/list/plugin-sass)：使用 Sass 作为 CSS 预处理器。
+- [Less 插件](https://rsbuild.rs/zh/plugins/list/plugin-less)：使用 Less 作为 CSS 预处理器。
+- [Stylus 插件](https://rsbuild.rs/zh/plugins/list/plugin-stylus)：使用 Stylus 作为 CSS 预处理器。
+- [ESLint 插件](https://github.com/rspack-contrib/rsbuild-plugin-eslint)：用于在编译过程中运行 ESLint 检查。
+- [publint 插件](https://github.com/rspack-contrib/rsbuild-plugin-publint)：在构建后运行 `publint` 来检查 npm 包。
+- [Type Check 插件](https://github.com/rspack-contrib/rsbuild-plugin-type-check)：用于在单独的进程中运行 TypeScript 类型检查。
+- [Image Compress 插件](https://github.com/rspack-contrib/rsbuild-plugin-image-compress)：压缩图片资源。
+- [MDX 插件](https://github.com/rspack-contrib/rsbuild-plugin-mdx)：提供 MDX 支持。
+- [Node Polyfill 插件](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill)：用于注入 Node 核心模块在浏览器端的 polyfills。
+- [Source Build 插件](https://github.com/rspack-contrib/rsbuild-plugin-source-build)：用于 monorepo 场景，支持引用其他子目录的源代码，并完成构建和热更新。
+- [Check Syntax 插件](https://github.com/rspack-contrib/rsbuild-plugin-check-syntax)：检查构建产物的语法兼容性，判断是否存在导致兼容性问题的高级语法。
+- [CSS Minimizer 插件](https://github.com/rspack-contrib/rsbuild-plugin-css-minimizer)：用于自定义 CSS 压缩工具，切换到 [cssnano](https://github.com/cssnano/cssnano) 或其他工具进行 CSS 压缩。
+- [Typed CSS Modules 插件](https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules)：用于为 CSS Modules 文件生成类型声明。
+- [Pug 插件](https://github.com/rspack-contrib/rsbuild-plugin-pug)：提供对 Pug 模板引擎的支持。
+- [Rem 插件](https://github.com/rspack-contrib/rsbuild-plugin-rem)：用于实现移动端页面的 rem 自适应布局。
+- [UMD 插件](https://github.com/rspack-contrib/rsbuild-plugin-umd)：用于构建 UMD 格式的产物。
+- [YAML 插件](https://github.com/rspack-contrib/rsbuild-plugin-yaml)：引用 YAML 文件，并将其转换为 JavaScript 对象。
+- [TOML 插件](https://github.com/rspack-contrib/rsbuild-plugin-toml)：引用 TOML 文件，并将其转换为 JavaScript 对象。
+
+:::tip
+你可以在 [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) 和 [rspack-contrib](https://github.com/rspack-contrib) 中找到这些插件的源代码。
+:::
+
+## 社区插件
+
+你可以在 [awesome-rspack - Rsbuild Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rsbuild-plugins) 中查看社区提供的 Rsbuild 插件。
+
+也可以在 npm 上搜索 [rsbuild-plugin](https://www.npmjs.com/search?q=rsbuild-plugin&ranking=popularity) 关键词来发现更多 Rsbuild 插件。


### PR DESCRIPTION
## Summary

Rstest and Rsbuild share the same plugin system, so you can use Rsbuild plugins in Rstest.

https://rsbuild.dev/config/plugins

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
