### PR TITLE
feat(vscode): remove unnecessary logger code

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -15,10 +15,10 @@ The extension activates automatically when your workspace contains Rstest config
 
 ## Configuration
 
-| Setting                      | Type     | Default                          | Description                                                                     |
-| ---------------------------- | -------- | -------------------------------- | ------------------------------------------------------------------------------- |
-| `rstest.testFileGlobPattern` | string[] | `["**/*.test.*", "**/*.spec.*"]` | Glob pattern(s) used to discover test files in the workspace.                   |
-| `rstest.logLevel`            | string   | `default`                        | Controls Output channel verbosity; set to `debug` for extra diagnostic logging. |
+| Setting                      | Type     | Default                          | Description                                                                                                                                                                                                                                                           |
+| ---------------------------- | -------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rstest.testFileGlobPattern` | string[] | `["**/*.test.*", "**/*.spec.*"]` | Glob pattern(s) used to discover test files in the workspace.                                                                                                                                                                                                         |
+| `rstest.rstestPackagePath`   | string   | `undefined`                      | The path to a `package.json` file of a Rstest executable (it's usually inside `node_modules`) in case the extension cannot find it. It will be used to resolve Rstest API paths. This should be used as a last resort fix. Supports `${workspaceFolder}` placeholder. |
 
 ## How it works
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -39,16 +39,6 @@
             "**/*.spec.*"
           ]
         },
-        "rstest.logLevel": {
-          "markdownDescription": "Controls how much diagnostic output the Rstest extension emits to the Output view.",
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "default",
-            "debug"
-          ],
-          "default": "default"
-        },
         "rstest.rstestPackagePath": {
           "markdownDescription": "The path to a `package.json` file of a Rstest executable (it's usually inside `node_modules`) in case the extension cannot find it. It will be used to resolve Rstest API paths. This should be used as a last resort fix. Supports `${workspaceFolder}` placeholder.",
           "scope": "resource",

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -1,15 +1,11 @@
 import vscode from 'vscode';
 
-export type LogLevel = 'default' | 'debug';
-
 // Centralized configuration types for the extension.
 // Add new keys here to extend configuration in a type-safe way.
 export type ExtensionConfig = {
   // Glob patterns that determine which files are considered tests.
   // Must be an array of strings.
   testFileGlobPattern: string[];
-  // Controls verbosity of extension logging routed to the Output channel.
-  logLevel: LogLevel;
   // The path to a package.json file of a Rstest executable.
   // Used as a last resort if the extension cannot auto-detect @rstest/core.
   rstestPackagePath?: string;
@@ -17,7 +13,6 @@ export type ExtensionConfig = {
 
 export const defaultConfig: ExtensionConfig = {
   testFileGlobPattern: ['**/*.test.*', '**/*.spec.*'],
-  logLevel: 'default',
 };
 
 // Type-safe getter for a single config value with priority:
@@ -42,11 +37,6 @@ export function getConfigValue<K extends keyof ExtensionConfig>(
     return (isStringArray(v) ? v : defaultConfig[key]) as ExtensionConfig[K];
   }
 
-  if (key === 'logLevel') {
-    const v = value as unknown;
-    return (isLogLevel(v) ? v : defaultConfig[key]) as ExtensionConfig[K];
-  }
-
   if (key === 'rstestPackagePath') {
     const v = value as unknown;
     return (
@@ -61,15 +51,10 @@ function isStringArray(v: unknown): v is string[] {
   return Array.isArray(v) && v.every((x) => typeof x === 'string');
 }
 
-function isLogLevel(v: unknown): v is LogLevel {
-  return v === 'default' || v === 'debug';
-}
-
 // Convenience to get a full, normalized config object at the given scope.
 export function getConfig(folder?: vscode.WorkspaceFolder): ExtensionConfig {
   return {
     testFileGlobPattern: getConfigValue('testFileGlobPattern', folder),
-    logLevel: getConfigValue('logLevel', folder),
     rstestPackagePath: getConfigValue('rstestPackagePath', folder),
   } satisfies ExtensionConfig;
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -35,7 +35,7 @@ class Rstest {
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.ctrl = vscode.tests.createTestController('rstest', 'Rstest');
-    context.subscriptions.push(this.ctrl, logger);
+    context.subscriptions.push(this.ctrl);
 
     this.fileChangedEmitter = new vscode.EventEmitter<vscode.Uri>();
     this.watchingTests = new Map<

--- a/packages/vscode/tests/fixtures/.vscode/settings.json
+++ b/packages/vscode/tests/fixtures/.vscode/settings.json
@@ -1,3 +1,1 @@
-{
-  "rstest.logLevel": "default"
-}
+{}

--- a/packages/vscode/tests/suite/config.test.ts
+++ b/packages/vscode/tests/suite/config.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { delay, waitForConfigValue } from './helpers';
+import { delay } from './helpers';
 
 suite('Configuration Integration', () => {
   function clearController(ctrl: vscode.TestController) {
@@ -123,37 +123,6 @@ suite('Configuration Integration', () => {
       if (fs.existsSync(fixturesVscodeDir)) {
         fs.rmSync(fixturesVscodeDir, { recursive: true, force: true });
       }
-    }
-  });
-
-  test('respects rstest.logLevel', async () => {
-    const config = vscode.workspace.getConfiguration('rstest');
-    const prev = config.get('logLevel');
-
-    try {
-      await config.update(
-        'logLevel',
-        'debug',
-        vscode.ConfigurationTarget.Workspace,
-      );
-      await delay(500);
-
-      let logLevel = config.get('logLevel');
-
-      logLevel = await waitForConfigValue({
-        initialValue: logLevel,
-        read: () => vscode.workspace.getConfiguration('rstest').get('logLevel'),
-        expected: 'debug',
-      });
-
-      assert.strictEqual(logLevel, 'debug');
-    } finally {
-      await config.update(
-        'logLevel',
-        (prev as any) ?? undefined,
-        vscode.ConfigurationTarget.Workspace,
-      );
-      await delay(100);
     }
   });
 });


### PR DESCRIPTION
## Summary

1. Using VSCode builtin log output instead
2. Only external resources, like temporary files, require cleanup

<img width="2646" height="808" alt="image" src="https://github.com/user-attachments/assets/a2c9a6a8-afc9-41e3-88db-3d89b4e54f6e" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
