### PR TITLE
release: 0.5.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "The Rsbuild-based test tool.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "description": "Istanbul coverage provider for Rstest",
   "author": "Travis Zhang<https://github.com/travzhang>",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Breaking changes 
* feat!: merge `exclude` values by default by @9aoy in https://github.com/web-infra-dev/rstest/pull/588

### New Features 🎉
* feat: support `coverage.include` by @9aoy in https://github.com/web-infra-dev/rstest/pull/585
* feat: `coverage.includes` works in projects by @9aoy in https://github.com/web-infra-dev/rstest/pull/593
* feat: support use `<rootDir>` in path-based configuration settings by @9aoy in https://github.com/web-infra-dev/rstest/pull/583
* feat: support checking coverage threshold for glob files by @9aoy in https://github.com/web-infra-dev/rstest/pull/589
* feat: support check coverage threshold for per file by @9aoy in https://github.com/web-infra-dev/rstest/pull/590
* feat: `stubEnv` support `import.meta.env` by @9aoy in https://github.com/web-infra-dev/rstest/pull/594
### Bug Fixes 🐞
* fix: should not watch coverage reportsDirectory by @9aoy in https://github.com/web-infra-dev/rstest/pull/586
* fix: `coverage.exclude` should exclude path correctly by @9aoy in https://github.com/web-infra-dev/rstest/pull/592
### Document 📖
* docs: add examples for testEnvironment by @9aoy in https://github.com/web-infra-dev/rstest/pull/584
* docs: adding type declarations via tsconfig.json by @chenjiahan in https://github.com/web-infra-dev/rstest/pull/587
* docs: update `coverage.include` by @9aoy in https://github.com/web-infra-dev/rstest/pull/591
### Other Changes
* chore: bundle more dependencies by @9aoy in https://github.com/web-infra-dev/rstest/pull/582


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.4.1...v0.5.0