### PR TITLE
feat: support check coverage threshold for per file

### DIFF
--- a/e2e/test-coverage/fixtures/rstest.perFileThresholds.config.ts
+++ b/e2e/test-coverage/fixtures/rstest.perFileThresholds.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    provider: 'istanbul',
+    reporters: [],
+    thresholds: {
+      'src/**': {
+        perFile: true,
+        statements: 100,
+      },
+    },
+  },
+  setupFiles: ['./rstest.setup.ts'],
+});

--- a/e2e/test-coverage/thresholds.test.ts
+++ b/e2e/test-coverage/thresholds.test.ts
@@ -19,12 +19,12 @@ describe('coverageThresholds', () => {
     const logs = cli.stdout.split('\n').filter(Boolean);
 
     expectLog(
-      /Coverage for statements .* does not meet global threshold/,
+      /Coverage for statements .* does not meet global threshold/i,
       logs,
     );
 
     expectLog(
-      /Uncovered lines .* exceeds maximum global threshold allowed/,
+      /Uncovered lines .* exceeds maximum global threshold allowed/i,
       logs,
     );
   });
@@ -45,10 +45,31 @@ describe('coverageThresholds', () => {
     const logs = cli.stdout.split('\n').filter(Boolean);
 
     expectLog(
-      /Coverage for statements .* does not meet "src\/\*\*" threshold/,
+      /Error: coverage for statements .* does not meet "src\/\*\*" threshold/i,
       logs,
     );
 
-    expectLog(/Coverage data for "node\/\*\*" was not found/, logs);
+    expectLog(/Coverage data for "node\/\*\*" was not found/i, logs);
+  });
+
+  it('should check per files threshold correctly', async () => {
+    const { expectLog, expectExecFailed, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', 'rstest.perFileThresholds.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecFailed();
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expectLog(
+      /src\/string.ts coverage for statements .* does not meet "src\/\*\*" threshold/,
+      logs,
+    );
   });
 });

