### PR TITLE
feat: support `onTestFinished` hook

### DIFF
--- a/e2e/lifecycle/fixtures/onTestFinished.failed.test.ts
+++ b/e2e/lifecycle/fixtures/onTestFinished.failed.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, it, onTestFinished } from '@rstest/core';
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+
+    onTestFinished(() => {
+      throw new Error('onTestFinished failed');
+    });
+  });
+
+  afterEach(() => {
+    console.log('[afterEach] in level A');
+  });
+});

--- a/e2e/lifecycle/fixtures/onTestFinished.outside.test.ts
+++ b/e2e/lifecycle/fixtures/onTestFinished.outside.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, it, onTestFinished } from '@rstest/core';
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  onTestFinished(() => {
+    console.log('[onTestFinished]');
+  });
+
+  afterEach(() => {
+    console.log('[afterEach] in level A');
+  });
+});

--- a/e2e/lifecycle/fixtures/onTestFinished.test.ts
+++ b/e2e/lifecycle/fixtures/onTestFinished.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, onTestFinished } from '@rstest/core';
+
+afterEach(() => {
+  console.log('[afterEach] root');
+});
+
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(2);
+
+    onTestFinished(() => {
+      console.log('[onTestFinished] in level A');
+    });
+  });
+
+  afterEach(() => {
+    console.log('[afterEach] in level A');
+  });
+});
+
+it('it in level B', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/e2e/lifecycle/onTestFinished.test.ts
+++ b/e2e/lifecycle/onTestFinished.test.ts
@@ -1,0 +1,67 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('onTestFinished', () => {
+  it('onTestFinished should be invoked in the correct order', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'onTestFinished.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[afterEach] in level A",
+        "[afterEach] root",
+        "[onTestFinished] in level A",
+        "[afterEach] root",
+      ]
+    `);
+  });
+
+  it('should run test failed when onTestFinished error', async () => {
+    const { cli, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'onTestFinished.failed.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    expectLog('onTestFinished failed');
+  });
+
+  it('should run onTestFinished failed when onTestFinished outside', async () => {
+    const { cli, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'onTestFinished.outside.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    expectLog('onTestFinished() can only be called inside a test');
+  });
+});

--- a/packages/core/src/runtime/api/public.ts
+++ b/packages/core/src/runtime/api/public.ts
@@ -14,3 +14,4 @@ export declare const beforeEach: Rstest['beforeEach'];
 export declare const afterEach: Rstest['afterEach'];
 export declare const rstest: RstestUtilities;
 export declare const rs: RstestUtilities;
+export declare const onTestFinished: Rstest['onTestFinished'];

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -34,7 +34,12 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
   const testRunner: TestRunner = new TestRunner();
 
   return {
-    api: runtime.api,
+    api: {
+      ...runtime.api,
+      onTestFinished: (fn, timeout) => {
+        testRunner.onTestFinished(fn, timeout);
+      },
+    },
     runner: {
       runTests: async (testPath: string, hooks: RunnerHooks, api: Rstest) => {
         const tests = await runtime.instance.getTests();

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -448,7 +448,7 @@ export const createRuntimeAPI = ({
   testPath: string;
   runtimeConfig: RuntimeConfig;
 }): {
-  api: RunnerAPI;
+  api: Omit<RunnerAPI, 'onTestFinished'>;
   instance: RunnerRuntime;
 } => {
   const runtimeInstance: RunnerRuntime = new RunnerRuntime({

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -144,6 +144,8 @@ export type TestAPIs<ExtraContext = object> = TestAPI<ExtraContext> & {
   }>;
 };
 
+export type OnTestFinishedHandler = () => MaybePromise<void>;
+
 export type RunnerAPI = {
   describe: DescribeAPI;
   it: TestAPIs;
@@ -152,6 +154,7 @@ export type RunnerAPI = {
   afterAll: (fn: AfterAllListener, timeout?: number) => MaybePromise<void>;
   beforeEach: (fn: BeforeEachListener, timeout?: number) => MaybePromise<void>;
   afterEach: (fn: AfterEachListener, timeout?: number) => MaybePromise<void>;
+  onTestFinished: (fn: OnTestFinishedHandler, timeout?: number) => void;
 };
 
 export type RstestExpect = ExpectStatic;

--- a/website/docs/en/api/test-api/hooks.mdx
+++ b/website/docs/en/api/test-api/hooks.mdx
@@ -62,3 +62,23 @@ afterEach(async () => {
   // Cleanup logic after each test
 });
 ```
+
+## onTestFinished
+
+- **Type:** `(fn: () => void | Promise<void>, timeout?: number) => void`
+
+Called after the test has finished running **whatever the test result is**. This can be used to perform cleanup actions. This hook will be called after `afterEach`.
+
+```ts
+import { onTestFinished, test } from '@rstest/core';
+
+test('test server', () => {
+  const server = startServer();
+  // Register a cleanup function to close the server after the test
+  onTestFinished(() => server.close());
+
+  server.listen(3000, () => {
+    console.log('Server is running on port 3000');
+  });
+});
+```

--- a/website/docs/zh/api/test-api/hooks.mdx
+++ b/website/docs/zh/api/test-api/hooks.mdx
@@ -62,3 +62,23 @@ afterEach(async () => {
   // 每个测试后的清理逻辑
 });
 ```
+
+## onTestFinished
+
+- **类型：** `(fn: () => void | Promise<void>, timeout?: number) => void`
+
+测试运行完成后调用，无论测试成功或失败。可用于执行清理操作。该 hook 会在 `afterEach` 之后执行。
+
+```ts
+import { onTestFinished, test } from '@rstest/core';
+
+test('test server', () => {
+  const server = startServer();
+  // Register a cleanup function to close the server after the test
+  onTestFinished(() => server.close());
+
+  server.listen(3000, () => {
+    console.log('Server is running on port 3000');
+  });
+});
+```


### PR DESCRIPTION
## Summary


`onTestFinished` hook will called after the test has finished running **whatever the test result is**. This can be used to perform cleanup actions. This hook will be called after `afterEach`.

```ts
import { onTestFinished, test } from '@rstest/core';

test('test server', () => {
  const server = startServer();
  // Register a cleanup function to close the server after the test
  onTestFinished(() => server.close());

  server.listen(3000, () => {
    console.log('Server is running on port 3000');
  });
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
