### PR TITLE
docs: fix GitHub Actions spelling in reporter and documentation

### DIFF
--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -85,7 +85,7 @@ export class GithubActionsReporter {
       }
     }
 
-    this.log('::group::error for github actions');
+    this.log('::group::Error for GitHub Actions');
 
     for (const log of logs) {
       this.log(log);

--- a/website/docs/en/config/test/reporters.mdx
+++ b/website/docs/en/config/test/reporters.mdx
@@ -75,13 +75,13 @@ With verbose reporter, Rstest outputs:
    Duration 112ms (build 19ms, tests 93ms)
 ```
 
-### Github actions reporter
+### GitHub Actions reporter
 
-The Github Actions reporter outputs error messages in the form of [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) when tests fail.
+The GitHub Actions reporter outputs error messages in the form of [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) when tests fail.
 
 #### Output example
 
-When tests fail, the Github Actions reporter outputs information in a format similar to:
+When tests fail, the GitHub Actions reporter outputs information in a format similar to:
 
 ```bash
 ::error file=src/index.ts,line=4,col=17,title=test/index.test.ts > should add two numbers correctly::expected 2 to be 4

--- a/website/docs/zh/config/test/reporters.mdx
+++ b/website/docs/zh/config/test/reporters.mdx
@@ -75,13 +75,13 @@ export default defineConfig({
    Duration 112ms (build 19ms, tests 93ms)
 ```
 
-### Github actions reporter
+### GitHub Actions reporter
 
-Github Actions 报告器将在测试失败时以 [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) 的形式输出错误信息。
+GitHub Actions 报告器将在测试失败时以 [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) 的形式输出错误信息。
 
 #### 输出示例
 
-当测试失败时，Github Actions 报告器会输出类似以下格式的信息：
+当测试失败时，GitHub Actions 报告器会输出类似以下格式的信息：
 
 ```bash
 ::error file=src/index.ts,line=4,col=17,title=test/index.test.ts > should add two numbers correctly::expected 2 to be 4


### PR DESCRIPTION
## Summary

Fix GitHub Actions spelling in reporter and documentation (`github actions` -> `GitHub Actions`).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
