### PR TITLE
chore: correct check-dependency-version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:example": "pnpm --filter @examples/* test",
     "change": "changeset",
     "changeset": "changeset",
-    "check-dependency-version": "pnpx check-dependency-version-consistency .",
+    "check-dependency-version": "pnpx check-dependency-version-consistency . && echo",
     "check-spell": "pnpx cspell && heading-case",
     "format": "prettier --write . && heading-case --write",
     "lint": "biome check . --diagnostic-level=warn && pnpm run check-spell",


### PR DESCRIPTION
## Summary

fix `pnpm run check-dependency-version` error when commit.
`check-dependency-version` 5.0.1 update command from v12 to v13 which will throw an error with excessArguments

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/1116a732-b934-4be7-86ce-68a04b7ebc99" />


## Related Links

https://github.com/web-infra-dev/rslib/pull/1107

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
