### PR TITLE
fix: should throw error when specified config not found

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -28,8 +28,7 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
     if (fs.existsSync(customConfigPath)) {
       return customConfigPath;
     }
-    logger.warn(`Cannot find config file: ${color.dim(customConfigPath)}`);
-    logger.log('');
+    throw `Cannot find config file: ${color.dim(customConfigPath)}`;
   }
 
   const configFilePath = findConfig(join(root, DEFAULT_CONFIG_NAME));
@@ -58,7 +57,7 @@ export async function loadConfig({
   const configFilePath = resolveConfigPath(cwd, path);
 
   if (!configFilePath) {
-    logger.debug('no config file found');
+    logger.debug('no rstest config file found');
     return {
       content: {},
       filePath: configFilePath,

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,0 +1,75 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = dirname(__filename);
+
+describe('test config load', () => {
+  it('should throw error when custom test config not found', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'success.test.ts', '-c', 'a.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('Cannot find config file')),
+    ).toBeDefined();
+  });
+
+  it('should throw error when plugin setup error', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'success.test.ts', '-c', 'fixtures/plugin.error.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('plugin setup error')),
+    ).toBeDefined();
+  });
+
+  it('should throw error when plugin setup error in watch mode', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'watch',
+        'success.test.ts',
+        '-c',
+        'fixtures/plugin.error.config.ts',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('plugin setup error')),
+    ).toBeDefined();
+  });
+});

--- a/tests/cli/fixtures/plugin.error.config.ts
+++ b/tests/cli/fixtures/plugin.error.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'test',
+      setup: (_api) => {
+        throw new Error('plugin setup error');
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- should throw error when specified config not found
- fix `rstest watch` exception exit without any error message

## Related Links

fix: #396 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
