### PR TITLE
fix: should bind setTimetout to globalThis

### DIFF
--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -9,7 +9,7 @@ const REAL_TIMERS: {
 
 // store the original timers
 export const setRealTimers = (): void => {
-  REAL_TIMERS.setTimeout ??= globalThis.setTimeout;
+  REAL_TIMERS.setTimeout ??= globalThis.setTimeout.bind(globalThis);
 };
 
 export const getRealTimers = (): typeof REAL_TIMERS => {


### PR DESCRIPTION
## Summary

to avoid possible `TypeError: Illegal invocation` when running in [browser](https://stackoverflow.com/questions/47608666/settimeout-illegal-invocation-typeerror-illegal-invocation) (encounter this issue when developing browser mode).

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
