### PR TITLE
feat: support `onTestFailed` hook

### DIFF
--- a/e2e/lifecycle/fixtures/onTestFailed.test.ts
+++ b/e2e/lifecycle/fixtures/onTestFailed.test.ts
@@ -1,0 +1,27 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFailed,
+} from '@rstest/core';
+
+beforeEach(() => {
+  onTestFailed(({ task }) => {
+    console.log('[onTestFailed]', task.result.name);
+  });
+});
+describe('level A', () => {
+  it('it in level A', () => {
+    expect(1 + 1).toBe(3);
+  });
+
+  afterEach(() => {
+    console.log('[afterEach] in level A');
+  });
+});
+
+it('it in level B', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/e2e/lifecycle/onTestFailed.test.ts
+++ b/e2e/lifecycle/onTestFailed.test.ts
@@ -1,0 +1,32 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('onTestFailed', () => {
+  it('onTestFailed should be called when test failed', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'onTestFailed.test'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    const logs = cli.stdout.split('\n').filter(Boolean);
+    expect(cli.exec.process?.exitCode).toBe(1);
+
+    expect(logs.filter((log) => log.startsWith('['))).toMatchInlineSnapshot(`
+      [
+        "[afterEach] in level A",
+        "[onTestFailed] it in level A",
+      ]
+    `);
+  });
+});

--- a/packages/core/globals.d.ts
+++ b/packages/core/globals.d.ts
@@ -8,6 +8,8 @@ declare global {
   const afterAll: typeof import('@rstest/core')['afterAll'];
   const beforeEach: typeof import('@rstest/core')['beforeEach'];
   const afterEach: typeof import('@rstest/core')['afterEach'];
+  const onTestFinished: typeof import('@rstest/core')['onTestFinished'];
+  const onTestFailed: typeof import('@rstest/core')['onTestFailed'];
   const rstest: typeof import('@rstest/core')['rstest'];
 }
 export {};

--- a/packages/core/src/runtime/api/public.ts
+++ b/packages/core/src/runtime/api/public.ts
@@ -15,3 +15,4 @@ export declare const afterEach: Rstest['afterEach'];
 export declare const rstest: RstestUtilities;
 export declare const rs: RstestUtilities;
 export declare const onTestFinished: Rstest['onTestFinished'];
+export declare const onTestFailed: Rstest['onTestFailed'];

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -39,6 +39,9 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
       onTestFinished: (fn, timeout) => {
         testRunner.onTestFinished(testRunner.getCurrentTest(), fn, timeout);
       },
+      onTestFailed: (fn, timeout) => {
+        testRunner.onTestFailed(testRunner.getCurrentTest(), fn, timeout);
+      },
     },
     runner: {
       runTests: async (testPath: string, hooks: RunnerHooks, api: Rstest) => {

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -321,6 +321,7 @@ export class RunnerRuntime {
       each,
       fails,
       onFinished: [],
+      onFailed: [],
     });
   }
 
