### PR TITLE
fix: `coverage.exclude` should exclude path correctly

### DIFF
--- a/e2e/test-coverage/fixtures/rstest.include.config.ts
+++ b/e2e/test-coverage/fixtures/rstest.include.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from '@rstest/core';
+import { join } from 'pathe';
 
 export default defineConfig({
   coverage: {
     enabled: true,
     provider: 'istanbul',
     include: ['src/**/*.{js,jsx,ts,tsx}'],
+    exclude: [
+      join(__dirname, '../404.ts'),
+      'a.ts',
+      join(__dirname, 'src/b.ts'),
+      './src/c.ts',
+    ],
     reporters: ['text'],
   },
   setupFiles: ['./rstest.setup.ts'],

--- a/e2e/test-coverage/fixtures/src/a.ts
+++ b/e2e/test-coverage/fixtures/src/a.ts
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/e2e/test-coverage/fixtures/src/b.ts
+++ b/e2e/test-coverage/fixtures/src/b.ts
@@ -1,0 +1,1 @@
+export const b = 1;

--- a/e2e/test-coverage/fixtures/src/c.ts
+++ b/e2e/test-coverage/fixtures/src/c.ts
@@ -1,0 +1,1 @@
+export const c = 1;

--- a/e2e/test-coverage/include.test.ts
+++ b/e2e/test-coverage/include.test.ts
@@ -29,6 +29,18 @@ describe('test coverage-istanbul include option', () => {
         ?.replaceAll(' ', ''),
     ).toMatchInlineSnapshot(`"date.ts|100|100|100|100|"`);
 
+    expect(
+      logs.find((log) => log.includes('a.ts') && log.includes('|')),
+    ).toBeFalsy();
+
+    expect(
+      logs.find((log) => log.includes('b.ts') && log.includes('|')),
+    ).toBeFalsy();
+
+    expect(
+      logs.find((log) => log.includes('c.ts') && log.includes('|')),
+    ).toBeFalsy();
+
     expectLog('Test Files 1 passed', logs);
   });
 });

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -1,5 +1,5 @@
 import { normalize } from 'pathe';
-import { glob } from 'tinyglobby';
+import { glob, isDynamicPattern } from 'tinyglobby';
 import type { TestFileResult } from '../types';
 import type {
   CoverageMap,
@@ -7,6 +7,42 @@ import type {
   CoverageProvider,
 } from '../types/coverage';
 import { logger } from '../utils';
+
+const getIncludedFiles = async (
+  coverage: CoverageOptions,
+  rootPath: string,
+): Promise<string[]> => {
+  // fix issue with glob not working correctly when exclude path was not in the cwd
+  const ignoredPatterns = coverage.exclude?.filter(
+    (item) =>
+      isDynamicPattern(item) ||
+      item.startsWith(rootPath) ||
+      item.startsWith('./'),
+  );
+  const allFiles = await glob(coverage.include!, {
+    cwd: rootPath,
+    absolute: true,
+    onlyFiles: true,
+    ignore: ignoredPatterns,
+    dot: true,
+    expandDirectories: false,
+  });
+
+  // 'a.ts' should match 'src/a.ts'
+  if (ignoredPatterns?.length !== coverage.exclude?.length) {
+    const excludes = coverage.exclude!.filter(
+      (item) =>
+        !isDynamicPattern(item) &&
+        !item.startsWith(rootPath) &&
+        !item.startsWith('./'),
+    );
+    return allFiles.filter((file) => {
+      return !excludes.some((exclude) => file.includes(exclude));
+    });
+  }
+
+  return allFiles;
+};
 
 export async function generateCoverage(
   coverage: CoverageOptions,
@@ -25,13 +61,7 @@ export async function generateCoverage(
     }
 
     if (coverage.include?.length) {
-      const allFiles = await glob(coverage.include, {
-        cwd: rootPath,
-        absolute: true,
-        ignore: coverage.exclude,
-        dot: true,
-        expandDirectories: false,
-      });
+      const allFiles = await getIncludedFiles(coverage, rootPath);
 
       // should be better to filter files before swc coverage is processed
       finalCoverageMap.filter((file) => allFiles.includes(normalize(file)));
@@ -79,6 +109,13 @@ async function generateCoverageForUntestedFiles(
   coverageProvider: CoverageProvider,
 ): Promise<void> {
   logger.debug('Generating coverage for untested files...');
+
+  if (!coverageProvider.generateCoverageForUntestedFiles) {
+    logger.warn(
+      'Current coverage provider does not support generating coverage for untested files.',
+    );
+    return;
+  }
 
   const coverages =
     await coverageProvider.generateCoverageForUntestedFiles(uncoveredFiles);


### PR DESCRIPTION
## Summary

`coverage.exclude` should exclude path correctly
- glob should working correctly when exclude path was not in the cwd
- exclude`'a.ts'` should match `'src/a.ts'`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
