### PR TITLE
fix(esm-output): `__webpack_require__.C` is not a function

### DIFF
--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -2,21 +2,32 @@
 // Rstest runtime code should be prefixed with `rstest_` to avoid conflicts with other runtimes.
 
 const originalWebpackRequire = __webpack_require__;
-__webpack_require__ = function (...args) {
-  try {
-    return originalWebpackRequire(...args);
-  } catch (e) {
-    const errMsg = e.message ?? e.toString();
-    if (errMsg.includes('__webpack_modules__[moduleId] is not a function')) {
-      throw new Error(`[Rstest] Cannot find module "${args[0]}"`);
+__webpack_require__ = new Proxy(
+  function (...args) {
+    try {
+      return originalWebpackRequire(...args);
+    } catch (e) {
+      const errMsg = e.message ?? e.toString();
+      if (errMsg.includes('__webpack_modules__[moduleId] is not a function')) {
+        throw new Error(`[Rstest] Cannot find module "${args[0]}"`);
+      }
+      throw e;
     }
-    throw e;
-  }
-};
-
-Object.keys(originalWebpackRequire).forEach((key) => {
-  __webpack_require__[key] = originalWebpackRequire[key];
-});
+  },
+  {
+    set(target, property, value) {
+      target[property] = value;
+      originalWebpackRequire[property] = value;
+      return true;
+    },
+    get(target, property) {
+      if (property in target) {
+        return target[property];
+      }
+      return originalWebpackRequire[property];
+    },
+  },
+);
 
 __webpack_require__.rstest_original_modules = {};
 __webpack_require__.rstest_original_module_factories = {};
@@ -50,7 +61,7 @@ __webpack_require__.rstest_require_actual =
 
 // #region rs.mock
 __webpack_require__.rstest_mock = (id, modFactory) => {
-  let requiredModule = undefined;
+  let requiredModule;
   try {
     requiredModule = __webpack_require__(id);
   } catch {
@@ -85,7 +96,7 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
 
 // #region rs.mockRequire
 __webpack_require__.rstest_mock_require = (id, modFactory) => {
-  let requiredModule = undefined;
+  let requiredModule;
   try {
     requiredModule = __webpack_require__(id);
   } catch {
@@ -107,7 +118,7 @@ __webpack_require__.rstest_mock_require = (id, modFactory) => {
 
 // #region rs.doMock
 __webpack_require__.rstest_do_mock = (id, modFactory) => {
-  let requiredModule = undefined;
+  let requiredModule;
   try {
     requiredModule = __webpack_require__(id);
   } catch {
@@ -128,7 +139,7 @@ __webpack_require__.rstest_do_mock = (id, modFactory) => {
 
 // #region rs.doMockRequire
 __webpack_require__.rstest_do_mock_require = (id, modFactory) => {
-  let requiredModule = undefined;
+  let requiredModule;
   try {
     requiredModule = __webpack_require__(id);
   } catch {


### PR DESCRIPTION
## Summary

fix `__webpack_require__.C` is not a function when outputs is esm format. 

![img_v3_02rh_8b30127c-2a7e-4242-aba7-2abc645d3feg](https://github.com/user-attachments/assets/02154b52-9287-42f7-a918-cccd1e6fa024)

<img width="2102" height="1174" alt="image" src="https://github.com/user-attachments/assets/2e97a1d1-4932-4985-9d22-0d0cb4d51e9d" />

<img width="1862" height="404" alt="image" src="https://github.com/user-attachments/assets/107b6056-051d-41a7-b4d6-0969af96e8f1" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
