### PR TITLE
enhance: filter file based on workspace's root

### DIFF
--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -33,7 +33,8 @@ export async function listTests(
     const entries = await getTestEntries({
       include,
       exclude,
-      root,
+      rootPath,
+      projectRoot: root,
       fileFilters: context.fileFilters || [],
       includeSource,
     });

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -32,7 +32,8 @@ export async function runTests(context: Rstest): Promise<void> {
       include,
       exclude,
       includeSource,
-      root,
+      rootPath,
+      projectRoot: root,
       fileFilters: context.fileFilters || [],
     });
 

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -48,20 +48,22 @@ export const formatTestEntryName = (name: string): string =>
 export const getTestEntries = async ({
   include,
   exclude,
-  root,
+  rootPath,
+  projectRoot,
   fileFilters,
   includeSource,
 }: {
+  rootPath: string;
   include: string[];
   exclude: string[];
   includeSource: string[];
   fileFilters: string[];
-  root: string;
+  projectRoot: string;
 }): Promise<{
   [name: string]: string;
 }> => {
   const testFiles = await glob(include, {
-    cwd: root,
+    cwd: projectRoot,
     absolute: true,
     ignore: exclude,
     dot: true,
@@ -70,7 +72,7 @@ export const getTestEntries = async ({
 
   if (includeSource?.length) {
     const sourceFiles = await glob(includeSource, {
-      cwd: root,
+      cwd: projectRoot,
       absolute: true,
       ignore: exclude,
       dot: true,
@@ -92,8 +94,8 @@ export const getTestEntries = async ({
   }
 
   return Object.fromEntries(
-    filterFiles(testFiles, fileFilters, root).map((entry) => {
-      const relativePath = pathe.relative(root, entry);
+    filterFiles(testFiles, fileFilters, rootPath).map((entry) => {
+      const relativePath = pathe.relative(rootPath, entry);
       return [formatTestEntryName(relativePath), entry];
     }),
   );


### PR DESCRIPTION
## Summary

Filter file based on workspace's root. 

Previously, when rstest matched test files in projects, it converted the project root to a relative path. Therefore, if the project root was `project/core`, `npx rstest core` would not match all test files under `project/core`. 
This now uses the workspace root as a unified root path for matching.

before:

<img width="575" height="272" alt="image" src="https://github.com/user-attachments/assets/7dedb0e0-2894-4f47-8cfb-0815be9d0591" />


after:
<img width="661" height="310" alt="image" src="https://github.com/user-attachments/assets/01fbb2b0-866e-4154-adcb-92d64782b249" />



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
