### PR TITLE
chore: enhance error logs of loading coverage plugin failed

### DIFF
--- a/packages/core/src/coverage/index.ts
+++ b/packages/core/src/coverage/index.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { CoverageOptions, CoverageProvider } from '../types/coverage';
+import { color } from '../utils';
 export const CoverageProviderMap: Record<string, string> = {
   istanbul: '@rstest/coverage-istanbul',
 };
@@ -31,10 +32,12 @@ export const loadCoverageProvider = async (
       pluginCoverage,
       CoverageProvider,
     };
-  } catch (error) {
-    throw new Error(
-      `Failed to load coverage provider module: ${moduleName} in ${root}. Make sure it is installed.\nOriginal error: ${(error as Error).message}`,
+  } catch {
+    const error = new Error(
+      `Failed to load coverage provider module: ${color.cyan(moduleName)} in ${color.underline(root)}, please make sure it is installed.\n`,
     );
+    error.stack = '';
+    throw error;
   }
 };
 


### PR DESCRIPTION
## Summary

enhance error logs of loading coverage plugin failed

### Before
<img width="2050" height="282" alt="image" src="https://github.com/user-attachments/assets/2da01ff2-1bee-45c0-8bba-7111cd026eab" />

### Now
<img width="2106" height="100" alt="image" src="https://github.com/user-attachments/assets/d32aefd0-6a90-4acf-bece-c4662dc9dc6d" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
