### PR TITLE
chore(workflow): enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     name: Release
     if: github.repository == 'web-infra-dev/rstest' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    environment: production
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Install pnpm
+      - name: Setup Pnpm
         run: |
           npm install -g corepack@latest --force
           corepack enable
@@ -47,12 +47,15 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      # Update npm to the latest version to enable OIDC
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install Dependencies
         run: pnpm install
 
       - name: Publish to npm
-        env:
-          NPM_TOKEN: ${{ secrets.RSTEST_NPM_TOKEN }}
         run: |
-          npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
           pnpm -r publish --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,7 +104,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Summary

Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

## Related Links

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
