### PR TITLE
fix: manualMockRoot in projects

### DIFF
--- a/e2e/projects/fixtures/packages/node/__mocks__/fs.js
+++ b/e2e/projects/fixtures/packages/node/__mocks__/fs.js
@@ -1,0 +1,6 @@
+// we can also use `import`, but then
+// every export should be explicitly defined
+
+const { fs } = require('memfs');
+
+module.exports = fs;

--- a/e2e/projects/fixtures/packages/node/src/readSomeFile.ts
+++ b/e2e/projects/fixtures/packages/node/src/readSomeFile.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from 'node:fs';
+
+export function readSomeFile(path: string) {
+  return readFileSync(path, 'utf-8');
+}

--- a/e2e/projects/fixtures/packages/node/test/mockFs.test.ts
+++ b/e2e/projects/fixtures/packages/node/test/mockFs.test.ts
@@ -1,0 +1,13 @@
+import { expect, it, rs } from '@rstest/core';
+import { fs } from 'memfs';
+import { readSomeFile } from '../src/readSomeFile';
+
+rs.mock('node:fs');
+
+it('should return correct text', () => {
+  const path = '/hello-world.txt';
+  fs.writeFileSync(path, 'hello world');
+
+  const text = readSomeFile(path);
+  expect(text).toBe('hello world');
+});

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -20,7 +20,9 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
             tools,
             performance,
             dev,
+            testEnvironment,
           },
+          rootPath,
         } = context.projects.find((p) => p.environmentName === name)!;
         return mergeEnvironmentConfig(
           config,
@@ -63,7 +65,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                     injectModulePathName: true,
                     importMetaPathName: true,
                     hoistMockModule: true,
-                    manualMockRoot: path.resolve(context.rootPath, '__mocks__'),
+                    manualMockRoot: path.resolve(rootPath, '__mocks__'),
                   }),
                 );
 
@@ -90,7 +92,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 config.resolve.extensionAlias['.js'] = ['.js', '.ts', '.tsx'];
                 config.resolve.extensionAlias['.jsx'] = ['.jsx', '.tsx'];
 
-                if (context.normalizedConfig.testEnvironment === 'node') {
+                if (testEnvironment === 'node') {
                   // skip `module` field in Node.js environment.
                   // ESM module resolved by module field is not always a native ESM module
                   config.resolve.mainFields = config.resolve.mainFields?.filter(


### PR DESCRIPTION
## Summary


fix `manualMockRoot` in projects, use `project.rootPath` instead of `context.rootPath`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
