### PR TITLE
refactor!: remove `node` exports

### DIFF
--- a/packages/core/bin/rstest.js
+++ b/packages/core/bin/rstest.js
@@ -13,7 +13,7 @@ if (enableCompileCache) {
 }
 
 async function main() {
-  const { runCLI } = await import('../dist/cli.js');
+  const { runCLI } = await import('../dist/index.js');
   runCLI();
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
   ],
   "license": "MIT",
   "type": "module",
-  "main": "./dist/public.js",
-  "types": "./dist-types/public.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist-types/index.d.ts",
   "bin": {
     "rstest": "./bin/rstest.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,12 +25,8 @@
   },
   "exports": {
     ".": {
-      "types": "./dist-types/public.d.ts",
-      "default": "./dist/public.js"
-    },
-    "./node": {
-      "types": "./dist-types/node.d.ts",
-      "default": "./dist/node.js"
+      "types": "./dist-types/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./globals": {
       "types": "./globals.d.ts"

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -65,9 +65,7 @@ export default defineConfig({
       },
       source: {
         entry: {
-          public: './src/public.ts',
-          node: './src/node.ts',
-          cli: './src/cli/index.ts',
+          index: './src/index.ts',
           worker: './src/runtime/worker/index.ts',
         },
         define: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 import type { RstestConfig } from './types';
 
+export { runCLI } from './cli';
+
 export * from './runtime/api/public';
 
 export type { RstestConfig };
@@ -24,3 +26,11 @@ export function defineConfig(config: RstestConfigExport): RstestConfigExport;
 export function defineConfig(config: RstestConfigExport) {
   return config;
 }
+
+export type {
+  Reporter,
+  RstestCommand,
+  TestFileInfo,
+  TestFileResult,
+  TestResult,
+} from './types';

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1,8 +1,0 @@
-export type {
-  Reporter,
-  RstestCommand,
-  RstestConfig,
-  TestFileInfo,
-  TestFileResult,
-  TestResult,
-} from './types';

--- a/tests/reporter/rstest.customReporterConfig.ts
+++ b/tests/reporter/rstest.customReporterConfig.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from '@rstest/core';
 import type {
   Reporter,
   TestFileInfo,
   TestFileResult,
   TestResult,
-} from '@rstest/core/node';
+} from '@rstest/core';
+import { defineConfig } from '@rstest/core';
 
 export const reporterResult: string[] = [];
 


### PR DESCRIPTION
## Summary

Remove `node` exports, only exports all `types` and `exports`  from main entry.

Restructures the public API surface of the `@rstest/core` package to simplify imports and clarify module boundaries. The main entry point has been consolidated to `index.ts`, and types and exports have been unified to reduce confusion for consumers. 

```diff
import type {
  Reporter,
  TestFileInfo,
  TestFileResult,
  TestResult,
- } from '@rstest/core/node';
+ } from '@rstest/core';
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
