### PR TITLE
feat: support inline project config

### DIFF
--- a/e2e/projects/fixtures/rstest.inline.config.ts
+++ b/e2e/projects/fixtures/rstest.inline.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  projects: [
+    {
+      root: 'packages/node',
+      globals: true,
+    },
+    {
+      root: 'packages/client',
+      globals: true,
+      include: ['test/index.test.ts'],
+    },
+  ],
+});

--- a/e2e/projects/inline.test.ts
+++ b/e2e/projects/inline.test.ts
@@ -1,0 +1,35 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('test projects inline projectConfig', () => {
+  it('should run projects correctly with inline projectConfig', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', 'rstest.inline.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    // test log print
+    expect(
+      logs.find((log) => log.includes('packages/node/test/index.test.ts')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('packages/client/test/index.test.ts')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('packages/client/test/App.test.tsx')),
+    ).toBeFalsy();
+  });
+});

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -6,6 +6,7 @@ import { GithubActionsReporter } from '../reporter/githubActions';
 import { VerboseReporter } from '../reporter/verbose';
 import type {
   NormalizedConfig,
+  NormalizedProjectConfig,
   Project,
   ProjectContext,
   Reporter,
@@ -93,7 +94,10 @@ export class Rstest implements RstestContext {
     this.projects = projects.length
       ? projects.map((project) => {
           // TODO: support extend projects config
-          const config = withDefaultConfig(project.config);
+          const config = withDefaultConfig(
+            project.config,
+          ) as NormalizedProjectConfig;
+          config.isolate = rstestConfig.isolate;
           return {
             configFilePath: project.configFilePath,
             rootPath: config.root,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -18,12 +18,17 @@ export type RstestPoolOptions = {
   execArgv?: string[];
 };
 
+export type ProjectConfig = Omit<
+  RstestConfig,
+  'projects' | 'reporters' | 'pool' | 'isolate'
+>;
+
 /**
  * A list of glob patterns or files that match your test projects.
  *
  * eg. ['packages/*', 'examples/node/rstest.config.ts']
  */
-type TestProject = string;
+type TestProject = string | ProjectConfig;
 
 export interface RstestConfig {
   /**
@@ -234,6 +239,12 @@ type OptionalKeys =
   | 'tools'
   | 'dev'
   | 'onConsoleLog';
+
+export type NormalizedProjectConfig = Required<
+  Omit<RstestConfig, OptionalKeys | 'projects' | 'reporters' | 'pool'>
+> & {
+  [key in OptionalKeys]?: RstestConfig[key];
+};
 
 export type NormalizedConfig = Required<
   Omit<RstestConfig, OptionalKeys | 'pool' | 'projects'>

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -1,5 +1,9 @@
 import type { SnapshotManager } from '@vitest/snapshot/manager';
-import type { NormalizedConfig, RstestConfig } from './config';
+import type {
+  NormalizedConfig,
+  NormalizedProjectConfig,
+  RstestConfig,
+} from './config';
 import type { Reporter } from './reporter';
 
 export type RstestCommand = 'watch' | 'run' | 'list';
@@ -11,7 +15,7 @@ export type ProjectContext = {
   environmentName: string;
   rootPath: string;
   configFilePath?: string;
-  normalizedConfig: NormalizedConfig;
+  normalizedConfig: NormalizedProjectConfig;
 };
 
 export type RstestContext = {

--- a/website/docs/en/config/test/projects.mdx
+++ b/website/docs/en/config/test/projects.mdx
@@ -1,9 +1,19 @@
 # projects
 
-- **Type:** `string[]`
+- **Type:**
+
+```ts
+type ProjectConfig = Omit<
+  RstestConfig,
+  'projects' | 'reporters' | 'pool' | 'isolate'
+>;
+
+type Projects = (string | ProjectConfig)[];
+```
+
 - **Default:** `[<rootDir>]`
 
-An array of directories, config files, or glob patterns that define multiple test projects.
+An array of directories, config files, or glob patterns, or an object to define multiple test projects.
 
 `rstest` will run the tests for each project according to the configuration defined in each project, and the test results from all projects will be combined and displayed.
 
@@ -27,11 +37,26 @@ export default defineConfig({
 
     // A specific project's config file
     './projects/web/rstest.config.ts',
+
+    // inline project configs
+    {
+      name: 'node',
+      include: ['tests/node/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+    },
+    {
+      name: 'react',
+      include: ['tests/react/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+      testEnvironment: 'jsdom',
+    },
   ],
 });
 ```
 
-It should be noted that project configuration does not inherit root configuration. If there is shared configuration between your sub-projects, you can extract the shared configuration and import it in the sub-project:
+## Configuration notes
+
+- Project configuration does not inherit root configuration. If there is shared configuration between your sub-projects, you can extract the shared configuration and import it in the sub-project.
+- Some root-level options such as `reporters`, `pool`, and `isolate` are not valid in a project configuration.
+- `projects` does not support nesting.
 
 ```ts title='packages/pkg-a/rstest.config.ts'
 import { defineConfig } from '@rstest/core';
@@ -39,5 +64,28 @@ import sharedConfig from '../shared/rstest.config';
 
 export default defineConfig({
   ...sharedConfig,
+});
+```
+
+## Inline configuration
+
+`rstest` supports configuring projects inline in the `projects` field. This lets you define multiple test projects in a single root without creating separate config files for each test project.
+
+```ts name='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  projects: [
+    // inline project configs
+    {
+      name: 'node',
+      include: ['tests/node/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+    },
+    {
+      name: 'react',
+      include: ['tests/react/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+      testEnvironment: 'jsdom',
+    },
+  ],
 });
 ```

--- a/website/docs/zh/config/test/projects.mdx
+++ b/website/docs/zh/config/test/projects.mdx
@@ -1,9 +1,19 @@
 # projects
 
-- **类型：** `string[]`
+- **类型：**
+
+```ts
+type ProjectConfig = Omit<
+  RstestConfig,
+  'projects' | 'reporters' | 'pool' | 'isolate'
+>;
+
+type Projects = (string | ProjectConfig)[];
+```
+
 - **默认值：** `[<rootDir>]`
 
-一组目录、配置文件或 glob 模式，用于定义多个测试项目。 `rstest` 将会按照各个项目定义的配置运行对应的测试，所有项目的测试结果将会合并展示。
+可以是一个目录、配置文件或 glob 模式，也可以是一个对象，用于定义多个测试项目。 `rstest` 将会按照各个项目定义的配置运行对应的测试，所有项目的测试结果将会合并展示。
 
 你可以通过 [--project](/guide/basic/test-filter#根据项目名称过滤) 选项来过滤运行特定项目。
 
@@ -25,11 +35,28 @@ export default defineConfig({
 
     // A specific project's config file
     './projects/web/rstest.config.ts',
+
+    // inline project configs
+    {
+      name: 'node',
+      include: ['tests/node/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+    },
+    {
+      name: 'react',
+      include: ['tests/react/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+      testEnvironment: 'jsdom',
+    },
   ],
 });
 ```
 
-需要注意的是，project 配置并不会继承全局配置，如果你的子项目间存在共享配置，可以抽取 shared 配置，并在子项目中引入：
+## 配置说明
+
+需要注意的是：
+
+- project 配置并不会继承全局配置，如果你的子项目间存在共享配置，可以抽取 shared 配置，并在子项目中引入
+- 一些全局配置，如 `reporters`、`pool`、`isolate` 等，在 project 配置中是无效的
+- 不支持嵌套的 `projects`
 
 ```ts title='packages/pkg-a/rstest.config.ts'
 import { defineConfig } from '@rstest/core';
@@ -37,5 +64,28 @@ import sharedConfig from '../shared/rstest.config';
 
 export default defineConfig({
   ...sharedConfig,
+});
+```
+
+## 内联配置
+
+Rstest 支持在 `projects` 字段中直接通过内联的方式配置 project。这允许你在单个项目下定义多个测试项目，而无需为每个测试项目创建单独的配置文件。
+
+```ts name='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  projects: [
+    // inline project configs
+    {
+      name: 'node',
+      include: ['tests/node/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+    },
+    {
+      name: 'react',
+      include: ['tests/react/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
+      testEnvironment: 'jsdom',
+    },
+  ],
 });
 ```


### PR DESCRIPTION
## Summary

Supports configuring projects inline in the `projects` field. This lets you define multiple test projects in a single root without creating separate config files for each test project.

```ts name='rstest.config.ts'
import { defineConfig } from '@rstest/core';

export default defineConfig({
  projects: [
    // inline project configs
    {
      name: 'node',
      include: ['tests/node/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
    },
    {
      name: 'react',
      include: ['tests/react/**/*.{test,spec}.{js,cjs,mjs,ts,tsx}'],
      testEnvironment: 'jsdom',
    },
  ],
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
