### PR TITLE
fix(browser): forever hang if playwright is not installed

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1012,6 +1012,7 @@ const createBrowserRuntime = async ({
     const playwright = await import('playwright');
     browserLauncher = playwright[browserName];
   } catch (_error) {
+    wss.close();
     await devServer.close();
     throw _error;
   }
@@ -1031,6 +1032,7 @@ const createBrowserRuntime = async ({
           : undefined,
     });
   } catch (_error) {
+    wss.close();
     await devServer.close();
     throw _error;
   }


### PR DESCRIPTION
## Summary

close wss to prevent forever hang is playwright is not installed.

<img width="2136" height="726" alt="image" src="https://github.com/user-attachments/assets/bc25ec56-5fb7-4216-bd1b-3b68f4cd7ba2" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
