### PR TITLE
feat(browser): trigger test re-runs on source file changes in watch mode

### DIFF
--- a/e2e/browser-mode/fixtures/watch/src/helper.ts
+++ b/e2e/browser-mode/fixtures/watch/src/helper.ts
@@ -1,0 +1,3 @@
+export function getMessage(): string {
+  return 'hello';
+}

--- a/e2e/browser-mode/fixtures/watch/tests/another.test.ts
+++ b/e2e/browser-mode/fixtures/watch/tests/another.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from '@rstest/core';
+import { getMessage } from '../src/helper';
+
+describe('another test', () => {
+  it('should also use helper', () => {
+    expect(getMessage()).toBe('hello');
+  });
+});

--- a/e2e/browser-mode/fixtures/watch/tests/index.test.ts
+++ b/e2e/browser-mode/fixtures/watch/tests/index.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from '@rstest/core';
+import { getMessage } from '../src/helper';
 
 describe('watch mode test', () => {
   it('should pass initial test', () => {
     expect('initial').toBe('initial');
+  });
+
+  it('should use helper', () => {
+    expect(getMessage()).toBe('hello');
   });
 });


### PR DESCRIPTION
## Summary

- Add chunk hash diffing to detect source file changes affecting test files
- Only re-run affected tests when source files change (not all tests)
- Track chunk hashes between compilations to identify changed dependencies
- Support multiple test files depending on same source file

human input:

previously, provide given files `a.test.ts -> src/a.ts`, changing `src/a.ts` won't trigger a test rerun (although it's recompiled), this PR is to address this by finding test file from changed chunk.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