--- a/packages/core/src/coverage/checkThresholds.ts
+++ b/packages/core/src/coverage/checkThresholds.ts
@@ -38,6 +38,7 @@ export function checkThresholds({
   const thresholdGroup: (CoverageThreshold & {
     name: string;
     coverageMap: CoverageMap;
+    perFile?: boolean;
   })[] = [
     {
       statements: thresholds.statements,
@@ -46,6 +47,7 @@ export function checkThresholds({
       lines: thresholds.lines,
       name: 'global',
       coverageMap,
+      perFile: false,
     },
   ];
 
@@ -66,7 +68,7 @@ export function checkThresholds({
 
     if (!matchedFiles.length) {
       failedThresholds.push(
-        `${color.red('Error')}: Coverage data for "${key}" was not found`,
+        `${color.red('Error')}: coverage data for "${key}" was not found`,
       );
       continue;
     }
@@ -87,34 +89,46 @@ export function checkThresholds({
     name: keyof CoverageSummary,
     type: string,
     actual: CoverageSummaryTotals,
-    expected?: number,
+    expected: number,
+    file?: string,
   ) => {
+    let errorMsg = '';
     if (expected !== undefined) {
       // Thresholds specified as a negative number represent the maximum number of uncovered entities allowed.
       if (expected < 0) {
         const uncovered = actual.total - actual.covered;
         if (uncovered > -expected) {
-          failedThresholds.push(
-            `${color.red('Error')}: Uncovered ${name} ${color.red(`${uncovered}`)} exceeds maximum ${type === 'global' ? 'global' : `"${type}"`} threshold allowed ${color.yellow(`${-expected}`)}`,
-          );
+          errorMsg += `uncovered ${name} ${color.red(`${uncovered}`)} exceeds maximum ${type === 'global' ? 'global' : `"${type}"`} threshold allowed ${color.yellow(`${-expected}`)}`;
         }
       }
       // Thresholds specified as a positive number are taken to be the minimum percentage required.
       else if (actual.pct < expected) {
-        failedThresholds.push(
-          `${color.red('Error')}: Coverage for ${name} ${color.red(`${actual.pct}%`)} does not meet ${type === 'global' ? 'global' : `"${type}"`} threshold ${color.yellow(`${expected}%`)}`,
-        );
+        errorMsg += `coverage for ${name} ${color.red(`${actual.pct}%`)} does not meet ${type === 'global' ? 'global' : `"${type}"`} threshold ${color.yellow(`${expected}%`)}`;
       }
+    }
+
+    if (errorMsg) {
+      failedThresholds.push(
+        `${color.red('Error')}: ${file ? `${relative(rootPath, file)} ` : ''}${errorMsg}`,
+      );
     }
   };
 
   thresholdGroup.forEach(({ name, coverageMap, ...thresholds }) => {
-    const summary = coverageMap.getCoverageSummary();
-    THRESHOLD_KEYS.forEach((key) => {
-      if (thresholds[key] !== undefined) {
-        check(key, name, summary[key], thresholds[key]);
+    const summaries = thresholds.perFile
+      ? coverageMap.files().map((file) => ({
+          file,
+          summary: coverageMap.fileCoverageFor(file).toSummary(),
+        }))
+      : [{ file: '', summary: coverageMap.getCoverageSummary() }];
+
+    for (const { summary, file } of summaries) {
+      for (const key of THRESHOLD_KEYS) {
+        if (thresholds[key] !== undefined) {
+          check(key, name, summary[key], thresholds[key], file);
+        }
       }
-    });
+    }
   });
 
   return {

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -63,14 +63,11 @@ export async function generateCoverage(
         thresholds: coverage.thresholds,
       });
       if (!thresholdResult.success) {
-        process.exitCode = 1;
         logger.log('');
         logger.log(thresholdResult.message);
+        process.exitCode = 1;
       }
     }
-
-    // Cleanup
-    coverageProvider.cleanup();
   } catch (error) {
     logger.error('Failed to generate coverage reports:', error);
   }

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -355,6 +355,8 @@ const runInPool = async (
               // Attach coverage data to test result
               test.coverage = coverageMap.toJSON();
             }
+            // Cleanup
+            coverageProvider.cleanup();
           }
           await rpc.onTestFileResult(test);
         },

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -31,7 +31,13 @@ export type CoverageThresholds =
   | CoverageThreshold
   | (CoverageThreshold & {
       /** check thresholds for matched files */
-      [glob: string]: CoverageThreshold;
+      [glob: string]: CoverageThreshold & {
+        /**
+         * check thresholds per file
+         * @default false
+         */
+        perFile?: boolean;
+      };
     });
 
 export type CoverageOptions = {

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -302,7 +302,7 @@ export default defineConfig({
     enabled: true,
     thresholds: {
       'src/**': {
-        statements: 100,
+        statements: 90,
         perFile: true,
       },
     },

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -222,7 +222,9 @@ type CoverageThreshold = {
 
 type CoverageThresholds = CoverageThreshold & {
   /** check thresholds for matched files */
-  [glob: string]: CoverageThreshold;
+  [glob: string]: CoverageThreshold & {
+    perFile?: boolean;
+  };
 };
 ```
 
@@ -287,3 +289,23 @@ Following the above configuration, rstest will fail if:
 - The total code coverage of all files in `src/**` is below 100%.
 - The total code coverage of all files in `node/**/*.js` is below 90%.
 - The global code coverage is below 80% for statements.
+
+#### check threshold for per file
+
+Rstest also supports checking thresholds for each matched file by setting `perFile` to `true`.
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    thresholds: {
+      'src/**': {
+        statements: 100,
+        perFile: true,
+      },
+    },
+  },
+});
+```

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -285,3 +285,23 @@ export default defineConfig({
 - `src/**` 匹配到的文件的总语句覆盖率低于 100%。
 - `node/**/*.js` 匹配到的文件的总语句覆盖率低于 90%。
 - 全局的语句覆盖率低于 80%。
+
+#### 单文件检查
+
+Rstest 支持通过将 `perFile` 设置为 `true` 来为每个匹配文件分别检查阈值。
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    thresholds: {
+      'src/**': {
+        statements: 90,
+        perFile: true,
+      },
+    },
+  },
+});
+```


### PR DESCRIPTION
## Summary

 support check coverage threshold for per file.

```ts title='rstest.config.ts'
import { defineConfig } from '@rstest/core';

export default defineConfig({
  coverage: {
    enabled: true,
    thresholds: {
      'src/**': {
        statements: 90,
        perFile: true,
      },
    },
  },
});
```

<img width="894" height="113" alt="image" src="https://github.com/user-attachments/assets/b8ee1b03-59b5-4aaf-bdcc-d48a876c0b2d" />



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
