### PR TITLE
ci: use test gate job as required job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,3 +156,15 @@ jobs:
 
       - name: VS Code Extension Test
         run: pnpm run test:vscode
+
+  # ======== gate ========
+  test-gate:
+    needs: [prepare, ut, e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test requirement
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ needs.prepare.outputs.changed }}" = "true" ]; then
+            [ "${{ needs.ut.result }}" = "success" ] && [ "${{ needs.e2e.result }}" = "success" ]
+          fi


### PR DESCRIPTION
## Summary

using a gate job as the required job in ruleset, to prevent forever hang required job in doc only changed PR (since no test job will run e.g. https://github.com/web-infra-dev/rstest/pull/895)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
