### PR TITLE
feat: init cli shortcut

### DIFF
--- a/packages/core/src/core/cliShortcuts.ts
+++ b/packages/core/src/core/cliShortcuts.ts
@@ -1,0 +1,75 @@
+import { color, isTTY, logger } from '../utils';
+
+export const isCliShortcutsEnabled = (): boolean => isTTY('stdin');
+
+export type CliShortcut = {
+  /**
+   * The key to trigger the shortcut.
+   */
+  key: string;
+  /**
+   * The description of the shortcut.
+   */
+  description: string;
+  /**
+   * The action to execute when the shortcut is triggered.
+   */
+  action: () => void | Promise<void>;
+};
+
+export async function setupCliShortcuts({
+  closeServer,
+}: {
+  closeServer: () => Promise<void>;
+}): Promise<() => void> {
+  const shortcuts = [
+    {
+      key: 'c',
+      description: `${color.bold('c + enter')}  ${color.dim('clear console')}`,
+      action: () => {
+        console.clear();
+      },
+    },
+    {
+      key: 'q',
+      description: `${color.bold('q + enter')}  ${color.dim('quit process')}`,
+      action: async () => {
+        try {
+          await closeServer();
+        } finally {
+          process.exit(0);
+        }
+      },
+    },
+  ];
+
+  logger.log(
+    `  ${color.dim('press')} ${color.bold('h')} ${color.dim('to show help')}${color.dim(', press')} ${color.bold('q')} ${color.dim('to quit')}\n`,
+  );
+
+  const { createInterface } = await import('node:readline');
+  const rl = createInterface({
+    input: process.stdin,
+  });
+
+  rl.on('line', (input) => {
+    if (input === 'h') {
+      let message = `\n  ${color.bold(color.blue('Shortcuts:'))}\n`;
+      for (const shortcut of shortcuts) {
+        message += `  ${shortcut.description}\n`;
+      }
+      logger.log(message);
+    }
+
+    for (const shortcut of shortcuts) {
+      if (input === shortcut.key) {
+        shortcut.action();
+        return;
+      }
+    }
+  });
+
+  return () => {
+    rl.close();
+  };
+}

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -1,6 +1,7 @@
 import { createPool } from '../pool';
 import type { RstestContext } from '../types';
 import { color, getSetupFiles, getTestEntries, logger } from '../utils';
+import { setupCliShortcuts } from './cliShortcuts';
 import { createRsbuildServer, prepareRsbuild } from './rsbuild';
 
 export async function runTests(
@@ -115,8 +116,14 @@ export async function runTests(
 
   if (command === 'watch') {
     rsbuildInstance.onDevCompileDone(async () => {
-      await run();
+      const close = await run();
+      // TODO: support clean logs before dev recompile
       logger.log(color.green('  Waiting for file changes...'));
+      await setupCliShortcuts({
+        closeServer: async () => {
+          await close();
+        },
+      });
     });
   } else {
     const close = await run();

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -230,3 +230,13 @@ export const NODE_BUILTINS: (string | RegExp)[] = [
 ];
 
 export { color };
+
+/**
+ * Check if running in a TTY context
+ */
+export const isTTY = (type: 'stdin' | 'stdout' = 'stdout'): boolean => {
+  return (
+    (type === 'stdin' ? process.stdin.isTTY : process.stdout.isTTY) &&
+    !process.env.CI
+  );
+};


### PR DESCRIPTION
## Summary

init cli shortcut, support `c` and `q` shortcuts in watch mode.

<img width="560" height="412" alt="image" src="https://github.com/user-attachments/assets/710a9091-2ced-4b58-937d-ab57e25c98a7" />



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
