### PR TITLE
feat: support rerun all tests via `a` CLI shortcut

### DIFF
--- a/packages/core/src/core/cliShortcuts.ts
+++ b/packages/core/src/core/cliShortcuts.ts
@@ -19,8 +19,10 @@ export type CliShortcut = {
 
 export async function setupCliShortcuts({
   closeServer,
+  runAll,
 }: {
   closeServer: () => Promise<void>;
+  runAll: () => Promise<void>;
 }): Promise<() => void> {
   const shortcuts = [
     {
@@ -28,6 +30,13 @@ export async function setupCliShortcuts({
       description: `${color.bold('c + enter')}  ${color.dim('clear console')}`,
       action: () => {
         console.clear();
+      },
+    },
+    {
+      key: 'a',
+      description: `${color.bold('a + enter')}  ${color.dim('rerun all tests')}`,
+      action: async () => {
+        await runAll();
       },
     },
     {
@@ -42,10 +51,6 @@ export async function setupCliShortcuts({
       },
     },
   ];
-
-  logger.log(
-    `  ${color.dim('press')} ${color.bold('h')} ${color.dim('to show help')}${color.dim(', press')} ${color.bold('q')} ${color.dim('to quit')}\n`,
-  );
 
   const { createInterface } = await import('node:readline');
   const rl = createInterface({

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -125,17 +125,17 @@ export const createRsbuildServer = async ({
   globTestSourceEntries: () => Promise<Record<string, string>>;
   setupFiles: Record<string, string>;
   rootPath: string;
-}): Promise<
-  () => Promise<{
+}): Promise<{
+  getRsbuildStats: () => Promise<{
     buildTime: number;
     entries: EntryInfo[];
     setupEntries: EntryInfo[];
     assetFiles: Record<string, string>;
     sourceMaps: Record<string, SourceMapInput>;
     getSourcemap: (sourcePath: string) => SourceMapInput | null;
-    close: () => Promise<void>;
-  }>
-> => {
+  }>;
+  closeServer: () => Promise<void>;
+}> => {
   // Read files from memory via `rspackCompiler.outputFileSystem`
   let rspackCompiler: Rspack.Compiler | Rspack.MultiCompiler | undefined;
 
@@ -298,9 +298,11 @@ export const createRsbuildServer = async ({
       getSourcemap: (sourcePath: string): SourceMapInput | null => {
         return sourceMaps[sourcePath] || null;
       },
-      close: devServer.close,
     };
   };
 
-  return getRsbuildStats;
+  return {
+    closeServer: devServer.close,
+    getRsbuildStats,
+  };
 };

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -111,6 +111,14 @@ export async function runTests(
   };
 
   if (command === 'watch') {
+    const afterTestsWatchRun = () => {
+      // TODO: support clean logs before dev recompile
+      logger.log(color.green('  Waiting for file changes...'));
+      // TODO: no need `enter`
+      logger.log(
+        `  ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show help')}${color.dim(', press')} ${color.bold('q + enter')} ${color.dim('to quit')}\n`,
+      );
+    };
     rsbuildInstance.onDevCompileDone(async ({ isFirstCompile }) => {
       await run();
 
@@ -119,15 +127,12 @@ export async function runTests(
           closeServer,
           runAll: async () => {
             await run();
+            afterTestsWatchRun();
           },
         });
       }
-      // TODO: support clean logs before dev recompile
-      logger.log(color.green('  Waiting for file changes...'));
-      // TODO: no need `enter`
-      logger.log(
-        `  ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show help')}${color.dim(', press')} ${color.bold('q + enter')} ${color.dim('to quit')}\n`,
-      );
+
+      afterTestsWatchRun();
     });
   } else {
     await run();


### PR DESCRIPTION
## Summary

 support rerun all tests via `a` CLI shortcut.

<img width="707" height="490" alt="image" src="https://github.com/user-attachments/assets/e8126a10-bcf7-4620-b3f1-d39dcd7383be" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
