### PR TITLE
perf: use `nosources-source-map`

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -65,6 +65,11 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 config.output.importFunctionName = '__rstest_dynamic_import__';
                 config.output.devtoolModuleFilenameTemplate =
                   '[absolute-resource-path]';
+
+                if (!config.devtool || !config.devtool.includes('inline')) {
+                  config.devtool = 'nosources-source-map';
+                }
+
                 config.plugins.push(
                   new rspack.experiments.RstestPlugin({
                     injectModulePathName: true,

--- a/packages/core/src/core/plugins/inspect.ts
+++ b/packages/core/src/core/plugins/inspect.ts
@@ -10,7 +10,7 @@ export const pluginInspect: () => RsbuildPlugin | null = () =>
         setup: (api) => {
           api.modifyRspackConfig(async (config) => {
             // use inline source map or write to disk
-            config.devtool = 'inline-source-map';
+            config.devtool = 'inline-nosources-source-map';
             config.optimization ??= {};
             config.optimization.splitChunks = {
               ...(config.optimization.splitChunks || {}),

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = `
 {
   "context": "<ROOT>/packages/core",
-  "devtool": "source-map",
+  "devtool": "nosources-source-map",
   "entry": {},
   "experiments": {
     "asyncWebAssembly": true,
@@ -522,7 +522,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
 exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
 {
   "context": "<ROOT>/packages/core",
-  "devtool": "source-map",
+  "devtool": "nosources-source-map",
   "entry": {},
   "experiments": {
     "asyncWebAssembly": true,
@@ -1033,7 +1033,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
 exports[`prepareRsbuild > should generate rspack config correctly in watch mode 1`] = `
 {
   "context": "<ROOT>/packages/core",
-  "devtool": "source-map",
+  "devtool": "nosources-source-map",
   "entry": [Function],
   "experiments": {
     "asyncWebAssembly": true,
@@ -1552,7 +1552,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
 exports[`prepareRsbuild > should generate rspack config correctly with projects 1`] = `
 {
   "context": "<ROOT>/packages/core",
-  "devtool": "source-map",
+  "devtool": "nosources-source-map",
   "entry": {},
   "experiments": {
     "asyncWebAssembly": true,
@@ -2071,7 +2071,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
 exports[`prepareRsbuild > should generate rspack config correctly with projects 2`] = `
 {
   "context": "<ROOT>/packages/core",
-  "devtool": "source-map",
+  "devtool": "nosources-source-map",
   "entry": {},
   "experiments": {
     "asyncWebAssembly": true,

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -75,6 +75,7 @@ mjsx
 modularly
 mtsx
 napi
+nosources
 nodenext
 nolyfill
 npmjs


### PR DESCRIPTION
## Summary

Use `nosources-source-map` instead of `source-map` to reduce source map size, since "sourcesContent" is unused in rstest.


https://rspack.rs/config/devtool#:~:text=nosources%2Dsource%2Dmap

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
