### PR TITLE
fix: add `rs` to global API

### DIFF
--- a/packages/core/globals.d.ts
+++ b/packages/core/globals.d.ts
@@ -10,6 +10,7 @@ declare global {
   const afterEach: typeof import('@rstest/core')['afterEach'];
   const onTestFinished: typeof import('@rstest/core')['onTestFinished'];
   const onTestFailed: typeof import('@rstest/core')['onTestFailed'];
+  const rs: typeof import('@rstest/core')['rs'];
   const rstest: typeof import('@rstest/core')['rstest'];
 }
 export {};


### PR DESCRIPTION
## Summary

add `rs` to global API.

```diff
- import { rs } from '@rstest/core';
import { sum } from './sum';

rs.mock('./sum', () => {
  return {
    sum: (a: number, b: number) => a + b + 100,
  };
});

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
