### PR TITLE
chore: exports some Rstest API types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,9 +65,14 @@ export function defineProject(config: RstestProjectConfigExport) {
 }
 
 export type {
+  Assertion,
+  DescribeAPI as Describe,
   ProjectConfig,
   Reporter,
+  Rstest,
   RstestCommand,
+  RstestExpect as Expect,
+  RstestUtilities,
   TestFileInfo,
   TestFileResult,
   TestResult,


### PR DESCRIPTION
## Summary

Exports some Rstest API types.

```ts
import type { Describe, Expect, RstestUtilities } from '@rstest/core';

type Options = {
  describe: Describe;
  expect:  Expect;
  rstest:  RstestUtilities;
}
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
