### PR TITLE
feat: support display the build progress via `dev.progressBar`

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -23,6 +23,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
             testEnvironment,
           },
           rootPath,
+          name: projectName,
         } = context.projects.find((p) => p.environmentName === name)!;
         return mergeEnvironmentConfig(
           config,
@@ -32,7 +33,15 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
             resolve,
             source,
             output,
-            dev,
+            dev: {
+              ...dev,
+              progressBar:
+                dev?.progressBar === true
+                  ? {
+                      id: projectName,
+                    }
+                  : dev?.progressBar,
+            },
           },
           {
             source: {

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -42,7 +42,7 @@ export class Rstest implements RstestContext {
   public command: RstestCommand;
   public fileFilters?: string[];
   public configFilePath?: string;
-  public reporters: (Reporter | GithubActionsReporter | JUnitReporter)[];
+  public reporters: Reporter[];
   public snapshotManager: SnapshotManager;
   public version: string;
   public rootPath: string;

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -2,13 +2,14 @@ import { relative } from 'pathe';
 import type {
   Duration,
   GetSourcemap,
+  Reporter,
   SnapshotSummary,
   TestFileResult,
   TestResult,
 } from '../types';
 import { getTaskNameWithPrefix, TEST_DELIMITER } from '../utils';
 
-export class GithubActionsReporter {
+export class GithubActionsReporter implements Reporter {
   private onWritePath: (path: string) => string;
   private rootPath: string;
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -213,7 +213,7 @@ export interface RstestConfig {
     'bundleAnalyze'
   >;
 
-  dev?: Pick<NonNullable<RsbuildConfig['dev']>, 'writeToDisk'>;
+  dev?: Pick<NonNullable<RsbuildConfig['dev']>, 'writeToDisk' | 'progressBar'>;
 
   output?: Pick<
     NonNullable<RsbuildConfig['output']>,

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -1036,6 +1036,132 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
 }
 `;
 
+exports[`prepareRsbuild > should generate rspack config correctly with progress bar 1`] = `
+[
+  {
+    "name": "RsbuildCorePlugin",
+  },
+  DefinePlugin {
+    "_args": [
+      {
+        "import.meta.env.ASSET_PREFIX": """",
+        "import.meta.env.BASE_URL": ""/"",
+        "import.meta.env.DEV": false,
+        "import.meta.env.MODE": ""none"",
+        "import.meta.env.PROD": false,
+        "import.meta.rstest": "global['@rstest/core']",
+        "process.env.ASSET_PREFIX": """",
+        "process.env.BASE_URL": ""/"",
+      },
+    ],
+    "affectedHooks": "compilation",
+    "name": "DefinePlugin",
+  },
+  WebpackManifestPlugin {
+    "options": {
+      "assetHookStage": Infinity,
+      "basePath": "",
+      "fileName": "test-manifest.json",
+      "filter": [Function],
+      "generate": [Function],
+      "map": null,
+      "publicPath": null,
+      "removeKeyHash": /\\(\\[a-f0-9\\]\\{16,32\\}\\\\\\.\\?\\)/gi,
+      "seed": undefined,
+      "serialize": [Function],
+      "sort": null,
+      "transformExtensions": /\\^\\(gz\\|map\\)\\$/i,
+      "useEntryKeys": false,
+      "useLegacyEmit": false,
+      "writeToFileEmit": false,
+    },
+  },
+  IgnoreModuleNotFoundErrorPlugin {},
+  MockRuntimeRspackPlugin {},
+  RstestCacheControlPlugin {},
+  RstestPlugin {
+    "_args": [
+      {
+        "hoistMockModule": true,
+        "importMetaPathName": true,
+        "injectModulePathName": true,
+        "manualMockRoot": "<ROOT>/packages/core/__mocks__",
+      },
+    ],
+    "affectedHooks": undefined,
+    "name": "RstestPlugin",
+  },
+]
+`;
+
+exports[`prepareRsbuild > should generate rspack config correctly with progress bar 2`] = `
+[
+  {
+    "name": "RsbuildCorePlugin",
+  },
+  DefinePlugin {
+    "_args": [
+      {
+        "import.meta.env.ASSET_PREFIX": """",
+        "import.meta.env.BASE_URL": ""/"",
+        "import.meta.env.DEV": false,
+        "import.meta.env.MODE": ""none"",
+        "import.meta.env.PROD": false,
+        "import.meta.rstest": "global['@rstest/core']",
+        "process.env.ASSET_PREFIX": """",
+        "process.env.BASE_URL": ""/"",
+      },
+    ],
+    "affectedHooks": "compilation",
+    "name": "DefinePlugin",
+  },
+  ProgressPlugin {
+    "_args": [
+      {
+        "id": "@test/node",
+        "prefix": "@test/node",
+      },
+    ],
+    "affectedHooks": undefined,
+    "name": "ProgressPlugin",
+  },
+  WebpackManifestPlugin {
+    "options": {
+      "assetHookStage": Infinity,
+      "basePath": "",
+      "fileName": "test-node-manifest.json",
+      "filter": [Function],
+      "generate": [Function],
+      "map": null,
+      "publicPath": null,
+      "removeKeyHash": /\\(\\[a-f0-9\\]\\{16,32\\}\\\\\\.\\?\\)/gi,
+      "seed": undefined,
+      "serialize": [Function],
+      "sort": null,
+      "transformExtensions": /\\^\\(gz\\|map\\)\\$/i,
+      "useEntryKeys": false,
+      "useLegacyEmit": false,
+      "writeToFileEmit": false,
+    },
+  },
+  IgnoreModuleNotFoundErrorPlugin {},
+  MockRuntimeRspackPlugin {},
+  RstestCacheControlPlugin {},
+  RstestPlugin {
+    "_args": [
+      {
+        "hoistMockModule": true,
+        "importMetaPathName": true,
+        "injectModulePathName": true,
+        "manualMockRoot": "<ROOT>/packages/core/__mocks__",
+      },
+    ],
+    "affectedHooks": undefined,
+    "name": "RstestPlugin",
+  },
+]
+`;
+
 exports[`prepareRsbuild > should generate rspack config correctly with projects 1`] = `
 {
   "context": "<ROOT>/packages/core",

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -140,6 +140,58 @@ describe('prepareRsbuild', () => {
     expect(bundlerConfigs[1]).toMatchSnapshot();
   });
 
+  it('should generate rspack config correctly with progress bar', async () => {
+    const rsbuildInstance = await prepareRsbuild(
+      {
+        rootPath,
+        normalizedConfig: {
+          root: rootPath,
+          name: 'test',
+        },
+        projects: [
+          {
+            name: 'test',
+            rootPath,
+            environmentName: 'test',
+            normalizedConfig: {
+              plugins: [],
+              resolve: {},
+              source: {},
+              output: {},
+              tools: {},
+              testEnvironment: 'jsdom',
+            },
+          },
+          {
+            name: '@test/node',
+            rootPath,
+            environmentName: 'test-node',
+            normalizedConfig: {
+              dev: {
+                progressBar: true,
+              },
+              plugins: [],
+              resolve: {},
+              source: {},
+              output: {},
+              tools: {},
+              testEnvironment: 'node',
+            },
+          },
+        ],
+      } as unknown as RstestContext,
+      async () => ({}),
+      {},
+    );
+    expect(rsbuildInstance).toBeDefined();
+    const {
+      origin: { bundlerConfigs },
+    } = await rsbuildInstance.inspectConfig();
+
+    expect(bundlerConfigs[0]?.plugins).toMatchSnapshot();
+    expect(bundlerConfigs[1]?.plugins).toMatchSnapshot();
+  });
+
   it('should generate swc config correctly with user customize', async () => {
     const rsbuildInstance = await prepareRsbuild(
       {

--- a/website/docs/en/config/build/dev.mdx
+++ b/website/docs/en/config/build/dev.mdx
@@ -7,3 +7,9 @@ Options for local development.
 ## dev.writeToDisk <RsbuildDocBadge path="/config/dev/write-to-disk" text="dev.writeToDisk" />
 
 By default, Rstest does not write test temporary files to disk, and this configuration item may be required when you debug rstest outputs.
+
+## dev.progressBar <RsbuildDocBadge path="/config/dev/progress-bar" text="dev.progressBar" />
+
+Whether to render progress bars to display the build progress.
+
+By default, Rstest does not display the build progress because the builds complete quickly. If the build takes a longer time, you can enable this configuration option to monitor the build progress.

--- a/website/docs/zh/config/build/dev.mdx
+++ b/website/docs/zh/config/build/dev.mdx
@@ -7,3 +7,9 @@ import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
 ## dev.writeToDisk <RsbuildDocBadge path="/config/dev/write-to-disk" text="dev.writeToDisk" />
 
 默认情况下，Rstest 不会将测试临时文件写入磁盘，当你需要调试 Rstest 产物时可能需要此配置项。
+
+## dev.progressBar <RsbuildDocBadge path="/config/dev/progress-bar" text="dev.progressBar" />
+
+是否渲染进度条以显示构建进度。
+
+默认情况下，Rstest 不会显示构建进度条因为构建会很快结束，如果构建时间较长，你可以开启此配置项以观测构建进度。

--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -112,7 +112,7 @@ const BUILD_OVERVIEW_GROUPS: Group[] = [
   },
   {
     name: 'dev',
-    items: ['dev.writeToDisk'],
+    items: ['dev.writeToDisk', 'dev.progressBar'],
   },
   {
     name: 'performance',


### PR DESCRIPTION
## Summary

Support display the build progress via `dev.progressBar` configuration.

By default, Rstest does not display the build progress because the builds complete quickly. If the build takes a longer time, you can enable `dev.progressBar`  configuration to monitor the build progress.

<img width="851" height="190" alt="image" src="https://github.com/user-attachments/assets/24011c59-5cea-4e8a-9663-254fedfcfbc3" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
