### PR TITLE
fix: should show `module not found` error codeFrame correctly

### DIFF
--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -100,6 +100,7 @@ const stackIgnores: (RegExp | string)[] = [
   /node_modules\/@vitest\/expect/,
   /node_modules\/@vitest\/snapshot/,
   /node:\w+/,
+  /webpack\/runtime/,
   '<anonymous>',
 ];
 

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -101,6 +101,8 @@ const stackIgnores: (RegExp | string)[] = [
   /node_modules\/@vitest\/snapshot/,
   /node:\w+/,
   /webpack\/runtime/,
+  // windows path
+  /webpack\\runtime/,
   '<anonymous>',
 ];
 

--- a/tests/scripts/index.ts
+++ b/tests/scripts/index.ts
@@ -92,7 +92,18 @@ export async function runRstestCli({
     }
   };
 
-  return { cli, expectExecSuccess };
+  const expectLog = async (
+    msg: string,
+    logs: string[] = cli.stdout.split('\n').filter(Boolean),
+  ) => {
+    const matchedLog = logs.find((log) => log.includes(msg));
+
+    if (!matchedLog) {
+      throw new Error(`Can't find log(${msg}) in:\n${logs.join('\n')}`);
+    }
+  };
+
+  return { cli, expectExecSuccess, expectLog };
 }
 
 export async function prepareFixtures({

--- a/tests/test-api/edgeCase.test.ts
+++ b/tests/test-api/edgeCase.test.ts
@@ -46,7 +46,7 @@ describe('Test Edge Cases', () => {
   });
 
   it('test module not found codeFrame', async () => {
-    const { cli } = await runRstestCli({
+    const { cli, expectLog } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/moduleNotFound.codeFrame.test.ts'],
       options: {
@@ -62,8 +62,8 @@ describe('Test Edge Cases', () => {
     const logs = cli.stdout.split('\n').filter(Boolean);
 
     // Module not found error should throw and show code frame correctly
-    expect(logs.find((log) => log.includes('Cannot find module'))).toBeTruthy();
-    expect(logs.find((log) => log.includes("import('aaa')"))).toBeTruthy();
+    expectLog('Cannot find module', logs);
+    expectLog("import('aaa')", logs);
   });
 
   it('should log build error message correctly', async () => {

--- a/tests/test-api/edgeCase.test.ts
+++ b/tests/test-api/edgeCase.test.ts
@@ -45,6 +45,27 @@ describe('Test Edge Cases', () => {
     expect(logs.find((log) => log.includes('Tests 2 passed'))).toBeTruthy();
   });
 
+  it('test module not found codeFrame', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/moduleNotFound.codeFrame.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    const exitCode = cli.exec.process?.exitCode;
+    expect(exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    // Module not found error should throw and show code frame correctly
+    expect(logs.find((log) => log.includes('Cannot find module'))).toBeTruthy();
+    expect(logs.find((log) => log.includes("import('aaa')"))).toBeTruthy();
+  });
+
   it('should log build error message correctly', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',

--- a/tests/test-api/fixtures/moduleNotFound.codeFrame.test.ts
+++ b/tests/test-api/fixtures/moduleNotFound.codeFrame.test.ts
@@ -1,0 +1,10 @@
+import { it } from '@rstest/core';
+
+const unexpectNotFound = async () => {
+  // @ts-expect-error
+  return import('aaa');
+};
+
+it('test expectNotFound error', async () => {
+  await unexpectNotFound();
+});


### PR DESCRIPTION
## Summary
should show `module not found` error codeFrame correctly.

before:
<img width="1846" height="306" alt="image" src="https://github.com/user-attachments/assets/edcb9fdf-acf7-4b0b-8af9-3dde512eab94" />

after:
<img width="1602" height="526" alt="image" src="https://github.com/user-attachments/assets/193ccbdd-b9ab-4e9e-a8af-8f305a050f84" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
