### PR TITLE
fix(coverage): fix coverage exclusion on windows

### DIFF
--- a/e2e/projects/coverage.test.ts
+++ b/e2e/projects/coverage.test.ts
@@ -7,8 +7,7 @@ import { runRstestCli } from '../scripts';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// TODO: swc-plugin-coverage-instrument `unstableExclude` option should works in windows
-describe.skipIf(process.platform === 'win32')('test projects coverage', () => {
+describe('test projects coverage', () => {
   it('should run projects correctly with coverage', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/e2e/test-coverage/index.test.ts
+++ b/e2e/test-coverage/index.test.ts
@@ -3,8 +3,7 @@ import { describe, expect, it } from '@rstest/core';
 import fs from 'fs-extra';
 import { runRstestCli } from '../scripts';
 
-// TODO: swc-plugin-coverage-instrument `unstableExclude` option should works in windows
-describe.skipIf(process.platform === 'win32')('test coverage-istanbul', () => {
+describe('test coverage-istanbul', () => {
   it('coverage-istanbul', async () => {
     const { expectExecSuccess, expectLog, cli } = await runRstestCli({
       command: 'rstest',

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -20,7 +20,7 @@
     "dev": "rslib build --watch"
   },
   "dependencies": {
-    "swc-plugin-coverage-instrument": "^0.0.28",
+    "swc-plugin-coverage-instrument": "^0.0.30",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-report": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,8 +529,8 @@ importers:
         specifier: ^3.1.7
         version: 3.1.7
       swc-plugin-coverage-instrument:
-        specifier: ^0.0.28
-        version: 0.0.28
+        specifier: ^0.0.30
+        version: 0.0.30
     devDependencies:
       '@rslib/core':
         specifier: 0.12.2
@@ -4557,8 +4557,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swc-plugin-coverage-instrument@0.0.28:
-    resolution: {integrity: sha512-ps70ske/LiIubyKOakw5rSOjHOIv6ecyyGQY0BctkVS2t776qtIVS2nqpAUaw3g5VMgAGoq/TShV12D3D7n3ag==}
+  swc-plugin-coverage-instrument@0.0.30:
+    resolution: {integrity: sha512-E9s0od1/42Sc4eYGB7EZgGWGX6wG5CgPqwqD3CBCd3psW20CGhnD/9MWlwgvD3KDAYdQfZa44ZhUeL/QFaweXA==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -9731,7 +9731,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-plugin-coverage-instrument@0.0.28: {}
+  swc-plugin-coverage-instrument@0.0.30: {}
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
## Summary

Fix coverage plugin's exclusion config on Windows, reenable https://github.com/web-infra-dev/rstest/blob/4aed867108285a08e16246cb292b1ead68dfbe7e/e2e/projects/coverage.test.ts#L10

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
