### PR TITLE
fix(mock): prevent mocked module overwrite by new loaded chunk modules

### DIFF
--- a/e2e/watch/index.test.ts
+++ b/e2e/watch/index.test.ts
@@ -50,10 +50,7 @@ describe.skipIf(process.platform === 'win32')('watch', () => {
 
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 2 passed');
-    // Updated as the shared module `src/index.ts` is extracted into another chunk.
-    expect(cli.stdout).toMatch(
-      /Test files to re-run.*:\n.*bar\.test\.ts\n.*index\.test\.ts\n\n/,
-    );
+    expect(cli.stdout).toMatch(/Test files to re-run.*:\n.*bar\.test\.ts\n\n/);
 
     // update
     cli.resetStd();
@@ -70,11 +67,8 @@ describe.skipIf(process.platform === 'win32')('watch', () => {
     cli.resetStd();
     fs.delete('./fixtures-test-0/bar.test.ts');
     await cli.waitForStdout('Duration');
+    expect(cli.stdout).toMatch('No test files need re-run.');
     expect(cli.stdout).toMatch('Test Files 1 passed');
-    // Updated as extracting the shared module `src/index.ts` is into another chunk in reverted.
-    expect(cli.stdout).toMatch(
-      /Test files to re-run.*:\n.*index\.test\.ts\n\n/,
-    );
 
     cli.exec.kill();
   });

--- a/packages/core/src/core/plugins/mockRuntime.ts
+++ b/packages/core/src/core/plugins/mockRuntime.ts
@@ -24,9 +24,26 @@ class MockRuntimeRspackPlugin {
       }
     }
 
-    compiler.hooks.thisCompilation.tap('CustomPlugin', (compilation) => {
+    compiler.hooks.compilation.tap('RstestMockPlugin', (compilation) => {
+      compilation.hooks.runtimeModule.tap(
+        'RstestMockChunkLoadingRuntimePlugin',
+        (module) => {
+          if (module.name === 'require_chunk_loading') {
+            const finalSource = module.source!.source.toString('utf-8').replace(
+              // Hard coded in EJS template https://github.com/web-infra-dev/rspack/blob/5b89b0b9810f15c6bd6494b9a3389db3071d93d1/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.ejs.
+              'for (var moduleId in moreModules) {',
+              'for (var moduleId in moreModules) {\n' +
+                '\t\tif (Object.keys(__webpack_require__.rstest_original_modules).includes(moduleId)) continue;',
+            );
+            module.source!.source = Buffer.from(finalSource);
+          }
+        },
+      );
+    });
+
+    compiler.hooks.thisCompilation.tap('RstestMockPlugin', (compilation) => {
       compilation.hooks.additionalTreeRuntimeRequirements.tap(
-        'CustomPlugin',
+        'RstestAddMockRuntimePlugin',
         (chunk) => {
           compilation.addRuntimeModule(chunk, new RetestImportRuntimeModule());
         },

--- a/packages/core/src/core/plugins/moduleCacheControl.ts
+++ b/packages/core/src/core/plugins/moduleCacheControl.ts
@@ -28,14 +28,17 @@ global.__rstest_clean_core_cache__ = __rstest_clean_core_cache__;
       }
     }
 
-    compiler.hooks.thisCompilation.tap('CustomPlugin', (compilation) => {
-      compilation.hooks.additionalTreeRuntimeRequirements.tap(
-        'CustomPlugin',
-        (chunk) => {
-          compilation.addRuntimeModule(chunk, new RetestCacheControlModule());
-        },
-      );
-    });
+    compiler.hooks.thisCompilation.tap(
+      'RstestCacheControlPlugin',
+      (compilation) => {
+        compilation.hooks.additionalTreeRuntimeRequirements.tap(
+          'RstestAddCacheControlRuntimePlugin',
+          (chunk) => {
+            compilation.addRuntimeModule(chunk, new RetestCacheControlModule());
+          },
+        );
+      },
+    );
   }
 }
 

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -6,7 +6,6 @@ import {
   logger as RsbuildLogger,
   type RsbuildPlugin,
   type Rspack,
-  rspack,
 } from '@rsbuild/core';
 import path from 'pathe';
 import type {
@@ -284,10 +283,6 @@ export const createRsbuildServer = async ({
     name: 'rstest:compiler',
     setup: (api) => {
       api.modifyBundlerChain((chain) => {
-        chain
-          .plugin('RemoveDuplicateModulesPlugin')
-          .use(rspack.experiments.RemoveDuplicateModulesPlugin);
-
         // add mock-loader to this rule
         chain.module
           .rule('rstest-mock-module-doppelgangers')


### PR DESCRIPTION
## Summary

when there are multiple bundled entry points (such as `rstest.setup.ts` and `index.test.ts`), the project's module may exist in `exports.modules` of each chunk, which can lead to the following problem: 

```txt
load rstest.setup.ts (it mocks module A) ->
module A been mocked ->
load index.test.ts ->
module A is re-installed since it's duplicated in this chunk, so it overwriting the mock ->
mocking module A in index.test.ts will not work
```

this PR modifies the internal logic of `installChunk` to no longer forcibly overwrite modules that have already been mocked. and because the use of `RemoveDuplicateModulesPlugin` has been removed, the overall chunk is now simpler, so the watch test has also been rolled back.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
