### PR TITLE
fix: should respect config.root option

### DIFF
--- a/e2e/projects/fixtures/packages/client/rstest.config.ts
+++ b/e2e/projects/fixtures/packages/client/rstest.config.ts
@@ -4,6 +4,7 @@ import rsbuildConfig from './rsbuild.config';
 export default defineProject({
   projects: [
     {
+      root: __dirname,
       ...(rsbuildConfig as RstestConfig),
       name: 'client-jsdom',
       testEnvironment: 'jsdom',
@@ -11,6 +12,7 @@ export default defineProject({
       exclude: ['test/node.test.ts'],
     },
     {
+      root: __dirname,
       name: 'client-node',
       include: ['test/node.test.ts'],
     },

--- a/e2e/projects/index.test.ts
+++ b/e2e/projects/index.test.ts
@@ -51,6 +51,33 @@ describe('test projects', () => {
     }, 15_000);
   });
 
+  it('should run project correctly with specified config root', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--globals', '-c', 'packages/client/rstest.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    // test log print
+    // should only run client project
+    expect(
+      logs.find((log) => log.includes('packages/node/test/index.test.ts')),
+    ).toBeFalsy();
+    expect(
+      logs.find((log) => log.includes('packages/client/test/App.test.tsx')),
+    ).toBeTruthy();
+    expect(
+      logs.find((log) => log.includes('packages/client/test/node.test.ts')),
+    ).toBeTruthy();
+  });
+
   it('should run projects fail when project not found', async () => {
     const { expectExecFailed, expectStderrLog } = await runRstestCli({
       command: 'rstest',

--- a/examples/node/rstest.config.ts
+++ b/examples/node/rstest.config.ts
@@ -1,3 +1,5 @@
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({});
+export default defineConfig({
+  root: __dirname,
+});


### PR DESCRIPTION
## Summary

fix: should respect config.root option. support run sub-project tests with specified config & `root` configuration in monorepo's root.

https://rstest.rs/config/test/root

<img width="959" height="712" alt="image" src="https://github.com/user-attachments/assets/2efba40d-35f7-4bde-bcde-0e13f3d49830" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
