### PR TITLE
feat: add JUnit reporter

### DIFF
--- a/e2e/reporter/fixtures/junit.test.ts
+++ b/e2e/reporter/fixtures/junit.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('Junit test', () => {
+  it('should pass', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  it('should fail', () => {
+    expect('hi').toBe('hii');
+  });
+
+  it.skip('should skip', () => {
+    expect(1 + 1).toBe(3);
+  });
+});

--- a/e2e/reporter/junit.test.ts
+++ b/e2e/reporter/junit.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+it('junit', async () => {
+  const { cli, expectLog } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'junit', '--reporter', 'junit'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(1);
+
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expectLog('<?xml version="1.0" encoding="UTF-8"?>', logs);
+
+  expectLog('<failure', logs);
+  expectLog('<skipped/>', logs);
+});

--- a/packages/core/LICENSE.md
+++ b/packages/core/LICENSE.md
@@ -928,6 +928,20 @@ Licensed under MIT license in the repository at git+https://github.com/errwischt
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
+### strip-ansi
+
+Licensed under MIT license.
+
+> MIT License
+>
+> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 ### supports-color
 
 Licensed under MIT license.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,6 +81,7 @@
     "rslog": "^1.2.11",
     "source-map-support": "^0.5.21",
     "stacktrace-parser": "0.1.11",
+    "strip-ansi": "^7.1.0",
     "tinyglobby": "^0.2.14",
     "tinyspy": "^4.0.3"
   },

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -3,6 +3,7 @@ import { isCI } from 'std-env';
 import { withDefaultConfig } from '../config';
 import { DefaultReporter } from '../reporter';
 import { GithubActionsReporter } from '../reporter/githubActions';
