### PR TITLE
fix: should catch `Worker exited unexpectedly` error

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -210,21 +210,32 @@ export const createPool = async ({
         entries.map((entryInfo) => {
           const { assetFiles, sourceMaps } = filterAssetsByEntry(entryInfo);
 
-          return pool.runTest({
-            options: {
-              entryInfo,
-              assetFiles,
-              context: {
-                rootPath: context.rootPath,
-                runtimeConfig: serializableConfig(runtimeConfig),
+          return pool
+            .runTest({
+              options: {
+                entryInfo,
+                assetFiles,
+                context: {
+                  rootPath: context.rootPath,
+                  runtimeConfig: serializableConfig(runtimeConfig),
+                },
+                type: 'run',
+                sourceMaps,
+                setupEntries,
+                updateSnapshot,
               },
-              type: 'run',
-              sourceMaps,
-              setupEntries,
-              updateSnapshot,
-            },
-            rpcMethods,
-          });
+              rpcMethods,
+            })
+            .catch((err) => {
+              err.fullStack = true;
+              return {
+                testPath: entryInfo.testPath,
+                status: 'fail',
+                name: '',
+                results: [],
+                errors: [err],
+              } as TestFileResult;
+            });
         }),
       );
 

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -254,21 +254,30 @@ export const createPool = async ({
         entries.map((entryInfo) => {
           const { assetFiles, sourceMaps } = filterAssetsByEntry(entryInfo);
 
-          return pool.collectTests({
-            options: {
-              entryInfo,
-              assetFiles,
-              context: {
-                rootPath: context.rootPath,
-                runtimeConfig: serializableConfig(runtimeConfig),
+          return pool
+            .collectTests({
+              options: {
+                entryInfo,
+                assetFiles,
+                context: {
+                  rootPath: context.rootPath,
+                  runtimeConfig: serializableConfig(runtimeConfig),
+                },
+                type: 'collect',
+                sourceMaps,
+                setupEntries,
+                updateSnapshot,
               },
-              type: 'collect',
-              sourceMaps,
-              setupEntries,
-              updateSnapshot,
-            },
-            rpcMethods,
-          });
+              rpcMethods,
+            })
+            .catch((err) => {
+              err.fullStack = true;
+              return {
+                testPath: entryInfo.testPath,
+                tests: [],
+                errors: [err],
+              };
+            });
         }),
       );
     },

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -96,6 +96,7 @@ export type Test = TestSuite | TestCase;
 export type TestResultStatus = 'skip' | 'pass' | 'fail' | 'todo';
 
 export type FormattedError = {
+  fullStack?: boolean;
   message: string;
   name?: string;
   stack?: string;

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -34,6 +34,7 @@ export async function printError(
   if (error.stack) {
     const stackFrames = await parseErrorStacktrace({
       stack: error.stack,
+      fullStack: error.fullStack,
       getSourcemap,
     });
 
@@ -105,15 +106,19 @@ const stackIgnores: (RegExp | string)[] = [
 async function parseErrorStacktrace({
   stack,
   getSourcemap,
+  fullStack,
 }: {
+  fullStack?: boolean;
   stack: string;
   getSourcemap: GetSourcemap;
 }): Promise<StackFrame[]> {
   return Promise.all(
     stackTraceParse(stack)
-      .filter(
-        (frame) =>
-          frame.file && !stackIgnores.some((entry) => frame.file?.match(entry)),
+      .filter((frame) =>
+        fullStack
+          ? true
+          : frame.file &&
+            !stackIgnores.some((entry) => frame.file?.match(entry)),
       )
       .map(async (frame) => {
         const sourcemap = getSourcemap(frame.file!);

--- a/tests/runner/test/fixtures/processKill.test.ts
+++ b/tests/runner/test/fixtures/processKill.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+it('process.kill', async () => {
+  process.kill(process.pid, 'SIGTERM');
+  expect(1 + 1).toBe(2);
+});

--- a/tests/runner/test/processKill.test.ts
+++ b/tests/runner/test/processKill.test.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = dirname(__filename);
+it('should catch `Worker exited unexpectedly` error correctly', async () => {
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'processKill.test.ts', '--disableConsoleIntercept'],
+    options: {
+      nodeOptions: {
+        cwd: join(__dirname, 'fixtures'),
+      },
+    },
+  });
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(1);
+
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expect(
+    logs.find((log) => log.includes('Worker exited unexpectedly')),
+  ).toBeDefined();
+
+  expect(logs.find((log) => log.includes('Test Files 1 failed'))).toBeDefined();
+});


### PR DESCRIPTION
## Summary

should handle `Worker exited unexpectedly` error correctly.

before:
<img width="949" height="144" alt="image" src="https://github.com/user-attachments/assets/ef3e35cb-3150-454c-a29c-a47fa8477c69" />

after:
<img width="972" height="346" alt="image" src="https://github.com/user-attachments/assets/e9873776-0fb0-48a5-b57e-32c46534f3b8" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
