### PR TITLE
feat: `coverage.includes` works in projects

### DIFF
--- a/e2e/projects/coverage.test.ts
+++ b/e2e/projects/coverage.test.ts
@@ -39,7 +39,30 @@ describe('test projects coverage', () => {
     ).toBeTruthy();
 
     expect(
+      logs.find((log) => log.includes('App1.ts') && log.includes('|')),
+    ).toBeFalsy();
+
+    expect(
       fs.existsSync(join(__dirname, 'fixtures/coverage/index.html')),
+    ).toBeTruthy();
+  }, 15000);
+
+  it('should run projects correctly with coverage.include', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--globals', '-c', 'rstest.coverage.include.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('App1.ts') && log.includes('|')),
     ).toBeTruthy();
   }, 15000);
 });

--- a/e2e/projects/fixtures/packages/client/src/App1.tsx
+++ b/e2e/projects/fixtures/packages/client/src/App1.tsx
@@ -1,0 +1,10 @@
+const App = () => {
+  return (
+    <div className="content">
+      <h1>Rsbuild with React</h1>
+      <p>Start building amazing things with Rsbuild.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/e2e/projects/fixtures/rstest.coverage.config.ts
+++ b/e2e/projects/fixtures/rstest.coverage.config.ts
@@ -2,9 +2,8 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   projects: ['packages/*'],
-  globals: true,
   coverage: {
     enabled: true,
+    reporters: ['text', 'html'],
   },
-  setupFiles: ['./setup.ts'],
 });

--- a/e2e/projects/fixtures/rstest.coverage.include.config.ts
+++ b/e2e/projects/fixtures/rstest.coverage.include.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  setupFiles: ['./rstest.setup.ts'],
+  projects: ['packages/*'],
   coverage: {
+    enabled: true,
     reporters: ['text'],
+    include: ['src/**/*'],
   },
 });

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -271,12 +271,7 @@ export async function runTests(context: Rstest): Promise<void> {
     if (coverageProvider) {
       const { generateCoverage } = await import('../coverage/generate');
 
-      await generateCoverage(
-        context.normalizedConfig.coverage,
-        context.rootPath,
-        results,
-        coverageProvider,
-      );
+      await generateCoverage(context, results, coverageProvider);
     }
   };
 

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -129,9 +129,10 @@ export declare class CoverageProvider {
   /**
    * Generate coverage for untested files
    */
-  generateCoverageForUntestedFiles(
-    untestedFiles: string[],
-  ): Promise<FileCoverageData[]>;
+  generateCoverageForUntestedFiles(params: {
+    environmentName: string;
+    files: string[];
+  }): Promise<FileCoverageData[]>;
 
   /**
    * Generate coverage reports

--- a/packages/coverage-istanbul/src/plugin.ts
+++ b/packages/coverage-istanbul/src/plugin.ts
@@ -74,9 +74,7 @@ export const pluginCoverage: (
     });
 
     api.onExit(() => {
-      Object.keys(transformCoverageFns).forEach((key) => {
-        delete transformCoverageFns[key];
-      });
+      Object.assign(transformCoverageFns, {});
     });
   },
 });

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -26,9 +26,13 @@ export class CoverageProvider implements RstestCoverageProvider {
     }
   }
 
-  async generateCoverageForUntestedFiles(
-    uncoveredFiles: string[],
-  ): Promise<FileCoverageData[]> {
+  async generateCoverageForUntestedFiles({
+    environmentName,
+    files,
+  }: {
+    environmentName: string;
+    files: string[];
+  }): Promise<FileCoverageData[]> {
     const { transformCoverage } = await import('./plugin');
 
     const { readInitialCoverage } = await import('istanbul-lib-instrument');
@@ -41,10 +45,14 @@ export class CoverageProvider implements RstestCoverageProvider {
     const { readFile } = await import('node:fs/promises');
 
     return await Promise.all(
-      uncoveredFiles.map(async (file) => {
+      files.map(async (file) => {
         try {
           const content = await readFile(file, 'utf-8');
-          const { code } = await transformCoverage(content, file);
+          const { code } = await transformCoverage(
+            environmentName,
+            content,
+            file,
+          );
           // replace _coverageSchema: "${swc_value}" to _coverageSchema: ${MAGIC_VALUE}
           const { coverageData } =
             readInitialCoverage(


### PR DESCRIPTION
## Summary

Scans the included files based on each project's root directory, so the pattern `'/src/**/*.{js,jsx,ts,tsx}'` can match:
- `/root/project1/src/index.ts`
- `/root/project2/src/index.ts`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
