### PR TITLE
fix: add `onTestFinished` / `onTestFailed` to global APIs

### DIFF
--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -31,6 +31,8 @@ export const globalApis: (keyof Rstest)[] = [
   'rstest',
   'rs',
   'assert',
+  'onTestFinished',
+  'onTestFailed',
 ];
 
 export const TS_CONFIG_FILE = 'tsconfig.json';


### PR DESCRIPTION
## Summary

add `onTestFinished` / `onTestFailed` to global APIs.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
