### PR TITLE
docs: add note for `describe.skip`

### DIFF
--- a/website/docs/en/api/test-api/describe.mdx
+++ b/website/docs/en/api/test-api/describe.mdx
@@ -40,8 +40,20 @@ describe.only('only this suite', () => {
 Skip the describe block(s) marked with `skip`.
 
 ```ts
-describe.skip('skip this suite', () => {
+describe.skip('Skip the test cases in this suite', () => {
   // ...
+});
+```
+
+It should be noted that the skip tag is only used to skip test cases, and the code inside the describe block will still be executed. This is because Rstest needs to collect information about test cases to ensure that all features work properly, even if they are marked as skipped. For example, in snapshot test, determine whether a snapshot is outdated or marked as skipped.
+
+```ts
+describe.skip('a', () => {
+  console.log('will run');
+  test('b', () => {
+    console.log('will not run');
+    expect(0).toBe(0);
+  });
 });
 ```
 

--- a/website/docs/en/api/test-api/describe.mdx
+++ b/website/docs/en/api/test-api/describe.mdx
@@ -45,7 +45,7 @@ describe.skip('Skip the test cases in this suite', () => {
 });
 ```
 
-It should be noted that the skip tag is only used to skip test cases, and the code inside the describe block will still be executed. This is because Rstest needs to collect information about test cases to ensure that all features work properly, even if they are marked as skipped. For example, in snapshot test, determine whether a snapshot is outdated or marked as skipped.
+It should be noted that the `skip` tag is only used to skip test cases, and the code inside the describe block will still be executed. This is because Rstest needs to collect information about test cases to ensure that all features work properly, even if they are marked as skipped. For example, in snapshot test, determine whether a snapshot is outdated or marked as skipped.
 
 ```ts
 describe.skip('a', () => {

--- a/website/docs/en/api/test-api/describe.mdx
+++ b/website/docs/en/api/test-api/describe.mdx
@@ -45,7 +45,7 @@ describe.skip('Skip the test cases in this suite', () => {
 });
 ```
 
-It should be noted that the `skip` tag is only used to skip test cases, and the code inside the describe block will still be executed. This is because Rstest needs to collect information about test cases to ensure that all features work properly, even if they are marked as skipped. For example, in snapshot test, determine whether a snapshot is outdated or marked as skipped.
+It should be noted that the skip tag is only used to skip test cases, and the code inside the describe block will still be executed. This is because Rstest needs to collect information about test cases to ensure that all features work properly, even if they are marked as skipped. For example, in snapshot tests, it determines whether a snapshot is outdated or marked as skipped.
 
 ```ts
 describe.skip('a', () => {

--- a/website/docs/zh/api/test-api/describe.mdx
+++ b/website/docs/zh/api/test-api/describe.mdx
@@ -37,11 +37,23 @@ describe.only('只运行这个套件', () => {
 
 ## describe.skip
 
-跳过被 skip 标记的 describe 块。
+跳过被 skip 标记的 describe 块里的测试用例。
 
 ```ts
-describe.skip('跳过这个套件', () => {
+describe.skip('跳过这个套件里的测试用例', () => {
   // ...
+});
+```
+
+需要注意的是，skip 标记仅用于跳过测试用例，describe 块内的代码仍会执行。这是因为 Rstest 需要收集测试用例的信息，以确保所有功能正常运行，即使它们被标记为跳过。例如，在快照测试中判断快照是过时还是被标记为 skipped。
+
+```ts
+describe.skip('a', () => {
+  console.log('will run');
+  test('b', () => {
+    console.log('will not run');
+    expect(0).toBe(0);
+  });
 });
 ```
 


### PR DESCRIPTION
## Summary

The `skip` tag is only used to skip test cases, and the code inside the describe block will still be executed.


```ts
describe.skip('a', () => {
  console.log('will run');
  test('b', () => {
    console.log('will not run');
    expect(0).toBe(0);
  });
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
