### PR TITLE
fix(browser-ui): auto-switch preview when clicking rerun

### DIFF
--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -191,6 +191,7 @@ const BrowserRunner: React.FC<{
 
   const handleRerunFile = useCallback(
     (file: string) => {
+      setActive(file);
       if (rpc && connected) {
         void rpc.rerunTest(file);
       }
@@ -200,6 +201,7 @@ const BrowserRunner: React.FC<{
 
   const handleRerunTestCase = useCallback(
     (file: string, testName: string) => {
+      setActive(file);
       if (rpc && connected) {
         void rpc.rerunTest(file, testName);
       }


### PR DESCRIPTION
## Summary

clicking rerun on file/case/suite now also switches preview to that file. reduces clicks needed: previously had to select file first, then rerun.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
