### PR TITLE
fix: not exit with code 1 when unexpectedly exited during teardown

### DIFF
--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -462,17 +462,28 @@ export async function runTests(context: Rstest): Promise<void> {
       afterTestsWatchRun();
     });
   } else {
+    let isTeardown = false;
+
     const unExpectedExit = (code?: number) => {
-      logger.log(
-        color.red(
-          `Rstest exited unexpectedly with code ${code}, terminating test run.`,
-        ),
-      );
-      process.exitCode = 1;
+      if (isTeardown) {
+        logger.log(
+          color.yellow(
+            `Rstest exited unexpectedly with code ${code}, this is likely caused by test environment teardown.`,
+          ),
+        );
+      } else {
+        logger.log(
+          color.red(
+            `Rstest exited unexpectedly with code ${code}, terminating test run.`,
+          ),
+        );
+        process.exitCode = 1;
+      }
     };
     process.on('exit', unExpectedExit);
 
     await run();
+    isTeardown = true;
     await pool.close();
     await closeServer();
     process.off('exit', unExpectedExit);


### PR DESCRIPTION
## Summary

not exit with code 1 when unexpectedly exited during teardown.
<img width="823" height="229" alt="image" src="https://github.com/user-attachments/assets/92fb135a-019f-420d-a8ba-ee1de953c6a3" />


## Related Links

https://github.com/web-infra-dev/rspack/actions/runs/20021870432/job/57410628304

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
