### PR TITLE
fix: support use rstest global APIs in external modules

### DIFF
--- a/e2e/runner/test/fixtures/globals.test.ts
+++ b/e2e/runner/test/fixtures/globals.test.ts
@@ -1,0 +1,5 @@
+import 'rstest-globals';
+
+it('should run setup correctly', async () => {
+  expect(process.env.A).toBe('A');
+});

--- a/e2e/runner/test/fixtures/test-rstest-globals/index.js
+++ b/e2e/runner/test/fixtures/test-rstest-globals/index.js
@@ -1,0 +1,16 @@
+beforeAll(() => {
+  process.env.A = 'A';
+});
+
+describe('wrap test', () => {
+  it('should run', () => {
+    const fn = rs.fn(() => 'hello');
+
+    expect(fn()).toBe('hello');
+    expect('call it').toBe('call it');
+  });
+
+  it.todo('should not run', () => {
+    expect(1 + 1).toBe(3);
+  });
+});

--- a/e2e/runner/test/fixtures/test-rstest-globals/package.json
+++ b/e2e/runner/test/fixtures/test-rstest-globals/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "@rstest/tests-rstest-globals",
+  "main": "index.js",
+  "type": "module",
+  "sideEffects": true,
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*"
+  }
+}

--- a/e2e/runner/test/runner.test.ts
+++ b/e2e/runner/test/runner.test.ts
@@ -27,3 +27,24 @@ it('should import rstest correctly in node_modules', async () => {
   await expectExecSuccess();
   expectLog('Tests 2 passed | 1 todo');
 });
+
+it('should use rstest global APIs correctly in node_modules', async () => {
+  await prepareFixtures({
+    fixturesPath: join(__dirname, './fixtures/test-rstest-globals'),
+    fixturesTargetPath: join(
+      __dirname,
+      './fixtures/node_modules/rstest-globals',
+    ),
+  });
+  const { expectExecSuccess, expectLog } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'globals.test.ts', '--globals'],
+    options: {
+      nodeOptions: {
+        cwd: join(__dirname, 'fixtures'),
+      },
+    },
+  });
+  await expectExecSuccess();
+  expectLog('Tests 2 passed | 1 todo');
+});

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -14,11 +14,12 @@ import { loadModule } from './loadModule';
 import { createForksRpcOptions, createRuntimeRpc } from './rpc';
 import { RstestSnapshotEnvironment } from './snapshot';
 
-const getGlobalApi = (api: Rstest) => {
+const registerGlobalApi = (api: Rstest) => {
   return globalApis.reduce<{
     [key in keyof Rstest]?: Rstest[key];
   }>((apis, key) => {
-    apis[key] = api[key] as any;
+    // @ts-expect-error register to global
+    globalThis[key] = api[key] as any;
     return apis;
   }, {});
 };
@@ -141,11 +142,14 @@ const preparePool = async ({
       throw new Error(`Unknown test environment: ${testEnvironment}`);
   }
 
+  if (globals) {
+    registerGlobalApi(api);
+  }
+
   const rstestContext = {
     global,
     console: global.console,
     Error,
-    ...(globals ? getGlobalApi(api) : {}),
   };
 
   // @ts-expect-error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
 
+  e2e/runner/test/fixtures/test-rstest-globals:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../../../packages/core
+
   e2e/runner/test/fixtures/test-rstest-import:
     devDependencies:
       '@rstest/core':


### PR DESCRIPTION
## Summary

support use rstest global APIs in external modules.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