+import { JunitReporter } from '../reporter/junit';
 import { VerboseReporter } from '../reporter/verbose';
 import type {
   NormalizedConfig,
@@ -39,7 +40,7 @@ export class Rstest implements RstestContext {
   public command: RstestCommand;
   public fileFilters?: string[];
   public configFilePath?: string;
-  public reporters: (Reporter | GithubActionsReporter)[];
+  public reporters: (Reporter | GithubActionsReporter | JunitReporter)[];
   public snapshotManager: SnapshotManager;
   public version: string;
   public rootPath: string;
@@ -159,10 +160,12 @@ const reportersMap: {
   default: typeof DefaultReporter;
   verbose: typeof VerboseReporter;
   'github-actions': typeof GithubActionsReporter;
+  junit: typeof JunitReporter;
 } = {
   default: DefaultReporter,
   verbose: VerboseReporter,
   'github-actions': GithubActionsReporter,
+  junit: JunitReporter,
 };
 
 export type BuiltInReporterNames = keyof typeof reportersMap;
@@ -170,7 +173,7 @@ export type BuiltInReporterNames = keyof typeof reportersMap;
 export function createReporters(
   reporters: RstestConfig['reporters'],
   initOptions: any = {},
-): (Reporter | GithubActionsReporter)[] {
+): (Reporter | GithubActionsReporter | JunitReporter)[] {
   const result = castArray(reporters).map((reporter) => {
     if (typeof reporter === 'string' || Array.isArray(reporter)) {
       const [name, options = {}] =

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -3,7 +3,7 @@ import { isCI } from 'std-env';
 import { withDefaultConfig } from '../config';
 import { DefaultReporter } from '../reporter';
 import { GithubActionsReporter } from '../reporter/githubActions';
-import { JunitReporter } from '../reporter/junit';
+import { JUnitReporter } from '../reporter/junit';
 import { VerboseReporter } from '../reporter/verbose';
 import type {
   NormalizedConfig,
@@ -40,7 +40,7 @@ export class Rstest implements RstestContext {
   public command: RstestCommand;
   public fileFilters?: string[];
   public configFilePath?: string;
-  public reporters: (Reporter | GithubActionsReporter | JunitReporter)[];
+  public reporters: (Reporter | GithubActionsReporter | JUnitReporter)[];
   public snapshotManager: SnapshotManager;
   public version: string;
   public rootPath: string;
@@ -160,12 +160,12 @@ const reportersMap: {
   default: typeof DefaultReporter;
   verbose: typeof VerboseReporter;
   'github-actions': typeof GithubActionsReporter;
-  junit: typeof JunitReporter;
+  junit: typeof JUnitReporter;
 } = {
   default: DefaultReporter,
   verbose: VerboseReporter,
   'github-actions': GithubActionsReporter,
-  junit: JunitReporter,
+  junit: JUnitReporter,
 };
 
 export type BuiltInReporterNames = keyof typeof reportersMap;
@@ -173,7 +173,7 @@ export type BuiltInReporterNames = keyof typeof reportersMap;
 export function createReporters(
   reporters: RstestConfig['reporters'],
   initOptions: any = {},
-): (Reporter | GithubActionsReporter | JunitReporter)[] {
+): (Reporter | GithubActionsReporter | JUnitReporter)[] {
   const result = castArray(reporters).map((reporter) => {
     if (typeof reporter === 'string' || Array.isArray(reporter)) {
       const [name, options = {}] =

--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -228,8 +228,7 @@ export class JUnitReporter implements Reporter {
       (test) => test.status === 'fail',
     ).length;
     const totalErrors = totalFailures; // In JUnit, failures are treated as errors
-    const totalSkipped = testResults.filter(
-      (test) => test.status === 'skip',
+      (test) => test.status === 'skip' || test.status === 'todo',
     ).length;
     const totalTime = duration.testTime / 1000; // Convert to seconds
 

--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -227,7 +227,7 @@ export class JUnitReporter implements Reporter {
     const totalFailures = testResults.filter(
       (test) => test.status === 'fail',
     ).length;
-    const totalErrors = totalFailures; // In JUnit, failures are treated as errors
+    const totalErrors = 0; // This framework does not distinguish between failures and errors, so errors are always reported as zero.
       (test) => test.status === 'skip' || test.status === 'todo',
     ).length;
     const totalTime = duration.testTime / 1000; // Convert to seconds

--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -228,6 +228,7 @@ export class JUnitReporter implements Reporter {
       (test) => test.status === 'fail',
     ).length;
     const totalErrors = 0; // This framework does not distinguish between failures and errors, so errors are always reported as zero.
+    const totalSkipped = testResults.filter(
       (test) => test.status === 'skip' || test.status === 'todo',
     ).length;
     const totalTime = duration.testTime / 1000; // Convert to seconds

--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -47,7 +47,7 @@ interface JUnitReport {
   };
 }
 
-export class JunitReporter implements Reporter {
+export class JUnitReporter implements Reporter {
   private rootPath: string;
   private outputPath?: string;
 

--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -241,7 +241,6 @@ export class JunitReporter implements Reporter {
         errors: totalErrors,
         skipped: totalSkipped,
         time: totalTime,
-        // TODO
         timestamp: new Date().toISOString(),
         testsuite: testSuites,
       },

--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -1,0 +1,270 @@
+import { writeFile } from 'node:fs/promises';
+import { relative } from 'pathe';
+import stripAnsi from 'strip-ansi';
+import type {
+  Duration,
+  GetSourcemap,
+  Reporter,
+  TestFileResult,
+  TestResult,
+} from '../types';
+import { getTaskNameWithPrefix } from '../utils';
+import { formatStack, parseErrorStacktrace } from '../utils/error';
+
+interface JUnitTestCase {
+  name: string;
+  classname: string;
+  time: number;
+  status: string;
+  errors?: {
+    message: string;
+    type: string;
+    details?: string;
+  }[];
+}
+
+interface JUnitTestSuite {
+  name: string;
+  tests: number;
+  failures: number;
+  errors: number;
+  skipped: number;
+  time: number;
+  timestamp: string;
+  testcases: JUnitTestCase[];
+}
+
+interface JUnitReport {
+  testsuites: {
+    name: string;
+    tests: number;
+    failures: number;
+    errors: number;
+    skipped: number;
+    time: number;
+    timestamp: string;
+    testsuite: JUnitTestSuite[];
+  };
+}
+
+export class JunitReporter implements Reporter {
+  private rootPath: string;
+  private outputPath?: string;
+
+  constructor({
+    rootPath,
+    options: { outputPath } = {},
+  }: {
+    rootPath: string;
+    options?: { outputPath?: string };
+  }) {
+    this.rootPath = rootPath;
+    this.outputPath = outputPath;
+  }
+
+  private sanitizeXml(text: string): string {
+    let result = '';
+
+    // XML 1.0 valid chars: \x09 | \x0A | \x0D | [\x20-\uD7FF] | [\uE000-\uFFFD] | [\u{10000}-\u{10FFFF}]
+    // Iterate code points to keep valid ones and drop invalid (e.g., 0x1B, other control chars)
+    for (const ch of stripAnsi(text)) {
+      const cp = ch.codePointAt(0)!;
+      const valid =
+        cp === 0x09 ||
+        cp === 0x0a ||
+        cp === 0x0d ||
+        (cp >= 0x20 && cp <= 0xd7ff) ||
+        (cp >= 0xe000 && cp <= 0xfffd) ||
+        (cp >= 0x10000 && cp <= 0x10ffff);
+      if (valid) {
+        result += ch;
+      }
+    }
+    return result;
+  }
+
+  private escapeXml(text: string): string {
+    const sanitized = this.sanitizeXml(text);
+    return sanitized
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  private async createJUnitTestCase(
+    test: TestResult,
+    getSourcemap: GetSourcemap,
+  ): Promise<JUnitTestCase> {
+    const testCase: JUnitTestCase = {
+      name: getTaskNameWithPrefix(test),
+      classname: relative(this.rootPath, test.testPath),
+      time: (test.duration || 0) / 1000, // Convert to seconds
+      status: test.status,
+    };
+
+    if (test.errors && test.errors.length > 0) {
+      testCase.errors = await Promise.all(
+        test.errors.map(async (error) => {
+          let details = `${error.message}${error.diff ? `\n${error.diff}` : ''}`;
+          const stackFrames = error.stack
+            ? await parseErrorStacktrace({
+                stack: error.stack,
+                fullStack: error.fullStack,
+                getSourcemap,
+              })
+            : [];
+
+          if (stackFrames[0]) {
+            details += `\n${formatStack(stackFrames[0], this.rootPath)}`;
+          }
+
+          return {
+            message: this.escapeXml(error.message),
+            type: error.name || 'Error',
+            details: this.escapeXml(details),
+          };
+        }),
+      );
+    }
+
+    return testCase;
+  }
+
+  private async createJUnitTestSuite(
+    fileResult: TestFileResult,
+    getSourcemap: GetSourcemap,
+  ): Promise<JUnitTestSuite> {
+    const testCases = await Promise.all(
+      fileResult.results.map(async (test) =>
+        this.createJUnitTestCase(test, getSourcemap),
+      ),
+    );
+
+    const failures = testCases.filter((test) => test.status === 'fail').length;
+    const errors = testCases.filter((test) => test.status === 'fail').length; // In JUnit, failures are treated as errors
+    const skipped = testCases.filter(
+      (test) => test.status === 'skip' || test.status === 'todo',
+    ).length;
+    const totalTime = testCases.reduce((sum, test) => sum + test.time, 0);
+
+    return {
+      name: relative(this.rootPath, fileResult.testPath),
+      tests: testCases.length,
+      failures,
+      errors,
+      skipped,
+      time: totalTime,
+      timestamp: new Date().toISOString(),
+      testcases: testCases,
+    };
+  }
+
+  private generateJUnitXml(report: JUnitReport): string {
+    const xmlDeclaration = '<?xml version="1.0" encoding="UTF-8"?>';
+
+    const testsuitesXml = `
+<testsuites name="${this.escapeXml(report.testsuites.name)}" tests="${report.testsuites.tests}" failures="${report.testsuites.failures}" errors="${report.testsuites.errors}" skipped="${report.testsuites.skipped}" time="${report.testsuites.time}" timestamp="${this.escapeXml(report.testsuites.timestamp)}">`;
+
+    const testsuiteXmls = report.testsuites.testsuite
+      .map((suite) => {
+        const testsuiteStart = `
+  <testsuite name="${this.escapeXml(suite.name)}" tests="${suite.tests}" failures="${suite.failures}" errors="${suite.errors}" skipped="${suite.skipped}" time="${suite.time}" timestamp="${this.escapeXml(suite.timestamp)}">`;
+
+        const testcaseXmls = suite.testcases
+          .map((testcase) => {
+            let testcaseXml = `
+    <testcase name="${this.escapeXml(testcase.name)}" classname="${this.escapeXml(testcase.classname)}" time="${testcase.time}">`;
+
+            if (testcase.status === 'skip' || testcase.status === 'todo') {
+              testcaseXml += `
+      <skipped/>`;
+            } else if (testcase.status === 'fail' && testcase.errors) {
+              testcase.errors.forEach((error) => {
+                testcaseXml += `
+      <failure message="${error.message}" type="${error.type}">${error.details || ''}</failure>`;
+              });
+            }
+
+            testcaseXml += `
+    </testcase>`;
+            return testcaseXml;
+          })
+          .join('');
+
+        const testsuiteEnd = `
+  </testsuite>`;
+
+        return testsuiteStart + testcaseXmls + testsuiteEnd;
+      })
+      .join('');
+
+    const testsuitesEnd = `
+</testsuites>`;
+
+    return xmlDeclaration + testsuitesXml + testsuiteXmls + testsuitesEnd;
+  }
+
+  async onTestRunEnd({
+    results,
+    testResults,
+    duration,
+    getSourcemap,
+  }: {
+    getSourcemap: GetSourcemap;
+    results: TestFileResult[];
+    testResults: TestResult[];
+    duration: Duration;
+  }): Promise<void> {
+    const testSuites = await Promise.all(
+      results.map(async (fileResult) =>
+        this.createJUnitTestSuite(fileResult, getSourcemap),
+      ),
+    );
+
+    const totalTests = testResults.length;
+    const totalFailures = testResults.filter(
+      (test) => test.status === 'fail',
+    ).length;
+    const totalErrors = totalFailures; // In JUnit, failures are treated as errors
+    const totalSkipped = testResults.filter(
+      (test) => test.status === 'skip',
+    ).length;
+    const totalTime = duration.testTime / 1000; // Convert to seconds
+
+    const report: JUnitReport = {
+      testsuites: {
+        name: 'rstest tests',
+        tests: totalTests,
+        failures: totalFailures,
+        errors: totalErrors,
+        skipped: totalSkipped,
+        time: totalTime,
+        // TODO
+        timestamp: new Date().toISOString(),
+        testsuite: testSuites,
+      },
+    };
+
+    const xmlContent = this.generateJUnitXml(report);
+
+    if (this.outputPath) {
+      try {
+        await writeFile(this.outputPath, xmlContent, 'utf-8');
+        console.log(`JUnit XML report written to: ${this.outputPath}`);
+      } catch (error) {
+        console.error(
+          `Failed to write JUnit XML report to ${this.outputPath}:`,
+          error,
+        );
+        // Fallback to console output
+        console.log('JUnit XML Report:');
+        console.log(xmlContent);
+      }
+    } else {
+      // Output to console by default
+      console.log(xmlContent);
+    }
+  }
+}

--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -143,7 +143,7 @@ export class JUnitReporter implements Reporter {
     );
 
     const failures = testCases.filter((test) => test.status === 'fail').length;
-    const errors = testCases.filter((test) => test.status === 'fail').length; // In JUnit, failures are treated as errors
+    const errors = 0; // No separate error tracking; set to 0 for clarity
     const skipped = testCases.filter(
       (test) => test.status === 'skip' || test.status === 'todo',
     ).length;

--- a/packages/core/tests/reporter/junit.test.ts
+++ b/packages/core/tests/reporter/junit.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, onTestFinished, rs } from '@rstest/core';
+import { JunitReporter } from '../../src/reporter/junit';
+import type { Duration, TestFileResult, TestResult } from '../../src/types';
+
+describe('JunitReporter', () => {
+  it('should create JUnit XML report correctly', async () => {
+    const reporter = new JunitReporter({
+      rootPath: '/test/root',
+      options: {},
+    });
+
+    const mockTestResults: TestResult[] = [
+      {
+        status: 'pass',
+        name: 'should pass',
+        testPath: '/test/root/test1.test.ts',
+        duration: 100,
+        project: 'default',
+      },
+      {
+        status: 'fail',
+        name: 'should fail',
+        testPath: '/test/root/test1.test.ts',
+        duration: 200,
+        errors: [
+          {
+            message: 'Test failed',
+            name: 'AssertionError',
+            stack:
+              'Error: Test failed\n    at test (/test/root/test1.test.ts:10:5)',
+          },
+        ],
+        project: 'default',
+      },
+      {
+        status: 'skip',
+        name: 'should skip',
+        testPath: '/test/root/test1.test.ts',
+        duration: 0,
+        project: 'default',
+      },
+    ];
+
+    const mockFileResults: TestFileResult[] = [
+      {
+        status: 'fail',
+        name: 'test1.test.ts',
+        testPath: '/test/root/test1.test.ts',
+        duration: 300,
+        results: mockTestResults,
+        project: 'default',
+      },
+    ];
+
+    const mockDuration: Duration = {
+      totalTime: 500,
+      buildTime: 100,
+      testTime: 300,
+    };
+
+    // Mock console.log to capture output
+    const logs: string[] = [];
+
+    rs.spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+
+    onTestFinished(() => {
+      rs.resetAllMocks();
+    });
+
+    await reporter.onTestRunEnd({
+      results: mockFileResults,
+      testResults: mockTestResults,
+      duration: mockDuration,
+      getSourcemap: () => null,
+    });
+
+    // Verify that XML was generated
+    expect(
+      logs.some((log) =>
+        log.includes('<?xml version="1.0" encoding="UTF-8"?>'),
+      ),
+    ).toBe(true);
+    expect(logs.some((log) => log.includes('<testsuites'))).toBe(true);
+    expect(logs.some((log) => log.includes('<testsuite'))).toBe(true);
+    expect(logs.some((log) => log.includes('<testcase'))).toBe(true);
+    expect(logs.some((log) => log.includes('should pass'))).toBe(true);
+    expect(logs.some((log) => log.includes('should fail'))).toBe(true);
+    expect(logs.some((log) => log.includes('should skip'))).toBe(true);
+    expect(logs.some((log) => log.includes('<failure'))).toBe(true);
+    expect(logs.some((log) => log.includes('<skipped'))).toBe(true);
+  });
+
+  it('should handle empty test results', async () => {
+    // Mock console.log to capture output
+    const logs: string[] = [];
+
+    rs.spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+
+    onTestFinished(() => {
+      rs.resetAllMocks();
+    });
+
+    const reporter = new JunitReporter({
+      rootPath: '/test/root',
+      options: {},
+    });
+
+    const mockDuration: Duration = {
+      totalTime: 0,
+      buildTime: 0,
+      testTime: 0,
+    };
+
+    await reporter.onTestRunEnd({
+      results: [],
+      testResults: [],
+      duration: mockDuration,
+      getSourcemap: () => null,
+    });
+
+    expect(logs.some((log) => log.includes('tests="0"'))).toBe(true);
+    expect(logs.some((log) => log.includes('failures="0"'))).toBe(true);
+  });
+
+  it('should escape XML special characters', async () => {
+    // Mock console.log to capture output
+    const logs: string[] = [];
+
+    rs.spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+
+    const reporter = new JunitReporter({
+      rootPath: '/test/root',
+    });
+
+    const mockTestResults: TestResult[] = [
+      {
+        status: 'fail',
+        name: 'test with <xml> & "quotes" & \'apos\'',
+        testPath: '/test/root/test.test.ts',
+        duration: 100,
+        errors: [
+          {
+            message: 'Error with <xml> & "quotes" & \'apos\'',
+            name: 'TestError',
+            stack: 'Error: <xml> & "quotes" & \'apos\'',
+          },
+        ],
+        project: 'default',
+      },
+    ];
+
+    const mockFileResults: TestFileResult[] = [
+      {
+        status: 'fail',
+        name: 'test.test.ts',
+        testPath: '/test/root/test.test.ts',
+        duration: 100,
+        results: mockTestResults,
+        project: 'default',
+      },
+    ];
+
+    const mockDuration: Duration = {
+      totalTime: 100,
+      buildTime: 0,
+      testTime: 100,
+    };
+
+    await reporter.onTestRunEnd({
+      results: mockFileResults,
+      testResults: mockTestResults,
+      duration: mockDuration,
+      getSourcemap: () => null,
+    });
+
+    // Verify XML is properly escaped
+    expect(logs.some((log) => log.includes('&lt;xml&gt;'))).toBe(true);
+    expect(logs.some((log) => log.includes('&amp;'))).toBe(true);
+    expect(logs.some((log) => log.includes('&quot;'))).toBe(true);
+    expect(logs.some((log) => log.includes('&apos;'))).toBe(true);
+    expect(logs.some((log) => log.includes('<xml>'))).toBe(false); // Should not contain unescaped XML
+  });
+});

--- a/packages/core/tests/reporter/junit.test.ts
+++ b/packages/core/tests/reporter/junit.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, onTestFinished, rs } from '@rstest/core';
-import { JunitReporter } from '../../src/reporter/junit';
+import { JUnitReporter } from '../../src/reporter/junit';
 import type { Duration, TestFileResult, TestResult } from '../../src/types';
 
-describe('JunitReporter', () => {
+describe('JUnitReporter', () => {
   it('should create JUnit XML report correctly', async () => {
-    const reporter = new JunitReporter({
+    const reporter = new JUnitReporter({
       rootPath: '/test/root',
       options: {},
     });
@@ -104,7 +104,7 @@ describe('JunitReporter', () => {
       rs.resetAllMocks();
     });
 
-    const reporter = new JunitReporter({
+    const reporter = new JUnitReporter({
       rootPath: '/test/root',
       options: {},
     });
@@ -134,7 +134,7 @@ describe('JunitReporter', () => {
       logs.push(args.join(' '));
     });
 
-    const reporter = new JunitReporter({
+    const reporter = new JUnitReporter({
       rootPath: '/test/root',
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,9 @@ importers:
       stacktrace-parser:
         specifier: 0.1.11
         version: 0.1.11
+      strip-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
       tinyglobby:
         specifier: ^0.2.14
         version: 0.2.14

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,6 +1,7 @@
 # Custom Dictionary Words
 antd
 apng
+apos
 applescript
 atrules
 autodocs

--- a/website/docs/en/config/test/reporters.mdx
+++ b/website/docs/en/config/test/reporters.mdx
@@ -115,3 +115,63 @@ export default defineConfig({
 ```
   </Tab>
 </Tabs>
+
+### JUnit reporter
+
+The JUnit reporter supports outputting test reports in JUnit XML format, making it easy to integrate with CI/CD.
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+```bash
+npx rstest --reporter=junit
+```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: [['junit', { outputPath: './junit.xml' }]]
+});
+```
+  </Tab>
+</Tabs>
+
+#### Options
+
+- `outputPath`: Configure the output path for the report. If not specified, it will output to the console.
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: [['junit', { outputPath: './junit.xml' }]],
+});
+```
+
+#### Output example
+
+The JUnit reporter generates XML format as follows:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="rstest tests" tests="3" failures="1" errors="1" skipped="1" time="0.3" timestamp="2024-01-01T00:00:00.000Z">
+  <testsuite name="test1.test.ts" tests="3" failures="1" errors="1" skipped="1" time="0.3" timestamp="2024-01-01T00:00:00.000Z">
+    <testcase name="should pass" classname="test1.test.ts" time="0.1">
+    </testcase>
+    <testcase name="should fail" classname="test1.test.ts" time="0.2">
+      <failure message="Test failed" type="AssertionError">expected 'hi' to be 'hii' // Object.is equality - Expected + Received - hii + hi at test1.test.ts:10:21</failure>
+    </testcase>
+    <testcase name="should skip" classname="test1.test.ts" time="0.0">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>
+```
+
+The JUnit reporter maps test case execution status to JUnit test status:
+
+- `pass`: Test passed
+- `fail`: Test failed, generates `<failure>` tag
+- `skip`: Test skipped, generates `<skipped>` tag
+- `todo`: Test todo, generates `<skipped>` tag

--- a/website/docs/zh/config/test/reporters.mdx
+++ b/website/docs/zh/config/test/reporters.mdx
@@ -115,3 +115,63 @@ export default defineConfig({
 ```
   </Tab>
 </Tabs>
+
+### JUnit reporter
+
+JUnit 报告器支持以 JUnit XML 格式输出测试报告，方便与 CI/CD 系统集成。
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+```bash
+npx rstest --reporter=junit
+```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: ['junit']
+});
+```
+  </Tab>
+</Tabs>
+
+#### 配置项
+
+- `outputPath`: 配置报告输出的路径，如果不指定则输出到控制台。
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: [['junit', { outputPath: './junit.xml' }]],
+});
+```
+
+#### 输出示例
+
+JUnit 报告器生成的 XML 格式如下：
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="rstest tests" tests="3" failures="1" errors="1" skipped="1" time="0.3" timestamp="2024-01-01T00:00:00.000Z">
+  <testsuite name="test1.test.ts" tests="3" failures="1" errors="1" skipped="1" time="0.3" timestamp="2024-01-01T00:00:00.000Z">
+    <testcase name="should pass" classname="test1.test.ts" time="0.1">
+    </testcase>
+    <testcase name="should fail" classname="test1.test.ts" time="0.2">
+      <failure message="Test failed" type="AssertionError">expected 'hi' to be 'hii' // Object.is equality - Expected + Received - hii + hi at test1.test.ts:10:21</failure>
+    </testcase>
+    <testcase name="should skip" classname="test1.test.ts" time="0.0">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>
+```
+
+JUnit 报告器会根据测试用例的执行状态，将其映射为 JUnit 测试状态：
+
+- `pass`: 测试通过
+- `fail`: 测试失败，会生成 `<failure>` 标签
+- `skip`: 测试跳过，会生成 `<skipped>` 标签
+- `todo`: 测试待办，会生成 `<skipped>` 标签


### PR DESCRIPTION
## Summary

The JUnit reporter supports outputting test reports in JUnit XML format, making it easy to integrate with CI/CD.

```ts title="rstest.config.ts"
import { defineConfig } from '@rstest/core';

export default defineConfig({
  reporters: [['junit', { outputPath: './junit.xml' }]],
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
