### PR TITLE
feat: support rerun failed tests via `f` shortcut

### DIFF
--- a/packages/core/src/core/cliShortcuts.ts
+++ b/packages/core/src/core/cliShortcuts.ts
@@ -21,7 +21,9 @@ export async function setupCliShortcuts({
   closeServer,
   runAll,
   updateSnapshot,
+  runFailedTests,
 }: {
+  runFailedTests: () => Promise<void>;
   closeServer: () => Promise<void>;
   runAll: () => Promise<void>;
   updateSnapshot: () => Promise<void>;
@@ -32,6 +34,13 @@ export async function setupCliShortcuts({
       description: `${color.bold('c + enter')}  ${color.dim('clear console')}`,
       action: () => {
         console.clear();
+      },
+    },
+    {
+      key: 'f',
+      description: `${color.bold('f + enter')}  ${color.dim('rerun failed tests')}`,
+      action: async () => {
+        await runFailedTests();
       },
     },
     {

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -111,13 +111,13 @@ export async function runTests(
       updateSnapshot: snapshotManager.options.updateSnapshot,
     });
 
-    const currentBuildTime = buildHash === hash ? 0 : buildTime;
+    const actualBuildTime = buildHash === hash ? 0 : buildTime;
 
     const testTime = Date.now() - testStart;
 
     const duration = {
-      totalTime: testTime + currentBuildTime,
-      buildTime: currentBuildTime,
+      totalTime: testTime + actualBuildTime,
+      buildTime: actualBuildTime,
       testTime,
     };
 


### PR DESCRIPTION
## Summary

support rerun only failed tests via `f` shortcut.

<img width="957" height="951" alt="image" src="https://github.com/user-attachments/assets/10243432-be61-42eb-80c6-1994f732c3a7" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
