### PR TITLE
fix: Using include in coverage will cause file items to be displayed repeatedly in the report.

### DIFF
--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -65,7 +65,7 @@ export async function generateCoverage(
     }
 
     if (coverage.include?.length) {
-      const coveredFiles = finalCoverageMap.files();
+      const coveredFiles = finalCoverageMap.files().map(normalize);
 
       let isTimeout = false;
 


### PR DESCRIPTION
fix: Using include in coverage will cause file items to be displayed repeatedly in the report.

## Summary

## Related Links

https://github.com/web-infra-dev/rstest/issues/815
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
