### PR TITLE
release: 0.7.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "The Rsbuild-based test tool.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "type": "module",
   "description": "Istanbul coverage provider for Rstest",
   "author": "Travis Zhang<https://github.com/travzhang>",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Rstest",
   "publisher": "rstack",
   "description": "VS Code extension for Rstest",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "private": true,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Breaking Changes
#### Use SWC v47
Since SWC 46 is incompatible with swc-plugin-coverage-instrument, we are skipping SWC 46 (rspack 1.6 and rsbuild 1.6). Instead, SWC 47 will be used in rspack 1.7, and rstest will directly use the canary version of rspack / rsbuild 1.7 with SWC 47.

If your project uses SWC Wasm plugins (such as `@swc/plugin-emotion`), you will need to upgrade the plugins to a version compatible with swc_core@47; otherwise, it may cause build errors due to version incompatibility.

see https://plugins.swc.rs/versions/range/768 to get all available swc plugin versions for Rstest v0.7.

### New Features 🎉
* faet: use rspack / rsbuild 1.7 canary (swc 47) by @9aoy in https://github.com/web-infra-dev/rstest/pull/712


### Bug Fixes 🐞
- fix wasm load error  in https://github.com/web-infra-dev/rstest/pull/712
- always hoist `@rstest/core` init fragment   in https://github.com/web-infra-dev/rspack/pull/12363

### Document 📖
* docs: add `node.js profiling` guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/736


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.6.9...v0.7.0