### PR TITLE
feat(cli): add short option -w for watch mode

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -214,7 +214,7 @@ export function setupCommands(): void {
 
   cli
     .command('[...filters]', 'run tests')
-    .option('--watch', 'Run tests in watch mode')
+    .option('-w, --watch', 'Run tests in watch mode')
     .action(
       async (
         filters: string[],

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -23,7 +23,7 @@ Commands:
   list [...filters]   lists all test files that Rstest will run
 
 Options:
-  --watch                                  Run tests in watch mode
+  -w, --watch                              Run tests in watch mode
   -h, --help                               Display this message
   -v, --version                            Display version number
   -c, --config <config>

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -23,7 +23,7 @@ Commands:
   list [...filters]   lists all test files that Rstest will run
 
 Options:
-  --watch                                  Run tests in watch mode
+  -w, --watch                              Run tests in watch mode
   -h, --help                               Display this message
   -v, --version                            Display version number
   -c, --config <config>


### PR DESCRIPTION
## Summary

Update CLI command and documentation to support `-w` as shorthand for `--watch` flag.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
