### PR TITLE
feat(mock): mock and doMock support typed first arg

### DIFF
--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -1,5 +1,5 @@
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers';
-import type { FunctionLike } from './utils';
+import type { FunctionLike, MaybePromise } from './utils';
 import type { RuntimeConfig } from './worker';
 
 interface MockResultReturn<T> {
@@ -172,8 +172,9 @@ export interface Mock<T extends FunctionLike = FunctionLike>
 }
 
 export type MockFn = <T extends FunctionLike = FunctionLike>(fn?: T) => Mock<T>;
+type MockFactory<T = unknown> = () => MaybePromise<Partial<T>>;
 
-export type RstestUtilities = {
+export interface RstestUtilities {
   /**
    * Creates a spy on a function.
    */
@@ -208,10 +209,10 @@ export type RstestUtilities = {
   /**
    * Mock a module
    */
-  mock: <T = unknown>(
-    moduleName: string,
-    moduleFactory?: () => T | Promise<T>,
-  ) => void;
+  mock<T = unknown>(
+    moduleName: string | Promise<T>,
+    moduleFactory?: MockFactory<T>,
+  ): void;
 
   /**
    * Mock a module
@@ -224,10 +225,10 @@ export type RstestUtilities = {
   /**
    * Mock a module, not hoisted.
    */
-  doMock: <T = unknown>(
-    moduleName: string,
-    moduleFactory?: () => T | Promise<T>,
-  ) => void;
+  doMock<T = unknown>(
+    moduleName: string | Promise<T>,
+    moduleFactory?: MockFactory<T>,
+  ): void;
 
   /**
    * Mock a module, not hoisted.
@@ -337,4 +338,4 @@ export type RstestUtilities = {
    * Removes all timers that are scheduled to run.
    */
   clearAllTimers: () => RstestUtilities;
-};
+}

--- a/tests/mock/src/b.ts
+++ b/tests/mock/src/b.ts
@@ -1,1 +1,1 @@
-export const b = 2;
+export const b: number = 2;

--- a/tests/mock/src/c.ts
+++ b/tests/mock/src/c.ts
@@ -1,1 +1,1 @@
-export const c = 3;
+export const c: number = 3;

--- a/tests/mock/src/d.ts
+++ b/tests/mock/src/d.ts
@@ -1,1 +1,1 @@
-export const d = 4;
+export const d: number = 4;

--- a/tests/mock/tests/mockTypedArg.test.ts
+++ b/tests/mock/tests/mockTypedArg.test.ts
@@ -1,0 +1,35 @@
+import { expect, it, rs } from '@rstest/core';
+import { b } from '../src/b';
+import { d } from '../src/d';
+
+// b
+rs.mock(import('../src/b'), async () => {
+  return {
+    b: 222,
+  };
+});
+
+it('mocked b', async () => {
+  expect(b).toBe(222);
+});
+
+// c
+it('mocked c', async () => {
+  rs.doMock(import('../src/c'), () => {
+    return { c: 333 };
+  });
+
+  const { c } = await import('../src/c');
+  expect(c).toBe(333);
+});
+
+// d
+rs.mock<{ d: number }>('../src/d', async () => {
+  return {
+    d: 444,
+  };
+});
+
+it('mocked d', async () => {
+  expect(d).toBe(444);
+});

--- a/website/docs/en/api/rstest/mockModules.mdx
+++ b/website/docs/en/api/rstest/mockModules.mdx
@@ -8,7 +8,7 @@ Rstest supports mocking modules, which allows you to replace the implementation 
 
 ## rs.mock
 
-- **Type**: `<T = unknown>(moduleName: string, moduleFactory?: () => T) => void`
+- **Type**: `<T = unknown>(moduleName: string | Promise<T>, moduleFactory?: (() => Promise<Partial<T>> | Partial<T>)) => void`
 
 When calling `rs.mock`, Rstest will mock and replace the module specified in the first parameter. `rs.mock` will determine how to handle the mocked module based on whether a second mock factory function is provided, as explained in detail below.
 
@@ -77,9 +77,20 @@ Based on the second parameter provided, `rs.mock` has two behaviors:
    lodash.random(multiple(1, 2), multiple(3, 4));
    ```
 
+   `rs.mock` and `rs.doMock` also support passing a `Promise<T>` as the first parameter, and use the type `T` as the return value type of the second factory function after awaiting (`Promise<T>`). This provides better type hints in IDEs and type validation for the factory function's return value. Passing `Promise<T>` only enhances type hints and has no impact on the module mocking capabilities.
+
+   ```ts
+   // Compared to rs.mock('../src/b', ...) the type is enhanced.
+   rs.mock(import('../src/b'), async () => {
+     return {
+       b: 222,
+     };
+   });
+   ```
+
 ## rs.doMock
 
-- **Type**: `<T = unknown>(moduleName: string, moduleFactory?: () => T | Promise<T>) => void`
+- **Type**: `<T = unknown>(moduleName: string | Promise<T>, moduleFactory?: (() => Promise<Partial<T>> | Partial<T>)) => void`
 
 Similar to `rs.mock`, `rs.doMock` also mocks modules, but it is not hoisted to the top of the module. It is called when it's executed, which means that if a module has already been imported before calling `rs.doMock`, that module will not be mocked, while modules imported after calling `rs.doMock` will be mocked.
 

--- a/website/docs/zh/api/rstest/mockModules.mdx
+++ b/website/docs/zh/api/rstest/mockModules.mdx
@@ -8,7 +8,7 @@ Rstest 支持对模块进行 mock，这使得你可以在测试中替换模块�
 
 ## rs.mock
 
-- **类型：**: `<T = unknown>(moduleName: string, moduleFactory?: () => T | Promise<T>) => void`
+- **类型：**: `<T = unknown>(moduleName: string | Promise<T>, moduleFactory?: (() => Promise<Partial<T>> | Partial<T>)) => void`
 
 调用 `rs.mock` 时，Rstest 会对第一个参数对应的模块进行 mock 替换。`rs.mock` 将根据是否提供了第二个 mock 工厂函数来决定如何处理被 mock 的模块，下面会详细介绍这两种情况。
 
@@ -77,9 +77,20 @@ Rstest 支持对模块进行 mock，这使得你可以在测试中替换模块�
    lodash.random(multiple(1, 2), multiple(3, 4));
    ```
 
+   `rs.mock` 和 `rs.doMock` 也支持第一个参数传入一个 `Promise<T>`，并将这个 `T` 的类型作为第二个工厂函数 await 后的返回值（`Promise<T>`），这能够让 IDE 获得更好的类型提示，并对工厂函数的返回值做类型校验。传入 `Promise<T>` 除对对类型提示有增强外，对 mock 模块能力没有任何影响。
+
+   ```ts
+   // Compared to rs.mock('../src/b', ...) the type is enhanced.
+   rs.mock(import('../src/b'), async () => {
+     return {
+       b: 222,
+     };
+   });
+   ```
+
 ## rs.doMock
 
-- **类型：**: `<T = unknown>(moduleName: string, moduleFactory?: () => T | Promise<T>) => void`
+- **类型：**: `<T = unknown>(moduleName: string | Promise<T>, moduleFactory?: (() => Promise<Partial<T>> | Partial<T>)) => void`
 
 与 `rs.mock` 类似，`rs.doMock` 也会 mock 模块，但它不会被提升到模块顶部。它会在被执行到时调用，这意味着，如果在调用 `rs.doMock` 之前已经导入了模块，则该模块不会被 mock，而在调用 `rs.doMock` 之后导入的模块会被 mock。
 


### PR DESCRIPTION
## Summary

`rs.mock` and `rs.doMock` also support passing a `Promise<T>` as the first parameter, and use the type `T` as the return value type of the second factory function after awaiting (`Promise<T>`). This provides better type hints in IDEs and type validation for the factory function's return value. Passing `Promise<T>` only enhances type hints and has no impact on the module mocking capabilities.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
