### PR TITLE
feat: support get runtime config via `rs.getConfig` API

### DIFF
--- a/e2e/test-api/fixtures/setConfig.test.ts
+++ b/e2e/test-api/fixtures/setConfig.test.ts
@@ -2,18 +2,22 @@ import { describe, expect, it, rs } from '@rstest/core';
 import { sleep } from '../../scripts';
 
 rs.setConfig({
-  testTimeout: 50,
+  testTimeout: 100,
 });
 
 describe('level A', () => {
   it('it in level A', async () => {
-    console.log('aaaa');
-    // await sleep(100);
     expect(1 + 1).toBe(3);
   });
 });
 
 it('it in level B', async () => {
-  await sleep(100);
+  await sleep(150);
   expect(1 + 1).toBe(2);
+});
+
+it('it in level C', async () => {
+  const config = rs.getConfig();
+
+  expect(config.testTimeout).toBe(100);
 });

--- a/e2e/test-api/setConfig.test.ts
+++ b/e2e/test-api/setConfig.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from '@rstest/core';
+import { describe, it } from '@rstest/core';
 import { runRstestCli } from '../scripts';
 
-describe('setConfig', () => {
+describe('setConfig & getConfig', () => {
   it('should throw timeout error when test timeout', async () => {
-    const { cli } = await runRstestCli({
+    const { expectExecFailed, expectLog } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/setConfig.test'],
       options: {
@@ -13,13 +13,8 @@ describe('setConfig', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(1);
-    const logs = cli.stdout.split('\n').filter(Boolean);
-
-    expect(
-      logs.find((log) => log.includes('Error: test timed out in 50ms')),
-    ).toBeTruthy();
-    expect(logs.find((log) => log.includes('Tests 2 failed'))).toBeTruthy();
+    await expectExecFailed();
+    expectLog(/Error: test timed out in 100ms/);
+    expectLog(/Tests 2 failed | 1 passed/);
   });
 });

--- a/examples/node/test/index.test.ts
+++ b/examples/node/test/index.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from '@rstest/core';
+import { describe, expect, it, rs } from '@rstest/core';
 import { sayHi } from '../src/index';
 
+const config = rs.getConfig();
+console.log(config);
 describe('Index', () => {
   it('should add two numbers correctly', () => {
     expect(1 + 1).toBe(2);

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -92,6 +92,27 @@ export const createRstestUtilities: (
       Object.assign(workerState.runtimeConfig, config);
     },
 
+    getConfig: () => {
+      const {
+        testTimeout,
+        hookTimeout,
+        clearMocks,
+        resetMocks,
+        restoreMocks,
+        maxConcurrency,
+        retry,
+      } = workerState.runtimeConfig;
+      return {
+        testTimeout,
+        hookTimeout,
+        clearMocks,
+        resetMocks,
+        restoreMocks,
+        maxConcurrency,
+        retry,
+      };
+    },
+
     resetConfig: () => {
       if (originalConfig) {
         Object.assign(workerState.runtimeConfig, originalConfig);

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -302,6 +302,11 @@ export interface RstestUtilities {
   setConfig: (config: RuntimeOptions) => void;
 
   /**
+   * get runtime config for the current test.
+   */
+  getConfig: () => RuntimeOptions;
+
+  /**
    * Reset runtime config that were changed with `rstest.setConfig`.
    */
   resetConfig: () => void;

--- a/website/docs/en/api/rstest/utilities.mdx
+++ b/website/docs/en/api/rstest/utilities.mdx
@@ -124,3 +124,18 @@ rstest.resetConfig(); // Restore to default config
 - **Type:** `() => void`
 
 Resets the runtime configuration that was changed using `rstest.setConfig` back to the default values.
+
+## rstest.getConfig
+
+- **Alias:** `rs.getConfig`
+
+- **Type:** `() => RuntimeConfig`
+
+Retrieves the current runtime configuration for the test file. Useful for inspecting or logging the current settings.
+
+**Example:**
+
+```ts
+const config = rstest.getConfig();
+console.log(config);
+```

--- a/website/docs/zh/api/rstest/utilities.mdx
+++ b/website/docs/zh/api/rstest/utilities.mdx
@@ -124,3 +124,18 @@ rstest.resetConfig(); // 恢复默认配置
 - **类型：** `() => void`
 
 将通过 `rstest.setConfig` 修改的运行时配置重置为默认值。
+
+## rstest.getConfig
+
+- **别名：** `rs.getConfig`
+
+- **类型：** `() => RuntimeConfig`
+
+获取当前测试文件的运行时配置。
+
+**示例：**
+
+```ts
+const config = rstest.getConfig();
+console.log(config);
+```


### PR DESCRIPTION
## Summary

support get runtime config via `rs.getConfig` API.

```ts
const config = rstest.getConfig();
console.log(config);

// will output:
// {
//   testTimeout: 5000,
//   hookTimeout: 10000,
//   clearMocks: false,
//   resetMocks: false,
//   restoreMocks: false,
//   maxConcurrency: 5,
//   retry: 0
// }
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
