### PR TITLE
chore: use `isFirstCompile` instead of `isFirstRun`

### DIFF
--- a/e2e/watch/index.test.ts
+++ b/e2e/watch/index.test.ts
@@ -28,7 +28,7 @@ describe('watch', () => {
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 1 passed');
     expect(cli.stdout).not.toMatch('Test files to re-run:');
-    expect(cli.stdout).toMatch('Fully run test files for first run.');
+    expect(cli.stdout).toMatch('Run all tests.');
 
     // create
     cli.resetStd();

--- a/e2e/watch/shortcuts.test.ts
+++ b/e2e/watch/shortcuts.test.ts
@@ -37,7 +37,7 @@ describe('CLI shortcuts', () => {
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 1 failed | 1 passed');
     await cli.waitForStdout('press h to show help');
-    expect(cli.stdout).toMatch('Fully run test files for first run.');
+    expect(cli.stdout).toMatch('Run all tests.');
 
     cli.exec.process!.stdin!.write('h');
 
@@ -82,7 +82,7 @@ describe('CLI shortcuts', () => {
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 1 failed | 1 passed');
     await cli.waitForStdout('press h to show help');
-    expect(cli.stdout).toMatch('Fully run test files for first run.');
+    expect(cli.stdout).toMatch('Run all tests.');
     cli.resetStd();
 
     // rerun failed tests

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -228,7 +228,6 @@ export const createRsbuildServer = async ({
     assetFiles: Record<string, string>;
     sourceMaps: Record<string, SourceMapInput>;
     getSourcemap: (sourcePath: string) => SourceMapInput | null;
-    isFirstRun: boolean;
     affectedEntries: EntryInfo[];
     deletedEntries: string[];
   }>;
@@ -236,7 +235,6 @@ export const createRsbuildServer = async ({
 }> => {
   // Read files from memory via `rspackCompiler.outputFileSystem`
   let rspackCompiler: Rspack.Compiler | Rspack.MultiCompiler | undefined;
-  let isFirstCompile = false;
 
   const rstestCompilerPlugin: RsbuildPlugin = {
     name: 'rstest:compiler',
@@ -244,10 +242,6 @@ export const createRsbuildServer = async ({
       api.onAfterCreateCompiler(({ compiler }) => {
         // outputFileSystem to be updated later by `rsbuild-dev-middleware`
         rspackCompiler = compiler;
-      });
-
-      api.onAfterDevCompile(({ isFirstCompile: _isFirstCompile }) => {
-        isFirstCompile = _isFirstCompile;
       });
     },
   };
@@ -410,7 +404,6 @@ export const createRsbuildServer = async ({
     return {
       affectedEntries,
       deletedEntries,
-      isFirstRun: isFirstCompile,
       hash,
       entries,
       setupEntries,


### PR DESCRIPTION
## Summary

simplify `isFirstRun` check when run tests.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
