### PR TITLE
fix: shim `require` in rstest bundle

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -59,6 +59,11 @@ export default defineConfig({
           },
         },
       },
+      shims: {
+        esm: {
+          require: true,
+        },
+      },
       source: {
         entry: {
           public: './src/public.ts',

--- a/packages/core/src/runtime/api/poll.ts
+++ b/packages/core/src/runtime/api/poll.ts
@@ -1,4 +1,3 @@
-import { setTimeout } from 'node:timers';
 /**
  * This method is modified based on source found in
  * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/integrations/chai/poll.ts
@@ -7,6 +6,7 @@ import { setTimeout } from 'node:timers';
 import type { Assertion } from '@vitest/expect';
 import * as chai from 'chai';
 import type { RstestExpect, TestCase } from '../../types';
+import { getRealTimers } from '../util';
 
 // these matchers are not supported because they don't make sense with poll
 const unsupported = [
@@ -86,11 +86,11 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
                 } catch (err) {
                   lastError = err;
                   if (!chai.util.flag(assertion, '_isLastPollAttempt')) {
-                    intervalId = setTimeout(check, interval);
+                    intervalId = getRealTimers().setTimeout!(check, interval);
                   }
                 }
               };
-              timeoutId = setTimeout(() => {
+              timeoutId = getRealTimers().setTimeout!(() => {
                 clearTimeout(intervalId);
                 chai.util.flag(assertion, '_isLastPollAttempt', true);
                 const rejectWithCause = (cause: any) => {

--- a/packages/core/src/runtime/api/poll.ts
+++ b/packages/core/src/runtime/api/poll.ts
@@ -16,7 +16,6 @@
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
  */
-import { setTimeout } from 'node:timers';
 import type { Assertion } from '@vitest/expect';
 import * as chai from 'chai';
 import type { RstestExpect, TestCase } from '../../types';

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -1,4 +1,3 @@
-import { setTimeout } from 'node:timers';
 import type {
   Test,
   TestCase,
@@ -9,6 +8,7 @@ import type {
   TestSuiteListeners,
 } from '../../types';
 import { getTaskNameWithPrefix, ROOT_SUITE_NAME } from '../../utils';
+import { getRealTimers } from '../util';
 
 export const getTestStatus = (
   results: TestResult[],
@@ -213,7 +213,7 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
   return (async (...args: Parameters<T>) => {
     let timeoutId: NodeJS.Timeout | undefined;
     const timeoutPromise = new Promise((_, reject) => {
-      timeoutId = setTimeout(
+      timeoutId = getRealTimers().setTimeout!(
         () =>
           reject(
             makeError(`${name} timed out in ${timeout}ms`, stackTraceError),

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -2,6 +2,19 @@ import { format } from 'node:util';
 import { diff } from 'jest-diff';
 import type { FormattedError } from '../types';
 
+const REAL_TIMERS: {
+  setTimeout?: typeof globalThis.setTimeout;
+} = {};
+
+// store the original timers
+export const setRealTimers = (): void => {
+  REAL_TIMERS.setTimeout ??= globalThis.setTimeout;
+};
+
+export const getRealTimers = (): typeof REAL_TIMERS => {
+  return REAL_TIMERS;
+};
+
 export const formatTestError = (err: any): FormattedError[] => {
   const errors = Array.isArray(err) ? err : [err];
 

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -7,10 +7,9 @@ import type {
   WorkerState,
 } from '../../types';
 import './setup';
-import { setTimeout } from 'node:timers';
 import { globalApis } from '../../utils/constants';
 import { color, undoSerializableConfig } from '../../utils/helper';
-import { formatTestError } from '../util';
+import { formatTestError, getRealTimers, setRealTimers } from '../util';
 import { loadModule } from './loadModule';
 import { createForksRpcOptions, createRuntimeRpc } from './rpc';
 import { RstestSnapshotEnvironment } from './snapshot';
@@ -33,6 +32,7 @@ const preparePool = async ({
   updateSnapshot,
   context,
 }: RunWorkerOptions['options']) => {
+  setRealTimers();
   context.runtimeConfig = undoSerializableConfig(context.runtimeConfig);
 
   const cleanupFns: (() => MaybePromise<void>)[] = [];
@@ -246,7 +246,7 @@ const runInPool = async (
   process.off('SIGTERM', onExit);
 
   const teardown = async () => {
-    await new Promise((resolve) => setTimeout(resolve));
+    await new Promise((resolve) => getRealTimers().setTimeout!(resolve));
 
     await Promise.all(cleanups.map((fn) => fn()));
     isTeardown = true;

--- a/tests/fakeTimers/index.test.ts
+++ b/tests/fakeTimers/index.test.ts
@@ -79,4 +79,17 @@ describe('fake timers', () => {
     rstest.runAllTimers();
     expect(rstest.getTimerCount()).toBe(0);
   });
+
+  it('should work with node:timers', () => {
+    const { setTimeout } = require('node:timers');
+    const cb = rstest.fn();
+    const cb1 = rstest.fn();
+    setTimeout(cb, 100);
+    setTimeout(cb1, 200);
+
+    expect(rstest.getTimerCount()).toBe(2);
+
+    rstest.runAllTimers();
+    expect(rstest.getTimerCount()).toBe(0);
+  });
 });

--- a/tests/fakeTimers/index.test.ts
+++ b/tests/fakeTimers/index.test.ts
@@ -80,7 +80,7 @@ describe('fake timers', () => {
     expect(rstest.getTimerCount()).toBe(0);
   });
 
-  it('should work with node:timers', () => {
+  it('should work with node:timers', async () => {
     const { setTimeout } = require('node:timers');
     const cb = rstest.fn();
     const cb1 = rstest.fn();
@@ -91,5 +91,14 @@ describe('fake timers', () => {
 
     rstest.runAllTimers();
     expect(rstest.getTimerCount()).toBe(0);
+
+    let i = 0;
+
+    await expect
+      .poll(() => {
+        i++;
+        return i;
+      })
+      .toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

shim `require` in rstest bundle. fix `require is not defined` error when fake timers.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
