### PR TITLE
fix(browser): use root path for container UI

### DIFF
--- a/e2e/browser-mode/fixtures/basic/src/index.ts
+++ b/e2e/browser-mode/fixtures/basic/src/index.ts
@@ -3,8 +3,8 @@
  *
  * Problem: When a project has `src/index.ts`, Rsbuild auto-detects it as the default entry
  * and generates `index.html`. Rsbuild's HTML fallback middleware then routes all unmatched
- * requests (including `/container.html`) to this `index.html`, bypassing rstest's custom
- * middleware that serves the test container UI.
+ * requests to this `index.html`, bypassing rstest's custom middleware that serves the test
+ * container UI at `/`.
  *
  * Solution: rstest uses `modifyEnvironmentConfig` with `order: 'post'` to completely
  * overwrite the entry config, ensuring browser mode entry is fully controlled by rstest.

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1077,7 +1077,7 @@ const createBrowserRuntime = async ({
       }
       return;
     }
-    if (url.pathname === '/' || url.pathname === '/container.html') {
+    if (url.pathname === '/') {
       if (await respondWithDevServerHtml(url, res)) {
         return;
       }
@@ -1524,14 +1524,12 @@ export const runBrowserController = async (context: Rstest): Promise<void> => {
 
   // Only navigate on first creation
   if (isNewPage) {
-    await containerPage.goto(`http://localhost:${port}/container.html`, {
+    await containerPage.goto(`http://localhost:${port}/`, {
       waitUntil: 'load',
     });
 
     logger.log(
-      color.cyan(
-        `\nContainer page opened at http://localhost:${port}/container.html\n`,
-      ),
+      color.cyan(`\nBrowser mode opened at http://localhost:${port}/\n`),
     );
   }
 


### PR DESCRIPTION
## Summary

before

<img width="529" height="383" alt="image" src="https://github.com/user-attachments/assets/5990f5a2-a95f-4391-8540-023f2cf32f35" />

now

<img width="657" height="388" alt="Google Chrome 2026-01-15 22 41 48" src="https://github.com/user-attachments/assets/c2a1e94b-f61c-4b6e-a96c-ae238022328f" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
