### PR TITLE
fix(vscode): should wait for initial scan

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -13,6 +13,7 @@ import { getWorkspaceTestPatterns, shouldIgnorePath } from './utils';
 
 export async function activate(context: vscode.ExtensionContext) {
   const rstest = new Rstest(context);
+  await rstest.initialize();
   return rstest;
 }
 
@@ -46,8 +47,10 @@ class Rstest {
     this.setupTestController();
     this.api = new RstestApi();
     this.api.createChildProcess();
+  }
 
-    scanAllTestFiles(this.ctrl);
+  async initialize() {
+    await scanAllTestFiles(this.ctrl);
   }
 
   private setupEventHandlers(context: vscode.ExtensionContext) {


### PR DESCRIPTION
## Summary

fixes a race where the VS Code extension finished its initial test-file scan after the test suite reconfigured `rstest.testFileGlobPattern`. previously the constructor kicked off `scanAllTestFiles` without awaiting it, so late completions could repopulate foo.test.ts even when only `*.spec.*` patterns were allowed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
