### PR TITLE
fix: should handle circular reference in error object correctly

### DIFF
--- a/e2e/test-api/edgeCase.test.ts
+++ b/e2e/test-api/edgeCase.test.ts
@@ -124,4 +124,19 @@ describe('Test Edge Cases', () => {
       logs.find((log) => log.includes('Test Files 1 skipped')),
     ).toBeTruthy();
   });
+
+  it('should handle circular reference in error object correctly', async () => {
+    const { expectExecFailed, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/circularReference.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecFailed();
+
+    expectLog(/AssertionError: expected .* to deeply equal undefined/);
+  });
 });

--- a/e2e/test-api/fixtures/circularReference.test.ts
+++ b/e2e/test-api/fixtures/circularReference.test.ts
@@ -1,0 +1,14 @@
+import { expect, it } from '@rstest/core';
+
+class A {
+  constructor(readonly b: B) {}
+}
+
+class B {
+  a: A = new A(this);
+}
+
+it('should throw AssertionError', () => {
+  const b = new B();
+  expect(b.a).toEqual(undefined);
+});

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -23,7 +23,7 @@ export const formatTestError = (err: any, test?: Test): FormattedError[] => {
     const error =
       typeof rawError === 'string' ? { message: rawError } : rawError;
     const errObj: FormattedError = {
-      ...error,
+      fullStack: error.fullStack,
       // Some error attributes cannot be enumerated
       message: error.message,
       name: error.name,
@@ -43,16 +43,6 @@ export const formatTestError = (err: any, test?: Test): FormattedError[] => {
       errObj.diff = diff(err.expected, err.actual, {
         expand: false,
       })!;
-    }
-
-    for (const key of ['actual', 'expected'] as const) {
-      if (typeof err[key] !== 'string') {
-        (errObj as Record<string, any>)[key] = JSON.stringify(
-          err[key],
-          null,
-          10,
-        );
-      }
     }
 
     return errObj;


### PR DESCRIPTION
## Summary

should handle circular reference in error object correctly.
before:
<img width="587" height="153" alt="image" src="https://github.com/user-attachments/assets/0d280ea6-2eec-4d7b-8130-0697632c3914" />

after: 
<img width="816" height="241" alt="image" src="https://github.com/user-attachments/assets/0fb4b276-06f9-42c7-a777-1c21c076daef" />


## Related Links
fix https://github.com/web-infra-dev/rstest/issues/726
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
