### PR TITLE
docs: display llms UI

### DIFF
--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,7 +1,36 @@
-import { Layout as BaseLayout } from '@rspress/core/theme';
+import {
+  Layout as BaseLayout,
+  getCustomMDXComponent as basicGetCustomMDXComponent,
+} from '@rspress/core/theme';
+import {
+  LlmsContainer,
+  LlmsCopyButton,
+  LlmsViewOptions,
+} from '@rspress/plugin-llms/runtime';
 import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
+
 import { HomeLayout } from './pages';
 import './index.scss';
+
+export function getCustomMDXComponent() {
+  const { h1: H1, ...mdxComponents } = basicGetCustomMDXComponent();
+
+  const MyH1 = ({ ...props }) => {
+    return (
+      <>
+        <H1 {...props} />
+        <LlmsContainer>
+          <LlmsCopyButton />
+          <LlmsViewOptions />
+        </LlmsContainer>
+      </>
+    );
+  };
+  return {
+    ...mdxComponents,
+    h1: MyH1,
+  };
+}
 
 const Layout = () => {
   return <BaseLayout beforeNavTitle={<NavIcon />} />;


### PR DESCRIPTION
## Summary

display llms UI

https://v2.rspress.rs/plugin/official-plugins/llms#2-ui-display

<img width="984" height="222" alt="image" src="https://github.com/user-attachments/assets/6b444ae6-967e-4205-809b-783787218af7" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
