### PR TITLE
fix: support npm package names in setupFiles

### DIFF
--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -158,9 +158,10 @@ export const getSetupFiles = (
         const relativePath = pathe.relative(rootPath, setupFilePath);
         return [formatTestEntryName(relativePath), setupFilePath];
       } catch (err) {
+        const resolvedPath = tryResolve(setupFile, rootPath);
         // support use package name as setupFiles value
-        if (tryResolve(setupFile, rootPath)) {
-          return [formatTestEntryName(setupFile), setupFile];
+        if (resolvedPath) {
+          return [formatTestEntryName(setupFile), resolvedPath];
         }
         throw err;
       }


### PR DESCRIPTION
## Summary

support npm package names in setupFiles.

## Related Links
close: https://github.com/web-infra-dev/rstest/issues/669
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
