### PR TITLE
fix: should catch `onTestCaseResult` rpc timeout error

### DIFF
--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -65,7 +65,11 @@ const preparePool = async ({
 
   const cleanupFns: (() => MaybePromise<void>)[] = [];
 
-  const { rpc } = createRuntimeRpc(createForksRpcOptions());
+  const originalConsole = global.console;
+
+  const { rpc } = createRuntimeRpc(createForksRpcOptions(), {
+    originalConsole,
+  });
   const {
     runtimeConfig: {
       globals,

--- a/packages/core/src/runtime/worker/rpc.ts
+++ b/packages/core/src/runtime/worker/rpc.ts
@@ -1,7 +1,7 @@
 import v8 from 'node:v8';
 import { type BirpcOptions, type BirpcReturn, createBirpc } from 'birpc';
 import type { TinypoolWorkerMessage } from 'tinypool';
-import type { RuntimeRPC, ServerRPC } from '../../types';
+import type { RuntimeRPC, ServerRPC, TestResult } from '../../types';
 
 export type WorkerRPC = BirpcReturn<RuntimeRPC, ServerRPC>;
 
@@ -43,8 +43,37 @@ export function createRuntimeRpc(
     BirpcOptions<void>,
     'on' | 'post' | 'serialize' | 'deserialize'
   >,
+  {
+    originalConsole,
+  }: {
+    originalConsole: Console;
+  },
 ): { rpc: WorkerRPC } {
-  const rpc = createBirpc<RuntimeRPC, ServerRPC>({}, options);
+  const rpc = createBirpc<RuntimeRPC, ServerRPC>(
+    {},
+    {
+      ...options,
+      onTimeoutError: (functionName, error) => {
+        switch (functionName) {
+          case 'onTestCaseResult': {
+            const caseResult = error[0] as unknown as TestResult;
+            console.error(
+              `[Rstest] timeout on calling "onTestCaseResult" rpc method (Case: "${caseResult.name}", Result: "${caseResult.status}")`,
+            );
+            return true;
+          }
+          case 'onConsoleLog': {
+            originalConsole.error(
+              `[Rstest] timeout on calling "onConsoleLog" rpc method (Original log: ${error[0].content})`,
+            );
+            return true;
+          }
+          default:
+            return false;
+        }
+      },
+    },
+  );
 
   return {
     rpc,


### PR DESCRIPTION
## Summary

The `onTestCaseResult` / `onConsoleLog` RPC timeout error should be captured because it will not affect the test. Use the logged error instead of the test's unhandled rejection error.


before:
![img_v3_02ri_93664c40-a659-48a4-8f54-63f4521a5a8g](https://github.com/user-attachments/assets/63c7f1ea-37d9-4601-b248-046366338a62)


after:
![img_v3_02ri_f273561f-ec04-4bab-8cbe-19c0215d9cag](https://github.com/user-attachments/assets/05c172cb-5ed9-46ac-afa7-3a229864fe23)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
