### PR TITLE
fix: use project root's absolute path

### DIFF
--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -100,6 +100,8 @@ export class Rstest implements RstestContext {
     this.normalizedConfig = rstestConfig;
     this.projects = projects.length
       ? projects.map((project) => {
+          project.config.root = getAbsolutePath(rootPath, project.config.root!);
+
           // TODO: support extend projects config
           const config = withDefaultConfig(
             project.config,

--- a/packages/core/tests/core/rstest.test.ts
+++ b/packages/core/tests/core/rstest.test.ts
@@ -35,7 +35,7 @@ describe('rstest context', () => {
           },
           {
             config: {
-              root: join(rootPath, 'test-project1'),
+              root: 'test-project1',
               name: 'test-project1',
               setupFiles: ['<rootDir>/scripts/rstest.setup.ts'],
             },


### PR DESCRIPTION
## Summary

fix rspack ci, use project root's absolute path.

<img width="1146" height="298" alt="image" src="https://github.com/user-attachments/assets/6ef86205-b164-4097-b98a-f6db25ebf682" />


## Related Links

https://github.com/web-infra-dev/rspack/actions/runs/18646266154/job/53154423141#step:8:1354

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
