### PR TITLE
feat: support filter projects via `--project` option

### DIFF
--- a/e2e/projects/filter.test.ts
+++ b/e2e/projects/filter.test.ts
@@ -23,6 +23,6 @@ describe('test projects filter', () => {
 
     // test log print
     expect(logs.find((log) => log.includes('node/test/index'))).toBeTruthy();
-    expect(logs.find((log) => log.includes('react/test/index'))).toBeFalsy();
+    expect(logs.find((log) => log.includes('client/test/index'))).toBeFalsy();
   });
 });

--- a/e2e/projects/filter.test.ts
+++ b/e2e/projects/filter.test.ts
@@ -1,0 +1,28 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test projects filter', () => {
+  it('should run test success with project filter', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--project', 'node', '--globals'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    // test log print
+    expect(logs.find((log) => log.includes('node/test/index'))).toBeTruthy();
+    expect(logs.find((log) => log.includes('react/test/index'))).toBeFalsy();
+  });
+});

--- a/e2e/projects/filter.test.ts
+++ b/e2e/projects/filter.test.ts
@@ -25,7 +25,7 @@ describe('test projects filter', () => {
     expect(logs.find((log) => log.includes('node/test/index'))).toBeFalsy();
     expect(logs.find((log) => log.includes('client/test/index'))).toBeTruthy();
   });
