### PR TITLE
docs: clarify mock behavior in vitest migration guide

### DIFF
--- a/website/docs/en/guide/migration/vitest.mdx
+++ b/website/docs/en/guide/migration/vitest.mdx
@@ -95,7 +95,7 @@ test('should be mocked', () => {
 });
 ```
 
-Rstest handles this differently. Calling `rs.mock()` with only the module path will _only_ look for a mock in the `__mocks__` directory and will error if one isn't found. To achieve auto-mocking, you must explicitly pass the `{ mock: true }` option.
+Rstest handles this differently. Calling `rs.mock()` with only the module path will _only_ look for a mock in the `__mocks__` directory and will throw an error if one isn't found. To achieve auto-mocking, you must explicitly pass the `{ mock: true }` option.
 
 ```ts
 // Rstest
@@ -111,7 +111,7 @@ test('should be mocked', () => {
 });
 ```
 
-This distinction is important: Vitest has implicit auto-mocking as a fallback, while Rstest requires explicit configuration for the same behavior. For more details, see [`rs.mock()` with `{ mock: true }`](/api/runtime-api/rstest/mock-modules#with-mock-true-option).
+This distinction is important: Vitest has implicit auto-mocking as a fallback, while Rstest requires explicit configuration for the same behavior. For more details, see [`rs.mock()` with `{ mock: true }`](/api/runtime-api/rstest/mock-modules#with--mock-true--option).
 
 ### Mock async modules
 

--- a/website/docs/zh/guide/migration/vitest.mdx
+++ b/website/docs/zh/guide/migration/vitest.mdx
@@ -111,7 +111,7 @@ test('should be mocked', () => {
 });
 ```
 
-这种区别很重要：Vitest 默认提供了隐式的自动模拟回退，而 Rstest 则需要显式配置才能实现相同的行为。更多详细信息，请参阅 [`rs.mock()` 的 `{ mock: true }` 选项](/api/runtime-api/rstest/mock-modules#with-mock-true-option)。
+这种区别很重要：Vitest 默认提供了隐式的自动模拟回退，而 Rstest 则需要显式配置才能实现相同的行为。更多详细信息，请参阅 [`rs.mock()` 的 `{ mock: true }` 选项](/api/runtime-api/rstest/mock-modules#使用--mock-true--选项)。
 
 ### Mock 异步模块
 


### PR DESCRIPTION
## Summary

Clarifies the auto-mocking behavior of Vitest and Rstest in the migration guide.

-  Vitest's `vi.mock()` without a factory first checks for a ` __mocks__` directory before falling back to auto-mocking.
-  Rstest's `rs.mock()` requires the explicit `{ mock: true }` option for auto-mocking and only checks for `__mocks__` otherwise.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
