### PR TITLE
feat: support VerboseReporter

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -21,6 +21,7 @@ type CommonOptions = {
   isolate?: boolean;
   include?: string[];
   exclude?: string[];
+  reporter?: string[];
   passWithNoTests?: boolean;
   printConsoleTrace?: boolean;
   disableConsoleIntercept?: boolean;
@@ -74,6 +75,7 @@ const applyCommonOptions = (cli: CAC) => {
       '--slowTestThreshold <value>',
       'The number of milliseconds after which a test or suite is considered slow',
     )
+    .option('--reporter <reporter>', 'Specify the reporter to use')
     .option(
       '-t, --testNamePattern <value>',
       'Run only tests with a name that matches the regex',
@@ -147,6 +149,10 @@ export async function initCli(options: CommonOptions): Promise<{
 
   if (options.exclude) {
     config.exclude = castArray(options.exclude);
+  }
+
+  if (options.reporter) {
+    config.reporters = castArray(options.reporter) as typeof config.reporters;
   }
 
   if (options.include) {

--- a/packages/core/src/core/context.ts
+++ b/packages/core/src/core/context.ts
@@ -2,11 +2,13 @@ import { SnapshotManager } from '@vitest/snapshot/manager';
 import { isCI } from 'std-env';
 import { withDefaultConfig } from '../config';
 import { DefaultReporter } from '../reporter';
+import { VerboseReporter } from '../reporter/verbose';
 import type { RstestCommand, RstestConfig, RstestContext } from '../types';
 import { castArray, getAbsolutePath } from '../utils/helper';
 
 const reportersMap = {
   default: DefaultReporter as typeof DefaultReporter,
+  verbose: VerboseReporter as typeof VerboseReporter,
 };
 
 export type BuiltInReporterNames = keyof typeof reportersMap;
@@ -17,10 +19,8 @@ function createReporters(
 ) {
   const result = castArray(reporters).map((reporter) => {
     if (typeof reporter === 'string' || Array.isArray(reporter)) {
-      const [name, options = {}] = castArray(reporter) as [
-        BuiltInReporterNames,
-        Record<string, any>,
-      ];
+      const [name, options = {}] =
+        typeof reporter === 'string' ? [reporter, {}] : reporter;
       // built-in reporters
       if (name in reportersMap) {
         const Reporter = reportersMap[name]!;

--- a/packages/core/src/reporter/utils.ts
+++ b/packages/core/src/reporter/utils.ts
@@ -1,0 +1,74 @@
+import type { TestFileResult, TestResult } from '../types';
+import {
+  color,
+  getTaskNameWithPrefix,
+  logger,
+  prettyTestPath,
+  prettyTime,
+} from '../utils';
+
+export const statusStr = {
+  fail: '✗',
+  pass: '✓',
+  todo: '-',
+  skip: '-',
+};
+
+export const statusColorfulStr = {
+  fail: color.red(statusStr.fail) as string,
+  pass: color.green(statusStr.pass) as string,
+  todo: color.gray(statusStr.todo) as string,
+  skip: color.gray(statusStr.skip) as string,
+};
+
+export const logCase = (
+  result: TestResult,
+  slowTestThreshold: number,
+): void => {
+  const isSlowCase = (result.duration || 0) > slowTestThreshold;
+
+  const icon =
+    isSlowCase && result.status === 'pass'
+      ? color.yellow(statusStr[result.status])
+      : statusColorfulStr[result.status];
+  const nameStr = getTaskNameWithPrefix(result);
+  const duration =
+    typeof result.duration !== 'undefined'
+      ? ` (${prettyTime(result.duration)})`
+      : '';
+  const retry = result.retryCount
+    ? color.yellow(` (retry x${result.retryCount})`)
+    : '';
+  logger.log(`  ${icon} ${nameStr}${color.gray(duration)}${retry}`);
+
+  if (result.errors) {
+    for (const error of result.errors) {
+      console.error(color.red(`    ${error.message}`));
+    }
+  }
+};
+
+export const logFileTitle = (
+  test: TestFileResult,
+  relativePath: string,
+  slowTestThreshold: number,
+  alwaysShowTime = false,
+): void => {
+  let title = ` ${color.bold(statusColorfulStr[test.status])} ${prettyTestPath(relativePath)}`;
+
+  const formatDuration = (duration: number) => {
+    return color[duration > slowTestThreshold ? 'yellow' : 'green'](
+      `${prettyTime(duration)}`,
+    );
+  };
+
+  title += ` ${color.gray(`(${test.results.length})`)}`;
+
+  const isTooSlow = test.duration && test.duration > slowTestThreshold;
+
+  if (alwaysShowTime || isTooSlow) {
+    title += ` ${formatDuration(test.duration!)}`;
+  }
+
+  logger.log(title);
+};

--- a/packages/core/src/reporter/verbose.ts
+++ b/packages/core/src/reporter/verbose.ts
@@ -1,0 +1,19 @@
+import { relative } from 'pathe';
+import type { TestFileResult } from '../types';
+import { DefaultReporter } from './index';
+import { logCase, logFileTitle } from './utils';
+
+export class VerboseReporter extends DefaultReporter {
+  override onTestFileResult(test: TestFileResult): void {
+    this.statusRenderer?.removeRunningModule(test.testPath);
+
+    const relativePath = relative(this.rootPath, test.testPath);
+    const { slowTestThreshold } = this.config;
+
+    logFileTitle(test, relativePath, slowTestThreshold, true);
+
+    for (const result of test.results) {
+      logCase(result, slowTestThreshold);
+    }
+  }
+}

--- a/tests/reporter/index.test.ts
+++ b/tests/reporter/index.test.ts
@@ -22,6 +22,21 @@ describe.concurrent('reporters', () => {
     expect(cli.stdout).toContain('✗ basic > b');
   });
 
+  it('verbose', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--reporter=verbose'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.stdout).toContain('✓ basic > a');
+  });
+
   it('custom', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',

--- a/website/docs/en/config/test/_meta.json
+++ b/website/docs/en/config/test/_meta.json
@@ -10,6 +10,7 @@
   "hookTimeout",
   "retry",
   "root",
+  "reporters",
   "name",
   "isolate",
   "pool",

--- a/website/docs/en/config/test/reporters.mdx
+++ b/website/docs/en/config/test/reporters.mdx
@@ -1,0 +1,69 @@
+---
+overviewHeaders: []
+---
+
+# Reporters
+
+- **Type:**
+
+```ts
+type Reporter = ReporterName | [ReporterName, ReporterOptions];
+
+type Reporters = Reporter | Reporter[];
+```
+
+- **Default:** `'default'`
+- **CLI:** `--reporter=<name> --reporter=<name1>`
+
+Customize the reporter type. If no reporter is specified, Rstest will use the built-in default reporter.
+
+## Built-in Reporters
+
+### Default Reporter
+
+By default, Rstest displays test run status, results, and summary information in the terminal.
+
+Output example:
+
+```bash
+ ✓ test/index.test.ts (2)
+
+ Test Files 1 passed
+      Tests 2 passed
+   Duration 112ms (build 19ms, tests 93ms)
+```
+
+### Verbose Reporter
+
+The default reporter only outputs test case information when tests fail or run slowly. The verbose reporter outputs all test case information after test completion.
+
+import { Tab, Tabs } from '@theme';
+
+<Tabs>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --reporter=verbose 
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+  ```ts
+  import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+    reporters: 'verbose'
+});
+```
+  </Tab>
+</Tabs>
+
+With verbose reporter, Rstest outputs:
+
+```bash
+ ✓ test/index.test.ts (2) 2ms
+  ✓ Index > should add two numbers correctly (1ms)
+  ✓ Index > should test source code correctly (1ms)
+
+ Test Files 1 passed
+      Tests 2 passed
+   Duration 112ms (build 19ms, tests 93ms)
+```

--- a/website/docs/en/config/test/reporters.mdx
+++ b/website/docs/en/config/test/reporters.mdx
@@ -2,7 +2,7 @@
 overviewHeaders: []
 ---
 
-# Reporters
+# reporters
 
 - **Type:**
 

--- a/website/docs/en/config/test/reporters.mdx
+++ b/website/docs/en/config/test/reporters.mdx
@@ -35,7 +35,7 @@ Output example:
 
 ### Verbose Reporter
 
-The default reporter only outputs test case information when tests fail or run slowly. The verbose reporter outputs all test case information after test completion.
+The default reporter only outputs test case information when tests fail or run slowly. The verbose reporter will output all test case information after test completion.
 
 import { Tab, Tabs } from '@theme';
 

--- a/website/docs/zh/config/test/_meta.json
+++ b/website/docs/zh/config/test/_meta.json
@@ -10,6 +10,7 @@
   "hookTimeout",
   "retry",
   "root",
+  "reporters",
   "name",
   "isolate",
   "pool",

--- a/website/docs/zh/config/test/reporters.mdx
+++ b/website/docs/zh/config/test/reporters.mdx
@@ -1,0 +1,65 @@
+# reporters
+
+- **类型：**
+
+```ts
+type Reporter = ReporterName | [ReporterName, ReporterOptions];
+
+type Reporters = Reporter | Reporter[];
+```
+
+- **默认值：** `'default'`
+- **CLI：** `--reporter=<name> --reporter=<name1>`
+
+自定义输出报告器的类型。如果没有指定报告器，Rstest 会使用内置的默认报告器。
+
+## 内置报告器
+
+### 默认报告器
+
+默认情况下，Rstest 会在终端显示测试运行状态、结果以及汇总信息。
+
+输出如下：
+
+```bash
+ ✓ test/index.test.ts (2)
+
+ Test Files 1 passed
+      Tests 2 passed
+   Duration 112ms (build 19ms, tests 93ms)
+```
+
+### Verbose 报告器
+
+默认报告器仅在测试运行失败或耗时缓慢时输出相关的测试用例信息，Verbose 报告器会在测试完成后输出所有的测试用例信息。
+
+import { Tab, Tabs } from '@theme';
+
+<Tabs>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --reporter=verbose 
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+  ```ts
+  import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+    reporters: 'verbose'
+});
+```
+  </Tab>
+</Tabs>
+
+此时，Rstest 输出如下：
+
+```bash
+ ✓ test/index.test.ts (2) 2ms
+  ✓ Index > should add two numbers correctly (1ms)
+  ✓ Index > should test source code correctly (1ms)
+
+ Test Files 1 passed
+      Tests 2 passed
+   Duration 112ms (build 19ms, tests 93ms)
+```

--- a/website/docs/zh/config/test/reporters.mdx
+++ b/website/docs/zh/config/test/reporters.mdx
@@ -1,3 +1,7 @@
+---
+overviewHeaders: []
+---
+
 # reporters
 
 - **类型：**


### PR DESCRIPTION
## Summary

The default reporter only outputs test case information when tests fail or run slowly. The verbose reporter will output all test case information after test completion.


  ```ts
  import { defineConfig } from '@rstest/core';

export default defineConfig({
    reporters: 'verbose'
});
```

With verbose reporter, Rstest outputs:

```bash
 ✓ test/index.test.ts (2) 2ms
  ✓ Index > should add two numbers correctly (1ms)
  ✓ Index > should test source code correctly (1ms)

 Test Files 1 passed
      Tests 2 passed
   Duration 112ms (build 19ms, tests 93ms)
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
