### PR TITLE
feat: support `externals` configuration

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -195,7 +195,7 @@ export interface RstestConfig {
 
   output?: Pick<
     NonNullable<RsbuildConfig['output']>,
-    'cssModules' | 'externals'
+    'cssModules' | 'externals' | 'cleanDistPath'
   >;
 
   resolve?: RsbuildConfig['resolve'];

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -193,7 +193,10 @@ export interface RstestConfig {
 
   dev?: Pick<NonNullable<RsbuildConfig['dev']>, 'writeToDisk'>;
 
-  output?: Pick<NonNullable<RsbuildConfig['output']>, 'cssModules'>;
+  output?: Pick<
+    NonNullable<RsbuildConfig['output']>,
+    'cssModules' | 'externals'
+  >;
 
   resolve?: RsbuildConfig['resolve'];
 

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -12,7 +12,6 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
     {
       "@rstest/core": "global @rstest/core",
     },
-    {},
   ],
   "externalsPresets": {
     "node": true,
@@ -350,11 +349,7 @@ exports[`prepareRsbuild > should generate rspack config correctly 1`] = `
     "runtimeChunk": {
       "name": "runtime",
     },
-    "splitChunks": {
-      "chunks": "all",
-      "maxInitialRequests": Infinity,
-      "minSize": 0,
-    },
+    "splitChunks": false,
   },
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",

--- a/tests/jsdom/fixtures/rstest.externals.config.ts
+++ b/tests/jsdom/fixtures/rstest.externals.config.ts
@@ -1,0 +1,11 @@
+import { type RstestConfig, defineConfig } from '@rstest/core';
+import rsbuildConfig from './rsbuild.config';
+
+export default defineConfig({
+  ...(rsbuildConfig as RstestConfig),
+  testEnvironment: 'jsdom',
+  setupFiles: ['./test/setup.ts'],
+  output: {
+    externals: [/react/],
+  },
+});

--- a/tests/jsdom/index.test.ts
+++ b/tests/jsdom/index.test.ts
@@ -20,6 +20,20 @@ it('should run jsdom test correctly', async () => {
   await expectExecSuccess();
 });
 
+it('should run jsdom test correctly with custom externals', async () => {
+  const { expectExecSuccess } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'test/App', '--config', 'rstest.externals.config.ts'],
+    options: {
+      nodeOptions: {
+        cwd: join(__dirname, 'fixtures'),
+      },
+    },
+  });
+
+  await expectExecSuccess();
+});
+
 it('should run jsdom test correctly with jest-dom', async () => {
   const { expectExecSuccess } = await runRstestCli({
     command: 'rstest',

--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -1,0 +1,32 @@
+import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
+
+# output
+
+## output.externals <RsbuildDocBadge path="/config/output/externals" text="output.externals" />
+
+Prevent some `import` dependencies from being packed into bundles in your code, and instead Rstest will `import` them at runtime.
+
+- In the Node.js test environment, all packages in `node_modules` are externalized by default.
+- In the browser-like (jsdom, etc) test environment, all packages are bundled by default.
+
+If you want a dependency to be externalized, you can configure it in `output.externals`.
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    externals: ['react'],
+  },
+});
+```
+
+## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
+
+For custom CSS Modules configuration.
+
+## output.cleanDistPath <RsbuildDocBadge path="/config/output/clean-dist-path" text="output.cleanDistPath" />
+
+Whether to clean up all test temporary files under the output directory before the test starts.
+
+By default, rstest does not write test temporary files to disk, and this configuration item may be required when you debug rstest outputs.

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -1,0 +1,32 @@
+import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
+
+# output
+
+## output.externals <RsbuildDocBadge path="/config/output/externals" text="output.externals" />
+
+配置代码中的某些 `import` 的依赖不被打包，而是由 Rstest 在运行时去获取这些依赖。
+
+- 在 Node.js 测试环境中，默认将 `node_modules` 下的所有包都进行 external。
+- 在类浏览器（jsdom 等）测试环境中，默认打包所有依赖。
+
+如果你想某个依赖不被打包，可以在 `output.externals` 中进行配置。
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    externals: ['react'],
+  },
+});
+```
+
+## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
+
+用于自定义 CSS Modules 的配置。
+
+## output.cleanDistPath <RsbuildDocBadge path="/config/output/clean-dist-path" text="output.cleanDistPath" />
+
+是否在测试开始前，清空输出目录下的所有测试临时文件。
+
+默认情况下，Rstest 不会将测试临时文件写入磁盘，当你开启 Rstest 产物调试时可能需要此配置项。


### PR DESCRIPTION
## Summary

`externals` can be prevent some `import` dependencies from being packed into bundles in your code, and instead Rstest will `import` them at runtime.
 
```ts title="rstest.config.ts"
import { defineConfig } from '@rstest/core';

export default defineConfig({
  output: {
    externals: ['react'],
  },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
