### PR TITLE
feat: support using package name as `setupFiles` value

### DIFF
--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -15,7 +15,15 @@ const createRequire = (
   assetFiles: Record<string, string>,
   interopDefault: boolean,
 ): NodeJS.Require => {
-  const _require = createNativeRequire(filename);
+  const _require = (() => {
+    try {
+      // compat with some testPath may not be an available path but the third-party package name
+      return createNativeRequire(filename);
+    } catch (_err) {
+      return createNativeRequire(distPath);
+    }
+  })();
+
   const require = ((id: string) => {
     const currentDirectory = path.dirname(distPath);
 

--- a/tests/setup/fixtures/package-name/index.test.ts
+++ b/tests/setup/fixtures/package-name/index.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+it('should run setup file correctly', () => {
+  expect(process.env.RETEST_SETUP_FLAG).toBe('1');
+  expect(process.env.NODE_ENV).toBe('rstest:production');
+});

--- a/tests/setup/fixtures/package-name/rstest.config.ts
+++ b/tests/setup/fixtures/package-name/rstest.config.ts
@@ -1,0 +1,15 @@
+import { join } from 'node:path';
+import { defineConfig } from '@rstest/core';
+
+import fse from 'fs-extra';
+
+fse.copySync(
+  join(__dirname, './test-setup-fixtures'),
+  join(__dirname, './node_modules/test-setup'),
+);
+
+export default defineConfig({
+  passWithNoTests: true,
+  setupFiles: ['test-setup'],
+  exclude: ['**/node_modules/**', '**/dist/**'],
+});

--- a/tests/setup/fixtures/package-name/test-setup-fixtures/index.js
+++ b/tests/setup/fixtures/package-name/test-setup-fixtures/index.js
@@ -1,0 +1,2 @@
+process.env.RETEST_SETUP_FLAG = '1';
+process.env.NODE_ENV = 'rstest:production';

--- a/tests/setup/fixtures/package-name/test-setup-fixtures/package.json
+++ b/tests/setup/fixtures/package-name/test-setup-fixtures/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@rstest/tests-setup",
+  "main": "index.js",
+  "version": "1.0.0"
+}

--- a/tests/setup/index.test.ts
+++ b/tests/setup/index.test.ts
@@ -46,4 +46,17 @@ describe('test setup file', async () => {
       logs.find((log) => log.includes('rstest.setup.ts:1:7')),
     ).toBeTruthy();
   });
+
+  it('should run setup file correctly when setupFiles value is package name', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures/package-name'),
+        },
+      },
+    });
+    await expectExecSuccess();
+  });
 });


### PR DESCRIPTION
## Summary

support using package name as `setupFiles` value.

```ts
import { defineConfig } from '@rstest/core';

export default defineConfig({
  setupFiles: ['jsdom-global/register', 'rstest-canvas-mock'],
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
