### PR TITLE
chore: support print full error stack in debug mode

### DIFF
--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
 import { type StackFrame, parse as stackTraceParse } from 'stacktrace-parser';
 import type { FormattedError, GetSourcemap } from '../types';
-import { color, formatTestPath, logger } from '../utils';
+import { color, formatTestPath, isDebug, logger } from '../utils';
 
 export async function printError(
   error: FormattedError,
@@ -109,7 +109,7 @@ const stackIgnores: (RegExp | string)[] = [
 export async function parseErrorStacktrace({
   stack,
   getSourcemap,
-  fullStack,
+  fullStack = isDebug(),
 }: {
   fullStack?: boolean;
   stack: string;

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -152,7 +152,7 @@ export async function parseErrorStacktrace({
 
   if (!stackFrames.length && stack.length) {
     logger.log(
-      `${color.gray("No error stack found, set 'DEBUG=rstest' to show fullStack.")}`,
+      color.gray("No error stack found, set 'DEBUG=rstest' to show fullStack."),
     );
   }
 

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -115,7 +115,7 @@ export async function parseErrorStacktrace({
   stack: string;
   getSourcemap: GetSourcemap;
 }): Promise<StackFrame[]> {
-  return Promise.all(
+  const stackFrames = await Promise.all(
     stackTraceParse(stack)
       .filter((frame) =>
         fullStack
@@ -149,4 +149,12 @@ export async function parseErrorStacktrace({
   ).then((frames) =>
     frames.filter((frame): frame is StackFrame => frame !== null),
   );
+
+  if (!stackFrames.length && stack.length) {
+    logger.log(
+      `${color.gray(`No error stack found, set 'DEBUG=rstest' to show fullStack.`)}`,
+    );
+  }
+
+  return stackFrames;
 }

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -152,7 +152,7 @@ export async function parseErrorStacktrace({
 
   if (!stackFrames.length && stack.length) {
     logger.log(
-      `${color.gray(`No error stack found, set 'DEBUG=rstest' to show fullStack.`)}`,
+      `${color.gray("No error stack found, set 'DEBUG=rstest' to show fullStack.")}`,
     );
   }
 


### PR DESCRIPTION
## Summary


Rstest will ignore some stack traces that are not related to the user's source code, such as `webpack/runtime` and `@rstest/core` by default.

Support printing the full error stack in debug mode, making the stack trace more verbose and easier to analyze.



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
