### PR TITLE
feat: allow set coverage thresholds as negative number

### DIFF
--- a/e2e/test-coverage/fixtures/rstest.thresholds.config.ts
+++ b/e2e/test-coverage/fixtures/rstest.thresholds.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     reporters: [],
     thresholds: {
       statements: 100,
+      lines: -1,
     },
   },
   setupFiles: ['./rstest.setup.ts'],

--- a/e2e/test-coverage/fixtures/test/string.test.ts
+++ b/e2e/test-coverage/fixtures/test/string.test.ts
@@ -1,21 +1,7 @@
 import { describe, expect, it } from '@rstest/core';
-import { capitalize, countWords, isPalindrome, truncate } from '../src/string';
+import { countWords, isPalindrome, truncate } from '../src/string';
 
 describe('String Utils', () => {
-  describe('capitalize', () => {
-    it('should capitalize first letter', () => {
-      expect(capitalize('hello')).toBe('Hello');
-    });
-
-    it('should handle empty string', () => {
-      expect(capitalize('')).toBe('');
-    });
-
-    it('should handle single character', () => {
-      expect(capitalize('a')).toBe('A');
-    });
-  });
-
   describe('isPalindrome', () => {
     it('should return true for palindrome', () => {
       expect(isPalindrome('racecar')).toBe(true);

--- a/e2e/test-coverage/index.test.ts
+++ b/e2e/test-coverage/index.test.ts
@@ -47,11 +47,11 @@ describe('test coverage-istanbul', () => {
     ).toBeTruthy();
     expect(
       logs.find((log) => log.includes('string.ts'))?.replaceAll(' ', ''),
-    ).toMatchInlineSnapshot(`"string.ts|95.23|100|83.33|92.85|7"`);
+    ).toMatchInlineSnapshot(`"string.ts|80.95|50|66.66|78.57|2-3,7"`);
 
     expect(
       logs.find((log) => log.includes('All files'))?.replaceAll(' ', ''),
-    ).toMatchInlineSnapshot(`"Allfiles|98.68|100|94.44|98.21|"`);
+    ).toMatchInlineSnapshot(`"Allfiles|94.73|83.33|88.88|94.64|"`);
 
     // text reporter
     expectLog('% Stmts', logs);
@@ -111,7 +111,7 @@ describe('test coverage-istanbul', () => {
     expect(logs.find((log) => log.includes('index.ts'))).toBeFalsy();
     expect(
       logs.find((log) => log.includes('string.ts'))?.replaceAll(' ', ''),
-    ).toMatchInlineSnapshot(`"string.ts|95.23|100|83.33|92.85|7"`);
+    ).toMatchInlineSnapshot(`"string.ts|80.95|50|66.66|78.57|2-3,7"`);
 
     // text reporter
     expectLog('% Stmts', logs);
@@ -163,6 +163,11 @@ describe('test coverage-istanbul', () => {
 
     expectLog(
       /Coverage for statements .* does not meet global threshold/,
+      logs,
+    );
+
+    expectLog(
+      /Uncovered lines .* exceeds maximum global threshold allowed/,
       logs,
     );
   });

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -1,4 +1,8 @@
-import type { CoverageMap, CoverageSummary } from 'istanbul-lib-coverage';
+import type {
+  CoverageMap,
+  CoverageSummary,
+  Totals,
+} from 'istanbul-lib-coverage';
 import type { ReportOptions } from 'istanbul-reports';
 
 type ReportWithOptions<Name extends keyof ReportOptions = keyof ReportOptions> =
@@ -16,6 +20,8 @@ type Thresholds = {
   /** Thresholds for lines */
   lines?: number;
 };
+
+export type CoverageSummaryTotals = Totals;
 
 export type { CoverageMap, CoverageSummary };
 

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -205,6 +205,8 @@ type CoverageThresholds = {
 
 Coverage thresholds for enforcing minimum coverage requirements. You can set thresholds for statements, functions, branches, and lines.
 
+Thresholds specified as a positive number are taken to be the minimum percentage required. Thresholds specified as a negative number represent the maximum number of uncovered entities allowed.
+
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
 
@@ -215,7 +217,7 @@ export default defineConfig({
       statements: 80,
       functions: 80,
       branches: 80,
-      lines: 80,
+      lines: -10,
     },
   },
 });
@@ -224,8 +226,8 @@ export default defineConfig({
 When the code coverage is below the specified thresholds, the test will fail and output an error message like below:
 
 ```bash
-Coverage for statements 75% does not meet global threshold 80%
-Coverage for functions 75% does not meet global threshold 80%
-Coverage for branches 75% does not meet global threshold 80%
-Coverage for lines 75% does not meet global threshold 80%
+Error: Coverage for statements 75% does not meet global threshold 80%
+Error: Coverage for functions 75% does not meet global threshold 80%
+Error: Coverage for branches 75% does not meet global threshold 80%
+Error: Uncovered lines 20 exceeds maximum global threshold allowed 10
 ```

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -205,6 +205,8 @@ type CoverageThresholds = {
 
 设置最低代码覆盖率要求。你可以为语句、函数、分支和行覆盖率设置阈值。
 
+当阈值设置为正数时，表示所需的最低百分比。当阈值设置为负数时，表示允许未覆盖的最大数量。
+
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
 
@@ -215,7 +217,7 @@ export default defineConfig({
       statements: 80,
       functions: 80,
       branches: 80,
-      lines: 80,
+      lines: -10,
     },
   },
 });
@@ -224,8 +226,8 @@ export default defineConfig({
 当代码覆盖率低于指定阈值时，测试将失败并输出如下错误信息：
 
 ```bash
-Coverage for statements 75% does not meet global threshold 80%
-Coverage for functions 75% does not meet global threshold 80%
-Coverage for branches 75% does not meet global threshold 80%
-Coverage for lines 75% does not meet global threshold 80%
+Error: Coverage for statements 75% does not meet global threshold 80%
+Error: Coverage for functions 75% does not meet global threshold 80%
+Error: Coverage for branches 75% does not meet global threshold 80%
+Error: Uncovered lines 20 exceeds maximum global threshold allowed 10
 ```


### PR DESCRIPTION
## Summary

Allow set coverage thresholds as negative number. Thresholds specified as a negative number represent the maximum number of uncovered entities allowed.

```ts title='rstest.config.ts'
import { defineConfig } from '@rstest/core';

export default defineConfig({
  coverage: {
    enabled: true,
    thresholds: {
      lines: -10,
    },
  },
});
```

```bash
Error: Uncovered lines 20 exceeds maximum global threshold allowed 10
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
