### PR TITLE
fix(browser): should not tip `no test files found`

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1227,11 +1227,14 @@ export const runBrowserController = async (
 
   if (totalTests === 0) {
     const code = context.normalizedConfig.passWithNoTests ? 0 : 1;
-    logger.log(
-      color[code ? 'red' : 'yellow'](
-        `No test files found, exiting with code ${code}.`,
-      ),
-    );
+    if (!skipOnTestRunEnd) {
+      logger.log(
+        color[code ? 'red' : 'yellow'](
+          `No test files found, exiting with code ${code}.`,
+        ),
+      );
+    }
+
     if (code !== 0) {
       ensureProcessExitCode(code);
     }


### PR DESCRIPTION
## Summary

Should not tip`no test files found` when node tests existed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
