### PR TITLE
perf: disable some of rsbuild's default devMiddlewares

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -143,6 +143,12 @@ export const prepareRsbuild = async (
         printUrls: false,
         strictPort: false,
         middlewareMode: true,
+        compress: false,
+        cors: false,
+        publicDir: false,
+      },
+      dev: {
+        hmr: false,
       },
       performance,
       environments: {


### PR DESCRIPTION
## Summary

Disable some of rsbuild's default devMiddlewares that are not used in rstest.

https://rsbuild.rs/config/

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
