### PR TITLE
fix: mock error when external static import to dynamic import

### DIFF
--- a/e2e/externals/fixtures/getFs.ts
+++ b/e2e/externals/fixtures/getFs.ts
@@ -1,0 +1,3 @@
+import fs from 'node:fs/promises';
+
+export { fs };

--- a/e2e/externals/mock.test.ts
+++ b/e2e/externals/mock.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, rs } from '@rstest/core';
+import { fs as memfs } from 'memfs';
+import { fs } from './fixtures/getFs';
+
+rs.mock('node:fs/promises', () => {
+  return {
+    default: {
+      ...memfs.promises,
+      name: 'memfs',
+    },
+  };
+});
+
+describe('test externals mock', () => {
+  it('should external node_modules by default', async () => {
+    // @ts-expect-error
+    expect(fs.name).toBe('memfs');
+  });
+});

--- a/packages/core/src/core/plugins/external.ts
+++ b/packages/core/src/core/plugins/external.ts
@@ -24,7 +24,7 @@ const autoExternalNodeModules: (
     callback(
       undefined,
       externalPath,
-      dependencyType === 'commonjs' ? 'commonjs' : 'import',
+      dependencyType === 'commonjs' ? 'commonjs' : 'commonjs-import',
     );
   };
 
@@ -74,7 +74,7 @@ function autoExternalNodeBuiltin(
     callback(
       undefined,
       request,
-      dependencyType === 'commonjs' ? 'commonjs' : 'module-import',
+      dependencyType === 'commonjs' ? 'commonjs' : 'commonjs-import',
     );
   } else {
     callback();


### PR DESCRIPTION
## Summary

should not external `static import` to `dynamic import` which will cause mock factory error.

<img width="2218" height="1640" alt="image" src="https://github.com/user-attachments/assets/0d4e88ba-645d-4135-88a2-b259bda5f3b4" />


![62fc8fe3-0846-4ba9-a308-ca66984978fb](https://github.com/user-attachments/assets/0b30fa2f-b811-498c-bb84-a1e2b4bc1d0e)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