- 
+
   it('should run test success with project filter', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -35,6 +35,10 @@ const applyCommonOptions = (cli: CAC) => {
     .option('--exclude <exclude>', 'Exclude files from test')
     .option('-u, --update', 'Update snapshot files')
     .option(
+      '--project <name>',
+      'Run only projects that match the name, can be a full name or wildcards pattern',
+    )
+    .option(
       '--passWithNoTests',
       'Allows the test suite to pass when no files are found',
     )

--- a/packages/core/tests/utils/testFiles.test.ts
+++ b/packages/core/tests/utils/testFiles.test.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
-import { filterFiles, formatTestEntryName } from '../../src/utils/testFiles';
+import {
+  filterFiles,
+  filterProjects,
+  formatTestEntryName,
+} from '../../src/utils/testFiles';
 
 describe('test filterFiles', () => {
   it('should filter files correctly', () => {
@@ -28,4 +32,60 @@ test('formatTestEntryName', () => {
   expect(formatTestEntryName('setup.ts')).toBe('setup~ts');
   expect(formatTestEntryName('some.setup.ts')).toBe('some~setup~ts');
   expect(formatTestEntryName('some/setup.ts')).toBe('some_setup~ts');
+});
+
+test('filterProjects', () => {
+  const projects = [
+    {
+      config: { name: '@rstest/core' },
+      relativeRoot: 'packages/core',
+    },
+    {
+      config: { name: '@rstest/coverage' },
+      relativeRoot: 'packages/coverage',
+    },
+    {
+      config: { name: 'react' },
+      relativeRoot: 'example/react',
+    },
+  ];
+
+  expect(filterProjects(projects, {})).toEqual(projects);
+
+  expect(
+    filterProjects(projects, {
+      project: ['@rstest/core'],
+    }),
+  ).toEqual([
+    {
+      config: { name: '@rstest/core' },
+      relativeRoot: 'packages/core',
+    },
+  ]);
+
+  expect(
+    filterProjects(projects, {
+      project: ['@rstest/*'],
+    }),
+  ).toEqual([
+    {
+      config: { name: '@rstest/core' },
+      relativeRoot: 'packages/core',
+    },
+    {
+      config: { name: '@rstest/coverage' },
+      relativeRoot: 'packages/coverage',
+    },
+  ]);
+
+  expect(
+    filterProjects(projects, {
+      project: ['!@rstest/*'],
+    }),
+  ).toEqual([
+    {
+      config: { name: 'react' },
+      relativeRoot: 'example/react',
+    },
+  ]);
 });

--- a/website/docs/en/config/test/name.mdx
+++ b/website/docs/en/config/test/name.mdx
@@ -4,3 +4,15 @@
 - **Default:** `rstest`
 
 The name of the test project.
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  name: 'node',
+});
+```
+
+When you define multiple test projects via [projects](/config/test/projects), it's recommended to give each project a unique name so that you can filter specific projects using the [--project](/guide/basic/test-filter#filter-by-project-name) option.
+
+If a project's name is not provided, Rstest will use the `name` field from the current project's `package.json`. If it does not exist, the folder name will be used instead.

--- a/website/docs/en/config/test/projects.mdx
+++ b/website/docs/en/config/test/projects.mdx
@@ -7,6 +7,8 @@ An array of directories, config files, or glob patterns that define multiple tes
 
 `rstest` will run the tests for each project according to the configuration defined in each project, and the test results from all projects will be combined and displayed.
 
+You can filter the specified projects to run by using the [--project](/guide/basic/test-filter#filter-by-project-name) option.
+
 If there is no `projects` field, `rstest` will treat current directory as a single project.
 
 ```ts name='rstest.config.ts'

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -118,6 +118,7 @@ Rstest CLI provides several common options that can be used with all commands:
 | `-u, --update`                  | Update snapshot files, see [update](/config/test/update)                                                                                                          |
 | `--passWithNoTests`             | Allows the test suite to pass when no files are found, see [passWithNoTests](/config/test/passWithNoTests)                                                        |
 | `--printConsoleTrace`           | Print console traces when calling any console method, see [printConsoleTrace](/config/test/printConsoleTrace)                                                     |
+| `--project <name>`              | Only run tests for the specified project, see [Filter by project name](/guide/basic/test-filter#filter-by-project-name)                                           |
 | `--disableConsoleIntercept`     | Disable console intercept, see [disableConsoleIntercept](/config/test/disableConsoleIntercept)                                                                    |
 | `--slowTestThreshold <value>`   | The number of milliseconds after which a test or suite is considered slow, see [slowTestThreshold](/config/test/slowTestThreshold)                                |
 | `-t, --testNamePattern <value>` | Run only tests with a name that matches the regex, see [testNamePattern](/config/test/testNamePattern)                                                            |

--- a/website/docs/en/guide/basic/test-filter.mdx
+++ b/website/docs/en/guide/basic/test-filter.mdx
@@ -63,6 +63,28 @@ rstest --testNamePattern login
 rstest -t login
 ```
 
+## Filter by project name
+
+Rstest supports defining multiple test projects via [projects](/config/test/projects). You can filter to run specific projects with the `--project` option.
+
+For example, to match projects whose [name](/config/test/name) is `@test/a` or `@test/b`:
+
+```bash
+rstest --project '@test/a' --project '@test/b'
+```
+
+You can also use wildcards to match project names:
+
+```bash
+rstest --project '@test/*'
+```
+
+You can exclude certain projects by negation:
+
+```bash
+rstest --project '!@test/a'
+```
+
 ## Combined filtering
 
 All filtering methods can be combined. For example:

--- a/website/docs/zh/config/test/name.mdx
+++ b/website/docs/zh/config/test/name.mdx
@@ -4,3 +4,15 @@
 - **默认值：** `rstest`
 
 测试项目的名称。
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  name: 'node',
+});
+```
+
+当你通过 [projects](/config/test/projects) 定义多个测试项目时，建议为每个项目指定唯一的名称，方便通过 [--project](/guide/basic/test-filter#根据项目名称过滤) 选项来过滤运行特定项目。
+
+如果 project 未提供名称，Rstest 将会使用当前项目的 `package.json` 中定义的 `name` 属性，如果不存在，则使用文件夹名称。

--- a/website/docs/zh/config/test/projects.mdx
+++ b/website/docs/zh/config/test/projects.mdx
@@ -5,6 +5,8 @@
 
 一组目录、配置文件或 glob 模式，用于定义多个测试项目。 `rstest` 将会按照各个项目定义的配置运行对应的测试，所有项目的测试结果将会合并展示。
 
+你可以通过 [--project](/guide/basic/test-filter#根据项目名称过滤) 选项来过滤运行特定项目。
+
 如果没有 `projects` 字段，`rstest` 会将当前目录视为单个项目。
 
 ```ts name='rstest.config.ts'

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -117,6 +117,7 @@ Rstest CLI 支持以下常用参数，所有命令均可使用：
 | `-u, --update`                  | 更新快照文件，详见 [update](/config/test/update)                                                                                             |
 | `--passWithNoTests`             | 当未找到测试文件时允许测试通过，详见 [passWithNoTests](/config/test/passWithNoTests)                                                         |
 | `--printConsoleTrace`           | 调用 console 方法时打印调用栈，详见 [printConsoleTrace](/config/test/printConsoleTrace)                                                      |
+| `--project <name>`              | 仅运行指定项目的测试，详见 [根据项目名称过滤](/guide/basic/test-filter#根据项目名称过滤)                                                     |
 | `--disableConsoleIntercept`     | 禁用 console 拦截，详见 [disableConsoleIntercept](/config/test/disableConsoleIntercept)                                                      |
 | `--slowTestThreshold <value>`   | 设置测试或套件被视为慢的阈值（毫秒），详见 [slowTestThreshold](/config/test/slowTestThreshold)                                               |
 | `-t, --testNamePattern <value>` | 仅运行名称匹配正则的测试，详见 [testNamePattern](/config/test/testNamePattern)                                                               |

--- a/website/docs/zh/guide/basic/test-filter.mdx
+++ b/website/docs/zh/guide/basic/test-filter.mdx
@@ -65,7 +65,7 @@ rstest -t login
 
 ## 根据项目名称过滤
 
-Rstest 支持通过 [projects](/config/test/project) 配置来定义多个测试项目，你可以通过 `--project` 选项来过滤运行特定项目。
+Rstest 支持通过 [projects](/config/test/projects) 配置来定义多个测试项目，你可以通过 `--project` 选项来过滤运行特定项目。
 
 如，匹配[名称](/config/test/name)为 `@test/a` 或 `@test/b` 的项目：
 

--- a/website/docs/zh/guide/basic/test-filter.mdx
+++ b/website/docs/zh/guide/basic/test-filter.mdx
@@ -63,6 +63,28 @@ rstest --testNamePattern login
 rstest -t login
 ```
 
+## 根据项目名称过滤
+
+Rstest 支持通过 [projects](/config/test/project) 配置来定义多个测试项目，你可以通过 `--project` 选项来过滤运行特定项目。
+
+如，匹配[名称](/config/test/name)为 `@test/a` 或 `@test/b` 的项目：
+
+```bash
+rstest --project '@test/a' --project '@test/b'
+```
+
+你也可以使用通配符来匹配项目名称：
+
+```bash
+rstest --project '@test/*'
+```
+
+你也可以通过取反来排除某些项目：
+
+```bash
+rstest --project '!@test/a'
+```
+
 ## 组合过滤
 
 所有过滤方式都可以组合使用。例如：


### PR DESCRIPTION
## Summary

Support filter projects via `--project` option.

For example, to match projects whose [name](/config/test/name) is `@test/a` or `@test/b`:

```bash
rstest --project '@test/a' --project '@test/b'
```

You can also use wildcards to match project names:

```bash
rstest --project '@test/*'
```

You can exclude certain projects by negation:

```bash
rstest --project '!@test/a'
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
