### PR TITLE
fix(core): lazy initialize StatusRenderer to prevent clearing early error messages

### DIFF
--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -39,16 +39,30 @@ export class DefaultReporter implements Reporter {
     this.config = config;
     this.options = options;
     this.testState = testState;
-    if (isTTY() || options.logger) {
+    // Note: StatusRenderer is created lazily in onTestFileStart() to avoid
+    // intercepting stdout/stderr too early. This ensures that errors occurring
+    // before tests start (e.g., Playwright browser not installed) are visible
+    // and not cleared by WindowRenderer's TTY control sequences.
+  }
+
+  /**
+   * Lazily create StatusRenderer on first test file start.
+   * This avoids intercepting stdout/stderr before tests actually begin,
+   * ensuring early errors (like missing Playwright browsers) remain visible.
+   */
+  private ensureStatusRenderer(): void {
+    if (this.statusRenderer) return;
+    if (isTTY() || this.options.logger) {
       this.statusRenderer = new StatusRenderer(
-        rootPath,
-        testState,
-        options.logger,
+        this.rootPath,
+        this.testState,
+        this.options.logger,
       );
     }
   }
 
   onTestFileStart(): void {
+    this.ensureStatusRenderer();
     this.statusRenderer?.onTestFileStart();
   }
 


### PR DESCRIPTION
## Summary

- Lazy initialize `StatusRenderer` in `DefaultReporter` to avoid early stdout/stderr interception
- Fix visibility of fatal errors (e.g., missing Playwright browsers) in interactive terminals

human input:

when playwright doesn't installed any browsers, the error message throw from `browser.launch` will be cleared by StatusRenderer, while no test file has started yet. so lazy initialize StatusRenderer to allow error message throw in Rsbuild initializing phase.

| Before | After |
|--------|-------|
|    <img width="624" height="110" alt="image" src="https://github.com/user-attachments/assets/ca8f651f-5b96-46d1-b5d3-f35a17b7cc39" /> |     <img width="736" height="374" alt="image" src="https://github.com/user-attachments/assets/1949b632-0116-430c-95d0-f456cd6eb384" />  |

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
