### PR TITLE
feat: support `--include` CLI option to match test files

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -14,6 +14,7 @@ type CommonOptions = {
   configLoader?: LoadConfigOptions['loader'];
   globals?: boolean;
   isolate?: boolean;
+  include?: string[];
   exclude?: string[];
   passWithNoTests?: boolean;
   printConsoleTrace?: boolean;
@@ -52,6 +53,7 @@ const applyCommonOptions = (cli: CAC) => {
     )
     .option('--globals', 'Provide global APIs')
     .option('--isolate', 'Run tests in an isolated environment')
+    .option('--include <include>', 'Match test files')
     .option('--exclude <exclude>', 'Exclude files from test')
     .option('-u, --update', 'Update snapshot files')
     .option(
@@ -140,6 +142,10 @@ export async function initCli(options: CommonOptions): Promise<{
 
   if (options.exclude) {
     config.exclude = castArray(options.exclude);
+  }
+
+  if (options.include) {
+    config.include = castArray(options.include);
   }
 
   return {

--- a/website/docs/en/config/test/include.mdx
+++ b/website/docs/en/config/test/include.mdx
@@ -2,7 +2,7 @@
 
 - **Type:** `string[]`
 - **Default:** `['**/*.{test,spec}.?(c|m)[jt]s?(x)']`
-- **CLI:** `rstest **/*.test.ts`, `rstest index.test.ts`
+- **CLI:** `--include **/*.test.ts --include **/*.spec.ts`
 
 A list of glob patterns that match your test files.
 

--- a/website/docs/en/guide/basic/_meta.json
+++ b/website/docs/en/guide/basic/_meta.json
@@ -1,1 +1,1 @@
-["cli", "configure-rstest"]
+["cli", "configure-rstest", "test-filter"]

--- a/website/docs/en/guide/basic/test-filter.mdx
+++ b/website/docs/en/guide/basic/test-filter.mdx
@@ -1,0 +1,116 @@
+# Filtering Tests
+
+Rstest provides a variety of flexible ways to filter and select which test files and test cases to run. You can precisely control the test scope via configuration files, command-line arguments, and test APIs.
+
+## Filter by File Name
+
+Run all tests:
+
+```bash
+rstest
+```
+
+Run a specific test file:
+
+```bash
+rstest test/foo.test.ts
+```
+
+Use glob patterns:
+
+```bash
+rstest test/**/*.test.ts
+```
+
+You can also specify multiple test files or glob patterns:
+
+```bash
+rstest test/foo.test.ts test/bar.test.ts
+```
+
+### include/exclude
+
+When you filter files directly with `rstest **/*.test.ts`, rstest will further filter files based on the [include](/config/test/include) and [exclude](/config/test/exclude) configuration.
+You can modify the test file scope using the `include` and `exclude` options.
+
+For example, to match test files named index in the `test/a` directory:
+
+```bash
+rstest index.test.ts --include test/a/*.test.ts
+```
+
+To match test files in both `test/a` and `test/b` directories:
+
+```bash
+rstest --include test/a/*.test.ts --include test/b/*.test.ts
+```
+
+## Filter by Test Name
+
+If you only want to run test cases whose names contain a specific keyword, you can use [testNamePattern](/config/test/testNamePattern).
+
+For example, to only run test cases whose names contain "login":
+
+```bash
+rstest --testNamePattern login
+# or
+rstest -t login
+```
+
+## Combined Filtering
+
+All filtering methods can be combined. For example:
+
+```bash
+rstest test/**/*.test.ts --exclude test/legacy/** --testNamePattern login
+```
+
+In this case, rstest will only run test cases whose names contain login in all `.test.ts` files under the `test` directory, while excluding the `test/legacy` directory.
+
+## Common Usage
+
+- **Run a specific file only**: `rstest test/foo.test.ts`
+
+- **Run tests in a specific directory only**: `rstest test/api/*.test.ts`
+
+- **Exclude certain tests**: `rstest --exclude test/legacy/**`
+
+- **Run only tests whose names contain login**: `rstest -t login`
+
+- **Combined filtering**: `rstest test/**/*.test.ts --exclude test/legacy/** --testNamePattern login`
+
+## Filter via Test API
+
+Use the `.only` modifier to run only certain test suites or cases.
+
+For example, only the test cases in `suite A` and `case A` will be run:
+
+```ts
+describe.only('suite A', () => {
+  // ...
+});
+
+describe('suite B', () => {
+  // ...
+});
+
+test.only('case A', () => {
+  // ...
+});
+
+test('case B', () => {
+  // ...
+});
+```
+
+Use `.skip` or `.todo` to skip certain test suites or cases.
+
+```ts
+describe.skip('suite A', () => {
+  // ...
+});
+
+test.todo('case A', () => {
+  // ...
+});
+```

--- a/website/docs/en/guide/basic/test-filter.mdx
+++ b/website/docs/en/guide/basic/test-filter.mdx
@@ -22,6 +22,12 @@ Use glob patterns:
 rstest test/**/*.test.ts
 ```
 
+Run test files with `foo` in the name, such as `foo.test.ts`, `foo/index.test.ts`, `foo-bar/index.test.ts`, etc.:
+
+```bash
+rstest foo
+```
+
 You can also specify multiple test files or glob patterns:
 
 ```bash
@@ -33,13 +39,13 @@ rstest test/foo.test.ts test/bar.test.ts
 When you filter files directly with `rstest **/*.test.ts`, rstest will further filter files based on the [include](/config/test/include) and [exclude](/config/test/exclude) configuration.
 You can modify the test file scope using the `include` and `exclude` options.
 
-For example, to match test files named index in the `test/a` directory:
+For example, to match test files named `index` in the `test/a` directory:
 
 ```bash
-rstest index.test.ts --include test/a/*.test.ts
+rstest index --include test/a/*.test.ts
 ```
 
-To match test files in both `test/a` and `test/b` directories:
+To match test files in `test/a` or `test/b` directories:
 
 ```bash
 rstest --include test/a/*.test.ts --include test/b/*.test.ts

--- a/website/docs/en/guide/basic/test-filter.mdx
+++ b/website/docs/en/guide/basic/test-filter.mdx
@@ -1,8 +1,8 @@
-# Filtering Tests
+# Filtering tests
 
 Rstest provides a variety of flexible ways to filter and select which test files and test cases to run. You can precisely control the test scope via configuration files, command-line arguments, and test APIs.
 
-## Filter by File Name
+## Filter by file name
 
 Run all tests:
 
@@ -51,7 +51,7 @@ To match test files in `test/a` or `test/b` directories:
 rstest --include test/a/*.test.ts --include test/b/*.test.ts
 ```
 
-## Filter by Test Name
+## Filter by test name
 
 If you only want to run test cases whose names contain a specific keyword, you can use [testNamePattern](/config/test/testNamePattern).
 
@@ -63,7 +63,7 @@ rstest --testNamePattern login
 rstest -t login
 ```
 
-## Combined Filtering
+## Combined filtering
 
 All filtering methods can be combined. For example:
 
@@ -73,7 +73,7 @@ rstest test/**/*.test.ts --exclude test/legacy/** --testNamePattern login
 
 In this case, rstest will only run test cases whose names contain login in all `.test.ts` files under the `test` directory, while excluding the `test/legacy` directory.
 
-## Common Usage
+## Common usage
 
 - **Run a specific file only**: `rstest test/foo.test.ts`
 
@@ -85,7 +85,7 @@ In this case, rstest will only run test cases whose names contain login in all `
 
 - **Combined filtering**: `rstest test/**/*.test.ts --exclude test/legacy/** --testNamePattern login`
 
-## Filter via Test API
+## Filter via test API
 
 Use the `.only` modifier to run only certain test suites or cases.
 

--- a/website/docs/zh/config/test/include.mdx
+++ b/website/docs/zh/config/test/include.mdx
@@ -2,7 +2,7 @@
 
 - **类型：** `string[]`
 - **默认值：** `['**/*.{test,spec}.?(c|m)[jt]s?(x)']`
-- **CLI：** `rstest **/*.test.ts`, `rstest index.test.ts`
+- **CLI：** `--include **/*.test.ts --include **/*.spec.ts`
 
 匹配 glob 规则的文件将被视为测试文件。
 

--- a/website/docs/zh/guide/basic/_meta.json
+++ b/website/docs/zh/guide/basic/_meta.json
@@ -1,1 +1,1 @@
-["cli", "configure-rstest"]
+["cli", "configure-rstest", "test-filter"]

--- a/website/docs/zh/guide/basic/test-filter.mdx
+++ b/website/docs/zh/guide/basic/test-filter.mdx
@@ -22,6 +22,12 @@ rstest test/foo.test.ts
 rstest test/**/*.test.ts
 ```
 
+运行名称中包含 `foo` 的测试文件，如 `foo.test.ts`, `foo/index.test.ts`, `foo-bar/index.test.ts` 等:
+
+```bash
+rstest foo
+```
+
 你也可以指定多组测试文件或通配符：
 
 ```bash
@@ -33,10 +39,10 @@ rstest test/foo.test.ts test/bar.test.ts
 当你直接通过 `rstest **/*.test.ts` 过滤文件时，Rstest 会在 [include](/config/test/include) 和 [exclude](/config/test/exclude) 配置的基础上进一步筛选文件。
 你可以通过 `include` 和 `exclude` 选项修改测试文件的范围。
 
-如，匹配 `test/a` 目录下的名为 index 的测试文件：
+如，匹配 `test/a` 目录下的名为 `index` 的测试文件：
 
 ```bash
-rstest index.test.ts --include test/a/*.test.ts
+rstest index --include test/a/*.test.ts
 ```
 
 匹配 `test/a` 和 `test/b` 目录下的测试文件：

--- a/website/docs/zh/guide/basic/test-filter.mdx
+++ b/website/docs/zh/guide/basic/test-filter.mdx
@@ -1,0 +1,116 @@
+# 过滤测试
+
+Rstest 提供了多种灵活的方式来过滤和选择要运行的测试文件和测试用例。你可以通过配置文件、命令行参数、测试 API 等方式精准控制测试范围。
+
+## 根据文件名过滤
+
+运行所有测试：
+
+```bash
+rstest
+```
+
+只运行某个测试文件：
+
+```bash
+rstest test/foo.test.ts
+```
+
+用通配符匹配：
+
+```bash
+rstest test/**/*.test.ts
+```
+
+你也可以指定多组测试文件或通配符：
+
+```bash
+rstest test/foo.test.ts test/bar.test.ts
+```
+
+### include/exclude
+
+当你直接通过 `rstest **/*.test.ts` 过滤文件时，Rstest 会在 [include](/config/test/include) 和 [exclude](/config/test/exclude) 配置的基础上进一步筛选文件。
+你可以通过 `include` 和 `exclude` 选项修改测试文件的范围。
+
+如，匹配 `test/a` 目录下的名为 index 的测试文件：
+
+```bash
+rstest index.test.ts --include test/a/*.test.ts
+```
+
+匹配 `test/a` 和 `test/b` 目录下的测试文件：
+
+```bash
+rstest --include test/a/*.test.ts --include test/b/*.test.ts
+```
+
+## 根据测试名称过滤
+
+如果你只想运行名称中包含特定关键字的测试用例，可以使用 [testNamePattern](/config/test/testNamePattern)。
+
+如，只运行名称包含 "login" 的测试用例：
+
+```bash
+rstest --testNamePattern login
+# 或
+rstest -t login
+```
+
+## 组合过滤
+
+所有过滤方式都可以组合使用。例如：
+
+```bash
+rstest test/**/*.test.ts --exclude test/legacy/** --testNamePattern login
+```
+
+此时，rstest 会只运行 `test` 目录下所有 `.test.ts` 文件中名称包含 login 的测试用例，同时排除 `test/legacy` 目录。
+
+## 常见用法
+
+- **只运行某个文件**：`rstest test/foo.test.ts`
+
+- **只运行某个目录下的测试**：`rstest test/api/*.test.ts`
+
+- **排除某些测试**：`rstest --exclude test/legacy/**`
+
+- **只运行名称包含 login 的测试**：`rstest -t login`
+
+- **组合过滤**：`rstest test/**/*.test.ts --exclude test/legacy/** --testNamePattern login`
+
+## 通过测试 API 过滤
+
+使用 `.only` 标记将仅运行某些测试套件或用例。
+
+如，此时将仅运行 `suite A` 内的测试用例及 `case A`：
+
+```ts
+describe.only('suite A', () => {
+  // ...
+});
+
+describe('suite B', () => {
+  // ...
+});
+
+test.only('case A', () => {
+  // ...
+});
+
+test('case B', () => {
+  // ...
+});
+```
+
+使用 `.skip` 或 `.todo` 标记将跳过某些测试套件或用例。
+
+```ts
+describe.skip('suite A', () => {
+  // ...
+});
+
+test.todo('case A', () => {
+  // ...
+});
+```


### PR DESCRIPTION
## Summary

- support`--include` CLI option to match test files. 
- add `test filter` chapter

Match test files in the `test/a` directory:

```bash
rstest --include test/a/*.test.ts
```

Match test files in `test/a` or `test/b` directories:

```bash
rstest --include test/a/*.test.ts --include test/b/*.test.ts
```

## Related Links

close: https://github.com/web-infra-dev/rstest/issues/383

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
