### PR TITLE
feat: support bundle `node_modules` in node environment

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -75,16 +75,17 @@ const autoExternalNodeModules: (
   });
 };
 
-const autoExternalNodeBuiltin: (
-  data: Rspack.ExternalItemFunctionData,
+function autoExternalNodeBuiltin(
+  { request, dependencyType }: Rspack.ExternalItemFunctionData,
   callback: (
     err?: Error,
     result?: Rspack.ExternalItemValue,
     type?: Rspack.ExternalsType,
   ) => void,
-) => void = ({ request, dependencyType }, callback) => {
+): void {
   if (!request) {
-    return callback();
+    callback();
+    return;
   }
 
   const isNodeBuiltin = NODE_BUILTINS.some((builtin) => {
@@ -104,7 +105,7 @@ const autoExternalNodeBuiltin: (
   } else {
     callback();
   }
-};
+}
 
 export const prepareRsbuild = async (
   context: RstestContext,
@@ -166,6 +167,10 @@ export const prepareRsbuild = async (
             sourceMap: {
               js: 'source-map',
             },
+            externals:
+              testEnvironment === 'node'
+                ? [autoExternalNodeModules]
+                : undefined,
             distPath: {
               root: TEMP_RSTEST_OUTPUT_DIR,
             },
@@ -196,10 +201,6 @@ export const prepareRsbuild = async (
               config.externals.unshift({
                 '@rstest/core': 'global @rstest/core',
               });
-
-              if (testEnvironment === 'node') {
-                config.externals.push(autoExternalNodeModules);
-              }
 
               config.externalsPresets ??= {};
               config.externalsPresets.node = false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,8 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0
 
+  tests/externals/fixtures/test-bundle: {}
+
   tests/externals/fixtures/test-interop: {}
 
   tests/externals/fixtures/test-lodash: {}

--- a/tests/externals/bundle.test.ts
+++ b/tests/externals/bundle.test.ts
@@ -1,0 +1,36 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import fse from 'fs-extra';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test externals false', () => {
+  beforeAll(() => {
+    fse.copySync(
+      join(__dirname, './fixtures/test-bundle'),
+      join(__dirname, './fixtures/test-pkg/node_modules/test-bundle'),
+    );
+  });
+
+  it('should bundle node_modules', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        './fixtures/bundle.test.ts',
+        '-c',
+        './fixtures/rstest.bundle.config.ts',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+});

--- a/tests/externals/bundle.test.ts
+++ b/tests/externals/bundle.test.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, it } from '@rstest/core';
+import { beforeAll, describe, it } from '@rstest/core';
 import fse from 'fs-extra';
 import { runRstestCli } from '../scripts/';
 

--- a/tests/externals/fixtures/bundle.test.ts
+++ b/tests/externals/fixtures/bundle.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+import { a } from './test-pkg/testBundle';
+
+it('should load pkg correctly with bundled', () => {
+  expect(a).toBe(1);
+});

--- a/tests/externals/fixtures/rstest.bundle.config.ts
+++ b/tests/externals/fixtures/rstest.bundle.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  tools: {
+    rspack: (config) => {
+      config.externals = [];
+    },
+  },
+});

--- a/tests/externals/fixtures/test-bundle/index.ts
+++ b/tests/externals/fixtures/test-bundle/index.ts
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/tests/externals/fixtures/test-bundle/package.json
+++ b/tests/externals/fixtures/test-bundle/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@rstest/tests-bundle",
+  "main": "index.ts",
+  "version": "1.0.0"
+}

--- a/tests/externals/fixtures/test-pkg/env.d.ts
+++ b/tests/externals/fixtures/test-pkg/env.d.ts
@@ -1,0 +1,1 @@
+declare module 'test-bundle';

--- a/tests/externals/fixtures/test-pkg/testBundle.ts
+++ b/tests/externals/fixtures/test-pkg/testBundle.ts
@@ -1,0 +1,1 @@
+export { a } from 'test-bundle';

--- a/tests/vue/sfc.test.ts
+++ b/tests/vue/sfc.test.ts
@@ -19,5 +19,6 @@ describe('vue sfc', () => {
     });
 
     await expectExecSuccess();
-  });
+    // fix timeout in CI
+  }, 20000);
 });

--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -21,6 +21,20 @@ export default defineConfig({
 });
 ```
 
+If you want all dependencies to be bundled, you can configure it through the following configuration:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  tools: {
+    rspack: (config) => {
+      config.externals = [];
+    },
+  },
+});
+```
+
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 
 For custom CSS Modules configuration.

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -21,6 +21,20 @@ export default defineConfig({
 });
 ```
 
+如果你希望所有依赖都被打包，可以通过如下配置：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  tools: {
+    rspack: (config) => {
+      config.externals = [];
+    },
+  },
+});
+```
+
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 
 用于自定义 CSS Modules 的配置。


### PR DESCRIPTION
## Summary

In the Node.js test environment, all packages in `node_modules` are externalized by default.

If you want all dependencies to be bundled, you can configure it through the following configuration:

```ts title="rstest.config.ts"
import { defineConfig } from '@rstest/core';

export default defineConfig({
  tools: {
    rspack: (config) => {
      config.externals = [];
    },
  },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
