### PR TITLE
chore: extract rsbuild / rspack config modify into rsbuild plugin

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -10,7 +10,11 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
   setup: (api) => {
     api.modifyRsbuildConfig(async (config) => {
       config.environments = {
-        [context.normalizedConfig.name]: {},
+        [context.normalizedConfig.name]: {
+          output: {
+            target: 'node',
+          },
+        },
       };
     });
     api.modifyEnvironmentConfig(async (config, { mergeEnvironmentConfig }) => {
@@ -29,7 +33,6 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
           distPath: {
             root: TEMP_RSTEST_OUTPUT_DIR,
           },
-          target: 'node',
         },
         tools: {
           rspack: (config, { isProd, rspack }) => {

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -1,0 +1,100 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+import path from 'pathe';
+import type { RstestContext } from '../..//types';
+import { TEMP_RSTEST_OUTPUT_DIR } from '../../utils';
+
+export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
+  context,
+) => ({
+  name: 'rstest:basic',
+  setup: (api) => {
+    api.modifyRsbuildConfig(async (config) => {
+      config.environments = {
+        [context.normalizedConfig.name]: {},
+      };
+    });
+    api.modifyEnvironmentConfig(async (config, { mergeEnvironmentConfig }) => {
+      return mergeEnvironmentConfig(config, {
+        source: {
+          define: {
+            'import.meta.rstest': "global['@rstest/core']",
+          },
+        },
+        output: {
+          // Pass resources to the worker on demand according to entry
+          manifest: true,
+          sourceMap: {
+            js: 'source-map',
+          },
+          distPath: {
+            root: TEMP_RSTEST_OUTPUT_DIR,
+          },
+          target: 'node',
+        },
+        tools: {
+          rspack: (config, { isProd, rspack }) => {
+            // treat `test` as development mode
+            config.mode = isProd ? 'production' : 'development';
+            config.output ??= {};
+            config.output.iife = false;
+            // polyfill interop
+            config.output.importFunctionName = '__rstest_dynamic_import__';
+            config.output.devtoolModuleFilenameTemplate =
+              '[absolute-resource-path]';
+            config.plugins.push(
+              new rspack.experiments.RstestPlugin({
+                injectModulePathName: true,
+                importMetaPathName: true,
+                hoistMockModule: true,
+                manualMockRoot: path.resolve(context.rootPath, '__mocks__'),
+              }),
+            );
+
+            config.module.parser ??= {};
+            config.module.parser.javascript = {
+              // Keep dynamic import expressions.
+              // eg. (modulePath) => import(modulePath)
+              importDynamic: false,
+              // Keep dynamic require expressions.
+              // eg. (modulePath) => require(modulePath)
+              requireDynamic: false,
+              requireAsExpression: false,
+              // Keep require.resolve expressions.
+              requireResolve: false,
+              ...(config.module.parser.javascript || {}),
+            };
+
+            config.resolve ??= {};
+            config.resolve.extensions ??= [];
+            config.resolve.extensions.push('.cjs');
+
+            if (context.normalizedConfig.testEnvironment === 'node') {
+              // skip `module` field in Node.js environment.
+              // ESM module resolved by module field is not always a native ESM module
+              config.resolve.mainFields = config.resolve.mainFields?.filter(
+                (filed) => filed !== 'module',
+              ) || ['main'];
+            }
+
+            config.resolve.byDependency ??= {};
+            config.resolve.byDependency.commonjs ??= {};
+            // skip `module` field when commonjs require
+            // By default, rspack resolves the "module" field for commonjs first, but this is not always returned synchronously in esm
+            config.resolve.byDependency.commonjs.mainFields = ['main', '...'];
+
+            config.optimization = {
+              moduleIds: 'named',
+              chunkIds: 'named',
+              nodeEnv: false,
+              ...(config.optimization || {}),
+              // make sure setup file and test file share the runtime
+              runtimeChunk: {
+                name: 'runtime',
+              },
+            };
+          },
+        },
+      });
+    });
+  },
+});

--- a/packages/core/src/core/plugins/external.ts
+++ b/packages/core/src/core/plugins/external.ts
@@ -1,0 +1,110 @@
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+import type { NormalizedConfig } from '../..//types';
+import { castArray, NODE_BUILTINS } from '../../utils';
+
+const autoExternalNodeModules: (
+  data: Rspack.ExternalItemFunctionData,
+  callback: (
+    err?: Error,
+    result?: Rspack.ExternalItemValue,
+    type?: Rspack.ExternalsType,
+  ) => void,
+) => void = ({ context, request, dependencyType, getResolve }, callback) => {
+  if (!request) {
+    return callback();
+  }
+
+  if (request.startsWith('@swc/helpers/')) {
+    // @swc/helper is a special case (Load by require but resolve to esm)
+    return callback();
+  }
+
+  const doExternal = (externalPath: string = request) => {
+    callback(
+      undefined,
+      externalPath,
+      dependencyType === 'commonjs' ? 'commonjs' : 'import',
+    );
+  };
+
+  const resolver = getResolve?.();
+
+  if (!resolver) {
+    return callback();
+  }
+
+  resolver(context!, request, (err, resolvePath) => {
+    if (err) {
+      // ignore resolve error
+      return callback();
+    }
+
+    if (resolvePath && /node_modules/.test(resolvePath)) {
+      return doExternal(resolvePath);
+    }
+    return callback();
+  });
+};
+
+function autoExternalNodeBuiltin(
+  { request, dependencyType }: Rspack.ExternalItemFunctionData,
+  callback: (
+    err?: Error,
+    result?: Rspack.ExternalItemValue,
+    type?: Rspack.ExternalsType,
+  ) => void,
+): void {
+  if (!request) {
+    callback();
+    return;
+  }
+
+  const isNodeBuiltin = NODE_BUILTINS.some((builtin) => {
+    if (typeof builtin === 'string') {
+      return builtin === request;
+    }
+
+    return builtin.test(request);
+  });
+
+  if (isNodeBuiltin) {
+    callback(
+      undefined,
+      request,
+      dependencyType === 'commonjs' ? 'commonjs' : 'module-import',
+    );
+  } else {
+    callback();
+  }
+}
+
+export const pluginExternal: (
+  testEnvironment: NormalizedConfig['testEnvironment'],
+) => RsbuildPlugin = (testEnvironment) => ({
+  name: 'rstest:external',
+  setup: (api) => {
+    api.modifyRsbuildConfig(async (config, { mergeRsbuildConfig }) => {
+      return mergeRsbuildConfig(config, {
+        output: {
+          externals:
+            testEnvironment === 'node' ? [autoExternalNodeModules] : undefined,
+        },
+        tools: {
+          // Make sure that externals configuration is not modified by users
+          rspack: (config) => {
+            // Avoid externals configuration being modified by users
+            config.externals = castArray(config.externals) || [];
+
+            config.externals.unshift({
+              '@rstest/core': 'global @rstest/core',
+            });
+
+            config.externalsPresets ??= {};
+            config.externalsPresets.node = false;
+            config.externals.push(autoExternalNodeBuiltin);
+          },
+        },
+      });
+    });
+  },
+});

--- a/tests/snapshot/file.test.ts
+++ b/tests/snapshot/file.test.ts
@@ -62,6 +62,8 @@ describe('test snapshot', () => {
   });
 
   it('test toMatchFileSnapshot correctly', async () => {
-    expect('hello world').toMatchFileSnapshot('__snapshots__/file.output.txt');
+    await expect('hello world').toMatchFileSnapshot(
+      '__snapshots__/file.output.txt',
+    );
   });
 });

--- a/website/docs/en/api/test-api/expect.mdx
+++ b/website/docs/en/api/test-api/expect.mdx
@@ -251,6 +251,10 @@ expect('hello world').toMatchSnapshot();
 expect(() => {
   throw new Error('fail');
 }).toThrowErrorMatchingSnapshot();
+
+await expect('hello world').toMatchFileSnapshot(
+  '__snapshots__/file.output.txt',
+);
 ```
 
 ### Promise matchers

--- a/website/docs/zh/api/test-api/expect.mdx
+++ b/website/docs/zh/api/test-api/expect.mdx
@@ -251,6 +251,10 @@ expect('hello world').toMatchSnapshot();
 expect(() => {
   throw new Error('fail');
 }).toThrowErrorMatchingSnapshot();
+
+await expect('hello world').toMatchFileSnapshot(
+  '__snapshots__/file.output.txt',
+);
 ```
 
 ### Promise 匹配器


### PR DESCRIPTION
## Summary

chore: extract rsbuild / rspack config modify into rsbuild plugin:
- `pluginBasic` Plugin: handle core `rsbuild` configurations, including environment setup, output configuration, and optimization settings. This modularizes previously inline configurations.
- `pluginExternal` Plugin: manage external dependencies, including automatic handling of Node.js built-ins and `node_modules`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
