### PR TITLE
feat(core): support pool shorthand and granular CLI options

### DIFF
--- a/e2e/cli/index.test.ts
+++ b/e2e/cli/index.test.ts
@@ -55,6 +55,21 @@ describe.concurrent('test exit code', () => {
     expectStderrLog(/Unknown option `-a`/);
   });
 
+  it('should support --pool shorthand', async ({ onTestFinished }) => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'success.test.ts', '--pool', 'forks'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
   it('should return code 1 and print error correctly when test config error', async ({
     onTestFinished,
   }) => {

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -63,6 +63,17 @@ pnpm --filter @rstest/core typecheck
 - Use `npx rstest --globals` for running tests
 - Update snapshots with `-- --updateSnapshot` only when behavior changes
 
+### E2E note (build required)
+
+All E2E tests execute `rstest` via `@rstest/core`'s built output (e.g. `packages/core/dist` / `packages/core/bin`), not the TypeScript sources under `packages/core/src`.
+
+That means: if you change anything in `@rstest/core`, you must rebuild before running E2E tests, otherwise E2E will run against stale output.
+
+```bash
+pnpm --filter @rstest/core build
+cd e2e && pnpm rstest
+```
+
 ## Good examples
 
 - Runner implementation: `src/runtime/runner/runner.ts`

--- a/packages/core/LICENSE.md
+++ b/packages/core/LICENSE.md
@@ -1510,17 +1510,3 @@ Licensed under MIT license in the repository at sindresorhus/url-extras.
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 >
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### yn
-
-Licensed under MIT license in the repository at sindresorhus/yn.
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -107,6 +107,22 @@ const applyCommonOptions = (cli: CAC) => {
       '--includeTaskLocation',
       'Collect test and suite locations. This might increase the running time.',
     );
+
+  cli
+    .option('--pool <type>', 'Shorthand for --pool.type')
+    .option('--pool.type <type>', 'Specify the test pool type (e.g. forks)')
+    .option(
+      '--pool.maxWorkers <value>',
+      'Maximum number or percentage of workers (e.g. 4 or 50%)',
+    )
+    .option(
+      '--pool.minWorkers <value>',
+      'Minimum number or percentage of workers (e.g. 1 or 25%)',
+    )
+    .option(
+      '--pool.execArgv <arg>',
+      'Additional Node.js execArgv passed to worker processes (can be specified multiple times)',
+    );
 };
 
 const handleUnexpectedExit = (rstest: RstestInstance | undefined, err: any) => {

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -18,6 +18,19 @@ export type CommonOptions = {
   configLoader?: LoadConfigOptions['loader'];
   globals?: boolean;
   /**
+   * Pool options.
+   * - `string`: shorthand for `{ type: string }` (from `--pool` flag)
+   * - `object`: detailed pool config (from `--pool.*` options)
+   */
+  pool?:
+    | string
+    | {
+        type?: string;
+        maxWorkers?: string | number;
+        minWorkers?: string | number;
+        execArgv?: string[] | string;
+      };
+  /**
    * Browser mode options.
    * - `boolean`: shorthand for `{ enabled: boolean }` (from `--browser` flag)
    * - `object`: detailed browser config (from `--browser.*` options)
@@ -137,6 +150,51 @@ function mergeWithCLIOptions(
       }
       if (options.browser.strictPort !== undefined) {
         config.browser.strictPort = options.browser.strictPort;
+      }
+    }
+  }
+
+  if (options.pool !== undefined) {
+    const poolFromCli = options.pool;
+
+    if (typeof poolFromCli === 'string') {
+      if (typeof config.pool === 'string') {
+        config.pool = { type: config.pool };
+      }
+
+      config.pool ??= {};
+      if (typeof config.pool !== 'object') {
+        config.pool = {};
+      }
+
+      const pool = config.pool;
+      pool.type = poolFromCli as any;
+    } else {
+      if (typeof config.pool === 'string') {
+        config.pool = { type: config.pool };
+      }
+
+      config.pool ??= {};
+      if (typeof config.pool !== 'object') {
+        config.pool = {};
+      }
+
+      const pool = config.pool;
+
+      if (poolFromCli.type !== undefined) {
+        pool.type = poolFromCli.type as any;
+      }
+
+      if (poolFromCli.maxWorkers !== undefined) {
+        pool.maxWorkers = poolFromCli.maxWorkers as any;
+      }
+
+      if (poolFromCli.minWorkers !== undefined) {
+        pool.minWorkers = poolFromCli.minWorkers as any;
+      }
+
+      if (poolFromCli.execArgv !== undefined) {
+        pool.execArgv = castArray(poolFromCli.execArgv);
       }
     }
   }

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -328,4 +328,89 @@ describe('resolveProjects', () => {
       });
     });
   });
+
+  describe('pool CLI options', () => {
+    it('should apply --pool shorthand (string) and preserve other pool fields', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [{ name: 'test-project' }],
+          pool: { type: 'forks', maxWorkers: '50%' },
+        },
+        root: rootPath,
+        options: { pool: 'forks' },
+      });
+
+      expect(projects[0]!.config.pool).toEqual({
+        type: 'forks',
+      });
+    });
+
+    it('should convert string config.pool and apply --pool shorthand', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [{ name: 'test-project' }],
+          pool: 'forks',
+        },
+        root: rootPath,
+        options: { pool: 'forks' },
+      });
+
+      expect(projects[0]!.config.pool).toEqual({ type: 'forks' });
+    });
+
+    it('should merge pool.* options into string config.pool', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [{ name: 'test-project' }],
+          pool: 'forks',
+        },
+        root: rootPath,
+        options: {
+          pool: {
+            minWorkers: 1,
+          },
+        },
+      });
+
+      expect(projects[0]!.config.pool).toEqual({
+        minWorkers: 1,
+      });
+    });
+
+    it('should cast pool.execArgv to array', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [{ name: 'test-project' }],
+        },
+        root: rootPath,
+        options: {
+          pool: {
+            execArgv: '--conditions=development',
+          },
+        },
+      });
+
+      expect(projects[0]!.config.pool).toEqual({
+        execArgv: ['--conditions=development'],
+      });
+    });
+
+    it('should keep pool.execArgv array when passed multiple times', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [{ name: 'test-project' }],
+        },
+        root: rootPath,
+        options: {
+          pool: {
+            execArgv: ['--conditions=development', '--no-warnings'],
+          },
+        },
+      });
+
+      expect(projects[0]!.config.pool).toEqual({
+        execArgv: ['--conditions=development', '--no-warnings'],
+      });
+    });
+  });
 });

--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -7,9 +7,11 @@ overviewHeaders: []
 - **Type:**
 
 ```ts
+export type RstestPoolType = 'forks';
+
 export type RstestPoolOptions = {
   /** Pool used to run tests in. */
-  type?: 'fork';
+  type?: RstestPoolType;
   /** Maximum number or percentage of workers to run tests in. */
   maxWorkers?: number | string;
   /** Minimum number or percentage of workers to run tests in. */
@@ -17,21 +19,49 @@ export type RstestPoolOptions = {
   /** Pass additional arguments to node process in the child processes. */
   execArgv?: string[];
 };
+
+export type RstestConfig = {
+  /** Pool used to run tests in. */
+  pool?: RstestPoolType | RstestPoolOptions;
+};
 ```
 
 - **Default:**
 
 ```ts
 const defaultPool = {
-  type: 'fork'
-  maxWorkers: available CPUs
-  minWorkers: available CPUs
-}
+  type: 'forks',
+  // maxWorkers/minWorkers are computed from CPU count and command mode
+};
 ```
 
 Options of pool used to run tests in.
 
 ## Example
+
+### Shorthand
+
+You can use a string shorthand to set the pool type:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'forks',
+});
+```
+
+This is equivalent to:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: {
+    type: 'forks',
+  },
+});
+```
 
 Run all tests inside a single child process.
 

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -172,7 +172,11 @@ Rstest CLI provides several common options that can be used with all commands:
 | `--hideSkippedTestFiles`        | Do not display skipped test file logs, see [hideSkippedTestFiles](/config/test/hide-skipped-test-files)                                                           |
 | `--chaiConfig <config>`         | Customize Chai configuration, see [chaiConfig](/config/test/chai-config)                                                                                          |
 | `--env <key=value>`             | Set environment variables, see [env](/config/test/env)                                                                                                            |
-| `--pool <options>`              | Configure test pool options, see [pool](/config/test/pool)                                                                                                        |
+| `--pool <type>`                 | Shorthand for `--pool.type`, see [pool](/config/test/pool)                                                                                                        |
+| `--pool.type <type>`            | Specify the test pool type, see [pool](/config/test/pool)                                                                                                         |
+| `--pool.maxWorkers <value>`     | Maximum number or percentage of workers, see [pool](/config/test/pool)                                                                                            |
+| `--pool.minWorkers <value>`     | Minimum number or percentage of workers, see [pool](/config/test/pool)                                                                                            |
+| `--pool.execArgv <arg>`         | Additional Node.js execArgv for worker processes (repeatable), see [pool](/config/test/pool)                                                                      |
 | `--setupFiles <files>`          | Specify setup files list, see [setupFiles](/config/test/setup-files)                                                                                              |
 | `--snapshotFormat <options>`    | Customize snapshot format, see [snapshotFormat](/config/test/snapshot-format)                                                                                     |
 | `--resolveSnapshotPath`         | Customize snapshot path resolution, see [resolveSnapshotPath](/config/test/resolve-snapshot-path)                                                                 |

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -7,9 +7,11 @@ overviewHeaders: []
 - **类型：**
 
 ```ts
+export type RstestPoolType = 'forks';
+
 export type RstestPoolOptions = {
   /** 用于运行测试的线程池 */
-  type?: 'fork';
+  type?: RstestPoolType;
   /** 最大运行的线程池的数量或百分比 */
   maxWorkers?: number | string;
   /** 最小运行的线程池的数量或百分比 */
@@ -17,21 +19,49 @@ export type RstestPoolOptions = {
   /** 向子进程中的 node 进程传递附加参数。 */
   execArgv?: string[];
 };
+
+export type RstestConfig = {
+  /** 用于运行测试的线程池 */
+  pool?: RstestPoolType | RstestPoolOptions;
+};
 ```
 
 - **默认值：**
 
 ```ts
 const defaultPool = {
-  type: 'fork'
-  maxWorkers: available CPUs
-  minWorkers: available CPUs
-}
+  type: 'forks',
+  // maxWorkers/minWorkers 会根据 CPU 数量和运行模式自动计算
+};
 ```
 
 用于运行测试的线程池的选项。
 
 ## 示例
+
+### Shorthand
+
+你可以使用 string shorthand 来设置 pool type：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'forks',
+});
+```
+
+等价于：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: {
+    type: 'forks',
+  },
+});
+```
 
 在单个子进程中运行所有测试。
 

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -172,7 +172,11 @@ Rstest CLI 支持以下常用参数，所有命令均可使用：
 | `--hideSkippedTestFiles`        | 不展示跳过测试文件的日志，详见 [hideSkippedTestFiles](/config/test/hide-skipped-test-files)                                                  |
 | `--chaiConfig <config>`         | 自定义 Chai 配置，详见 [chaiConfig](/config/test/chai-config)                                                                                |
 | `--env <key=value>`             | 设置环境变量，详见 [env](/config/test/env)                                                                                                   |
-| `--pool <options>`              | 配置测试线程池选项，详见 [pool](/config/test/pool)                                                                                           |
+| `--pool <type>`                 | `--pool.type` 的 shorthand，详见 [pool](/config/test/pool)                                                                                   |
+| `--pool.type <type>`            | 指定测试线程池类型，详见 [pool](/config/test/pool)                                                                                           |
+| `--pool.maxWorkers <value>`     | 最大 worker 数量或百分比，详见 [pool](/config/test/pool)                                                                                     |
+| `--pool.minWorkers <value>`     | 最小 worker 数量或百分比，详见 [pool](/config/test/pool)                                                                                     |
+| `--pool.execArgv <arg>`         | 传给 worker 进程的额外 Node.js execArgv（可重复传入），详见 [pool](/config/test/pool)                                                        |
 | `--setupFiles <files>`          | 指定 setup 文件列表，详见 [setupFiles](/config/test/setup-files)                                                                             |
 | `--snapshotFormat <options>`    | 自定义快照格式，详见 [snapshotFormat](/config/test/snapshot-format)                                                                          |
 | `--resolveSnapshotPath`         | 自定义快照路径解析，详见 [resolveSnapshotPath](/config/test/resolve-snapshot-path)                                                           |


### PR DESCRIPTION
## Summary

- **CLI Enhancements**
  - Add `--pool <type>` shorthand for `--pool.type`
  - Add granular flags: `--pool.maxWorkers`, `--pool.minWorkers`, and `--pool.execArgv`
- **Config Logic**
  - Update `mergeWithCLIOptions` to normalize `pool` config (string to object) before merging
  - Support multiple `--pool.execArgv` occurrences via `castArray`
- **Documentation**
  - Update EN/ZH CLI guides to replace generic `--pool` with specific nested flags
  - Add `pool: 'forks'` shorthand documentation and type definitions to Pool config pages
- **Testing & DX**
  - Add E2E test case for `--pool` shorthand verification
  - Add critical note to `packages/core/AGENTS.md` regarding E2E build requirements

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
