### PR TITLE
fix(cli): exit with non-zero code when failed

### DIFF
--- a/e2e/cli/index.test.ts
+++ b/e2e/cli/index.test.ts
@@ -38,6 +38,23 @@ describe.concurrent('test exit code', () => {
     expect(cli.exec.process?.exitCode).toBe(1);
   });
 
+  it('should return code 1 when cli options error', async ({
+    onTestFinished,
+  }) => {
+    const { expectStderrLog, expectExecFailed } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-a', 'success.test.ts'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecFailed();
+    expectStderrLog(/Unknown option `-a`/);
+  });
+
   it('should return code 1 and print error correctly when test config error', async ({
     onTestFinished,
   }) => {

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -15,5 +15,6 @@ export async function runCLI(): Promise<void> {
   } catch (err) {
     logger.error('Failed to start Rstest CLI.');
     logger.error(err);
+    process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

should exit with non-zero code when CLI start failed.

<img width="895" height="232" alt="image" src="https://github.com/user-attachments/assets/20161fe6-cf70-43af-a4fe-7c5e9a69878d" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
