### PR TITLE
perf: add pre-filter for css

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!**/*.vue", "!**/dist/**"]
+    "includes": ["**", "!**/*.vue", "!**/dist/**", "!**/dist-types/**"]
   },
   "formatter": {
     "indentStyle": "space"

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -53,6 +53,21 @@ export default defineConfig({
         },
       },
     },
+    {
+      id: 'esm_loaders',
+      format: 'esm',
+      syntax: 'es2021',
+      source: {
+        entry: {
+          cssFilterLoader: './src/core/plugins/css-filter/loader.ts',
+        },
+      },
+      output: {
+        filename: {
+          js: '[name].mjs',
+        },
+      },
+    },
   ],
   tools: {
     rspack: {

--- a/packages/core/src/core/plugins/css-filter/index.ts
+++ b/packages/core/src/core/plugins/css-filter/index.ts
@@ -1,3 +1,8 @@
+/**
+ * reference:
+ * https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules/blob/main/src/loader.ts
+ * https://github.com/web-infra-dev/rsbuild/blob/a0939d8994589819cc8ddd8982a69a0743a3227a/packages/core/src/loader/ignoreCssLoader.ts
+ */
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { CSSLoaderOptions, RsbuildPlugin } from '@rsbuild/core';

--- a/packages/core/src/core/plugins/css-filter/index.ts
+++ b/packages/core/src/core/plugins/css-filter/index.ts
@@ -6,7 +6,7 @@ export const PLUGIN_CSS_FILTER = 'rstest:css-filter';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * When css is not need emit, set the css content to empty (except css modules)
+ * When CSS does not need to be emitted, pre-set the CSS content to empty (except for CSS modules) to reduce time costs in less-loader / sass-loader / css-loader.
  */
 export const pluginCSSFilter = (): RsbuildPlugin => ({
   name: PLUGIN_CSS_FILTER,

--- a/packages/core/src/core/plugins/css-filter/index.ts
+++ b/packages/core/src/core/plugins/css-filter/index.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CSSLoaderOptions, RsbuildPlugin } from '@rsbuild/core';
+
+export const PLUGIN_CSS_FILTER = 'rstest:css-filter';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * When css is not need emit, set the css content to empty (except css modules)
+ */
+export const pluginCSSFilter = (): RsbuildPlugin => ({
+  name: PLUGIN_CSS_FILTER,
+
+  setup(api) {
+    api.modifyBundlerChain({
+      order: 'post',
+      handler: async (chain, { target, CHAIN_ID, environment }) => {
+        const emitCss = environment.config.output.emitCss ?? target === 'web';
+        if (!emitCss) {
+          const ruleIds = [
+            CHAIN_ID.RULE.CSS,
+            CHAIN_ID.RULE.SASS,
+            CHAIN_ID.RULE.LESS,
+            CHAIN_ID.RULE.STYLUS,
+          ];
+
+          for (const ruleId of ruleIds) {
+            if (!chain.module.rules.has(ruleId)) {
+              continue;
+            }
+
+            const rule = chain.module.rule(ruleId);
+
+            if (!rule.uses.has(CHAIN_ID.USE.CSS)) {
+              continue;
+            }
+
+            const cssLoaderOptions: CSSLoaderOptions = rule
+              .use(CHAIN_ID.USE.CSS)
+              .get('options');
+
+            if (
+              !cssLoaderOptions.modules ||
+              (typeof cssLoaderOptions.modules === 'object' &&
+                cssLoaderOptions.modules.auto === false)
+            ) {
+              continue;
+            }
+
+            rule
+              .use('rstest-css-pre-filter')
+              .loader(path.join(__dirname, 'cssFilterLoader.mjs'))
+              .options({
+                modules: cssLoaderOptions.modules,
+              })
+              .after(ruleId);
+          }
+        }
+      },
+    });
+  },
+});

--- a/packages/core/src/core/plugins/css-filter/loader.ts
+++ b/packages/core/src/core/plugins/css-filter/loader.ts
@@ -1,8 +1,3 @@
-/**
- * reference:
- * https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules/blob/main/src/loader.ts
- * https://github.com/web-infra-dev/rsbuild/blob/a0939d8994589819cc8ddd8982a69a0743a3227a/packages/core/src/loader/ignoreCssLoader.ts
- */
 import type { CSSModules, Rspack } from '@rsbuild/core';
 
 type CssLoaderModules =

--- a/packages/core/src/core/plugins/css-filter/loader.ts
+++ b/packages/core/src/core/plugins/css-filter/loader.ts
@@ -1,0 +1,68 @@
+/**
+ * reference:
+ * https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules/blob/main/src/loader.ts
+ * https://github.com/web-infra-dev/rsbuild/blob/a0939d8994589819cc8ddd8982a69a0743a3227a/packages/core/src/loader/ignoreCssLoader.ts
+ */
+import type { CSSModules, Rspack } from '@rsbuild/core';
+
+type CssLoaderModules =
+  | boolean
+  | string
+  | Required<Pick<CSSModules, 'auto' | 'namedExport'>>;
+
+const CSS_MODULES_REGEX = /\.module\.\w+$/i;
+
+const isCSSModules = ({
+  resourcePath,
+  resourceQuery,
+  resourceFragment,
+  modules,
+}: {
+  resourcePath: string;
+  resourceQuery: string;
+  resourceFragment: string;
+  modules: CssLoaderModules;
+}): boolean => {
+  if (typeof modules === 'boolean') {
+    return modules;
+  }
+
+  // Same as the `mode` option
+  // https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#mode
+  if (typeof modules === 'string') {
+    // CSS Modules will be disabled if mode is 'global'
+    return modules !== 'global';
+  }
+
+  const { auto } = modules;
+
+  if (typeof auto === 'boolean') {
+    return auto && CSS_MODULES_REGEX.test(resourcePath);
+  }
+  if (auto instanceof RegExp) {
+    return auto.test(resourcePath);
+  }
+  if (typeof auto === 'function') {
+    return auto(resourcePath, resourceQuery, resourceFragment);
+  }
+  return true;
+};
+
+export default function (
+  this: Rspack.LoaderContext<{
+    mode: string;
+    modules: CssLoaderModules;
+  }>,
+  content: string,
+): string {
+  const { resourcePath, resourceQuery, resourceFragment } = this;
+  const { modules = true } = this.getOptions() || {};
+
+  if (
+    isCSSModules({ resourcePath, resourceQuery, resourceFragment, modules })
+  ) {
+    return content;
+  }
+
+  return '';
+}

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -17,6 +17,7 @@ import {
   NODE_BUILTINS,
   TEMP_RSTEST_OUTPUT_DIR,
 } from '../utils';
+import { pluginCSSFilter } from './plugins/css-filter';
 import { pluginEntryWatch } from './plugins/entry';
 import { pluginIgnoreResolveError } from './plugins/ignoreResolveError';
 import { pluginMockRuntime } from './plugins/mockRuntime';
@@ -238,6 +239,7 @@ export const prepareRsbuild = async (
           plugins: [
             pluginIgnoreResolveError,
             pluginMockRuntime,
+            pluginCSSFilter(),
             pluginEntryWatch({
               globTestSourceEntries,
               setupFiles,

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -77,6 +77,19 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
               "sourceMap": false,
             },
           },
+          {
+            "loader": "<ROOT>/packages/core/src/core/plugins/css-filter/cssFilterLoader.mjs",
+            "options": {
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+            },
+          },
         ],
       },
       {
@@ -541,6 +554,19 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/core/src/core/plugins/css-filter/cssFilterLoader.mjs",
+            "options": {
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
             },
           },
         ],

