### PR TITLE
feat: add `RSTEST` flag

### DIFF
--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -8,6 +8,7 @@ function initNodeEnv() {
 
 export function prepareCli(): void {
   initNodeEnv();
+  process.env.RSTEST = 'true';
 
   // Print a blank line to keep the greet log nice.
   // Some package managers automatically output a blank line, some do not.

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -133,6 +133,7 @@ export const prepareRsbuild = async (
   const writeToDisk = dev.writeToDisk || debugMode;
 
   const rsbuildInstance = await createRsbuild({
+    callerName: 'rstest',
     rsbuildConfig: {
       tools,
       plugins,

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -133,7 +133,6 @@ export const prepareRsbuild = async (
   const writeToDisk = dev.writeToDisk || debugMode;
 
   const rsbuildInstance = await createRsbuild({
-    callerName: 'rstest',
     rsbuildConfig: {
       tools,
       plugins,

--- a/tests/basic/test/index.test.ts
+++ b/tests/basic/test/index.test.ts
@@ -11,6 +11,10 @@ describe('Index', () => {
     expect(sayHi()).toBe('hi');
   });
 
+  it('should get RSTEST flag correctly', () => {
+    expect(process.env.RSTEST).toBe('true');
+  });
+
   it('should use node API correctly', async () => {
     expect(
       pathe

--- a/tests/cli/fixtures/flag.config.ts
+++ b/tests/cli/fixtures/flag.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rstest/core';
+
+if (!process.env.RSTEST) {
+  throw new Error('load config failed');
+}
+
+console.log('load config success');
+
+export default defineConfig({});

--- a/tests/cli/index.test.ts
+++ b/tests/cli/index.test.ts
@@ -55,4 +55,24 @@ describe.concurrent('test exit code', () => {
       logs.find((log) => log.includes('Invalid pool configuration')),
     ).toBeDefined();
   });
+
+  it('should get RSTEST flag correctly in config', async () => {
+    const { expectExecSuccess, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'success.test.ts', '-c', 'fixtures/flag.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('load config success')),
+    ).toBeDefined();
+  });
 });

--- a/website/docs/en/config/test/includeSource.mdx
+++ b/website/docs/en/config/test/includeSource.mdx
@@ -38,7 +38,7 @@ if (import.meta.rstest) {
 
 ### For production
 
-Put the test code inside the `if (import.meta.rstest)` block, and define `import.meta.rstest` as `undefined` in your build configuration (e.g., `rsbuild.config.ts`), which will help the bundler eliminate dead code.
+Put the test code inside the `if (import.meta.rstest)` block, and define `import.meta.rstest` as `false` in your build configuration (e.g., `rsbuild.config.ts`), which will help the bundler eliminate dead code.
 
 ```diff title=rsbuild.config.ts
 import { defineConfig } from '@rsbuild/core';

--- a/website/docs/en/guide/basic/configure-rstest.mdx
+++ b/website/docs/en/guide/basic/configure-rstest.mdx
@@ -52,7 +52,7 @@ if (process.env.RSTEST) {
 }
 ```
 
-It should be noted that if you use `process.env.RSTEST` in your source code, define `process.env.RSTEST` as `false` in your build configuration (such as `rsbuild.config.ts`) as `false` during production builds, this will help the bundler eliminate dead code.
+It should be noted that if you use `process.env.RSTEST` in your source code, define `process.env.RSTEST` as `false` in your build configuration (such as `rsbuild.config.ts`) during production builds, this will help the bundler eliminate dead code.
 
 ```diff title=rsbuild.config.ts
 import { defineConfig } from '@rsbuild/core';

--- a/website/docs/en/guide/basic/configure-rstest.mdx
+++ b/website/docs/en/guide/basic/configure-rstest.mdx
@@ -41,7 +41,7 @@ You can also abbreviate the `--config` option to `-c`:
 rstest -c scripts/rstest.config.mjs
 ```
 
-## Detect Rstest Environment
+## Detect Rstest environment
 
 You can use `process.env.RSTEST` to detect whether it is an Rstest test environment to apply different configurations/codes in your tests.
 

--- a/website/docs/en/guide/basic/configure-rstest.mdx
+++ b/website/docs/en/guide/basic/configure-rstest.mdx
@@ -40,3 +40,28 @@ You can also abbreviate the `--config` option to `-c`:
 ```bash
 rstest -c scripts/rstest.config.mjs
 ```
+
+## Detect Rstest Environment
+
+You can use `process.env.RSTEST` to detect whether it is an Rstest test environment to apply different configurations/codes in your tests.
+
+```ts
+if (process.env.RSTEST) {
+  // 'true' will be returned in the rstest environment
+  // do something...
+}
+```
+
+It should be noted that if you use `process.env.RSTEST` in your source code, define `process.env.RSTEST` as `false` in your build configuration (such as `rsbuild.config.ts`) as `false` during production builds, this will help the bundler eliminate dead code.
+
+```diff title=rsbuild.config.ts
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    define: {
++      'process.env.RSTEST': false,
+    },
+  },
+});
+```

--- a/website/docs/zh/config/test/includeSource.mdx
+++ b/website/docs/zh/config/test/includeSource.mdx
@@ -38,7 +38,7 @@ if (import.meta.rstest) {
 
 ### 生产环境构建
 
-将测试代码写在 `if (import.meta.rstest)` 代码块内，并在你的构建配置（如 `rsbuild.config.ts`）中将 `import.meta.rstest` 定义为 `undefined`，这样将有助于打包工具消除无用代码。
+将测试代码写在 `if (import.meta.rstest)` 代码块内，并在你的构建配置（如 `rsbuild.config.ts`）中将 `import.meta.rstest` 定义为 `false`，这样将有助于打包工具消除无用代码。
 
 ```diff title=rsbuild.config.ts
 import { defineConfig } from '@rsbuild/core';

--- a/website/docs/zh/guide/basic/configure-rstest.mdx
+++ b/website/docs/zh/guide/basic/configure-rstest.mdx
@@ -40,3 +40,28 @@ Rstest CLI 通过 `--config` 选项来指定配置文件，可以设置为相对
 ```bash
 rstest -c scripts/rstest.config.mjs
 ```
+
+## 检测 Rstest 环境
+
+你可以使用 `process.env.RSTEST` 来检测是否是 Rstest 测试环境以应用不同的配置 / 代码在你的测试中。
+
+```ts
+if (process.env.RSTEST) {
+  // 在 rstest 环境下将会返回 'true'
+  // do something...
+}
+```
+
+需要注意的是，如果你使用 `process.env.RSTEST` 在你的源码中，在生产环境构建时，在你的构建配置（如 `rsbuild.config.ts`）中将 `process.env.RSTEST` 定义为 `false`，这样将有助于打包工具消除无用代码。
+
+```diff title=rsbuild.config.ts
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    define: {
++      'process.env.RSTEST': false,
+    },
+  },
+});
+```


### PR DESCRIPTION
## Summary

`process.env.RSTEST` can be used to determine if it is an rstest environment.

```ts
if (process.env.RSTEST) {
   // do something...
}
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
