### PR TITLE
feat: support `env` option

### DIFF
--- a/e2e/env/fixtures/index.test.ts
+++ b/e2e/env/fixtures/index.test.ts
@@ -1,0 +1,5 @@
+import { expect, it } from '@rstest/core';
+
+it('should get environment variables correctly', () => {
+  expect(process.env.printLogger).toBe('true');
+});

--- a/e2e/env/fixtures/rstest.config.ts
+++ b/e2e/env/fixtures/rstest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  env: {
+    printLogger: 'true',
+  },
+});

--- a/e2e/env/index.test.ts
+++ b/e2e/env/index.test.ts
@@ -1,0 +1,25 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import { join } from 'pathe';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = dirname(__filename);
+
+describe('test environment variables', () => {
+  it('should get environment variables correctly in test', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'index.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -145,6 +145,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   printConsoleTrace: false,
   disableConsoleIntercept: false,
   snapshotFormat: {},
+  env: {},
   coverage: {
     exclude: [
       '**/node_modules/**',

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -52,9 +52,11 @@ const getRuntimeConfig = (context: ProjectContext): RuntimeConfig => {
     isolate,
     coverage,
     snapshotFormat,
+    env,
   } = context.normalizedConfig;
 
   return {
+    env,
     testNamePattern,
     testTimeout,
     hookTimeout,

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -28,6 +28,12 @@ const registerGlobalApi = (api: Rstest) => {
 const listeners: (() => void)[] = [];
 let isTeardown = false;
 
+const setupEnv = (env?: Partial<NodeJS.ProcessEnv>) => {
+  if (env) {
+    Object.assign(process.env, env);
+  }
+};
+
 const preparePool = async ({
   entryInfo: { distPath, testPath },
   sourceMaps,
@@ -47,8 +53,11 @@ const preparePool = async ({
       disableConsoleIntercept,
       testEnvironment,
       snapshotFormat,
+      env,
     },
   } = context;
+
+  setupEnv(env);
 
   if (!disableConsoleIntercept) {
     const { createCustomConsole } = await import('./console');

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -219,6 +219,11 @@ export interface RstestConfig {
   snapshotFormat?: SnapshotFormat;
 
   /**
+   * Custom environment variables available on `process.env` during tests.
+   */
+  env?: Partial<NodeJS.ProcessEnv>;
+
+  /**
    * Coverage options
    */
   coverage?: CoverageOptions;

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -49,6 +49,7 @@ export type RuntimeConfig = Pick<
   | 'hookTimeout'
   | 'coverage'
   | 'snapshotFormat'
+  | 'env'
 >;
 
 export type WorkerContext = {

--- a/website/docs/en/config/test/_meta.json
+++ b/website/docs/en/config/test/_meta.json
@@ -11,6 +11,7 @@
   "includeSource",
   "testNamePattern",
 
+  "env",
   "retry",
   "testTimeout",
   "hookTimeout",

--- a/website/docs/en/config/test/env.mdx
+++ b/website/docs/en/config/test/env.mdx
@@ -1,0 +1,30 @@
+---
+overviewHeaders: []
+---
+
+# env
+
+- **Type:** `Partial<NodeJS.ProcessEnv>`
+- **Default:** `undefined`
+
+Custom environment variables available on `process.env` during tests.
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  env: {
+    PRINT_LOGGER: 'true',
+  },
+});
+```
+
+After setting the above configuration, you can access the `PRINT_LOGGER` variable in your tests:
+
+```ts title="index.test.ts"
+import { describe, it } from '@rstest/core';
+
+if (process.env.PRINT_LOGGER === 'true') {
+  console.log('PRINT_LOGGER is enabled');
+}
+```

--- a/website/docs/zh/config/test/_meta.json
+++ b/website/docs/zh/config/test/_meta.json
@@ -11,6 +11,7 @@
   "includeSource",
   "testNamePattern",
 
+  "env",
   "retry",
   "testTimeout",
   "hookTimeout",

--- a/website/docs/zh/config/test/env.mdx
+++ b/website/docs/zh/config/test/env.mdx
@@ -1,0 +1,30 @@
+---
+overviewHeaders: []
+---
+
+# env
+
+- **类型：** `Partial<NodeJS.ProcessEnv>`
+- **默认值：** `undefined`
+
+自定义环境变量，在测试过程中可以通过 `process.env` 访问。
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  env: {
+    PRINT_LOGGER: 'true',
+  },
+});
+```
+
+在设置上述配置后，现在，你可以在测试中访问 `PRINT_LOGGER` 变量：
+
+```ts title="index.test.ts"
+import { describe, it } from '@rstest/core';
+
+if (process.env.PRINT_LOGGER === 'true') {
+  console.log('PRINT_LOGGER is enabled');
+}
+```

--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -31,7 +31,7 @@ const OVERVIEW_GROUPS: Group[] = [
   },
   {
     name: 'runtime',
-    items: ['retry', 'testTimeout', 'hookTimeout', 'maxConcurrency'],
+    items: ['env', 'retry', 'testTimeout', 'hookTimeout', 'maxConcurrency'],
   },
   {
     name: 'environment',


### PR DESCRIPTION
## Summary

Support custom environment variables via `env` option, custom environment variables can be available on `process.env` during tests.
```ts title="rstest.config.ts"
import { defineConfig } from '@rstest/core';

export default defineConfig({
  env: {
    PRINT_LOGGER: 'true',
  },
});
```

After setting the above configuration, you can access the `PRINT_LOGGER` variable in your tests:

```ts title="index.test.ts"
import { describe, it } from '@rstest/core';

if (process.env.PRINT_LOGGER === 'true') {
  console.log('PRINT_LOGGER is enabled');
}
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
