### PR TITLE
fix: should get project's tsconfigPath correctly

### DIFF
--- a/packages/core/rstest.config.ts
+++ b/packages/core/rstest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   include: ['<rootDir>/tests/**/*.test.ts'],
   globals: true,
   source: {
+    tsconfigPath: './tests/tsconfig.json',
     define: {
       RSTEST_VERSION: JSON.stringify('0.0.0'),
       'process.env.GITHUB_ACTIONS': JSON.stringify('false'),

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -119,6 +119,11 @@ export class Rstest implements RstestContext {
             if (existsSync(tsconfigPath)) {
               config.source.tsconfigPath = tsconfigPath;
             }
+          } else {
+            config.source.tsconfigPath = getAbsolutePath(
+              config.root,
+              config.source.tsconfigPath,
+            );
           }
           return {
             configFilePath: project.configFilePath,


### PR DESCRIPTION
## Summary

fix: should get project's tsconfigPath correctly.

expect get `rstest/packages/core/tests/tsconfig.json`, but got `rstest/tests/tsconfig.json`
<img width="2852" height="1608" alt="img_v3_02ru_5e7d7381-4c4a-4c79-87a8-c380e46d07ag" src="https://github.com/user-attachments/assets/4ab6aa35-a9ea-4514-90ab-5835b91899b2" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
