### PR TITLE
release: 0.8.1

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "React component testing support for Rstest browser mode",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Browser mode support for Rstest testing framework.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The Rsbuild-based test tool.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Rstest",
   "publisher": "rstack",
   "description": "VS Code extension for Rstest",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(core): add `mockObject` and `mocked` utilities by @9aoy in https://github.com/web-infra-dev/rstest/pull/881
* feat(core): disable ANSI and VT output in AI agent environments by @fi3ework in https://github.com/web-infra-dev/rstest/pull/899
* feat(core): support pool shorthand and granular CLI options by @fi3ework in https://github.com/web-infra-dev/rstest/pull/904
* feat(mock): support `spy: true` option in `rs.mock()` by @9aoy in https://github.com/web-infra-dev/rstest/pull/901
* feat(mock): support `mock: true` option in rs.mock()  by @9aoy in https://github.com/web-infra-dev/rstest/pull/907
### Bug Fixes 🐞
* fix(cli): exit with non-zero code when failed by @9aoy in https://github.com/web-infra-dev/rstest/pull/898
* fix(browser): should not tip `no test files found` by @9aoy in https://github.com/web-infra-dev/rstest/pull/900
### Document 📖
* docs: polish `hideSkippedTestFiles` and `hideSkippedTests` guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/893
* docs: polish chaiConfig by @9aoy in https://github.com/web-infra-dev/rstest/pull/897
* docs: add `react` guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/903
* docs: add `vue` guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/905
### Other Changes
* ci: use test gate job as required job by @fi3ework in https://github.com/web-infra-dev/rstest/pull/896
* chore: inline problem matcher by @fi3ework in https://github.com/web-infra-dev/rstest/pull/902
* refactor(core): simplify ANSI suppress color logic  by @fi3ework in https://github.com/web-infra-dev/rstest/pull/906


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.8.0...v0.8.1