### PR TITLE
refactor!: enable run mode by default when run `rstest` command

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -4,8 +4,8 @@
   "type": "commonjs",
   "scripts": {
     "build": "rsbuild build",
-    "test": "rstest run",
-    "test:watch": "rstest"
+    "test": "rstest",
+    "test:watch": "rstest --watch"
   },
   "devDependencies": {
     "@rstest/core": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -5,8 +5,8 @@
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",
     "preview": "rsbuild preview",
-    "test": "rstest run",
-    "test:watch": "rstest"
+    "test": "rstest",
+    "test:watch": "rstest --watch"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "typecheck": "cross-env NX_DAEMON=false nx run-many -t typecheck --exclude @examples/* --parallel=10",
     "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* @rstest/tests-* --parallel=10",
     "e2e": "cd tests && pnpm test",
-    "test": "rstest run",
+    "test": "rstest",
     "test:example": "pnpm --filter @examples/* test",
     "change": "changeset",
     "changeset": "changeset",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "build": "rslib build && npx prettier ./LICENSE.md --write",
     "typecheck": "tsc --noEmit",
     "dev": "rslib build --watch",
-    "test": "npx rstest run --globals"
+    "test": "npx rstest --globals"
   },
   "dependencies": {
     "chai": "^5.2.1",

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,7 +1,6 @@
 import type { LoadConfigOptions } from '@rsbuild/core';
 import cac, { type CAC } from 'cac';
 import { normalize } from 'pathe';
-import { isCI } from 'std-env';
 import { loadConfig } from '../config';
 import type {
   ListCommandOptions,
@@ -176,14 +175,22 @@ export function setupCommands(): void {
 
   cli
     .command('[...filters]', 'run tests')
-    .action(async (filters: string[], options: CommonOptions) => {
-      showRstest();
-      if (isCI) {
-        await runRest(options, filters, 'run');
-      } else {
-        await runRest(options, filters, 'watch');
-      }
-    });
+    .option('--watch', 'Run tests in watch mode')
+    .action(
+      async (
+        filters: string[],
+        options: CommonOptions & {
+          watch?: boolean;
+        },
+      ) => {
+        showRstest();
+        if (options.watch) {
+          await runRest(options, filters, 'watch');
+        } else {
+          await runRest(options, filters, 'run');
+        }
+      },
+    );
 
   const runRest = async (
     options: CommonOptions,

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -23,6 +23,7 @@ Commands:
   list [...filters]   lists all test files that Rstest will run
 
 Options:
+  --watch                                  Run tests in watch mode
   -h, --help                               Display this message
   -v, --version                            Display version number
   -c, --config <config>
@@ -31,7 +32,7 @@ Options:
 
 ## rstest [...filters]
 
-Running `rstest` directly will enable the Rstest test in the current directory. Listening mode is automatically entered in the development environment (equivalent to `rstest watch`), while a single test is performed in the CI environment or non-terminal interactive mode (equivalent to `rstest run`).
+Running `rstest` directly will enable the Rstest test in the current directory.
 
 ```bash
 $ npx rstest
@@ -41,6 +42,14 @@ $ npx rstest
   Test Files 1 passed (1)
        Tests 2 passed (2)
     Duration 189 ms (build 22 ms, tests 167 ms)
+```
+
+### Watch mode
+
+If you want to automatically rerun the test when the file changes, you can use the `--watch` flag or `rstest watch` command:
+
+```bash
+$ npx rstest --watch
 ```
 
 ## rstest run

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -23,6 +23,7 @@ Commands:
   list [...filters]   lists all test files that Rstest will run
 
 Options:
+  --watch                                  Run tests in watch mode
   -h, --help                               Display this message
   -v, --version                            Display version number
   -c, --config <config>
@@ -31,7 +32,7 @@ Options:
 
 ## rstest [...filters]
 
-直接运行 `rstest` 命令将会在当前目录执行 Rstest 测试。在开发环境下会自动进入监听模式 (等同于 `rstest watch`)，而在 CI 环境或非终端交互模式下会执行单次测试 (等同于 `rstest run`)。
+直接运行 `rstest` 命令将会在当前目录执行 Rstest 测试。
 
 ```bash
 $ npx rstest
@@ -41,6 +42,14 @@ $ npx rstest
   Test Files 1 passed (1)
        Tests 2 passed (2)
     Duration 189 ms (build 22 ms, tests 167 ms)
+```
+
+### Watch 模式
+
+如果你希望在文件更改时自动重新运行测试，可以使用 `--watch` 或 `rstest watch` 命令：
+
+```bash
+$ npx rstest --watch
 ```
 
 ## rstest run


### PR DESCRIPTION
## Summary

Enable `run mode` by default when run `rstest` command, rather than `watch mode`. This is more in line with the development habits and testing framework usage of most people.

If you want to automatically rerun the test when the file changes, you can use the `--watch` flag or `rstest watch` command:

```diff
- npx rstest
+ npx rstest --watch
```

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
