### PR TITLE
enhance: only rerun failed snapshot test files when update snapshots

### DIFF
--- a/packages/core/src/core/plugins/entry.ts
+++ b/packages/core/src/core/plugins/entry.ts
@@ -57,7 +57,10 @@ export const pluginEntryWatch: (params: {
           );
         }
 
-        config.watchOptions.ignored.push(TEMP_RSTEST_OUTPUT_DIR_GLOB);
+        config.watchOptions.ignored.push(
+          TEMP_RSTEST_OUTPUT_DIR_GLOB,
+          '**/*.snap',
+        );
       } else {
         // watch false seems not effect when rspack.watch()
         config.watch = false;

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -263,10 +263,7 @@ export async function runTests(context: RstestContext): Promise<void> {
               return;
             }
             const failedTests = testFileResult
-              .filter(
-                (result) =>
-                  result.status === 'fail' && result.snapshotResult?.unmatched,
-              )
+              .filter((result) => result.snapshotResult?.unmatched)
               .map((r) => r.testPath);
 
             clearLogs();

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -262,6 +262,12 @@ export async function runTests(context: RstestContext): Promise<void> {
               );
               return;
             }
+            const failedTests = testFileResult
+              .filter(
+                (result) =>
+                  result.status === 'fail' && result.snapshotResult?.unmatched,
+              )
+              .map((r) => r.testPath);
 
             clearLogs();
 
@@ -269,7 +275,7 @@ export async function runTests(context: RstestContext): Promise<void> {
               snapshotManager.options.updateSnapshot;
             snapshotManager.clear();
             snapshotManager.options.updateSnapshot = 'all';
-            await run();
+            await run({ fileFilters: failedTests });
             afterTestsWatchRun();
             snapshotManager.options.updateSnapshot = originalUpdateSnapshot;
           },


### PR DESCRIPTION
## Summary

only rerun failed snapshot test files when update snapshots.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
