### PR TITLE
fix(docs): use `rp-not-doc` for rsbuild doc badge

### DIFF
--- a/website/theme/components/RsbuildDocBadge.tsx
+++ b/website/theme/components/RsbuildDocBadge.tsx
@@ -19,7 +19,7 @@ export function RsbuildDocBadge({ path, text, alt }: Props) {
       href={href}
       target="_blank"
       rel="noreferrer"
-      className="rspress-toc-exclude"
+      className="rspress-toc-exclude rp-not-doc"
     >
       <Badge type="info">
         <img


### PR DESCRIPTION
## Summary

same as https://github.com/web-infra-dev/rslib/pull/1236

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
