### PR TITLE
feat: export Mock type

### DIFF
--- a/packages/core/src/runtime/api/public.ts
+++ b/packages/core/src/runtime/api/public.ts
@@ -1,6 +1,7 @@
 import type { Rstest, RstestUtilities } from '../../types';
 
 export type { Assertion } from '../../types/expect';
+export type { Mock } from '../../types/mock';
 
 export declare const expect: Rstest['expect'];
 export declare const assert: Rstest['assert'];


### PR DESCRIPTION
## Summary

Export the `Mock` type to be consistent with other testing frameworks.

## Related Links

See https://github.com/rspack-contrib/rslog/pull/33/files#diff-c9ee165b9d352060be99cc2d36531c8071b4ad61aa6d7ffe9c7dc37b92042eeaL3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
