### PR TITLE
feat: add `defineProject` helper

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ import type {
   CoverageOptions,
   CoverageProvider,
   NormalizedCoverageOptions,
+  ProjectConfig,
   RstestConfig,
 } from './types';
 
@@ -31,13 +32,35 @@ export type RstestConfigExport =
 
 /**
  * This function helps you to autocomplete configuration types.
- * It accepts a Rsbuild config object, or a function that returns a config.
+ * It accepts a Rstest config object, or a function that returns a config.
  */
 export function defineConfig(config: RstestConfig): RstestConfig;
 export function defineConfig(config: RstestConfigSyncFn): RstestConfigSyncFn;
 export function defineConfig(config: RstestConfigAsyncFn): RstestConfigAsyncFn;
 export function defineConfig(config: RstestConfigExport): RstestConfigExport;
 export function defineConfig(config: RstestConfigExport) {
+  return config;
+}
+
+type ProjectConfigAsyncFn = () => Promise<ProjectConfig>;
+
+type ProjectConfigSyncFn = () => ProjectConfig;
+
+type RstestProjectConfigExport =
+  | ProjectConfig
+  | ProjectConfigSyncFn
+  | ProjectConfigAsyncFn;
+
+/**
+ * This function helps you to autocomplete configuration types.
+ * It accepts a Rstest project config object, or a function that returns a config.
+ */
+export function defineProject(config: ProjectConfig): ProjectConfig;
+export function defineProject(config: ProjectConfigSyncFn): ProjectConfigSyncFn;
+export function defineProject(
+  config: ProjectConfigAsyncFn,
+): ProjectConfigAsyncFn;
+export function defineProject(config: RstestProjectConfigExport) {
   return config;
 }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -22,7 +22,14 @@ export type RstestPoolOptions = {
 
 export type ProjectConfig = Omit<
   RstestConfig,
-  'projects' | 'reporters' | 'pool' | 'isolate' | 'coverage'
+  | 'projects'
+  | 'reporters'
+  | 'pool'
+  | 'isolate'
+  | 'coverage'
+  | 'resolveSnapshotPath'
+  | 'onConsoleLog'
+  | 'hideSkippedTests'
 >;
 
 type SnapshotFormat = Omit<


### PR DESCRIPTION
## Summary

`defineProject` helps you to autocomplete configuration types. It accepts a Rstest project config object, or a function that returns a config.

```ts
import { defineProject } from '@rstest/core';

export default defineProject({
  setupFiles: ['./rstest.setup.ts'],
});

```
## Related Links

close: https://github.com/web-infra-dev/rstest/issues/668
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
