### PR TITLE
feat: handle process.exit in pool

### DIFF
--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -227,7 +227,11 @@ const runInPool = async (
     }
   }
 
+  const exit = process.exit;
   try {
+    process.exit = (code = process.exitCode || 0): never => {
+      throw new Error(`process.exit unexpectedly called with "${code}"`);
+    };
     const {
       rstestContext,
       runner,
@@ -282,6 +286,7 @@ const runInPool = async (
     };
   } finally {
     await Promise.all(cleanups.map((fn) => fn()));
+    process.exit = exit;
   }
 };
 

--- a/tests/runner/test/processExit.test.ts
+++ b/tests/runner/test/processExit.test.ts
@@ -1,0 +1,12 @@
+import { expect, it } from '@rstest/core';
+
+it('Calling process.exit will turn to throw an error', () => {
+  let err: Error | null = null;
+  try {
+    process.exit(42);
+  } catch (error) {
+    err = error as Error;
+  }
+
+  expect(err?.message).toBe('process.exit unexpectedly called with "42"');
+});


### PR DESCRIPTION
## Summary

Allow call `process.exit` in user land code, which will turn to be an `Error` instead of terminating the process.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
