### PR TITLE
fix: use `inline-source-map` when debugger

### DIFF
--- a/packages/core/src/core/plugins/inspect.ts
+++ b/packages/core/src/core/plugins/inspect.ts
@@ -1,0 +1,22 @@
+import inspector from 'node:inspector';
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+const enable = inspector.url() !== undefined;
+
+export const pluginInspect: () => RsbuildPlugin | null = () =>
+  enable
+    ? {
+        name: 'rstest:inspect',
+        setup: (api) => {
+          api.modifyRspackConfig(async (config) => {
+            config.devtool = 'inline-source-map';
+            config.optimization ??= {};
+            config.optimization.splitChunks = {
+              ...(config.optimization.splitChunks || {}),
+              maxSize: 1024 * 1024,
+              chunks: 'all',
+            };
+          });
+        },
+      }
+    : null;

--- a/packages/core/src/core/plugins/inspect.ts
+++ b/packages/core/src/core/plugins/inspect.ts
@@ -9,11 +9,13 @@ export const pluginInspect: () => RsbuildPlugin | null = () =>
         name: 'rstest:inspect',
         setup: (api) => {
           api.modifyRspackConfig(async (config) => {
+            // use inline source map or write to disk
             config.devtool = 'inline-source-map';
             config.optimization ??= {};
             config.optimization.splitChunks = {
               ...(config.optimization.splitChunks || {}),
-              maxSize: 1024 * 1024,
+              // Limit the size of each chunk to speed up the source map loading in inspector
+              maxSize: 1024 * 1024, // 1MB
               chunks: 'all',
             };
           });


### PR DESCRIPTION
## Summary

 use `inline-source-map` when debugger.

## Related Links
fix https://github.com/web-infra-dev/rstest/issues/409
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
