### PR TITLE
fix: skip `module` field when commonjs require

### DIFF
--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -463,6 +463,14 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
+    "byDependency": {
+      "commonjs": {
+        "mainFields": [
+          "main",
+          "...",
+        ],
+      },
+    },
     "extensions": [
       ".ts",
       ".tsx",
@@ -934,6 +942,14 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
+    "byDependency": {
+      "commonjs": {
+        "mainFields": [
+          "main",
+          "...",
+        ],
+      },
+    },
     "extensions": [
       ".ts",
       ".tsx",
@@ -942,6 +958,9 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
       ".jsx",
       ".json",
       ".cjs",
+    ],
+    "mainFields": [
+      "main",
     ],
   },
   "target": "node",

--- a/tests/externals/fixtures/moduleField.test.ts
+++ b/tests/externals/fixtures/moduleField.test.ts
@@ -1,6 +1,10 @@
 import { expect, it } from '@rstest/core';
-import { a } from './test-pkg/importModule';
+import { a, b } from './test-pkg/importModule';
 
 it('should interop correctly', () => {
   expect(a).toBe(1);
+});
+
+it('should load correctly via require', () => {
+  expect(b).toBe(1);
 });

--- a/tests/externals/fixtures/test-module-field/index.es.js
+++ b/tests/externals/fixtures/test-module-field/index.es.js
@@ -1,1 +1,6 @@
+import { dirname } from 'node:path';
+
+if (!dirname) {
+  throw new Error('dirname is not defined');
+}
 export const a = 1;

--- a/tests/externals/fixtures/test-module-field/index.js
+++ b/tests/externals/fixtures/test-module-field/index.js
@@ -1,1 +1,6 @@
+const { dirname } = require('node:path');
+
+if (!dirname) {
+  throw new Error('dirname is not defined');
+}
 exports.a = 1;

--- a/tests/externals/fixtures/test-pkg/importModule.ts
+++ b/tests/externals/fixtures/test-pkg/importModule.ts
@@ -1,4 +1,6 @@
 // @ts-expect-error: the package is alongside, only for testing purposes
 import { a } from 'test-module-field';
 
-export { a };
+const { a: b } = require('test-module-field');
+
+export { a, b };

--- a/tests/externals/moduleField.test.ts
+++ b/tests/externals/moduleField.test.ts
@@ -15,10 +15,24 @@ describe('test module field', () => {
     );
   });
 
-  it('should load module correctly with module field', async () => {
+  it('should load pkg correctly with module field', async () => {
     const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', './fixtures/moduleField'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
+  it('should load pkg correctly with module field in dom environment', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', './fixtures/moduleField', '--testEnvironment=jsdom'],
       options: {
         nodeOptions: {
           cwd: __dirname,


### PR DESCRIPTION
## Summary

skip `module` field when commonjs require.

By default, rspack resolves the "module" field for commonjs first, but this is not always returned synchronously in esm.

<img width="1568" height="764" alt="image" src="https://github.com/user-attachments/assets/22570d56-09c2-4998-9d1c-5933fb19a1c3" />

<img width="1624" height="890" alt="image" src="https://github.com/user-attachments/assets/471939f2-a285-42ba-8524-09736f9aa500" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
