### PR TITLE
docs: remove netlify.toml

### DIFF
--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -1,6 +1,0 @@
-# Redirect rstest.dev to rstest.rs
-[[redirects]]
-from = "https://rstest.dev/*"
-to = "https://rstest.rs/:splat"
-status = 301
-force = true


### PR DESCRIPTION
## Summary

This PR removes the unused netlify.toml file, as `rstest.rs` has migrated from Netlify to Cloudflare Pages.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
