### PR TITLE
fix: type error when each template type is primitive

### DIFF
--- a/e2e/test-api/each.test.ts
+++ b/e2e/test-api/each.test.ts
@@ -23,3 +23,7 @@ it.each([
   expect(a + b).toBe(expected);
   logs.push('executed');
 });
+
+it.each([1, 2, 3])('test number %i', (a) => {
+  expect(a).toBeTypeOf('number');
+});

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -41,6 +41,13 @@ export interface TestEachFn {
     fn: (...args: [...T]) => MaybePromise<void>,
     timeout?: number,
   ) => void;
+  <T>(
+    cases: readonly T[],
+  ): (
+    description: string,
+    fn: (...args: T[]) => MaybePromise<void>,
+    timeout?: number,
+  ) => void;
 }
 
 export type TestForFn<ExtraContext = object> = <T>(


### PR DESCRIPTION
## Summary

fix type error when each template type is primitive.


expect: 
<img width="764" height="169" alt="image" src="https://github.com/user-attachments/assets/f07531bb-0623-4495-a0d2-f547e83d6e43" />



actual: 
<img width="1049" height="265" alt="image" src="https://github.com/user-attachments/assets/44262280-39ad-4f01-a4b6-2bfc3ad711ac" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
