### PR TITLE
feat: support check coverage threshold for glob files

### DIFF
--- a/e2e/test-coverage/fixtures/rstest.globThresholds.config.ts
+++ b/e2e/test-coverage/fixtures/rstest.globThresholds.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    provider: 'istanbul',
+    reporters: [],
+    thresholds: {
+      'node/**': {
+        statements: 90,
+      },
+      'src/**': {
+        statements: 100,
+      },
+    },
+  },
+  setupFiles: ['./rstest.setup.ts'],
+});

--- a/e2e/test-coverage/index.test.ts
+++ b/e2e/test-coverage/index.test.ts
@@ -142,33 +142,4 @@ describe('test coverage-istanbul', () => {
       fs.existsSync(join(__dirname, 'fixtures/test-temp-coverage/index.html')),
     ).toBeTruthy();
   });
-
-  it('coverage-istanbul with thresholds check', async () => {
-    const { expectLog, cli } = await runRstestCli({
-      command: 'rstest',
-      args: ['run', '-c', 'rstest.thresholds.config.ts'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures'),
-        },
-      },
-    });
-
-    await cli.exec;
-    const exitCode = cli.exec.process?.exitCode;
-
-    expect(exitCode).toBe(1);
-
-    const logs = cli.stdout.split('\n').filter(Boolean);
-
-    expectLog(
-      /Coverage for statements .* does not meet global threshold/,
-      logs,
-    );
-
-    expectLog(
-      /Uncovered lines .* exceeds maximum global threshold allowed/,
-      logs,
-    );
-  });
 });

