### PR TITLE
fix(e2e): ensure environment variables are truly unset in CLI helper

### DIFF
--- a/e2e/scripts/index.ts
+++ b/e2e/scripts/index.ts
@@ -122,7 +122,10 @@ export async function runRstestCli({
 
   const baseEnv: Record<string, string | undefined> = { ...process.env };
   for (const key of unsetEnv ?? []) {
-    delete baseEnv[key];
+    // tinyexec merges env as `{ ...process.env, ...options.env }`, so deleting the
+    // key here is not enough if the parent process has it set (e.g. FORCE_COLOR).
+    // Setting it to `undefined` ensures it is treated as unset in the spawned process.
+    baseEnv[key] = undefined;
   }
 
   const exec = x(command, args, {


### PR DESCRIPTION
## Summary

- Fix `runRstestCli` helper to correctly unset environment variables by setting them to `undefined` instead of deleting the keys
- Fix an issue where parent process environment variables (like `FORCE_COLOR`) were being merged back into the spawned process due to `tinyexec` behavior
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
