### PR TITLE
test: exclude mock cases when isolate false

### DIFF
--- a/e2e/rstest.config.ts
+++ b/e2e/rstest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     '**/dist/**',
     '**/fixtures/**',
     '**/fixtures-*/**',
-    process.env.ISOLATE === 'false' ? '**/watch/**' : '',
-  ].filter(Boolean),
+  ].concat(
+    process.env.ISOLATE === 'false' ? ['**/watch/**', '**/mock/**'] : [],
+  ),
 });


### PR DESCRIPTION
## Summary
Exclude mock cases when isolate false, since mock cases have side effects and are unstable when isolate is enabled (false).

TODO:
- fix   unstable vscode extension case https://github.com/web-infra-dev/rstest/actions/runs/20460779317/job/58792843745?pr=797
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
