### PR TITLE
feat: support hookTimeout

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -21,6 +21,7 @@ type CommonOptions = {
   update?: boolean;
   testNamePattern?: RegExp | string;
   testTimeout?: number;
+  hookTimeout?: number;
   testEnvironment?: string;
   clearMocks?: boolean;
   resetMocks?: boolean;
@@ -75,6 +76,7 @@ const applyCommonOptions = (cli: CAC) => {
       'The environment that will be used for testing',
     )
     .option('--testTimeout <value>', 'Timeout of a test in milliseconds')
+    .option('--hookTimeout <value>', 'Timeout of hook in milliseconds')
     .option('--retry <retry>', 'Number of times to retry a test if it fails')
     .option('--maxConcurrency <value>', 'Maximum number of concurrent tests')
     .option(
@@ -117,6 +119,7 @@ export async function initCli(options: CommonOptions): Promise<{
     'update',
     'testNamePattern',
     'testTimeout',
+    'hookTimeout',
     'clearMocks',
     'resetMocks',
     'restoreMocks',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -96,6 +96,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   passWithNoTests: false,
   update: false,
   testTimeout: 5_000,
+  hookTimeout: 10_000,
   testEnvironment: 'node',
   retry: 0,
   reporters: ['default'],

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -134,11 +134,13 @@ export const createPool = async ({
     printConsoleTrace,
     disableConsoleIntercept,
     testEnvironment,
+    hookTimeout,
   } = context.normalizedConfig;
 
   const runtimeConfig = {
     testNamePattern,
     testTimeout,
+    hookTimeout,
     passWithNoTests,
     retry,
     globals,

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -25,11 +25,12 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
 } {
   const {
     testPath,
-    runtimeConfig: { testTimeout, testNamePattern },
+    runtimeConfig: { testTimeout, testNamePattern, hookTimeout },
   } = workerState;
   const runtime = createRuntimeAPI({
     testPath,
     testTimeout,
+    hookTimeout,
   });
   const testRunner: TestRunner = new TestRunner();
 

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -41,18 +41,21 @@ export class RunnerRuntime {
    */
   private collectStatus: CollectStatus = 'lazy';
   private currentCollectList: Array<() => MaybePromise<void>> = [];
-  private defaultHookTimeout = 5_000;
+  private defaultHookTimeout;
   private defaultTestTimeout;
 
   constructor({
     testPath,
     testTimeout,
+    hookTimeout,
   }: {
     testTimeout: number;
+    hookTimeout: number;
     testPath: string;
   }) {
     this.testPath = testPath;
     this.defaultTestTimeout = testTimeout;
+    this.defaultHookTimeout = hookTimeout;
   }
 
   afterAll(
@@ -427,9 +430,11 @@ export class RunnerRuntime {
 export const createRuntimeAPI = ({
   testPath,
   testTimeout,
+  hookTimeout,
 }: {
   testPath: string;
   testTimeout: number;
+  hookTimeout: number;
 }): {
   api: RunnerAPI;
   instance: RunnerRuntime;
@@ -437,6 +442,7 @@ export const createRuntimeAPI = ({
   const runtimeInstance: RunnerRuntime = new RunnerRuntime({
     testPath,
     testTimeout,
+    hookTimeout,
   });
 
   const createTestAPI = (

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -134,6 +134,12 @@ export interface RstestConfig {
   testTimeout?: number;
 
   /**
+   * Timeout of hook in milliseconds.
+   * @default 10000
+   */
+  hookTimeout?: number;
+
+  /**
    * Automatically clear mock calls, instances, contexts and results before every test.
    * @default false
    */

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -45,6 +45,7 @@ export type RuntimeConfig = Pick<
   | 'disableConsoleIntercept'
   | 'testEnvironment'
   | 'isolate'
+  | 'hookTimeout'
 >;
 
 export type WorkerContext = {

--- a/website/docs/en/config/test/_meta.json
+++ b/website/docs/en/config/test/_meta.json
@@ -7,6 +7,7 @@
   "testEnvironment",
   "testNamePattern",
   "testTimeout",
+  "hookTimeout",
   "retry",
   "root",
   "name",

--- a/website/docs/en/config/test/hookTimeout.mdx
+++ b/website/docs/en/config/test/hookTimeout.mdx
@@ -1,0 +1,7 @@
+# hookTimeout
+
+- **Type:** `number`
+- **Default:** `10_000`
+- **CLI:** `--hookTimeout=10000`
+
+Default timeout of [hook](/api/test-api/hooks) in milliseconds. `0` will disable the timeout.

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -113,6 +113,7 @@ Rstest CLI provides several common options that can be used with all commands:
 | `-t, --testNamePattern <value>` | Run only tests with a name that matches the regex, see [testNamePattern](/config/test/testNamePattern)                                                            |
 | `--testEnvironment <name>`      | The environment that will be used for testing, see [testEnvironment](/config/test/testEnvironment)                                                                |
 | `--testTimeout <value>`         | Timeout of a test in milliseconds, see [testTimeout](/config/test/testTimeout)                                                                                    |
+| `--hookTimeout <value>`         | Timeout of hook in milliseconds, see [hookTimeout](/config/test/hookTimeout)                                                                                      |
 | `--retry <retry>`               | Number of times to retry a test if it fails, see [retry](/config/test/retry)                                                                                      |
 | `--maxConcurrency <value>`      | Maximum number of concurrent tests, see [maxConcurrency](/config/test/maxConcurrency)                                                                             |
 | `--clearMocks`                  | Automatically clear mock calls, instances, contexts and results before every test, see [clearMocks](/config/test/clearMocks)                                      |

--- a/website/docs/zh/config/test/_meta.json
+++ b/website/docs/zh/config/test/_meta.json
@@ -7,6 +7,7 @@
   "testEnvironment",
   "testNamePattern",
   "testTimeout",
+  "hookTimeout",
   "retry",
   "root",
   "name",

--- a/website/docs/zh/config/test/hookTimeout.mdx
+++ b/website/docs/zh/config/test/hookTimeout.mdx
@@ -1,0 +1,7 @@
+# hookTimeout
+
+- **类型：** `number`
+- **默认值：** `10_000`
+- **CLI：** `--hookTimeout=10000`
+
+单个测试 [hook](/api/test-api/hooks) 的超时时间（毫秒）。设置为 `0` 禁用超时。

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -113,6 +113,7 @@ Rstest CLI 支持以下常用参数，所有命令均可使用：
 | `-t, --testNamePattern <value>` | 仅运行名称匹配正则的测试，详见 [testNamePattern](/config/test/testNamePattern)                                                               |
 | `--testEnvironment <name>`      | 指定测试环境，详见 [testEnvironment](/config/test/testEnvironment)                                                                           |
 | `--testTimeout <value>`         | 设置单个测试的超时时间（毫秒），详见 [testTimeout](/config/test/testTimeout)                                                                 |
+| `--hookTimeout <value>`         | 设置单个测试 hook 的超时时间（毫秒），详见 [hookTimeout](/config/test/hookTimeout)                                                           |
 | `--retry <retry>`               | 测试失败时重试次数，详见 [retry](/config/test/retry)                                                                                         |
 | `--maxConcurrency <value>`      | 最大并发测试数，详见 [maxConcurrency](/config/test/maxConcurrency)                                                                           |
 | `--clearMocks`                  | 每个测试前自动清除 mock 调用、实例、上下文和结果，详见 [clearMocks](/config/test/clearMocks)                                                 |


### PR DESCRIPTION
## Summary

support `hookTimeout` configuration. update default hookTimeout value from 5_000 to 10_000 (Consistent with vitest).
## Related Links

close: https://github.com/web-infra-dev/rstest/issues/361
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
