### PR TITLE
feat:  support customize the chai config via `chaiConfig` configuration.

### DIFF
--- a/e2e/chaiConfigs/fixtures/index.test.ts
+++ b/e2e/chaiConfigs/fixtures/index.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('Index', () => {
+  it('test truncateThreshold', () => {
+    expect([1, 2, [3, [4], { a: 1, length: 1 }]]).toStrictEqual([1, 2, [3]]);
+  });
+});

--- a/e2e/chaiConfigs/fixtures/rstest.config.ts
+++ b/e2e/chaiConfigs/fixtures/rstest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  chaiConfig: {
+    truncateThreshold: 100,
+  },
+});

--- a/e2e/chaiConfigs/index.test.ts
+++ b/e2e/chaiConfigs/index.test.ts
@@ -1,0 +1,27 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = dirname(__filename);
+
+describe('test chai config', () => {
+  it('should return test correct with chai config', async () => {
+    const { expectExecFailed, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecFailed();
+    expectLog(
+      'expected [ 1, 2, [ 3, [ 4 ], { a: 1, length: 1 } ] ] to strictly equal',
+    );
+  });
+});

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "rsbuild build",
     "test": "rstest",
+    "test:coverage": "rstest --coverage",
     "test:watch": "rstest --watch"
   },
   "devDependencies": {

--- a/examples/node/rstest.config.ts
+++ b/examples/node/rstest.config.ts
@@ -1,8 +1,3 @@
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({
-  coverage: {
-    enabled: true,
-    provider: 'istanbul',
-  },
-});
+export default defineConfig({});

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -55,6 +55,7 @@ const getRuntimeConfig = (context: ProjectContext): RuntimeConfig => {
     snapshotFormat,
     env,
     logHeapUsage,
+    chaiConfig,
   } = context.normalizedConfig;
 
   return {
@@ -78,6 +79,7 @@ const getRuntimeConfig = (context: ProjectContext): RuntimeConfig => {
     coverage,
     snapshotFormat,
     logHeapUsage,
+    chaiConfig,
   };
 };
 

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -31,6 +31,7 @@ import {
 import * as chai from 'chai';
 import type {
   Assertion,
+  ChaiConfig,
   MatcherState,
   RstestExpect,
   TestCase,
@@ -44,6 +45,10 @@ chai.use(JestChaiExpect);
 chai.use(SnapshotPlugin);
 chai.use(JestAsymmetricMatchers);
 export { GLOBAL_EXPECT };
+
+export function setupChaiConfig(config: ChaiConfig): void {
+  Object.assign(chai.config, config);
+}
 
 export function createExpect({
   getCurrentTest,

--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -8,7 +8,7 @@ import type {
   WorkerState,
 } from '../../types';
 import { createRunner } from '../runner';
-import { assert, createExpect, GLOBAL_EXPECT } from './expect';
+import { assert, createExpect, GLOBAL_EXPECT, setupChaiConfig } from './expect';
 import { createRstestUtilities } from './utilities';
 
 export const createRstestRuntime = (
@@ -26,6 +26,10 @@ export const createRstestRuntime = (
   api: Rstest;
 } => {
   const { runner, api: runnerAPI } = createRunner({ workerState });
+
+  if (workerState.runtimeConfig.chaiConfig) {
+    setupChaiConfig(workerState.runtimeConfig.chaiConfig);
+  }
 
   const expect: RstestExpect = createExpect({
     workerState,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,11 +1,16 @@
 import type { RsbuildConfig } from '@rsbuild/core';
 import type { SnapshotStateOptions } from '@vitest/snapshot';
+import type { config } from 'chai';
 import type { CoverageOptions, NormalizedCoverageOptions } from './coverage';
 import type {
   BuiltInReporterNames,
   Reporter,
   ReporterWithOptions,
 } from './reporter';
+
+export type ChaiConfig = Partial<
+  Omit<typeof config, 'useProxy' | 'proxyExcludedKeys' | 'deepEqual'>
+>;
 
 export type RstestPoolType = 'forks';
 
@@ -251,6 +256,11 @@ export interface RstestConfig {
    */
   coverage?: CoverageOptions;
 
+  /**
+   * chai configuration options
+   */
+  chaiConfig?: ChaiConfig;
+
   // Rsbuild configs
 
   plugins?: RsbuildConfig['plugins'];
@@ -290,6 +300,7 @@ type OptionalKeys =
   | 'tools'
   | 'dev'
   | 'onConsoleLog'
+  | 'chaiConfig'
   | 'resolveSnapshotPath';
 
 export type NormalizedConfig = Required<

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -49,6 +49,7 @@ export type RuntimeConfig = Pick<
   | 'snapshotFormat'
   | 'env'
   | 'logHeapUsage'
+  | 'chaiConfig'
 >;
 
 export type WorkerContext = {

--- a/website/docs/en/config/test/_meta.json
+++ b/website/docs/en/config/test/_meta.json
@@ -33,6 +33,7 @@
   "hideSkippedTests",
   "slowTestThreshold",
   "snapshotFormat",
+  "chaiConfig",
   "resolveSnapshotPath",
   "printConsoleTrace",
   "onConsoleLog",

--- a/website/docs/en/config/test/chaiConfig.mdx
+++ b/website/docs/en/config/test/chaiConfig.mdx
@@ -1,0 +1,34 @@
+# chaiConfig
+
+- **Type:**
+
+```ts
+type ChaiConfig = {
+  /**
+   * @default false
+   */
+  includeStack: boolean;
+  /**
+   * @default true
+   */
+  showDiff: boolean;
+  /**
+   * @default 40
+   */
+  truncateThreshold: number;
+};
+```
+
+- **Default:** `undefined`
+
+Customize the [Chai config](https://github.com/chaijs/chai/blob/5.x.x/lib/chai/config.js).
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  chaiConfig: {
+    truncateThreshold: 100,
+  },
+});
+```

--- a/website/docs/zh/config/test/_meta.json
+++ b/website/docs/zh/config/test/_meta.json
@@ -33,6 +33,7 @@
   "hideSkippedTests",
   "slowTestThreshold",
   "snapshotFormat",
+  "chaiConfig",
   "resolveSnapshotPath",
   "printConsoleTrace",
   "onConsoleLog",

--- a/website/docs/zh/config/test/chaiConfig.mdx
+++ b/website/docs/zh/config/test/chaiConfig.mdx
@@ -1,0 +1,34 @@
+# chaiConfig
+
+- **类型：**
+
+```ts
+type ChaiConfig = {
+  /**
+   * @default false
+   */
+  includeStack: boolean;
+  /**
+   * @default true
+   */
+  showDiff: boolean;
+  /**
+   * @default 40
+   */
+  truncateThreshold: number;
+};
+```
+
+- **默认值：** `undefined`
+
+自定义 [Chai config](https://github.com/chaijs/chai/blob/5.x.x/lib/chai/config.js)。
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  chaiConfig: {
+    truncateThreshold: 100,
+  },
+});
+```

--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -56,6 +56,7 @@ const OVERVIEW_GROUPS: Group[] = [
       'hideSkippedTests',
       'slowTestThreshold',
       'snapshotFormat',
+      'chaiConfig',
       'resolveSnapshotPath',
       'onConsoleLog',
       'printConsoleTrace',


### PR DESCRIPTION
## Summary

 support customize the chai config via `chaiConfig` configuration.

```ts
type ChaiConfig = {
  /**
   * @default false
   */
  includeStack: boolean;
  /**
   * @default true
   */
  showDiff: boolean;
  /**
   * @default 40
   */
  truncateThreshold: number;
};
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
