### PR TITLE
chore: auto exit nx console

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "tui": {
+    "autoExit": true
+  },
   "namedInputs": {
     "default": ["{projectRoot}/src/**/*"],
     "build": [


### PR DESCRIPTION
## Summary

It's very hard for me to understand why nx doesn't exit automatically by default.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
