### PR TITLE
feat: set callerName as `rstest`

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -133,6 +133,7 @@ export const prepareRsbuild = async (
   const writeToDisk = dev.writeToDisk || debugMode;
 
   const rsbuildInstance = await createRsbuild({
+    callerName: 'rstest',
     rsbuildConfig: {
       tools,
       plugins,

--- a/tests/build/fixtures/plugin/rstest.config.ts
+++ b/tests/build/fixtures/plugin/rstest.config.ts
@@ -8,6 +8,11 @@ export default defineConfig({
     {
       name: 'plugin',
       setup(api) {
+        if (api.context.callerName !== 'rstest') {
+          throw new Error(
+            'This plugin should only be used in Rstest, please check your configuration.',
+          );
+        }
         api.transform({ test: /a.ts$/ }, ({ code }) => {
           return code.replace('count = 1', 'count = 2');
         });

--- a/website/docs/en/guide/basic/configure-rstest.mdx
+++ b/website/docs/en/guide/basic/configure-rstest.mdx
@@ -40,3 +40,22 @@ You can also abbreviate the `--config` option to `-c`:
 ```bash
 rstest -c scripts/rstest.config.mjs
 ```
+
+## Detect Rstest environment
+
+If you are developing the Rsbuild plugin, you can use [api.context.callerName](https://rsbuild.rs/api/javascript-api/instance#contextcallername) to determine the current plugin is being called.
+
+```ts
+export const myPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    const { callerName } = api.context;
+
+    if (callerName === 'rstest') {
+      // ...
+    } else if (callerName === 'rsbuild') {
+      // ...
+    }
+  },
+};
+```

--- a/website/docs/zh/guide/basic/configure-rstest.mdx
+++ b/website/docs/zh/guide/basic/configure-rstest.mdx
@@ -40,3 +40,22 @@ Rstest CLI 通过 `--config` 选项来指定配置文件，可以设置为相对
 ```bash
 rstest -c scripts/rstest.config.mjs
 ```
+
+## 检测 Rstest 环境
+
+如果你正在开发 Rsbuild 插件，你可以使用 [api.context.callerName](https://rsbuild.rs/zh/api/javascript-api/instance#contextcallername) 来判断当前插件被调用的环境。
+
+```ts
+export const myPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    const { callerName } = api.context;
+
+    if (callerName === 'rstest') {
+      // ...
+    } else if (callerName === 'rsbuild') {
+      // ...
+    }
+  },
+};
+```


### PR DESCRIPTION
## Summary

If you are developing the Rsbuild plugin, you can use [api.context.callerName](https://rsbuild.rs/api/javascript-api/instance#contextcallername) to determine the current plugin is being called.

```ts
export const myPlugin = {
  name: 'my-plugin',
  setup(api) {
    const { callerName } = api.context;

    if (callerName === 'rstest') {
      // ...
    } else if (callerName === 'rsbuild') {
      // ...
    }
  },
};
```

## Related Links

https://rsbuild.rs/api/javascript-api/instance#contextcallername

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
