### PR TITLE
chore(ci): manually update rsbuild core package until v1.7

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,6 +60,7 @@
     },
   ],
   ignoreDeps: [
+    // TODO: Remove this ignore rule for @rsbuild/core after v1.7 is released.
     // manually update rsbuild core package until v1.7
     '@rsbuild/core',
     // manually update some packages


### PR DESCRIPTION
## Summary

manually update rsbuild core package until v1.7.

## Related Links

https://github.com/web-infra-dev/rstest/pull/712

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
