### PR TITLE
fix(browser-ui): optimize

### DIFF
--- a/packages/browser-ui/src/components/PreviewHeader.tsx
+++ b/packages/browser-ui/src/components/PreviewHeader.tsx
@@ -1,6 +1,6 @@
 import { App, Button, Tooltip } from 'antd';
 import type { GlobalToken } from 'antd/es/theme/interface';
-import { Copy, SquareArrowOutUpRight } from 'lucide-react';
+import { Copy, FileCode, SquareArrowOutUpRight } from 'lucide-react';
 import React from 'react';
 import { openInEditor, toRelativePath } from '../utils';
 import { STATUS_META, type TestStatus } from '../utils/constants';
@@ -52,12 +52,11 @@ export const PreviewHeader: React.FC<PreviewHeaderProps> = ({
       }}
     >
       <div className="flex items-center gap-2 overflow-hidden">
-        <span className="text-[11px] font-medium tracking-wider text-(--accents-5) shrink-0">
-          PREVIEW
-        </span>
-        <span className="text-(--accents-3) font-light select-none shrink-0">
-          /
-        </span>
+        <FileCode
+          size={16}
+          strokeWidth={2}
+          className="shrink-0 text-(--accents-7)"
+        />
         <div className="flex items-center gap-1.5 overflow-hidden">
           {dirPath && (
             <>
@@ -83,7 +82,8 @@ export const PreviewHeader: React.FC<PreviewHeaderProps> = ({
                     <Button
                       type="text"
                       size="small"
-                      className="flex h-5 w-5 items-center justify-center rounded-md p-0 text-(--accents-4) hover:text-foreground hover:bg-(--accents-1) transition-all"
+                      className="flex ml-1 h-5 w-5 items-center justify-center rounded-md p-0 text-(--accents-4) hover:text-foreground hover:bg-(--accents-1) transition-all"
+                      style={{ color: token.colorTextDescription }}
                       data-testid="preview-copy-path"
                       icon={<Copy size={12} strokeWidth={2.5} />}
                       onClick={handleCopy}
@@ -99,6 +99,7 @@ export const PreviewHeader: React.FC<PreviewHeaderProps> = ({
                         <SquareArrowOutUpRight size={12} strokeWidth={2.5} />
                       }
                       onClick={() => openInEditor(activeFile)}
+                      style={{ color: token.colorTextDescription }}
                     />
                   </Tooltip>
                 </div>

--- a/packages/browser-ui/src/components/SidebarHeader.tsx
+++ b/packages/browser-ui/src/components/SidebarHeader.tsx
@@ -108,8 +108,9 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
             size="small"
             className="flex h-8 w-8 items-center justify-center rounded-md p-0"
             data-testid="theme-toggle"
-            icon={<ThemeIcon size={14} strokeWidth={2.5} />}
+            icon={<ThemeIcon size={15} strokeWidth={2.5} />}
             onClick={handleCycleTheme}
+            style={{ color: token.colorTextDescription }}
           />
         </Tooltip>
       </div>

--- a/packages/browser-ui/src/components/StatusGrid.tsx
+++ b/packages/browser-ui/src/components/StatusGrid.tsx
@@ -30,14 +30,16 @@ export const StatusGrid: React.FC<{
           return (
             <Tag
               key={item.label}
-              className={`m-0 flex items-center px-2 py-0 border-0 ${isRunningItem && isFileLoading ? 'animate-pulse' : ''}`}
+              className={`m-0 flex items-center gap-1 px-2 py-0 border-0 ${isRunningItem && isFileLoading ? 'animate-pulse' : ''}`}
               style={{
+                display: 'flex',
+                alignItems: 'center',
                 backgroundColor: `var(--ds-${item.color}-200)`,
                 color: `var(--ds-${item.color}-900)`,
                 borderRadius: '100px',
                 fontSize: '11px',
                 height: '20px',
-                lineHeight: '20px',
+                lineHeight: 'normal',
                 fontWeight: 700,
               }}
             >
@@ -49,7 +51,7 @@ export const StatusGrid: React.FC<{
                 }}
               >
                 {count}
-              </span>{' '}
+              </span>
               <span
                 className="text-[10px] uppercase tracking-wider"
                 style={{ fontWeight: 'inherit' }}

--- a/packages/browser-ui/src/components/TestFilesHeader.tsx
+++ b/packages/browser-ui/src/components/TestFilesHeader.tsx
@@ -38,7 +38,7 @@ export const TestFilesHeader: React.FC<TestFilesHeaderProps> = ({
         <div>
           <StatusGrid counts={counts} isRunning={isRunning} />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
           <Tooltip
             title={isAllExpanded ? 'Collapse all' : 'Expand all'}
             mouseLeaveDelay={0}
@@ -48,13 +48,13 @@ export const TestFilesHeader: React.FC<TestFilesHeaderProps> = ({
               size="small"
               icon={
                 isAllExpanded ? (
-                  <FoldVertical size={14} strokeWidth={2.5} />
+                  <FoldVertical size={13} strokeWidth={2.5} />
                 ) : (
-                  <UnfoldVertical size={14} strokeWidth={2.5} />
+                  <UnfoldVertical size={13} strokeWidth={2.5} />
                 )
               }
               onClick={onToggleExpandAll}
-              className="flex h-7 w-7 items-center justify-center rounded-md p-0"
+              className="flex h-8 w-8 items-center justify-center rounded-md p-0"
               data-testid="test-files-toggle-expand"
               style={{ color: token.colorTextDescription }}
             />
@@ -63,10 +63,10 @@ export const TestFilesHeader: React.FC<TestFilesHeaderProps> = ({
             <Button
               type="text"
               size="small"
-              icon={<RotateCw size={14} strokeWidth={2.5} />}
+              icon={<RotateCw size={15} strokeWidth={2.5} />}
               onClick={onRerun}
               disabled={!onRerun}
-              className="flex h-7 w-7 items-center justify-center rounded-md p-0"
+              className="flex h-8 w-8 items-center justify-center rounded-md p-0"
               data-testid="test-files-rerun-all"
               style={{ color: token.colorTextDescription }}
             />

--- a/packages/browser-ui/src/components/TestFilesTree.tsx
+++ b/packages/browser-ui/src/components/TestFilesTree.tsx
@@ -443,7 +443,8 @@ export const TestFilesTree: React.FC<TestFilesTreeProps> = ({
         }
       }}
       treeData={treeData}
-      className="m-1 bg-transparent"
+      className="bg-transparent"
+      style={{ marginLeft: '16px' }}
     />
   );
 };

--- a/packages/browser-ui/src/index.html
+++ b/packages/browser-ui/src/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="https://assets.rspack.rs/rstest/rstest-logo.svg"
+    />
     <title>Rstest Browser Test Runner</title>
     <script>
       window.__RSTEST_BROWSER_OPTIONS__ = __RSTEST_OPTIONS_PLACEHOLDER__;

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -428,6 +428,13 @@ const BrowserRunner: React.FC<{
     return [...new Set(keys)]; // Deduplicate
   }, [testFiles, caseMap]);
 
+  // Generate project-specific storage key for split position
+  const projectKey =
+    options.projects?.[0]?.name ||
+    options.rootPath.split('/').filter(Boolean).pop() ||
+    'default';
+  const splitStorageKey = `rstest-split-${projectKey}`;
+
   return (
     <div
       className="m-0 h-screen w-full overflow-hidden p-0"
@@ -436,7 +443,7 @@ const BrowserRunner: React.FC<{
       <ResizablePanelGroup
         direction="horizontal"
         className="h-full w-full"
-        autoSaveId="rstest-split"
+        autoSaveId={splitStorageKey}
       >
         <ResizablePanel defaultSize={32} minSize={20} maxSize={50}>
           <div
@@ -602,6 +609,14 @@ const App: React.FC = () => {
   }
 
   const isDark = theme === 'dark';
+
+  useEffect(() => {
+    const projectName =
+      options.projects?.[0]?.name ||
+      options.rootPath.split('/').filter(Boolean).pop() ||
+      'rstest';
+    document.title = `${projectName} [RSTEST BROWSER]`;
+  }, [options]);
 
   return (
     <ConfigProvider


### PR DESCRIPTION
## Summary

- Fix StatusGrid badge text vertical centering (add `display: flex`, `lineHeight: normal`, `gap-1`)
- Fix Tree expand arrows alignment with sidebar header icons (add `marginLeft: 16px`)
- Align icon spacing between SidebarHeader and TestFilesHeader rows (`gap-1.5`, button size `h-8 w-8`)
- Add dynamic page title based on project name (`{projectName} [browser mode]`)
- Add favicon using external rstest logo URL
- Implement localStorage persistence for resizable panel positions with project-specific keys
- Replace "TEST FILE" text with FileCode icon in PreviewHeader

<img width="673" height="357" alt="image" src="https://github.com/user-attachments/assets/a0db9cb7-0cb3-4c10-8d71-de1f5a281e20" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
