### PR TITLE
fix: allows importing TS files with `.js` extension

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -71,6 +71,11 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
             config.resolve.extensions ??= [];
             config.resolve.extensions.push('.cjs');
 
+            // TypeScript allows importing TS files with `.js` extension
+            config.resolve.extensionAlias ??= {};
+            config.resolve.extensionAlias['.js'] = ['.js', '.ts', '.tsx'];
+            config.resolve.extensionAlias['.jsx'] = ['.jsx', '.tsx'];
+
             if (context.normalizedConfig.testEnvironment === 'node') {
               // skip `module` field in Node.js environment.
               // ESM module resolved by module field is not always a native ESM module

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -472,6 +472,17 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
         ],
       },
     },
+    "extensionAlias": {
+      ".js": [
+        ".js",
+        ".ts",
+        ".tsx",
+      ],
+      ".jsx": [
+        ".jsx",
+        ".tsx",
+      ],
+    },
     "extensions": [
       ".ts",
       ".tsx",
@@ -951,6 +962,17 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
           "...",
         ],
       },
+    },
+    "extensionAlias": {
+      ".js": [
+        ".js",
+        ".ts",
+        ".tsx",
+      ],
+      ".jsx": [
+        ".jsx",
+        ".tsx",
+      ],
     },
     "extensions": [
       ".ts",


### PR DESCRIPTION
## Summary

allows importing TS files with `.js` extension by default.

Rsbuild allows importing TypeScript files with the `.js` extension when a `tsconfig.path` file exists. However, in the Rstest scenario, the workspace root directory may not have a `tsconfig.path`.


## Related Links

https://github.com/web-infra-dev/rsbuild/blob/4fa7e847ec66f6f0c5f5518e46185ee69ad0b819/packages/core/src/plugins/resolve.ts#L132

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
