### PR TITLE
fix: override globals that Fetch API relies on

### DIFF
--- a/e2e/dom/fixtures/test/App.test.tsx
+++ b/e2e/dom/fixtures/test/App.test.tsx
@@ -19,3 +19,11 @@ test('should get window property correctly', async () => {
 test('should get global property correctly', async () => {
   expect(global.URL).toBeDefined();
 });
+
+test('should support fetch', async () => {
+  await expect(
+    fetch(new URL('/404', location.href), {
+      signal: AbortSignal.timeout(0),
+    }),
+  ).rejects.toHaveProperty('name', 'TimeoutError');
+});

--- a/packages/core/src/runtime/worker/env/jsdomKeys.ts
+++ b/packages/core/src/runtime/worker/env/jsdomKeys.ts
@@ -5,8 +5,6 @@
 // SEE https://github.com/jsdom/jsdom/blob/master/lib/jsdom/living/interfaces.js
 const LIVING_KEYS = [
   'DOMException',
-  'URL',
-  'URLSearchParams',
   'EventTarget',
 
   'NamedNodeMap',
@@ -185,9 +183,6 @@ const LIVING_KEYS = [
   'ShadowRoot',
   'MutationObserver',
   'MutationRecord',
-  'Headers',
-  'AbortController',
-  'AbortSignal',
 
   'Uint8Array',
   'Uint16Array',
@@ -210,6 +205,13 @@ const LIVING_KEYS = [
   'Option',
 
   'CSS',
+
+  // Conflict with Node.js values
+  // 'Headers',
+  // 'AbortController',
+  // 'AbortSignal',
+  // 'URL',
+  // 'URLSearchParams',
 ];
 
 const OTHER_KEYS = [


### PR DESCRIPTION
## Summary

close #832 

## Related Links

credit to
https://github.com/vitest-dev/vitest/pull/8390/changes#diff-73ce7c0fd4c8496962cea34e837c9fb5e1b4932a36abf3294c0970f577069cbcR181-R183

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
