### PR TITLE
feat: support `rs.setConfig`

### DIFF
--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -38,7 +38,7 @@ export const createRstestRuntime = (
     configurable: true,
   });
 
-  const rstest = createRstestUtilities();
+  const rstest = createRstestUtilities(workerState);
 
   return {
     runner,

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -25,12 +25,11 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
 } {
   const {
     testPath,
-    runtimeConfig: { testTimeout, testNamePattern, hookTimeout },
+    runtimeConfig: { testNamePattern },
   } = workerState;
   const runtime = createRuntimeAPI({
     testPath,
-    testTimeout,
-    hookTimeout,
+    runtimeConfig: workerState.runtimeConfig,
   });
   const testRunner: TestRunner = new TestRunner();
 

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -10,6 +10,7 @@ import type {
   Fixtures,
   NormalizedFixtures,
   RunnerAPI,
+  RuntimeConfig,
   Test,
   TestAPI,
   TestAPIs,
@@ -41,26 +42,22 @@ export class RunnerRuntime {
    */
   private collectStatus: CollectStatus = 'lazy';
   private currentCollectList: Array<() => MaybePromise<void>> = [];
-  private defaultHookTimeout;
-  private defaultTestTimeout;
+  private runtimeConfig;
 
   constructor({
     testPath,
-    testTimeout,
-    hookTimeout,
+    runtimeConfig,
   }: {
-    testTimeout: number;
-    hookTimeout: number;
     testPath: string;
+    runtimeConfig: RuntimeConfig;
   }) {
     this.testPath = testPath;
-    this.defaultTestTimeout = testTimeout;
-    this.defaultHookTimeout = hookTimeout;
+    this.runtimeConfig = runtimeConfig;
   }
 
   afterAll(
     fn: AfterAllListener,
-    timeout: number = this.defaultHookTimeout,
+    timeout: number = this.runtimeConfig.hookTimeout,
   ): MaybePromise<void> {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
@@ -77,7 +74,7 @@ export class RunnerRuntime {
 
   beforeAll(
     fn: BeforeAllListener,
-    timeout: number = this.defaultHookTimeout,
+    timeout: number = this.runtimeConfig.hookTimeout,
   ): MaybePromise<void> {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
@@ -94,7 +91,7 @@ export class RunnerRuntime {
 
   afterEach(
     fn: AfterEachListener,
-    timeout: number = this.defaultHookTimeout,
+    timeout: number = this.runtimeConfig.hookTimeout,
   ): MaybePromise<void> {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
@@ -111,7 +108,7 @@ export class RunnerRuntime {
 
   beforeEach(
     fn: BeforeEachListener,
-    timeout: number = this.defaultHookTimeout,
+    timeout: number = this.runtimeConfig.hookTimeout,
   ): MaybePromise<void> {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
@@ -269,7 +266,7 @@ export class RunnerRuntime {
     fn,
     originalFn = fn,
     fixtures,
-    timeout = this.defaultTestTimeout,
+    timeout = this.runtimeConfig.testTimeout,
     runMode = 'run',
     fails = false,
     each = false,
@@ -368,7 +365,7 @@ export class RunnerRuntime {
     concurrent?: boolean;
     sequential?: boolean;
   }): ReturnType<TestEachFn> {
-    return (name, fn, timeout = this.defaultTestTimeout) => {
+    return (name, fn, timeout = this.runtimeConfig.testTimeout) => {
       for (let i = 0; i < cases.length; i++) {
         // TODO: template string table.
         const param = cases[i]!;
@@ -396,7 +393,7 @@ export class RunnerRuntime {
     concurrent?: boolean;
     sequential?: boolean;
   }): ReturnType<TestEachFn> {
-    return (name, fn, timeout = this.defaultTestTimeout) => {
+    return (name, fn, timeout = this.runtimeConfig.testTimeout) => {
       for (let i = 0; i < cases.length; i++) {
         // TODO: template string table.
         const param = cases[i]!;
@@ -429,20 +426,17 @@ export class RunnerRuntime {
 
 export const createRuntimeAPI = ({
   testPath,
-  testTimeout,
-  hookTimeout,
+  runtimeConfig,
 }: {
   testPath: string;
-  testTimeout: number;
-  hookTimeout: number;
+  runtimeConfig: RuntimeConfig;
 }): {
   api: RunnerAPI;
   instance: RunnerRuntime;
 } => {
   const runtimeInstance: RunnerRuntime = new RunnerRuntime({
     testPath,
-    testTimeout,
-    hookTimeout,
+    runtimeConfig,
   });
 
   const createTestAPI = (

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -1,5 +1,6 @@
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers';
 import type { FunctionLike } from './utils';
+import type { RuntimeConfig } from './worker';
 
 interface MockResultReturn<T> {
   type: 'return';
@@ -37,6 +38,19 @@ interface MockSettledResultRejected {
 type MockSettledResult<T> =
   | MockSettledResultFulfilled<T>
   | MockSettledResultRejected;
+
+type RuntimeOptions = Partial<
+  Pick<
+    RuntimeConfig,
+    | 'testTimeout'
+    | 'hookTimeout'
+    | 'clearMocks'
+    | 'resetMocks'
+    | 'restoreMocks'
+    | 'maxConcurrency'
+    | 'retry'
+  >
+>;
 
 export type MockContext<T extends FunctionLike = FunctionLike> = {
   /**
@@ -274,6 +288,16 @@ export type RstestUtilities = {
    * Restores all global variables that were changed with `rstest.stubGlobal`.
    */
   unstubAllGlobals: () => RstestUtilities;
+
+  /**
+   * Update runtime config for the current test.
+   */
+  setConfig: (config: RuntimeOptions) => void;
+
+  /**
+   * Reset runtime config that were changed with `rstest.setConfig`.
+   */
+  resetConfig: () => void;
 
   /**
    * Mocks timers using `@sinonjs/fake-timers`.

--- a/tests/test-api/fixtures/setConfig.test.ts
+++ b/tests/test-api/fixtures/setConfig.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, rs } from '@rstest/core';
+import { sleep } from '../../scripts';
+
+rs.setConfig({
+  testTimeout: 50,
+});
+
+describe('level A', () => {
+  it('it in level A', async () => {
+    console.log('aaaa');
+    // await sleep(100);
+    expect(1 + 1).toBe(3);
+  });
+});
+
+it('it in level B', async () => {
+  await sleep(100);
+  expect(1 + 1).toBe(2);
+});

--- a/tests/test-api/setConfig.test.ts
+++ b/tests/test-api/setConfig.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+describe('setConfig', () => {
+  it('should throw timeout error when test timeout', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/setConfig.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('Error: test timed out in 50ms')),
+    ).toBeTruthy();
+    expect(logs.find((log) => log.includes('Tests 2 failed'))).toBeTruthy();
+  });
+});

--- a/website/docs/en/api/rstest/utilities.mdx
+++ b/website/docs/en/api/rstest/utilities.mdx
@@ -76,3 +76,37 @@ rstest.stubGlobal('myGlobal', 123);
 rstest.unstubAllGlobals();
 expect(globalThis.myGlobal).toBeUndefined();
 ```
+
+## rstest.setConfig
+
+**Type:**
+
+```ts
+type RuntimeConfig = {
+  testTimeout?: number;
+  hookTimeout?: number;
+  clearMocks?: boolean;
+  resetMocks?: boolean;
+  restoreMocks?: boolean;
+  maxConcurrency?: number;
+  retry?: number;
+};
+
+type SetConfig = (config: RuntimeConfig) => void;
+```
+
+Dynamically updates the runtime configuration for the current test file. Useful for temporarily overriding test settings such as timeouts, concurrency, or mock behavior.
+
+**Example:**
+
+```ts
+rstest.setConfig({ testTimeout: 1000, retry: 2 });
+// ... run some code with the new config
+rstest.resetConfig(); // Restore to default config
+```
+
+## rstest.resetConfig
+
+**Type:** `() => void`
+
+Resets the runtime configuration that was changed using `rstest.setConfig` back to the default values.

--- a/website/docs/zh/api/rstest/utilities.mdx
+++ b/website/docs/zh/api/rstest/utilities.mdx
@@ -76,3 +76,37 @@ rstest.stubGlobal('myGlobal', 123);
 rstest.unstubAllGlobals();
 expect(globalThis.myGlobal).toBeUndefined();
 ```
+
+## rstest.setConfig
+
+**类型：**
+
+```ts
+type RuntimeConfig = {
+  testTimeout?: number;
+  hookTimeout?: number;
+  clearMocks?: boolean;
+  resetMocks?: boolean;
+  restoreMocks?: boolean;
+  maxConcurrency?: number;
+  retry?: number;
+};
+
+type SetConfig = (config: RuntimeConfig) => void;
+```
+
+动态更新当前测试的运行时配置。适用于需要在单个测试文件中临时覆盖某些测试设置（如超时时间、并发数、mock 行为等）的场景。
+
+**示例：**
+
+```ts
+rstest.setConfig({ testTimeout: 1000, retry: 2 });
+// ... 在新的配置下运行代码
+rstest.resetConfig(); // 恢复默认配置
+```
+
+## rstest.resetConfig
+
+**类型：** `() => void`
+
+将通过 `rstest.setConfig` 修改的运行时配置重置为默认值。


### PR DESCRIPTION
## Summary

`rs.setConfig` is used to dynamically updates the runtime configuration for the current test file. Useful for temporarily overriding test settings such as timeouts, concurrency, or mock behavior.

`rs.resetConfig` is used to resets the runtime configuration that was changed using `rs.setConfig` back to the default values.

**Example:**

```ts
rs.setConfig({ testTimeout: 1000, retry: 2 });
// ... run some code with the new config
rs.resetConfig(); // Restore to default config
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
