### PR TITLE
feat: support Github Actions Reporter

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -98,7 +98,10 @@ const createDefaultConfig = (): NormalizedConfig => ({
   hookTimeout: 10_000,
   testEnvironment: 'node',
   retry: 0,
-  reporters: ['default'],
+  reporters:
+    process.env.GITHUB_ACTIONS === 'true'
+      ? ['default', 'github-actions']
+      : ['default'],
   clearMocks: false,
   resetMocks: false,
   restoreMocks: false,

--- a/packages/core/src/core/context.ts
+++ b/packages/core/src/core/context.ts
@@ -2,6 +2,7 @@ import { SnapshotManager } from '@vitest/snapshot/manager';
 import { isCI } from 'std-env';
 import { withDefaultConfig } from '../config';
 import { DefaultReporter } from '../reporter';
+import { GithubActionsReporter } from '../reporter/githubActions';
 import { VerboseReporter } from '../reporter/verbose';
 import type { RstestCommand, RstestConfig, RstestContext } from '../types';
 import { castArray, getAbsolutePath } from '../utils/helper';
@@ -9,6 +10,7 @@ import { castArray, getAbsolutePath } from '../utils/helper';
 const reportersMap = {
   default: DefaultReporter as typeof DefaultReporter,
   verbose: VerboseReporter as typeof VerboseReporter,
+  'github-actions': GithubActionsReporter as typeof GithubActionsReporter,
 };
 
 export type BuiltInReporterNames = keyof typeof reportersMap;

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -6,12 +6,7 @@ import type {
   TestFileResult,
   TestResult,
 } from '../types';
-import {
-  getTaskNameWithPrefix,
-  logger,
-  prettyTestPath,
-  TEST_DELIMITER,
-} from '../utils';
+import { getTaskNameWithPrefix, logger, TEST_DELIMITER } from '../utils';
 
 export class GithubActionsReporter {
   private onWritePath: (path: string) => string;
@@ -54,7 +49,7 @@ export class GithubActionsReporter {
       const { testPath } = test;
       const nameStr = getTaskNameWithPrefix(test);
       const shortPath = relative(this.rootPath, testPath);
-      const title = `${prettyTestPath(shortPath)} ${TEST_DELIMITER} ${nameStr}`;
+      const title = `${shortPath} ${TEST_DELIMITER} ${nameStr}`;
 
       for (const error of test.errors || []) {
         let file = testPath;

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -8,6 +8,14 @@ import type {
 import { getTaskNameWithPrefix, logger } from '../utils';
 
 export class GithubActionsReporter {
+  private onWritePath: (path: string) => string;
+
+  constructor({
+    options,
+  }: { options: { onWritePath: (path: string) => string } }) {
+    this.onWritePath = options.onWritePath;
+  }
+
   async onTestRunEnd({
     results,
     testResults,
@@ -55,7 +63,7 @@ export class GithubActionsReporter {
         }
 
         logger.log(
-          `::${type} file=${file},line=${line},col=${column},title=${escapeData(title)}::${escapeData(message)}`,
+          `::${type} file=${this.onWritePath?.(file) || file},line=${line},col=${column},title=${escapeData(title)}::${escapeData(message)}`,
         );
       }
     }

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -1,0 +1,72 @@
+import type {
+  Duration,
+  GetSourcemap,
+  SnapshotSummary,
+  TestFileResult,
+  TestResult,
+} from '../types';
+import { getTaskNameWithPrefix, logger } from '../utils';
+
+export class GithubActionsReporter {
+  async onTestRunEnd({
+    results,
+    testResults,
+    getSourcemap,
+  }: {
+    results: TestFileResult[];
+    testResults: TestResult[];
+    duration: Duration;
+    snapshotSummary: SnapshotSummary;
+    getSourcemap: GetSourcemap;
+  }): Promise<void> {
+    const failedTests: TestResult[] = [
+      ...results.filter((i) => i.status === 'fail' && i.errors?.length),
+      ...testResults.filter((i) => i.status === 'fail'),
+    ];
+
+    if (failedTests.length === 0) {
+      return;
+    }
+
+    const { parseErrorStacktrace } = await import('../utils/error');
+
+    for (const test of failedTests) {
+      const nameStr = getTaskNameWithPrefix(test);
+      const title = nameStr.length ? nameStr : test.name;
+
+      for (const error of test.errors || []) {
+        let file = test.testPath;
+        let line = 1;
+        let column = 1;
+        const message = `${error.message}${error.diff ? `\n${error.diff}` : ''}`;
+        const type = 'error';
+
+        if (error.stack) {
+          const stackFrames = await parseErrorStacktrace({
+            stack: error.stack,
+            fullStack: error.fullStack,
+            getSourcemap,
+          });
+          if (stackFrames[0]) {
+            file = stackFrames[0].file || test.testPath;
+            line = stackFrames[0].lineNumber || 1;
+            column = stackFrames[0].column || 1;
+          }
+        }
+
+        logger.log(
+          `::${type} file=${file},line=${line},col=${column},title=${escapeData(title)}::${escapeData(message)}`,
+        );
+      }
+    }
+  }
+}
+
+function escapeData(s: string): string {
+  return s
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
+    .replace(/:/g, '%3A')
+    .replace(/,/g, '%2C');
+}

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -106,7 +106,7 @@ const stackIgnores: (RegExp | string)[] = [
   '<anonymous>',
 ];
 
-async function parseErrorStacktrace({
+export async function parseErrorStacktrace({
   stack,
   getSourcemap,
   fullStack,

--- a/tests/reporter/fixtures/githubActions.test.ts
+++ b/tests/reporter/fixtures/githubActions.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from '@rstest/core';
+
+it('should add two numbers correctly', () => {
+  expect(1 + 1).toBe(4);
+});
+
+it('test snapshot', () => {
+  expect('hello').toMatchInlineSnapshot(`"hello world"`);
+});

--- a/tests/reporter/githubActions.test.ts
+++ b/tests/reporter/githubActions.test.ts
@@ -1,6 +1,9 @@
 import { expect, it } from '@rstest/core';
 
-// TODO: debug
 it('should add two numbers correctly', () => {
   expect(1 + 1).toBe(4);
+});
+
+it('test snapshot', () => {
+  expect('hello').toMatchInlineSnapshot('hello world');
 });

--- a/tests/reporter/githubActions.test.ts
+++ b/tests/reporter/githubActions.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+// TODO: debug
+it('should add two numbers correctly', () => {
+  expect(1 + 1).toBe(3);
+});

--- a/tests/reporter/githubActions.test.ts
+++ b/tests/reporter/githubActions.test.ts
@@ -5,5 +5,5 @@ it('should add two numbers correctly', () => {
 });
 
 it('test snapshot', () => {
-  expect('hello').toMatchInlineSnapshot('hello world');
+  expect('hello').toMatchInlineSnapshot(`"hello world"`);
 });

--- a/tests/reporter/githubActions.test.ts
+++ b/tests/reporter/githubActions.test.ts
@@ -2,5 +2,5 @@ import { expect, it } from '@rstest/core';
 
 // TODO: debug
 it('should add two numbers correctly', () => {
-  expect(1 + 1).toBe(3);
+  expect(1 + 1).toBe(4);
 });

--- a/tests/reporter/githubActions.test.ts
+++ b/tests/reporter/githubActions.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from '@rstest/core';
 import { runRstestCli } from '../scripts';
 
-it('default', async () => {
+it('github-actions', async () => {
   const { cli } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'githubActions', '--reporter', 'github-actions'],

--- a/tests/reporter/githubActions.test.ts
+++ b/tests/reporter/githubActions.test.ts
@@ -1,9 +1,29 @@
 import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
 
-it('should add two numbers correctly', () => {
-  expect(1 + 1).toBe(4);
-});
+it('default', async () => {
+  const { cli } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'githubActions', '--reporter', 'github-actions'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
 
-it('test snapshot', () => {
-  expect('hello').toMatchInlineSnapshot(`"hello world"`);
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(1);
+
+  const logs = cli.stdout
+    .split('\n')
+    .filter(Boolean)
+    .filter((log) => log.startsWith('::error'));
+
+  expect(logs).toMatchInlineSnapshot(`
+    [
+      "::error file=<ROOT>/tests/reporter/fixtures/githubActions.test.ts,line=4,col=17,title=fixtures/githubActions.test.ts > should add two numbers correctly::expected 2 to be 4 // Object.is equality%0A- Expected%0A+ Received%0A%0A- 4%0A+ 2",
+      "::error file=<ROOT>/tests/reporter/fixtures/githubActions.test.ts,line=8,col=19,title=fixtures/githubActions.test.ts > test snapshot::Snapshot \`test snapshot 1\` mismatched%0A- Expected%0A+ Received%0A%0A- "hello world"%0A+ "hello"",
+    ]
+  `);
 });

--- a/tests/reporter/index.test.ts
+++ b/tests/reporter/index.test.ts
@@ -10,7 +10,7 @@ describe.concurrent('reporters', () => {
   it('default', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',
-      args: ['run'],
+      args: ['run', 'index'],
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -25,7 +25,7 @@ describe.concurrent('reporters', () => {
   it('verbose', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',
-      args: ['run', '--reporter=verbose'],
+      args: ['run', 'index', '--reporter=verbose'],
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -40,7 +40,7 @@ describe.concurrent('reporters', () => {
   it('custom', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',
-      args: ['run', '-c', './rstest.customReporterConfig.ts'],
+      args: ['run', 'index', '-c', './rstest.customReporterConfig.ts'],
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -59,7 +59,7 @@ describe.concurrent('reporters', () => {
   it('empty', async () => {
     const { cli } = await runRstestCli({
       command: 'rstest',
-      args: ['run', '-c', './rstest.emptyReporterConfig.ts'],
+      args: ['run', 'index', '-c', './rstest.emptyReporterConfig.ts'],
       options: {
         nodeOptions: {
           cwd: __dirname,

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
       react: 'commonjs react',
     },
   },
-  reporters: ['default', 'github-actions'],
   exclude: [
     '**/node_modules/**',
     '**/dist/**',

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -9,7 +9,25 @@ export default defineConfig({
       react: 'commonjs react',
     },
   },
-  reporters: ['default', 'github-actions'],
+  reporters: [
+    'default',
+    [
+      'github-actions',
+      {
+        onWritePath(path: string) {
+          if (process.env.GITHUB_WORKSPACE) {
+            const githubPath = path.replace(
+              new RegExp(`^${__dirname}\/`),
+              `${process.env.GITHUB_WORKSPACE}/tests/`,
+            );
+            console.log('onWritePath', githubPath);
+            return githubPath;
+          }
+          return path;
+        },
+      },
+    ],
+  ],
   exclude: [
     '**/node_modules/**',
     '**/dist/**',

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       react: 'commonjs react',
     },
   },
+  reporters: ['default', 'github-actions'],
   exclude: [
     '**/node_modules/**',
     '**/dist/**',

--- a/tests/rstest.config.ts
+++ b/tests/rstest.config.ts
@@ -9,25 +9,7 @@ export default defineConfig({
       react: 'commonjs react',
     },
   },
-  reporters: [
-    'default',
-    [
-      'github-actions',
-      {
-        onWritePath(path: string) {
-          if (process.env.GITHUB_WORKSPACE) {
-            const githubPath = path.replace(
-              new RegExp(`^${__dirname}\/`),
-              `${process.env.GITHUB_WORKSPACE}/tests/`,
-            );
-            console.log('onWritePath', githubPath);
-            return githubPath;
-          }
-          return path;
-        },
-      },
-    ],
-  ],
+  reporters: ['default', 'github-actions'],
   exclude: [
     '**/node_modules/**',
     '**/dist/**',

--- a/website/docs/en/config/test/reporters.mdx
+++ b/website/docs/en/config/test/reporters.mdx
@@ -75,11 +75,11 @@ With verbose reporter, Rstest outputs:
    Duration 112ms (build 19ms, tests 93ms)
 ```
 
-### Github Actions reporter
+### Github actions reporter
 
 The Github Actions reporter outputs error messages in the form of [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) when tests fail.
 
-#### Output Example
+#### Output example
 
 When tests fail, the Github Actions reporter outputs information in a format similar to:
 
@@ -95,7 +95,7 @@ These outputs are parsed by GitHub Actions and generate comments at the correspo
 
 When no reporter is manually set, Rstest automatically enables this reporter when it detects a GitHub Actions environment (`process.env.GITHUB_ACTIONS` is `'true'`).
 
-#### Manual Enablement
+#### Manual enablement
 
 You can also manually enable this reporter:
 

--- a/website/docs/en/config/test/reporters.mdx
+++ b/website/docs/en/config/test/reporters.mdx
@@ -12,7 +12,14 @@ type Reporter = ReporterName | [ReporterName, ReporterOptions];
 type Reporters = Reporter | Reporter[];
 ```
 
-- **Default:** `'default'`
+- **Default:**
+
+```ts
+process.env.GITHUB_ACTIONS === 'true'
+  ? ['default', 'github-actions']
+  : ['default'];
+```
+
 - **CLI:** `--reporter=<name> --reporter=<name1>`
 
 Customize the reporter type. If no reporter is specified, Rstest will use the built-in default reporter.
@@ -67,3 +74,44 @@ With verbose reporter, Rstest outputs:
       Tests 2 passed
    Duration 112ms (build 19ms, tests 93ms)
 ```
+
+### Github Actions reporter
+
+The Github Actions reporter outputs error messages in the form of [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) when tests fail.
+
+#### Output Example
+
+When tests fail, the Github Actions reporter outputs information in a format similar to:
+
+```bash
+::error file=src/index.ts,line=4,col=17,title=test/index.test.ts > should add two numbers correctly::expected 2 to be 4
+```
+
+These outputs are parsed by GitHub Actions and generate comments at the corresponding locations.
+
+![rstest-github-actions-example](https://assets.rspack.rs/rstest/assets/rstest-github-actions-example.jpg)
+
+#### Auto-enablement
+
+When no reporter is manually set, Rstest automatically enables this reporter when it detects a GitHub Actions environment (`process.env.GITHUB_ACTIONS` is `'true'`).
+
+#### Manual Enablement
+
+You can also manually enable this reporter:
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+```bash
+npx rstest --reporter=github-actions
+```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: ['github-actions']
+});
+```
+  </Tab>
+</Tabs>

--- a/website/docs/zh/config/test/reporters.mdx
+++ b/website/docs/zh/config/test/reporters.mdx
@@ -12,7 +12,14 @@ type Reporter = ReporterName | [ReporterName, ReporterOptions];
 type Reporters = Reporter | Reporter[];
 ```
 
-- **默认值：** `'default'`
+- **默认值：**
+
+```ts
+process.env.GITHUB_ACTIONS === 'true'
+  ? ['default', 'github-actions']
+  : ['default'];
+```
+
 - **CLI：** `--reporter=<name> --reporter=<name1>`
 
 自定义输出报告器的类型。如果没有指定报告器，Rstest 会使用内置的默认报告器。
@@ -67,3 +74,44 @@ export default defineConfig({
       Tests 2 passed
    Duration 112ms (build 19ms, tests 93ms)
 ```
+
+### Github Actions 报告器
+
+Github Actions 报告器将在测试失败时以 [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) 的形式输出错误信息。
+
+#### 输出示例
+
+当测试失败时，Github Actions 报告器会输出类似以下格式的信息：
+
+```bash
+::error file=src/index.ts,line=4,col=17,title=test/index.test.ts > should add two numbers correctly::expected 2 to be 4
+```
+
+这些输出会被 GitHub Actions 解析，并在对应的位置生成注释。
+
+![rstest-github-actions-example](https://assets.rspack.rs/rstest/assets/rstest-github-actions-example.jpg)
+
+#### 自动启用
+
+当未手动设置任何 reporter 时，Rstest 会在检测到 GitHub Actions 环境(`process.env.GITHUB_ACTIONS` 为 `'true'`)时自动启用此报告器。
+
+#### 手动启用
+
+你也可以手动启用此报告器：
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --reporter=github-actions
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: ['github-actions']
+});
+```
+  </Tab>
+</Tabs>

--- a/website/docs/zh/config/test/reporters.mdx
+++ b/website/docs/zh/config/test/reporters.mdx
@@ -24,9 +24,9 @@ process.env.GITHUB_ACTIONS === 'true'
 
 自定义输出报告器的类型。如果没有指定报告器，Rstest 会使用内置的默认报告器。
 
-## 内置报告器
+## Built-in Reporters
 
-### 默认报告器
+### Default reporter
 
 默认情况下，Rstest 会在终端显示测试运行状态、结果以及汇总信息。
 
@@ -40,7 +40,7 @@ process.env.GITHUB_ACTIONS === 'true'
    Duration 112ms (build 19ms, tests 93ms)
 ```
 
-### Verbose 报告器
+### Verbose reporter
 
 默认报告器仅在测试运行失败或耗时缓慢时输出相关的测试用例信息，Verbose 报告器会在测试完成后输出所有的测试用例信息。
 
@@ -75,7 +75,7 @@ export default defineConfig({
    Duration 112ms (build 19ms, tests 93ms)
 ```
 
-### Github Actions 报告器
+### Github actions reporter
 
 Github Actions 报告器将在测试失败时以 [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) 的形式输出错误信息。
 


### PR DESCRIPTION
## Summary

Github Actions Reporter will output [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message) to provide annotations for test failures.

<img width="1676" height="600" alt="image" src="https://github.com/user-attachments/assets/d1eb65d8-397e-44c1-9f3a-ac03adb1aeaf" />


When no reporter is manually set, Rstest automatically enables this reporter when it detects a GitHub Actions environment (`process.env.GITHUB_ACTIONS` is `'true'`).

You can also manually enable this reporter:

via `CLI`:
```bash
npx rstest --reporter=github-actions
```

via `rstest.config.ts`:
```ts
import { defineConfig } from '@rstest/core';

export default defineConfig({
  reporters: ['github-actions']
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
