### PR TITLE
fix: allow inlineSnapshot calls in each with same snapshot

### DIFF
--- a/e2e/snapshot/fixtures/inlineSnapshot.each.test.ts
+++ b/e2e/snapshot/fixtures/inlineSnapshot.each.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, it } from '@rstest/core';
 
 describe('test inlineSnapshot in each', () => {
   it.each([
-    { a: 1, b: 1 },
     { a: 1, b: 2 },
     { a: 2, b: 1 },
   ])('add two numbers correctly', ({ a, b }) => {
-    expect(a + b).toMatchInlineSnapshot();
+    expect(a + b).toMatchInlineSnapshot('3');
   });
 });
 
@@ -15,7 +14,7 @@ describe.each([
   { a: 1, b: 2, expected: 3 },
   { a: 2, b: 1, expected: 3 },
 ])('add two numbers correctly', ({ a, b, expected }) => {
-  it(`should return ${expected}`, () => {
-    expect(a + b).toMatchInlineSnapshot();
+  it(`${a} + ${b} should return ${expected}`, () => {
+    expect(a + b).toMatchInlineSnapshot('2');
   });
 });

--- a/e2e/snapshot/index.test.ts
+++ b/e2e/snapshot/index.test.ts
@@ -37,7 +37,7 @@ describe('test snapshot', () => {
   );
 
   it('should failed when use inline snapshot in each', async () => {
-    const { cli } = await runRstestCli({
+    const { expectLog, expectExecFailed } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/inlineSnapshot.each.test.ts'],
       options: {
@@ -47,19 +47,8 @@ describe('test snapshot', () => {
       },
     });
 
-    await cli.exec;
-    expect(cli.exec.process?.exitCode).toBe(1);
+    await expectExecFailed();
 
-    const logs = cli.stdout.split('\n').filter(Boolean);
-
-    expect(
-      logs.find((log) =>
-        log.includes(
-          'InlineSnapshot cannot be used inside of test.each or describe.each',
-        ),
-      ),
-    ).toBeTruthy();
-
-    expect(logs.find((log) => log.includes('Tests 6 failed'))).toBeTruthy();
+    expectLog(/Tests 2 failed \| 3 passed/);
   });
 });

--- a/packages/core/src/runtime/api/snapshot.ts
+++ b/packages/core/src/runtime/api/snapshot.ts
@@ -253,15 +253,6 @@ export const SnapshotPlugin: (workerState: WorkerState) => ChaiPlugin = (
         }
         const test = getTest(this);
 
-        if (test) {
-          const isInsideEach = test.each || test.inTestEach;
-          if (isInsideEach) {
-            throw new Error(
-              'InlineSnapshot cannot be used inside of test.each or describe.each',
-            );
-          }
-        }
-
         const expected = utils.flag(this, 'object');
         const error = utils.flag(this, 'error');
         if (typeof properties === 'string') {
@@ -335,14 +326,6 @@ export const SnapshotPlugin: (workerState: WorkerState) => ChaiPlugin = (
         }
         const test = getTest(this);
 
-        if (test) {
-          const isInsideEach = test.each || test.inTestEach;
-          if (isInsideEach) {
-            throw new Error(
-              'InlineSnapshot cannot be used inside of test.each or describe.each',
-            );
-          }
-        }
         const expected = utils.flag(this, 'object');
         const error = utils.flag(this, 'error');
         const promise = utils.flag(this, 'promise') as string | undefined;


### PR DESCRIPTION
## Summary

allow inlineSnapshot calls in each with same snapshot.

```ts
describe('test inlineSnapshot in each', () => {
  it.each([
    { a: 1, b: 2 },
    { a: 2, b: 1 },
  ])('add two numbers correctly', ({ a, b }) => {
    expect(a + b).toMatchInlineSnapshot('3');
  });
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