--- a/e2e/test-coverage/thresholds.test.ts
+++ b/e2e/test-coverage/thresholds.test.ts
@@ -1,0 +1,60 @@
+import { join } from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+describe('coverageThresholds', () => {
+  it('should check global threshold correctly', async () => {
+    const { expectLog, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', 'rstest.thresholds.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    const exitCode = cli.exec.process?.exitCode;
+
+    expect(exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expectLog(
+      /Coverage for statements .* does not meet global threshold/,
+      logs,
+    );
+
+    expectLog(
+      /Uncovered lines .* exceeds maximum global threshold allowed/,
+      logs,
+    );
+  });
+
+  it('should check glob threshold correctly', async () => {
+    const { expectLog, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', 'rstest.globThresholds.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await cli.exec;
+    const exitCode = cli.exec.process?.exitCode;
+
+    expect(exitCode).toBe(1);
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expectLog(
+      /Coverage for statements .* does not meet "src\/\*\*" threshold/,
+      logs,
+    );
+
+    expectLog(/Coverage data for "node\/\*\*" was not found/, logs);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,6 +72,7 @@
     "@types/jsdom": "^21.1.7",
     "@types/sinonjs__fake-timers": "^8.1.5",
     "@types/source-map-support": "^0.5.10",
+    "@types/picomatch": "^4.0.2",
     "cac": "^6.7.14",
     "chokidar": "^4.0.3",
     "happy-dom": "^18.0.1",
@@ -85,7 +86,8 @@
     "stacktrace-parser": "0.1.11",
     "strip-ansi": "^7.1.2",
     "tinyglobby": "^0.2.15",
-    "tinyspy": "^4.0.3"
+    "tinyspy": "^4.0.3",
+    "picomatch": "^4.0.3"
   },
   "peerDependencies": {
     "happy-dom": "*",

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -290,10 +290,12 @@ export async function runTests(context: Rstest): Promise<void> {
           const { checkThresholds } = await import(
             '../coverage/checkThresholds'
           );
-          const thresholdResult = checkThresholds(
-            finalCoverageMap,
-            context.normalizedConfig.coverage.thresholds,
-          );
+          const thresholdResult = checkThresholds({
+            coverageMap: finalCoverageMap,
+            thresholds: context.normalizedConfig.coverage.thresholds,
+            coverageProvider,
+            rootPath: context.rootPath,
+          });
           if (!thresholdResult.success) {
             process.exitCode = 1;
             logger.log('');

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -1,6 +1,8 @@
 import type {
   CoverageMap,
+  CoverageMapData,
   CoverageSummary,
+  FileCoverageData,
   Totals,
 } from 'istanbul-lib-coverage';
 import type { ReportOptions } from 'istanbul-reports';
@@ -10,22 +12,27 @@ type ReportWithOptions<Name extends keyof ReportOptions = keyof ReportOptions> =
     ? [Name, Partial<ReportOptions[Name]>]
     : [Name, Record<string, unknown>];
 
-type Thresholds = {
-  /** Thresholds for statements */
+export type CoverageThreshold = {
+  /** Threshold for statements */
   statements?: number;
-  /** Thresholds for functions */
+  /** Threshold for functions */
   functions?: number;
-  /** Thresholds for branches */
+  /** Threshold for branches */
   branches?: number;
-  /** Thresholds for lines */
+  /** Threshold for lines */
   lines?: number;
 };
 
 export type CoverageSummaryTotals = Totals;
 
-export type { CoverageMap, CoverageSummary };
+export type { CoverageMap, CoverageMapData, CoverageSummary };
 
-export type CoverageThresholds = Thresholds;
+export type CoverageThresholds =
+  | CoverageThreshold
+  | (CoverageThreshold & {
+      /** check thresholds for matched files */
+      [glob: string]: CoverageThreshold;
+    });
 
 export type CoverageOptions = {
   /**
@@ -33,6 +40,14 @@ export type CoverageOptions = {
    * @default false
    */
   enabled?: boolean;
+
+  /**
+   * A list of glob patterns that should be included for coverage collection.
+   * Only collect coverage for tested files by default.
+   *
+   * @default undefined
+   */
+  include?: string[];
 
   /**
    * A list of glob patterns that should be excluded from coverage collection.
@@ -82,9 +97,10 @@ export type CoverageOptions = {
 };
 
 export type NormalizedCoverageOptions = Required<
-  Omit<CoverageOptions, 'thresholds'>
+  Omit<CoverageOptions, 'thresholds' | 'include'>
 > & {
   thresholds?: CoverageThresholds;
+  include?: string[];
 };
 
 export declare class CoverageProvider {
@@ -103,6 +119,13 @@ export declare class CoverageProvider {
    * Create a new coverage map
    */
   createCoverageMap(): CoverageMap;
+
+  /**
+   * Generate coverage for untested files
+   */
+  generateCoverageForUntestedFiles(
+    untestedFiles: string[],
+  ): Promise<FileCoverageData[]>;
 
   /**
    * Generate coverage reports

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@types/sinonjs__fake-timers':
         specifier: ^8.1.5
         version: 8.1.5
@@ -489,6 +492,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      picomatch:
+        specifier: ^4.0.3
+        version: 4.0.3
       rslog:
         specifier: ^1.2.11
         version: 1.2.11
@@ -1939,6 +1945,9 @@ packages:
 
   '@types/node@22.16.5':
     resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
+
+  '@types/picomatch@4.0.2':
+    resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
 
   '@types/pixelmatch@5.2.6':
     resolution: {integrity: sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==}
@@ -6592,6 +6601,8 @@ snapshots:
   '@types/node@22.16.5':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/picomatch@4.0.2': {}
 
   '@types/pixelmatch@5.2.6':
     dependencies:

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -190,15 +190,16 @@ export default defineConfig({
 - **Type:**
 
 ```ts
-type CoverageThresholds = {
-  /** Thresholds for statements */
+type CoverageThreshold = {
   statements?: number;
-  /** Thresholds for functions */
   functions?: number;
-  /** Thresholds for branches */
   branches?: number;
-  /** Thresholds for lines */
   lines?: number;
+};
+
+type CoverageThresholds = CoverageThreshold & {
+  /** check thresholds for matched files */
+  [glob: string]: CoverageThreshold;
 };
 ```
 
@@ -232,3 +233,34 @@ Error: Coverage for functions 75% does not meet global threshold 80%
 Error: Coverage for branches 75% does not meet global threshold 80%
 Error: Uncovered lines 20 exceeds maximum global threshold allowed 10
 ```
+
+#### glob pattern
+
+If globs are specified, thresholds will be checked for each matched file pattern. If the file specified by path is not found, an error is returned.
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    thresholds: {
+      // Thresholds for matching glob pattern
+      'src/**': {
+        statements: 100,
+      },
+      'node/**/*.js': {
+        statements: 90,
+      },
+      // Thresholds for all files
+      statements: 80,
+    },
+  },
+});
+```
+
+Following the above configuration, rstest will fail if:
+
+- The total code coverage of all files in `src/**` is below 100%.
+- The total code coverage of all files in `node/**/*.js` is below 90%.
+- The global code coverage is below 80% for statements.

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -190,15 +190,16 @@ export default defineConfig({
 - **类型：**
 
 ```ts
-type CoverageThresholds = {
-  /** 语句的阈值 */
+type CoverageThreshold = {
   statements?: number;
-  /** 函数的阈值 */
   functions?: number;
-  /** 分支的阈值 */
   branches?: number;
-  /** 行的阈值 */
   lines?: number;
+};
+
+type CoverageThresholds = CoverageThreshold & {
+  /** 为匹配的文件指定覆盖率阈值 */
+  [glob: string]: CoverageThreshold;
 };
 ```
 
@@ -232,3 +233,34 @@ Error: Coverage for functions 75% does not meet global threshold 80%
 Error: Coverage for branches 75% does not meet global threshold 80%
 Error: Uncovered lines 20 exceeds maximum global threshold allowed 10
 ```
+
+#### glob 模式
+
+当指定 glob 模式时，Rstest 将根据匹配的文件模式进行代码覆盖率检查。如果指定的文件路径不存在，则返回错误。
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    thresholds: {
+      // 为匹配的文件指定覆盖率阈值
+      'src/**': {
+        statements: 100,
+      },
+      'node/**/*.js': {
+        statements: 90,
+      },
+      // 指定所有文件的总阈值
+      statements: 80,
+    },
+  },
+});
+```
+
+根据以上配置，rstest 将在以下情况下失败：
+
+- `src/**` 匹配到的文件的总语句覆盖率低于 100%。
+- `node/**/*.js` 匹配到的文件的总语句覆盖率低于 90%。
+- 全局的语句覆盖率低于 80%。


### PR DESCRIPTION
## Summary

If globs are specified, thresholds will be checked for each matched file pattern. If the file specified by path is not found, an error is returned.

```ts title='rstest.config.ts'
import { defineConfig } from '@rstest/core';

export default defineConfig({
  coverage: {
    enabled: true,
    thresholds: {
      // Thresholds for matching glob pattern
      'src/**': {
        statements: 100,
      },
      'node/**/*.js': {
        statements: 90,
      },
      // Thresholds for all files
      statements: 80,
    },
  },
});
```

Following the above configuration, rstest will fail if:

- The total code coverage of all files in `src/**` is below 100%.
- The total code coverage of all files in `node/**/*.js` is below 90%.
- The global code coverage is below 80% for statements.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