@@ -449,7 +450,7 @@ export const createRuntimeAPI = ({
   testPath: string;
   runtimeConfig: RuntimeConfig;
 }): {
-  api: Omit<RunnerAPI, 'onTestFinished'>;
+  api: Omit<RunnerAPI, 'onTestFinished' | 'onTestFailed'>;
   instance: RunnerRuntime;
 } => {
   const runtimeInstance: RunnerRuntime = new RunnerRuntime({

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -6,12 +6,14 @@ import type {
   AfterEachListener,
   BeforeAllListener,
   BeforeEachListener,
+  TestResult,
 } from './testSuite';
 import type { MaybePromise } from './utils';
 
 export type TestContext = {
   expect: RstestExpect;
   onTestFinished: RunnerAPI['onTestFinished'];
+  onTestFailed: RunnerAPI['onTestFailed'];
 };
 
 export type TestCallbackFn<ExtraContext = object> = (
@@ -145,7 +147,13 @@ export type TestAPIs<ExtraContext = object> = TestAPI<ExtraContext> & {
   }>;
 };
 
-export type OnTestFinishedHandler = () => MaybePromise<void>;
+export type OnTestFinishedHandler = (params: {
+  task: { result: Readonly<TestResult> };
+}) => MaybePromise<void>;
+
+export type OnTestFailedHandler = (params: {
+  task: { result: Readonly<TestResult> };
+}) => MaybePromise<void>;
 
 export type RunnerAPI = {
   describe: DescribeAPI;
@@ -156,6 +164,7 @@ export type RunnerAPI = {
   beforeEach: (fn: BeforeEachListener, timeout?: number) => MaybePromise<void>;
   afterEach: (fn: AfterEachListener, timeout?: number) => MaybePromise<void>;
   onTestFinished: (fn: OnTestFinishedHandler, timeout?: number) => void;
+  onTestFailed: (fn: OnTestFailedHandler, timeout?: number) => void;
 };
 
 export type RstestExpect = ExpectStatic;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -1,5 +1,10 @@
 import type { SnapshotResult } from '@vitest/snapshot';
-import type { NormalizedFixtures, TestContext } from './api';
+import type {
+  NormalizedFixtures,
+  OnTestFailedHandler,
+  OnTestFinishedHandler,
+  TestContext,
+} from './api';
 import type { MaybePromise, TestPath } from './utils';
 
 export type TestRunMode = 'run' | 'skip' | 'todo' | 'only';
@@ -36,7 +41,8 @@ export type TestCase = {
   inTestEach?: boolean;
   context: TestContext;
   only?: boolean;
-  onFinished: (() => MaybePromise<void>)[];
+  onFinished: OnTestFinishedHandler[];
+  onFailed: OnTestFailedHandler[];
   type: 'case';
   parentNames?: string[];
   /**
@@ -57,7 +63,9 @@ export type AfterAllListener = (ctx: SuiteContext) => MaybePromise<void>;
 export type BeforeAllListener = (
   ctx: SuiteContext,
 ) => MaybePromise<void | AfterAllListener>;
-export type AfterEachListener = () => MaybePromise<void>;
+export type AfterEachListener = (params: {
+  task: { result: Readonly<TestResult> };
+}) => MaybePromise<void>;
 export type BeforeEachListener = () => MaybePromise<void | AfterEachListener>;
 
 export type TestSuite = {

--- a/website/docs/en/api/test-api/hooks.mdx
+++ b/website/docs/en/api/test-api/hooks.mdx
@@ -51,7 +51,7 @@ beforeEach(async () => {
 
 ## afterEach
 
-- **Type:** `(fn: () => void | Promise<void>, timeout?: number) => void`
+- **Type:** `(fn: (ctx: { task: { result: Readonly<TestResult> } }) => void | Promise<void>, timeout?: number) => void`
 
 Runs after each test in the current suite.
 
@@ -65,7 +65,7 @@ afterEach(async () => {
 
 ## onTestFinished
 
-- **Type:** `(fn: () => void | Promise<void>, timeout?: number) => void`
+- **Type:** `(fn: (ctx: { task: { result: Readonly<TestResult> } }) => void | Promise<void>, timeout?: number) => void`
 
 Called after the test has finished running **whatever the test result is**. This can be used to perform cleanup actions. This hook will be called after `afterEach`.
 
@@ -95,3 +95,27 @@ describe.concurrent('concurrent suite', () => {
   });
 });
 ```
+
+## onTestFailed
+
+- **Type:** `(fn: (ctx: { task: { result: Readonly<TestResult> } }) => void | Promise<void>, timeout?: number) => void`
+
+Called after the test has failed.
+
+```ts
+import { onTestFailed, test } from '@rstest/core';
+
+test('test server', () => {
+  const server = startServer();
+
+  onTestFailed(({ task }) => {
+    console.log(task.result.errors);
+  });
+
+  server.listen(3000, () => {
+    console.log('Server is running on port 3000');
+  });
+});
+```
+
+It should be noted that when you use the `onTestFailed` hook in concurrent tests, you should get the hook from the test context. This is because Rstest cannot accurately track the specific test to which the global `onTestFailed` hook belongs in concurrent tests.

--- a/website/docs/zh/api/test-api/hooks.mdx
+++ b/website/docs/zh/api/test-api/hooks.mdx
@@ -51,7 +51,7 @@ beforeEach(async () => {
 
 ## afterEach
 
-- **类型：** `(fn: () => void | Promise<void>, timeout?: number) => void`
+- **类型：** `(fn: (ctx: { task: { result: Readonly<TestResult> } }) => void | Promise<void>, timeout?: number) => void`
 
 在当前套件的每个测试之后运行。
 
@@ -65,7 +65,7 @@ afterEach(async () => {
 
 ## onTestFinished
 
-- **类型：** `(fn: () => void | Promise<void>, timeout?: number) => void`
+- **类型：** `(fn: (ctx: { task: { result: Readonly<TestResult> } }) => void | Promise<void>, timeout?: number) => void`
 
 测试运行完成后调用，无论测试成功或失败。可用于执行清理操作。该 hook 会在 `afterEach` 之后执行。
 
@@ -95,3 +95,27 @@ describe.concurrent('并发套件', () => {
   });
 });
 ```
+
+## onTestFailed
+
+- **Type:** `(fn: (ctx: { task: { result: Readonly<TestResult> } }) => void | Promise<void>, timeout?: number) => void`
+
+测试运行失败后调用。
+
+```ts
+import { onTestFailed, test } from '@rstest/core';
+
+test('test server', () => {
+  const server = startServer();
+
+  onTestFailed(({ task }) => {
+    console.log(task.result.errors);
+  });
+
+  server.listen(3000, () => {
+    console.log('Server is running on port 3000');
+  });
+});
+```
+
+需要注意的是，当你在并发测试中使用 `onTestFailed` hook 时，你应当从测试上下文中获取该 hook。这是因为 Rstest 在并发测试中无法准确追踪来自全局的 onTestFailed hook 所属的具体测试。


### PR DESCRIPTION
## Summary

`onTestFailed` hook will be called after the test has failed.


```ts
import { onTestFailed, test } from '@rstest/core';

test('test server', () => {
  const server = startServer();

  onTestFailed(({ task }) => {
    console.log(task.result.errors);
  });

  server.listen(3000, () => {
    console.log('Server is running on port 3000');
  });
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
