### PR TITLE
perf: avoid creating unused workers

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -81,15 +81,21 @@ export const createPool = async ({
       ? Math.max(Math.floor(numCpus / 2), 1)
       : Math.max(numCpus - 1, 1);
 
+  // Avoid creating unused workers when the number of tests is less than the default thread count.
+  const recommendCount =
+    context.command === 'watch'
+      ? threadsCount
+      : Math.min(Object.keys(entries).length, threadsCount);
+
   const maxWorkers = poolOptions.maxWorkers
     ? parseWorkers(poolOptions.maxWorkers)
-    : threadsCount;
+    : recommendCount;
 
   const minWorkers = poolOptions.minWorkers
     ? parseWorkers(poolOptions.minWorkers)
-    : maxWorkers < threadsCount
+    : maxWorkers < recommendCount
       ? maxWorkers
-      : threadsCount;
+      : recommendCount;
 
   if (maxWorkers < minWorkers) {
     throw `Invalid pool configuration: maxWorkers(${maxWorkers}) cannot be less than minWorkers(${minWorkers}).`;


### PR DESCRIPTION
## Summary

Avoid creating unused workers when the number of tests is less than the default thread count.

This significantly improves performance when running a single test file.

before:
```bash
npx rstest run  1.29s user 0.45s system 85% cpu 2.031 total
```

after:
```bash
npx rstest run  0.72s user 0.26s system 86% cpu 1.137 total
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
