### PR TITLE
chore(workflow): disable fail-fast option in e2e test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,11 +72,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
         node_version: [18, 20, 22, 24]
-        fail-fast: false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

disable fail-fast option in e2e test due to unstable timeouts for some tests.
## Related Links

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
