### PR TITLE
feat(coverage): support `reportOnFailure` option

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -165,6 +165,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
     reporters: ['text', 'html', 'clover', 'json'],
     reportsDirectory: './coverage',
     clean: true,
+    reportOnFailure: false,
   },
 });
 

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -100,6 +100,12 @@ export type CoverageOptions = {
    * @default undefined
    */
   thresholds?: CoverageThresholds;
+
+  /**
+   * Whether to report coverage when tests fail.
+   * @default false
+   */
+  reportOnFailure?: boolean;
 };
 
 export type NormalizedCoverageOptions = Required<

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -10,6 +10,7 @@ type CoverageOptions = {
   exclude?: string[];
   reporters?: (keyof ReportOptions | ReportWithOptions)[];
   reportsDirectory?: string;
+  reportOnFailure?: boolean;
   clean?: boolean;
   thresholds?: CoverageThresholds;
 };
@@ -187,6 +188,23 @@ export default defineConfig({
   coverage: {
     enabled: true,
     reportsDirectory: './coverage-reports',
+  },
+});
+```
+
+### reportOnFailure
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Whether to report coverage and check thresholds when tests fail.
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    reportOnFailure: true,
   },
 });
 ```

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -10,6 +10,7 @@ type CoverageOptions = {
   exclude?: string[];
   reporters?: (keyof ReportOptions | ReportWithOptions)[];
   reportsDirectory?: string;
+  reportOnFailure?: boolean;
   clean?: boolean;
   thresholds?: CoverageThresholds;
 };
@@ -185,6 +186,23 @@ export default defineConfig({
   coverage: {
     enabled: true,
     reportsDirectory: './coverage-reports',
+  },
+});
+```
+
+### reportOnFailure
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+在测试失败时是否生成覆盖率报告并检查阈值。
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    reportOnFailure: true,
   },
 });
 ```


### PR DESCRIPTION
## Summary

Support `reportOnFailure` option. By default, rstest will not report coverage and check thresholds when test fails.

```ts title='rstest.config.ts'
import { defineConfig } from '@rstest/core';
export default defineConfig({
  coverage: {
    enabled: true,
    reportOnFailure: true,
  },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
