### PR TITLE
fix: should handle error string correctly

### DIFF
--- a/e2e/test-api/edgeCase.test.ts
+++ b/e2e/test-api/edgeCase.test.ts
@@ -25,6 +25,21 @@ describe('Test Edge Cases', () => {
     expect(logs.find((log) => log.includes('Error: Symbol('))).toBeFalsy();
   });
 
+  it('should handle error string correctly', async () => {
+    const { expectExecFailed, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/errorString.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecFailed();
+
+    expectLog('Unknown Error: aaaa');
+  });
+
   it('test module not found', async () => {
     // Module not found errors should be silent at build time, and throw errors at runtime
     const { cli, expectExecSuccess } = await runRstestCli({

--- a/e2e/test-api/fixtures/errorString.test.ts
+++ b/e2e/test-api/fixtures/errorString.test.ts
@@ -1,0 +1,7 @@
+import { it } from '@rstest/core';
+
+it('test error string', () => {
+  return new Promise((_resolve, reject) => {
+    reject('aaaa');
+  });
+});

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -19,7 +19,9 @@ export const getRealTimers = (): typeof REAL_TIMERS => {
 export const formatTestError = (err: any, test?: Test): FormattedError[] => {
   const errors = Array.isArray(err) ? err : [err];
 
-  return errors.map((error) => {
+  return errors.map((rawError) => {
+    const error =
+      typeof rawError === 'string' ? { message: rawError } : rawError;
     const errObj: FormattedError = {
       ...error,
       // Some error attributes cannot be enumerated

--- a/website/docs/en/guide/migration/jest.mdx
+++ b/website/docs/en/guide/migration/jest.mdx
@@ -129,6 +129,18 @@ The `done` callback is not supported in Rstest. Instead, you can return a Promis
 + }));
 ```
 
+If you need to handle errors, you can modify it as follows:
+
+```diff
+- test('async test with done', (done) => {
++ test('async test with done', () => new Promise((resolve, reject) => {
++   const done = err => (err ? reject(err) : resolve());
+  // ...
+  done(error);
+- });
++ }));
+```
+
 ### Hooks
 
 The return functions of the `beforeEach` and `beforeAll` hooks in Rstest are used to perform cleaning work after testing.

--- a/website/docs/zh/guide/migration/jest.mdx
+++ b/website/docs/zh/guide/migration/jest.mdx
@@ -129,6 +129,18 @@ Rstest 不支持 `done` 回调。作为替代，你可以返回一个 Promise �
 + }));
 ```
 
+如果你需要处理错误，你可以按照以下方式修改：
+
+```diff
+- test('async test with done', (done) => {
++ test('async test with done', () => new Promise((resolve, reject) => {
++   const done = err => (err ? reject(err) : resolve());
+  // ...
+  done(error);
+- });
++ }));
+```
+
 ### Hooks
 
 Rstest 中 `beforeEach` 和 `beforeAll` 钩子的返回函数用于执行测试后的清理工作。


### PR DESCRIPTION
## Summary

should handle error string correctly.

<img width="890" height="723" alt="image" src="https://github.com/user-attachments/assets/c1a4b98f-65a7-473f-81b0-7bdddaa7a7c8" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
