### PR TITLE
chore: only render status in tty context

### DIFF
--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -1,6 +1,5 @@
 import { relative } from 'pathe';
 import { parse as stackTraceParse } from 'stacktrace-parser';
-import { isCI } from 'std-env';
 import type {
   DefaultReporterOptions,
   Duration,
@@ -13,7 +12,7 @@ import type {
   TestResult,
   UserConsoleLog,
 } from '../types';
-import { color, logger } from '../utils';
+import { color, isTTY, logger } from '../utils';
 import { StatusRenderer } from './statusRenderer';
 import { printSummaryErrorLogs, printSummaryLog } from './summary';
 import { logCase, logFileTitle } from './utils';
@@ -36,7 +35,7 @@ export class DefaultReporter implements Reporter {
     this.rootPath = rootPath;
     this.config = config;
     this.options = options;
-    if (!isCI) {
+    if (isTTY()) {
       this.statusRenderer = new StatusRenderer(rootPath);
     }
   }


### PR DESCRIPTION
## Summary

only render status in tty context. 

<img width="586" height="215" alt="image" src="https://github.com/user-attachments/assets/1d96f059-521e-4044-8d99-993144ef09e3" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