--- a/tests/jsdom/css.test.ts
+++ b/tests/jsdom/css.test.ts
@@ -1,0 +1,21 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+it('should run css test correctly', async () => {
+  const { expectExecSuccess } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'test/css'],
+    options: {
+      nodeOptions: {
+        cwd: join(__dirname, 'fixtures'),
+      },
+    },
+  });
+
+  await expectExecSuccess();
+});

--- a/tests/jsdom/fixtures/rsbuild.config.ts
+++ b/tests/jsdom/fixtures/rsbuild.config.ts
@@ -3,4 +3,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
+  output: {
+    cssModules: {
+      localIdentName: '[name]_[local]',
+    },
+  },
 });

--- a/tests/jsdom/fixtures/src/App.css
+++ b/tests/jsdom/fixtures/src/App.css
@@ -18,9 +18,3 @@ body {
   font-size: 3.6rem;
   font-weight: 700;
 }
-
-.content p {
-  font-size: 1.2rem;
-  font-weight: 400;
-  opacity: 0.5;
-}

--- a/tests/jsdom/fixtures/src/App.module.css
+++ b/tests/jsdom/fixtures/src/App.module.css
@@ -1,0 +1,5 @@
+.content-p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/tests/jsdom/fixtures/src/App.tsx
+++ b/tests/jsdom/fixtures/src/App.tsx
@@ -1,4 +1,5 @@
 import './App.css';
+import style from './App.module.css';
 
 const App = () => {
   return (
@@ -14,7 +15,9 @@ const App = () => {
       >
         Rsbuild with React
       </h1>
-      <p>Start building amazing things with Rsbuild.</p>
+      <p className={style.contentP}>
+        Start building amazing things with Rsbuild.
+      </p>
     </div>
   );
 };

--- a/tests/jsdom/fixtures/test/css.test.tsx
+++ b/tests/jsdom/fixtures/test/css.test.tsx
@@ -9,13 +9,15 @@ test('should render App correctly', async () => {
 
   expect(element.tagName).toBe('H1');
 
-  expect(element.constructor).toBe(document.defaultView?.HTMLHeadingElement);
-});
+  expect(element.style.fontSize).toBe('16px');
 
-test('should get window property correctly', async () => {
-  expect(window.NodeList).toBeDefined();
-});
+  const elementP = screen.getByText(
+    'Start building amazing things with Rsbuild.',
+  );
 
-test('should get global property correctly', async () => {
-  expect(global.URL).toBeDefined();
+  expect(elementP.tagName).toBe('P');
+
+  expect(elementP.className).toBe('App-module_content-p');
+
+  expect(elementP.style.fontSize).toBe('');
 });


### PR DESCRIPTION
## Summary

When CSS does not need to be emitted, pre-set the CSS content to empty (except for CSS modules) to reduce time costs in less-loader / sass-loader / css-loader.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
