### PR TITLE
release: @rstest/adapter-rslib v0.1.1

### DIFF
--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Rstest adapter for rslib configuration",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
     }
   },
   "devDependencies": {
-    "@rslib/core": "^0.18.6",
+    "@rslib/core": "^0.19.0",
     "@rstest/core": "workspace:*",
     "typescript": "^5.9.3",
     "tsconfck": "3.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "@babel/code-frame": "^7.27.1",
     "@jridgewell/trace-mapping": "0.3.31",
     "@microsoft/api-extractor": "^7.55.2",
-    "@rslib/core": "^0.18.6",
+    "@rslib/core": "^0.19.0",
     "@rstest/tsconfig": "workspace:*",
     "@sinonjs/fake-timers": "^15.1.0",
     "@types/babel__code-frame": "^7.0.6",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@rstest/tsconfig": "workspace:*",
     "@rstest/core": "workspace:*",
-    "@rslib/core": "^0.18.6",
+    "@rslib/core": "^0.19.0",
     "@types/node": "^22.16.5",
     "typescript": "^5.9.3",
     "@types/istanbul-lib-coverage": "^2.0.6",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -105,7 +105,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "1.7.0-beta.1",
-    "@rslib/core": "^0.18.6",
+    "@rslib/core": "^0.19.0",
     "@rstest/core": "workspace:*",
     "@rstest/coverage-istanbul": "workspace:*",
     "@swc/core": "^1.15.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.2
-        version: 1.4.2(@rsbuild/core@1.7.0-beta.1)
+        version: 1.4.2(@rsbuild/core@1.7.0-beta.2)
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -423,8 +423,8 @@ importers:
   packages/adapter-rslib:
     devDependencies:
       '@rslib/core':
-        specifier: ^0.18.6
-        version: 0.18.6(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: ^0.19.0
+        version: 0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -460,8 +460,8 @@ importers:
         specifier: ^7.55.2
         version: 7.55.2(@types/node@22.18.6)
       '@rslib/core':
-        specifier: ^0.18.6
-        version: 0.18.6(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: ^0.19.0
+        version: 0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -572,8 +572,8 @@ importers:
         version: 0.0.32
     devDependencies:
       '@rslib/core':
-        specifier: ^0.18.6
-        version: 0.18.6(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: ^0.19.0
+        version: 0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -602,8 +602,8 @@ importers:
         specifier: 1.7.0-beta.1
         version: 1.7.0-beta.1
       '@rslib/core':
-        specifier: ^0.18.6
-        version: 0.18.6(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: ^0.19.0
+        version: 0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -668,7 +668,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.7.0-beta.1)
+        version: 1.4.0(@rsbuild/core@1.7.0-beta.2)
       '@rspress/core':
         specifier: 2.0.0-rc.3
         version: 2.0.0-rc.3(@types/react@19.2.7)
@@ -701,10 +701,10 @@ importers:
         version: 19.2.3(react@19.2.3)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@1.7.0-beta.1)
+        version: 1.0.4(@rsbuild/core@1.7.0-beta.2)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.7.0-beta.1)
+        version: 1.1.0(@rsbuild/core@1.7.0-beta.2)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.3
         version: 1.0.3(@rspress/core@2.0.0-rc.3(@types/react@19.2.7))
@@ -1691,6 +1691,11 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
+  '@rsbuild/core@1.7.0-beta.2':
+    resolution: {integrity: sha512-sPJ21GTJiX9dTj9xtB10ZFbWMdX2PML0MgF98msaLLVDpwYGa8kvS6jFGO+L2T+zbuWFxfMYdU7a8jX6G4JRsQ==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.6':
     resolution: {integrity: sha512-tWnqG938MedKJx7U4F1lHb156VDtNzj7mSsi2ZoxZVBnECQE01/V6QTN1XKw7nWunGyGoETb+nQBGc+fkVZjvw==}
     peerDependencies:
@@ -1763,6 +1768,19 @@ packages:
 
   '@rslib/core@0.18.6':
     resolution: {integrity: sha512-mMjfmtXRPHOCzO1A8KcAQckIHi/vA+qOHT/zK4M8Nnr5h1eAO6HIEN7AvJdgbIf5YXsVH6bXonrXdAwwP0gHow==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      typescript:
+        optional: true
+
+  '@rslib/core@0.19.0':
+    resolution: {integrity: sha512-t94QnZGU8YSn5xQ8vNqxIpee5Mo+S77SEVA/0Tjft0I0dLmU6GZHeYAmoztNfWLudSUl4KrvilnxGPlySMdPvw==}
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
@@ -5047,6 +5065,22 @@ packages:
       typescript:
         optional: true
 
+  rsbuild-plugin-dts@0.19.0:
+    resolution: {integrity: sha512-5NkHONFDMBXv0qr1voHQigVhPmqai2icbJtckXJSCrpSTAJO0eXkGsHNVR8QvnsZEZWXL+KsIgNEJ7C8tYginQ==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      '@rsbuild/core': 1.x
+      '@typescript/native-preview': 7.x
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+
   rsbuild-plugin-google-analytics@1.0.4:
     resolution: {integrity: sha512-K7KkgIUJWtoBpcCLBDLnBXezvQWdue5LCDO4NDvSDe/TEFxOlKb8wG6dDtp/A+CwbnZRVeNOZ9cB6vNg/y/Suw==}
     peerDependencies:
@@ -7173,6 +7207,14 @@ snapshots:
       core-js: 3.47.0
       jiti: 2.6.1
 
+  '@rsbuild/core@1.7.0-beta.2':
+    dependencies:
+      '@rspack/core': 1.7.0-beta.1(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.1.0
+      '@swc/helpers': 0.5.17
+      core-js: 3.47.0
+      jiti: 2.6.1
+
   '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@1.7.0-beta.1)':
     dependencies:
       '@babel/core': 7.28.3
@@ -7213,9 +7255,17 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.7.0-beta.1)':
+  '@rsbuild/plugin-react@1.4.2(@rsbuild/core@1.7.0-beta.2)':
     dependencies:
-      '@rsbuild/core': 1.7.0-beta.1
+      '@rsbuild/core': 1.7.0-beta.2
+      '@rspack/plugin-react-refresh': 1.5.2(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    transitivePeerDependencies:
+      - webpack-hot-middleware
+
+  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.7.0-beta.2)':
+    dependencies:
+      '@rsbuild/core': 1.7.0-beta.2
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
@@ -7348,6 +7398,16 @@ snapshots:
     dependencies:
       '@rsbuild/core': 1.7.0-beta.1
       rsbuild-plugin-dts: 0.18.6(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(@rsbuild/core@1.7.0-beta.1)(typescript@5.9.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.55.2(@types/node@22.18.6)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+
+  '@rslib/core@0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)':
+    dependencies:
+      '@rsbuild/core': 1.7.0-beta.2
+      rsbuild-plugin-dts: 0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(@rsbuild/core@1.7.0-beta.2)(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@22.18.6)
       typescript: 5.9.3
@@ -11265,13 +11325,21 @@ snapshots:
       '@microsoft/api-extractor': 7.55.2(@types/node@22.18.6)
       typescript: 5.9.3
 
-  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.7.0-beta.1):
+  rsbuild-plugin-dts@0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(@rsbuild/core@1.7.0-beta.2)(typescript@5.9.3):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 1.7.0-beta.2
     optionalDependencies:
-      '@rsbuild/core': 1.7.0-beta.1
+      '@microsoft/api-extractor': 7.55.2(@types/node@22.18.6)
+      typescript: 5.9.3
 
-  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.7.0-beta.1):
+  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.7.0-beta.2):
     optionalDependencies:
-      '@rsbuild/core': 1.7.0-beta.1
+      '@rsbuild/core': 1.7.0-beta.2
+
+  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.7.0-beta.2):
+    optionalDependencies:
+      '@rsbuild/core': 1.7.0-beta.2
 
   rslog@1.3.2: {}
 


### PR DESCRIPTION
## Summary

update peerDependencies @rslib/core to `>=0.18.6`

https://github.com/web-infra-dev/rslib/releases/tag/v0.19.0

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
