### PR TITLE
test: cleanup child process when test finished

### DIFF
--- a/e2e/scripts/index.ts
+++ b/e2e/scripts/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { onTestFinished } from '@rstest/core';
 import stripAnsi from 'strip-ansi';
 import type { Options, Result } from 'tinyexec';
 import { x } from 'tinyexec';
@@ -90,6 +91,10 @@ export async function runRstestCli({
     },
   } as Options);
   const cli = new Cli(process);
+
+  onTestFinished(() => {
+    cli.exec.kill();
+  });
 
   const expectExecSuccess = async () => {
     await cli.exec;


### PR DESCRIPTION
## Summary

test: cleanup child process when test finished.
fix some child processes not exit when the test failed in rstest's e2e tests.

<img width="1342" height="456" alt="image" src="https://github.com/user-attachments/assets/ea7819d6-6ddc-42db-b4c6-0ea85bf5c415" />




## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
