### PR TITLE
fix(mock): resetModules should not clear mock

### DIFF
--- a/packages/core/src/core/plugins/mockRuntime.ts
+++ b/packages/core/src/core/plugins/mockRuntime.ts
@@ -36,9 +36,10 @@ __webpack_require__.rstest_original_modules = {};
 
 // TODO: Remove "reset_modules" in next Rspack version.
 __webpack_require__.rstest_reset_modules = __webpack_require__.reset_modules = () => {
+  const mockedIds = Object.keys(__webpack_require__.rstest_original_modules)
   Object.keys(__webpack_module_cache__).forEach(id => {
     // Do not reset mocks registry.
-    if (!Object.keys(__webpack_require__.rstest_original_modules).includes(id)) {
+    if (!mockedIds.includes(id)) {
       delete __webpack_module_cache__[id];
     }
   });
@@ -70,7 +71,9 @@ __webpack_require__.rstest_set_mock = __webpack_require__.set_mock = (id, modFac
   if (typeof modFactory === 'string' || typeof modFactory === 'number') {
     __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };
   } else if (typeof modFactory === 'function') {
-    __webpack_module_cache__[id] = { exports: modFactory() };
+    let exports = modFactory();
+    __webpack_require__.r(exports);
+    __webpack_module_cache__[id] = { exports, id, loaded: true };
   }
 };
 `;

--- a/packages/core/src/core/plugins/mockRuntime.ts
+++ b/packages/core/src/core/plugins/mockRuntime.ts
@@ -36,7 +36,12 @@ __webpack_require__.rstest_original_modules = {};
 
 // TODO: Remove "reset_modules" in next Rspack version.
 __webpack_require__.rstest_reset_modules = __webpack_require__.reset_modules = () => {
-  __webpack_module_cache__ = {};
+  Object.keys(__webpack_module_cache__).forEach(id => {
+    // Do not reset mocks registry.
+    if (!Object.keys(__webpack_require__.rstest_original_modules).includes(id)) {
+      delete __webpack_module_cache__[id];
+    }
+  });
 }
 
 // TODO: Remove "unmock" in next Rspack version.
@@ -54,10 +59,13 @@ __webpack_require__.rstest_require_actual = __webpack_require__.rstest_import_ac
 
 // TODO: Remove "set_mock" in next Rspack version.
 __webpack_require__.rstest_set_mock = __webpack_require__.set_mock = (id, modFactory) => {
+  let requiredModule = undefined
   try {
-    __webpack_require__.rstest_original_modules[id] = __webpack_require__(id);
+    requiredModule = __webpack_require__(id);
   } catch {
     // TODO: non-resolved module
+  } finally {
+    __webpack_require__.rstest_original_modules[id] = requiredModule;
   }
   if (typeof modFactory === 'string' || typeof modFactory === 'number') {
     __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
       redux:
         specifier: ^5.0.1
         version: 5.0.1

--- a/tests/mock/tests/defaultInterop.test.ts
+++ b/tests/mock/tests/defaultInterop.test.ts
@@ -1,0 +1,13 @@
+import { expect, rs, test } from '@rstest/core';
+// @ts-expect-error: "react" has been mocked.
+import increment from 'react';
+
+rs.mock('react', () => {
+  return {
+    default: (num: number) => num + 42,
+  };
+});
+
+test('interop default export', async () => {
+  expect(increment(1)).toBe(43);
+});

--- a/tests/mock/tests/resetModules.test.ts
+++ b/tests/mock/tests/resetModules.test.ts
@@ -1,10 +1,19 @@
 import { expect, rs, test } from '@rstest/core';
 
+rs.doMock('../src/increment', () => ({
+  increment: (num: number) => num + 10,
+}));
+
 test('reset modules works', async () => {
+  const { increment: incrementWith10 } = await import('../src/increment');
+  expect(incrementWith10(1)).toBe(11);
   const mod1 = await import('../src/b');
   rs.resetModules();
   const mod2 = await import('../src/b');
   const mod3 = await import('../src/b');
   expect(mod1).not.toBe(mod2);
   expect(mod2).toBe(mod3);
+  // resetModules should not reset mocks registry.
+  const { increment: incrementStillWith10 } = await import('../src/increment');
+  expect(incrementStillWith10(1)).toBe(11);
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,11 +14,12 @@
     "@types/jest-image-snapshot": "^6.4.0",
     "axios": "^1.9.0",
     "jest-image-snapshot": "^6.5.1",
+    "memfs": "^4.17.2",
     "pathe": "^2.0.3",
+    "react": "^19.1.0",
     "redux": "^5.0.1",
     "strip-ansi": "^7.1.0",
     "tinyexec": "^1.0.1",
-    "memfs": "^4.17.2",
     "typescript": "^5.8.3"
   }
 }

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   setupFiles: ['../scripts/rstest.setup.ts'],
   testTimeout: process.env.CI ? 10_000 : 5_000,
   slowTestThreshold: 2_000,
+  output: {
+    externals: {
+      react: 'commonjs react',
+    },
+  },
   exclude: [
     '**/node_modules/**',
     '**/dist/**',


### PR DESCRIPTION
## Summary

`resetModules` should not clear mocked modules.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
