### PR TITLE
ci: optimize test workflow time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
 
+  schedule:
+    - cron: '0 16 * * *'
+
   workflow_dispatch:
 
 permissions:
@@ -17,8 +20,31 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 1
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            changed:
+              - "!**/*.md"
+              - "!**/*.mdx"
+              - "!**/_meta.json"
+              - "!**/dictionary.txt"
+
   # ======== ut ========
   ut:
+    needs: prepare
+    if: needs.prepare.outputs.changed == 'true' || github.event_name == 'schedule'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -32,47 +58,50 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
       - name: Setup Node.js
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: 22
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: pnpm fetch
+        run: pnpm fetch
 
       - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Run Type Check
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpm run typecheck
+      - name: Set Playwright cache path
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            echo "PLAYWRIGHT_BROWSERS_PATH=$USERPROFILE/AppData/Local/ms-playwright" >> "$GITHUB_ENV"
+          else
+            echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_ENV"
+          fi
+
+      - name: Cache Playwright Browsers
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.changed == 'true'
         run: npx playwright install chromium webkit
 
+      - name: Run Type Check
+        run: pnpm run typecheck
+
       - name: Run Test
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test
 
   # ======== e2e ========
   e2e:
+    needs: [prepare, ut]
+    if: needs.prepare.outputs.changed == 'true' || github.event_name == 'schedule'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -80,7 +109,7 @@ jobs:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
-        node_version: [18, 20, 22, 24]
+        node_version: ${{ fromJson(github.event_name == 'schedule' && '["18","20","22","24"]' || '["18","24"]') }}
 
     steps:
       - name: Checkout
@@ -88,41 +117,42 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
-
-      - name: Setup Node.js ${{ matrix.node-version }}
-        if: steps.changes.outputs.changed == 'true'
+      - name: Setup Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: pnpm fetch
+        run: pnpm fetch
 
       - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Set Playwright cache path
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            echo "PLAYWRIGHT_BROWSERS_PATH=$USERPROFILE/AppData/Local/ms-playwright" >> "$GITHUB_ENV"
+          else
+            echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_ENV"
+          fi
+
+      - name: Cache Playwright Browsers
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.changed == 'true'
         run: npx playwright install chromium webkit
 
       - name: E2E Test
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run e2e
 
       - name: VS Code Extension Test
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test:vscode


### PR DESCRIPTION
## Summary

- introduce prepare job to gate ut/e2e via paths-filter
- switch pnpm setup to setup-node with fetch/offline install
- cache Playwright browsers per OS using PLAYWRIGHT_BROWSERS_PATH
- reduce PR e2e matrix to node 18/24 while cron keeps full matrix (add daily scheduled full matrix at 00:00 CST to run full node version matrix)

[before](https://github.com/web-infra-dev/rstest/actions/runs/20943632774)

<img width="1503" height="618" alt="image" src="https://github.com/user-attachments/assets/e7676a8e-64ff-404a-b4b7-3d669aefbc7e" />

[now (without cache)](https://github.com/web-infra-dev/rstest/actions/runs/20955527892/attempts/1?pr=863)

<img width="1501" height="680" alt="image" src="https://github.com/user-attachments/assets/6a0dfaf8-caa7-44b2-a1a3-80b364e1b10b" />

[now (with cache)](https://github.com/web-infra-dev/rstest/actions/runs/20955527892/attempts/1?pr=863)

<img width="1503" height="761" alt="image" src="https://github.com/user-attachments/assets/a5905397-898a-4b2b-96bf-c7803d5f85c7" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
