### PR TITLE
docs: adding type declarations via tsconfig.json

### DIFF
--- a/website/docs/en/config/test/globals.mdx
+++ b/website/docs/en/config/test/globals.mdx
@@ -47,7 +47,17 @@ describe('Index', () => {
 
 ### TypeScript support
 
-To get TypeScript working with the global APIs, you can create a `src/rstestEnv.d.ts` file to reference:
+To enable TypeScript to properly recognize the global APIs, add the `@rstest/core/globals` type declaration in your `tsconfig.json`:
+
+```ts title=tsconfig.json
+{
+  "compilerOptions": {
+    "types": ["@rstest/core/globals"]
+  }
+}
+```
+
+Alternatively, create a `src/rstestEnv.d.ts` file to reference the type definitions:
 
 ```ts title=rstestEnv.d.ts
 /// <reference types="@rstest/core/globals" />

--- a/website/docs/zh/config/test/globals.mdx
+++ b/website/docs/zh/config/test/globals.mdx
@@ -47,7 +47,17 @@ describe('Index', () => {
 
 ### 类型支持
 
-为了让 TypeScript 支持全局 API，你可以创建一个 `src/rstestEnv.d.ts` 文件来引用：
+为了让 TypeScript 正确识别全局 API，在 `tsconfig.json` 中添加 `@rstest/core/globals` 类型声明：
+
+```ts title=tsconfig.json
+{
+  "compilerOptions": {
+    "types": ["@rstest/core/globals"]
+  }
+}
+```
+
+或者创建一个 `src/rstestEnv.d.ts` 文件来引用类型定义：
 
 ```ts title=rstestEnv.d.ts
 /// <reference types="@rstest/core/globals" />


### PR DESCRIPTION
## Summary

Add preferred method of adding type declarations via `tsconfig.json` and keep alternative method using `d.ts` file.

Switching from a local `.d.ts` file to `tsconfig.json` makes global types more explicit and aligned with TypeScript best practices.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
