### PR TITLE
feat: support `hideSkippedTests` option

### DIFF
--- a/e2e/reporter/fixtures/index.test.ts
+++ b/e2e/reporter/fixtures/index.test.ts
@@ -8,4 +8,8 @@ describe('basic', () => {
   it('b', () => {
     expect(1 + 1).not.toBe(2);
   });
+
+  it.skip('c', () => {
+    expect(1 + 1).not.toBe(2);
+  });
 });

--- a/e2e/reporter/index.test.ts
+++ b/e2e/reporter/index.test.ts
@@ -21,6 +21,7 @@ describe.concurrent('reporters', () => {
 
     await cli.exec;
     expect(cli.stdout).toContain('✗ basic > b');
+    expect(cli.stdout).not.toContain('- basic > c');
   });
 
   it('verbose', async ({ onTestFinished }) => {
@@ -37,6 +38,24 @@ describe.concurrent('reporters', () => {
 
     await cli.exec;
     expect(cli.stdout).toContain('✓ basic > a');
+    expect(cli.stdout).toContain('- basic > c');
+  });
+
+  it('hideSkippedTests', async ({ onTestFinished }) => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'index', '--reporter=verbose', '--hideSkippedTests'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await cli.exec;
+    expect(cli.stdout).toContain('✓ basic > a');
+    expect(cli.stdout).not.toContain('- basic > c');
   });
 
   it('custom', async ({ onTestFinished }) => {
@@ -55,7 +74,7 @@ describe.concurrent('reporters', () => {
     expect(cli.stdout).toContain('[custom reporter] onTestFileStart');
     expect(
       cli.stdout.match(/\[custom reporter\] onTestCaseResult/g)?.length,
-    ).toBe(2);
+    ).toBe(3);
     expect(cli.stdout).toContain('[custom reporter] onTestRunEnd');
   });
 

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -63,6 +63,7 @@ const applyCommonOptions = (cli: CAC) => {
     )
     .option('--testTimeout <value>', 'Timeout of a test in milliseconds')
     .option('--hookTimeout <value>', 'Timeout of hook in milliseconds')
+    .option('--hideSkippedTests', 'Hide skipped tests from the output')
     .option('--retry <retry>', 'Number of times to retry a test if it fails')
     .option('--maxConcurrency <value>', 'Maximum number of concurrent tests')
     .option(

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -40,6 +40,7 @@ export type CommonOptions = {
   retry?: number;
   maxConcurrency?: number;
   slowTestThreshold?: number;
+  hideSkippedTests?: boolean;
 };
 
 async function resolveConfig(
@@ -74,6 +75,7 @@ async function resolveConfig(
     'printConsoleTrace',
     'disableConsoleIntercept',
     'testEnvironment',
+    'hideSkippedTests',
   ];
   for (const key of keys) {
     if (options[key] !== undefined) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -146,6 +146,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   disableConsoleIntercept: false,
   snapshotFormat: {},
   env: {},
+  hideSkippedTests: false,
   coverage: {
     exclude: [
       '**/node_modules/**',

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -58,7 +58,11 @@ export class DefaultReporter implements Reporter {
         result.status === 'fail' ||
         (result.duration ?? 0) > slowTestThreshold ||
         (result.retryCount ?? 0) > 0;
-      isDisplayed && logCase(result, slowTestThreshold);
+      isDisplayed &&
+        logCase(result, {
+          slowTestThreshold,
+          hideSkippedTests: this.config.hideSkippedTests,
+        });
     }
   }
 

--- a/packages/core/src/reporter/utils.ts
+++ b/packages/core/src/reporter/utils.ts
@@ -28,9 +28,16 @@ export const statusColorfulStr: {
 
 export const logCase = (
   result: TestResult,
-  slowTestThreshold: number,
+  options: {
+    slowTestThreshold: number;
+    hideSkippedTests: boolean;
+  },
 ): void => {
-  const isSlowCase = (result.duration || 0) > slowTestThreshold;
+  const isSlowCase = (result.duration || 0) > options.slowTestThreshold;
+
+  if (options.hideSkippedTests && result.status === 'skip') {
+    return;
+  }
 
   const icon =
     isSlowCase && result.status === 'pass'

--- a/packages/core/src/reporter/verbose.ts
+++ b/packages/core/src/reporter/verbose.ts
@@ -13,7 +13,10 @@ export class VerboseReporter extends DefaultReporter {
     logFileTitle(test, relativePath, true);
 
     for (const result of test.results) {
-      logCase(result, slowTestThreshold);
+      logCase(result, {
+        slowTestThreshold,
+        hideSkippedTests: this.config.hideSkippedTests,
+      });
     }
   }
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -155,6 +155,12 @@ export interface RstestConfig {
         | ReporterWithOptions
       )[];
   /**
+   * Hide skipped tests logs.
+   *
+   * @default false
+   */
+  hideSkippedTests?: boolean;
+  /**
    * Run only tests with a name that matches the regex.
    */
   testNamePattern?: string | RegExp;

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -42,6 +42,7 @@ exports[`mergeRstestConfig > should merge config correctly with default config 1
     ],
   },
   "globals": false,
+  "hideSkippedTests": false,
   "hookTimeout": 10000,
   "include": [
     "tests/**/*.test.ts",

--- a/packages/core/tests/core/__snapshots__/rstest.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rstest.test.ts.snap
@@ -41,6 +41,7 @@ exports[`rstest context > should generate rstest context correctly 1`] = `
     ],
   },
   "globals": false,
+  "hideSkippedTests": false,
   "hookTimeout": 10000,
   "include": [
     "**/*.{test,spec}.?(c|m)[jt]s?(x)",
@@ -113,6 +114,7 @@ exports[`rstest context > should generate rstest context correctly with multiple
     ],
   },
   "globals": false,
+  "hideSkippedTests": false,
   "hookTimeout": 10000,
   "include": [
     "<ROOT>/packages/core/test-project/tests/**/*.test.ts",
@@ -188,6 +190,7 @@ exports[`rstest context > should generate rstest context correctly with multiple
     ],
   },
   "globals": false,
+  "hideSkippedTests": false,
   "hookTimeout": 10000,
   "include": [
     "**/*.{test,spec}.?(c|m)[jt]s?(x)",

--- a/website/docs/en/config/test/_meta.json
+++ b/website/docs/en/config/test/_meta.json
@@ -29,6 +29,7 @@
 
   "coverage",
   "reporters",
+  "hideSkippedTests",
   "slowTestThreshold",
   "snapshotFormat",
   "printConsoleTrace",

--- a/website/docs/en/config/test/hideSkippedTests.mdx
+++ b/website/docs/en/config/test/hideSkippedTests.mdx
@@ -1,0 +1,53 @@
+# hideSkippedTests
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **CLI:** `--hideSkippedTests`
+
+Hide skipped tests logs.
+
+import { Tab, Tabs } from '@theme';
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --hideSkippedTests
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  hideSkippedTests: true,
+});
+```
+  </Tab>
+</Tabs>
+
+## Example
+
+By default, Rstest displays logs for all test cases when you use the [verbose reporter](/config/test/reporters#verbose-reporter).
+
+```bash
+ ✓ test/index.test.ts (2) 1ms
+  ✓ Index > should add two numbers correctly (0ms)
+  - Index > should test source code correctly (1ms)
+
+ Test Files 1 passed
+      Tests 1 passed | 1 skipped (2)
+   Duration 93ms (build 50ms, tests 43ms)
+```
+
+When you set `hideSkippedTests` to `true`, Rstest will hide logs for all skipped test cases after the test run is complete.
+
+The output will look like this:
+
+```bash
+ ✓ test/index.test.ts (2) 1ms
+  ✓ Index > should add two numbers correctly (0ms)
+
+ Test Files 1 passed
+      Tests 1 passed | 1 skipped (2)
+   Duration 93ms (build 50ms, tests 43ms)
+```

--- a/website/docs/zh/config/test/_meta.json
+++ b/website/docs/zh/config/test/_meta.json
@@ -29,6 +29,7 @@
 
   "coverage",
   "reporters",
+  "hideSkippedTests",
   "slowTestThreshold",
   "snapshotFormat",
   "printConsoleTrace",

--- a/website/docs/zh/config/test/hideSkippedTests.mdx
+++ b/website/docs/zh/config/test/hideSkippedTests.mdx
@@ -1,0 +1,53 @@
+# hideSkippedTests
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **CLI：** `--hideSkippedTests`
+
+不展示跳过测试的日志。
+
+import { Tab, Tabs } from '@theme';
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --hideSkippedTests
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  hideSkippedTests: true,
+});
+```
+  </Tab>
+</Tabs>
+
+## 示例
+
+默认情况下，在你使用 [verbose 报告器](/config/test/reporters#verbose-reporter)时，Rstest 会显示所有测试用例的日志。
+
+```bash
+ ✓ test/index.test.ts (2) 1ms
+  ✓ Index > should add two numbers correctly (0ms)
+  - Index > should test source code correctly (1ms)
+
+ Test Files 1 passed
+      Tests 1 passed | 1 skipped (2)
+   Duration 93ms (build 50ms, tests 43ms)
+```
+
+当你设置 `hideSkippedTests` 为 `true` 时，Rstest 会在测试完成后隐藏所有跳过的测试用例的日志。
+
+此时输出如下：
+
+```bash
+ ✓ test/index.test.ts (2) 1ms
+  ✓ Index > should add two numbers correctly (0ms)
+
+ Test Files 1 passed
+      Tests 1 passed | 1 skipped (2)
+   Duration 93ms (build 50ms, tests 43ms)
+```

--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -52,6 +52,7 @@ const OVERVIEW_GROUPS: Group[] = [
     items: [
       'coverage',
       'reporters',
+      'hideSkippedTests',
       'slowTestThreshold',
       'snapshotFormat',
       'onConsoleLog',


### PR DESCRIPTION
## Summary

By default, Rstest displays logs for all test cases when you use the verbose reporter.

```bash
 ✓ test/index.test.ts (2) 1ms
  ✓ Index > should add two numbers correctly (0ms)
  - Index > should test source code correctly (1ms)

 Test Files 1 passed
      Tests 1 passed | 1 skipped (2)
   Duration 93ms (build 50ms, tests 43ms)
```

When you set `hideSkippedTests` to `true`, Rstest will hide logs for all skipped test cases after the test run is complete.

The output will look like this:

```bash
 ✓ test/index.test.ts (2) 1ms
  ✓ Index > should add two numbers correctly (0ms)

 Test Files 1 passed
      Tests 1 passed | 1 skipped (2)
   Duration 93ms (build 50ms, tests 43ms)
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
