### PR TITLE
docs: introduce beforeEach / beforeAll returns

### DIFF
--- a/website/docs/en/api/test-api/hooks.mdx
+++ b/website/docs/en/api/test-api/hooks.mdx
@@ -21,6 +21,21 @@ beforeAll(async (ctx) => {
 });
 ```
 
+`beforeAll` also supports returning a function that runs after all tests for cleanup (equivalent to `afterAll`):
+
+```ts
+import { beforeAll } from '@rstest/core';
+
+beforeAll(async () => {
+  const cleanUp = await doSomething();
+
+  // Cleanup logic after all tests
+  return async () => {
+    await cleanUp();
+  };
+});
+```
+
 ## afterAll
 
 - **Type:** `(fn: (ctx: SuiteContext) => void | Promise<void>, timeout?: number) => void`
@@ -46,6 +61,21 @@ import { beforeEach } from '@rstest/core';
 
 beforeEach(async () => {
   // Setup logic before each test
+});
+```
+
+`beforeEach` also supports returning a function that runs after each test for cleanup (equivalent to `afterEach`):
+
+```ts
+import { beforeEach } from '@rstest/core';
+
+beforeEach(async () => {
+  const cleanUp = await doSomething();
+
+  // Cleanup logic after each test
+  return async () => {
+    await cleanUp();
+  };
 });
 ```
 

--- a/website/docs/en/guide/migration/jest.mdx
+++ b/website/docs/en/guide/migration/jest.mdx
@@ -129,6 +129,15 @@ The `done` callback is not supported in Rstest. Instead, you can return a Promis
 + }));
 ```
 
+### Hooks
+
+The return functions of the `beforeEach` and `beforeAll` hooks in Rstest are used to perform cleaning work after testing.
+
+```diff
+- beforeEach(() => doSomething());
++ beforeEach(() => { doSomething() });
+```
+
 ### Timeout
 
 If you used `jest.setTimeout()` to set the timeout for a test, you can use `rstest.setConfig()` instead.

--- a/website/docs/zh/api/test-api/hooks.mdx
+++ b/website/docs/zh/api/test-api/hooks.mdx
@@ -21,6 +21,21 @@ beforeAll(async (ctx) => {
 });
 ```
 
+`beforeAll` 也支持返回一个函数，在所有测试之后运行，用于清理操作（等价于 `afterAll`）：
+
+```ts
+import { beforeAll } from '@rstest/core';
+
+beforeAll(async () => {
+  const cleanUp = await doSomething();
+
+  // 在所有测试后的清理逻辑
+  return async () => {
+    await cleanUp();
+  };
+});
+```
+
 ## afterAll
 
 - **类型：** `(fn: (ctx: SuiteContext) => void | Promise<void>, timeout?: number) => void`
@@ -46,6 +61,21 @@ import { beforeEach } from '@rstest/core';
 
 beforeEach(async () => {
   // 每个测试前的初始化逻辑
+});
+```
+
+`beforeEach` 也支持返回一个函数，在每个测试之后运行，用于清理操作（等价于 `afterEach`）：
+
+```ts
+import { beforeEach } from '@rstest/core';
+
+beforeEach(async () => {
+  const cleanUp = await doSomething();
+
+  // 每个测试后的清理逻辑
+  return async () => {
+    await cleanUp();
+  };
 });
 ```
 

--- a/website/docs/zh/guide/migration/jest.mdx
+++ b/website/docs/zh/guide/migration/jest.mdx
@@ -129,6 +129,15 @@ Rstest 不支持 `done` 回调。作为替代，你可以返回一个 Promise �
 + }));
 ```
 
+### Hooks
+
+Rstest 中 `beforeEach` 和 `beforeAll` 钩子的返回函数用于执行测试后的清理工作。
+
+```diff
+- beforeEach(() => doSomething());
++ beforeEach(() => { doSomething() });
+```
+
 ### 超时设置
 
 如果你使用 `jest.setTimeout()` 来设置测试的超时时间，你可以改用 `rstest.setConfig()`。


### PR DESCRIPTION
## Summary

The return functions of the `beforeEach` and `beforeAll` hooks in Rstest are used to perform cleaning work after testing.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
