### PR TITLE
Revert "chore(deps): update dependency tinypool to v2"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
     "birpc": "2.5.0",
     "pathe": "^2.0.3",
     "std-env": "^3.9.0",
-    "tinypool": "^2.0.0"
+    "tinypool": "^1.1.1"
   },
   "devDependencies": {
     "@vitest/expect": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,8 +390,8 @@ importers:
         specifier: ^3.9.0
         version: 3.9.0
       tinypool:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@babel/code-frame':
         specifier: ^7.27.1
@@ -4391,10 +4391,6 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinypool@2.0.0:
-    resolution: {integrity: sha512-/RX9RzeH2xU5ADE7n2Ykvmi9ED3FBGPAjw9u3zucrNNaEBIO0HPSYgL0NT7+3p147ojeSdaVu08F6hjpv31HJg==}
-    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -9376,8 +9372,6 @@ snapshots:
       picomatch: 4.0.2
 
   tinypool@1.1.1: {}
-
-  tinypool@2.0.0: {}
 
   tinyrainbow@2.0.0: {}
 


### PR DESCRIPTION
Node 18 still needs support.

Reverts web-infra-dev/rstest#536