### PR TITLE
fix(browser): decouple strictPort from port configuration

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -748,8 +748,8 @@ const createBrowserRuntime = async ({
       plugins: userPlugins,
       server: {
         printUrls: false,
-        port: context.normalizedConfig.browser.port,
-        strictPort: context.normalizedConfig.browser.port !== undefined,
+        port: context.normalizedConfig.browser.port ?? 4000,
+        strictPort: context.normalizedConfig.browser.strictPort,
       },
       dev: {
         client: {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -185,6 +185,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
     provider: 'playwright',
     browser: 'chromium',
     headless: isCI,
+    strictPort: false,
   },
   coverage: {
     exclude: [
@@ -249,6 +250,7 @@ export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {
     browser: merged.browser?.browser ?? 'chromium',
     headless: merged.browser?.headless ?? isCI,
     port: merged.browser?.port,
+    strictPort: merged.browser?.strictPort ?? false,
   };
 
   return {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -76,6 +76,12 @@ export type BrowserModeConfig = {
    * If not specified, a random available port will be used.
    */
   port?: number;
+  /**
+   * Whether to exit if the specified port is already in use.
+   *
+   * @default false
+   */
+  strictPort?: boolean;
 };
 
 type SnapshotFormat = Omit<
@@ -402,6 +408,7 @@ export type NormalizedBrowserModeConfig = {
   browser: 'chromium' | 'firefox' | 'webkit';
   headless: boolean;
   port?: number;
+  strictPort: boolean;
 };
 
 export type NormalizedConfig = Required<

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -9,6 +9,7 @@ exports[`mergeRstestConfig > should merge config correctly with default config 1
     "headless": false,
     "port": undefined,
     "provider": "playwright",
+    "strictPort": false,
   },
   "clearMocks": false,
   "coverage": {

--- a/packages/core/tests/core/__snapshots__/rstest.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rstest.test.ts.snap
@@ -9,6 +9,7 @@ exports[`rstest context > should generate rstest context correctly 1`] = `
     "headless": false,
     "port": undefined,
     "provider": "playwright",
+    "strictPort": false,
   },
   "clearMocks": false,
   "coverage": {
@@ -94,6 +95,7 @@ exports[`rstest context > should generate rstest context correctly with multiple
     "headless": false,
     "port": undefined,
     "provider": "playwright",
+    "strictPort": false,
   },
   "clearMocks": false,
   "coverage": {
@@ -182,6 +184,7 @@ exports[`rstest context > should generate rstest context correctly with multiple
     "headless": false,
     "port": undefined,
     "provider": "playwright",
+    "strictPort": false,
   },
   "clearMocks": false,
   "coverage": {


### PR DESCRIPTION
## Summary

- Add `browser.strictPort` as an independent config option (default: `false`)
- Remove implicit `strictPort: true` behavior when `port` is explicitly set
- Align with Rsbuild default behavior: port fallback is allowed unless `strictPort` is explicitly enabled
- set default port to `4000` to avoid conflict with Rsbuild default port.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
