### PR TITLE
chore(browser-ui): should be private

### DIFF
--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rstest/browser-ui",
-  "version": "0.7.9",
+  "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "description": "Prebuilt browser container UI for Rstest",
   "type": "module",
@@ -25,10 +26,6 @@
     "browser",
     "component"
   ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"
   },


### PR DESCRIPTION
## Summary

@rstest/browser-ui should be private, it's output is shipped via @rstest/browser

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
