### PR TITLE
chore: rename rsbuildConfig option to config

### DIFF
--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -76,7 +76,7 @@ export const prepareRsbuild = async (
 
   const rsbuildInstance = await createRsbuild({
     callerName: 'rstest',
-    rsbuildConfig: {
+    config: {
       root: context.rootPath,
       server: {
         printUrls: false,


### PR DESCRIPTION
## Summary

Simplify the configuration parameter name of `createRsbuild`, see https://github.com/web-infra-dev/rsbuild/pull/6245

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
