### PR TITLE
fix(vscode-extension): import rstest error on windows

### DIFF
--- a/packages/vscode/src/worker/index.ts
+++ b/packages/vscode/src/worker/index.ts
@@ -1,9 +1,16 @@
+import { pathToFileURL } from 'node:url';
 import { WebSocket } from 'ws';
 import type { WorkerInitData, WorkerRunTestData } from '../types';
 import { logger } from './logger';
 import { VscodeReporter } from './reporter';
 
 type CommonOptions = Parameters<typeof import('@rstest/core').initCli>[0];
+
+// fix ESM import path issue on windows
+// Only URLs with a scheme in: file, data, and node are supported by the default ESM loader.
+const normalizeImportPath = (path: string) => {
+  return pathToFileURL(path).toString();
+};
 
 class Worker {
   private ws: WebSocket;
@@ -51,7 +58,7 @@ class Worker {
 
   public async createRstest(data: WorkerRunTestData) {
     const rstestModule = (await import(
-      this.rstestPath
+      normalizeImportPath(this.rstestPath)
     )) as typeof import('@rstest/core');
     logger.debug('Loaded Rstest module');
     const { createRstest, initCli } = rstestModule;


### PR DESCRIPTION
## Summary

fix(vscode-extension): import rstest error on windows.

use `pathToFileUrl` to make esm `import()` work with absolute windows paths

<img width="670" height="335" alt="image" src="https://github.com/user-attachments/assets/64869d1c-45e2-4578-ae2b-53a6e19ce615" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
