### PR TITLE
fix(browser): avoid use the conventional index entry point

### DIFF
--- a/e2e/browser-mode/fixtures/basic/src/index.ts
+++ b/e2e/browser-mode/fixtures/basic/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * This file exists intentionally to test the default entry detection fix.
+ *
+ * Problem: When a project has `src/index.ts`, Rsbuild auto-detects it as the default entry
+ * and generates `index.html`. Rsbuild's HTML fallback middleware then routes all unmatched
+ * requests (including `/container.html`) to this `index.html`, bypassing rstest's custom
+ * middleware that serves the test container UI.
+ *
+ * Solution: rstest uses `modifyEnvironmentConfig` with `order: 'post'` to completely
+ * overwrite the entry config, ensuring browser mode entry is fully controlled by rstest.
+ *
+ * See: packages/browser/src/hostController.ts
+ */
+
+export const placeholder = 'This file should not affect rstest browser mode';

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -766,56 +766,63 @@ const createBrowserRuntime = async ({
     {
       name: 'rstest:browser-user-config',
       setup(api) {
-        api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) => {
-          // Merge order: current config -> userConfig -> rstest required config (highest priority)
-          const merged = mergeEnvironmentConfig(config, userRsbuildConfig, {
-            source: {
-              entry: {
-                runner: resolveBrowserFile('client/entry.ts'),
+        api.modifyEnvironmentConfig({
+          handler: (config, { mergeEnvironmentConfig }) => {
+            // Merge order: current config -> userConfig -> rstest required config (highest priority)
+            const merged = mergeEnvironmentConfig(config, userRsbuildConfig, {
+              resolve: {
+                alias: rstestInternalAliases,
               },
-            },
-            resolve: {
-              alias: rstestInternalAliases,
-            },
-            output: {
-              target: 'web',
-              // Enable source map for inline snapshot support
-              sourceMap: {
-                js: 'source-map',
+              output: {
+                target: 'web',
+                // Enable source map for inline snapshot support
+                sourceMap: {
+                  js: 'source-map',
+                },
               },
-            },
-            tools: {
-              rspack: (rspackConfig) => {
-                rspackConfig.mode = 'development';
-                rspackConfig.lazyCompilation = {
-                  imports: true,
-                  entries: false,
-                };
-                rspackConfig.plugins = rspackConfig.plugins || [];
-                rspackConfig.plugins.push(virtualManifestPlugin);
+              tools: {
+                rspack: (rspackConfig) => {
+                  rspackConfig.mode = 'development';
+                  rspackConfig.lazyCompilation = {
+                    imports: true,
+                    entries: false,
+                  };
+                  rspackConfig.plugins = rspackConfig.plugins || [];
+                  rspackConfig.plugins.push(virtualManifestPlugin);
 
-                // Extract and merge sourcemaps from pre-built @rstest/core files
-                // This preserves the sourcemap chain for inline snapshot support
-                // See: https://rspack.dev/config/module-rules#rulesextractsourcemap
-                const browserRuntimeDir = dirname(browserRuntimePath);
-                rspackConfig.module = rspackConfig.module || {};
-                rspackConfig.module.rules = rspackConfig.module.rules || [];
-                rspackConfig.module.rules.unshift({
-                  test: /\.js$/,
-                  include: browserRuntimeDir,
-                  extractSourceMap: true,
-                });
+                  // Extract and merge sourcemaps from pre-built @rstest/core files
+                  // This preserves the sourcemap chain for inline snapshot support
+                  // See: https://rspack.dev/config/module-rules#rulesextractsourcemap
+                  const browserRuntimeDir = dirname(browserRuntimePath);
+                  rspackConfig.module = rspackConfig.module || {};
+                  rspackConfig.module.rules = rspackConfig.module.rules || [];
+                  rspackConfig.module.rules.unshift({
+                    test: /\.js$/,
+                    include: browserRuntimeDir,
+                    extractSourceMap: true,
+                  });
 
-                if (isDebug()) {
-                  logger.log(
-                    `[rstest:browser] extractSourceMap rule added for: ${browserRuntimeDir}`,
-                  );
-                }
+                  if (isDebug()) {
+                    logger.log(
+                      `[rstest:browser] extractSourceMap rule added for: ${browserRuntimeDir}`,
+                    );
+                  }
+                },
               },
-            },
-          });
+            });
 
-          return merged;
+            // Completely overwrite entry to prevent Rsbuild default entry detection from taking effect.
+            // In browser mode, entry is fully controlled by rstest (not user's src/index.ts).
+            // This must be done after mergeEnvironmentConfig to ensure highest priority.
+            merged.source = merged.source || {};
+            merged.source.entry = {
+              runner: resolveBrowserFile('client/entry.ts'),
+            };
+
+            return merged;
+          },
+          // Execute after all other plugins to ensure rstest's entry config has the highest priority
+          order: 'post',
         });
       },
     },


### PR DESCRIPTION
## Summary

- Fix browser mode failing when project has `src/index.ts` (Rsbuild auto-detects it as default entry)
- Use `modifyEnvironmentConfig` with `order: 'post'` to ensure rstest's entry config has highest priority
- Directly overwrite `source.entry` after merge instead of relying on `mergeEnvironmentConfig`
- Add e2e test case with `src/index.ts` in `basic` fixture to prevent regression

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
