### PR TITLE
chore: update log display

### DIFF
--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -13,7 +13,7 @@ import type {
   TestResult,
   UserConsoleLog,
 } from '../types';
-import { color, logger, prettyTestPath } from '../utils';
+import { color, logger } from '../utils';
 import { StatusRenderer } from './statusRenderer';
 import { printSummaryErrorLogs, printSummaryLog } from './summary';
 import { logCase, logFileTitle } from './utils';
@@ -73,7 +73,7 @@ export class DefaultReporter implements Reporter {
       return;
     }
 
-    const titles = [log.name];
+    const titles = [];
 
     const testPath = relative(this.rootPath, log.testPath);
 
@@ -82,19 +82,18 @@ export class DefaultReporter implements Reporter {
       const filePath = relative(this.rootPath, frame!.file || '');
 
       if (filePath !== testPath) {
-        titles.push(prettyTestPath(testPath));
+        titles.push(testPath);
       }
-      titles.push(
-        prettyTestPath(filePath) +
-          color.gray(`:${frame!.lineNumber}:${frame!.column}`),
-      );
+      titles.push(`${filePath}:${frame!.lineNumber}:${frame!.column}`);
     } else {
-      titles.push(prettyTestPath(testPath));
+      titles.push(testPath);
     }
 
+    logger.log('');
     // TODO: output to stdout or stderr
-    logger.log(titles.join(color.gray(' | ')));
-
+    logger.log(
+      `${log.name}${color.gray(color.dim(` | ${titles.join(color.gray(color.dim(' | ')))}`))}`,
+    );
     logger.log(log.content);
     logger.log('');
   }


### PR DESCRIPTION
## Summary

 update log display: not highlight testPath

before:
![img_v3_02r8_c177f823-b3bf-4018-b4ee-fb53f10b551g](https://github.com/user-attachments/assets/55ebe0dd-3ca0-4c97-80eb-c19fa1e36482)

after:
<img width="626" height="147" alt="image" src="https://github.com/user-attachments/assets/c230f987-d827-4eba-a4bb-8b1a932cbe2f" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
