### PR TITLE
fix(vscode): relax @rstest/core version requirement

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -113,6 +113,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.16.5",
     "@types/picomatch": "^4.0.2",
+    "@types/semver": "^7.7.1",
     "@types/vscode": "1.97.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
@@ -122,6 +123,7 @@
     "mocha": "^11.7.5",
     "ovsx": "^0.10.7",
     "picomatch": "^4.0.3",
+    "semver": "^7.7.3",
     "tinyglobby": "^0.2.15",
     "typescript": "^5.9.3",
     "valibot": "^1.2.0"

--- a/packages/vscode/src/versionCheck.ts
+++ b/packages/vscode/src/versionCheck.ts
@@ -1,0 +1,18 @@
+import semver from 'semver';
+
+/**
+ * Minimum required @rstest/core version for this VS Code extension.
+ *
+ * Keep this value updated manually when the extension starts depending on
+ * newer core APIs.
+ */
+export const MIN_CORE_VERSION = '0.6.0';
+
+export function shouldWarnCoreVersion(coreVersion?: string): boolean {
+  if (!coreVersion) return false;
+  return semver.lt(coreVersion, MIN_CORE_VERSION);
+}
+
+export function formatCoreVersionWarningMessage(coreVersion?: string): string {
+  return `Rstest extension requires local @rstest/core >= ${MIN_CORE_VERSION}, but found ${coreVersion ?? 'unknown'}. Please upgrade @rstest/core.`;
+}

--- a/packages/vscode/tests/unit/versionCheck.test.ts
+++ b/packages/vscode/tests/unit/versionCheck.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  MIN_CORE_VERSION,
+  shouldWarnCoreVersion,
+} from '../../src/versionCheck';
+
+describe('versionCheck', () => {
+  it('should keep MIN_CORE_VERSION stable', () => {
+    expect(MIN_CORE_VERSION).toBe('0.6.0');
+  });
+
+  it('should warn when core is lower than minimum', () => {
+    expect(shouldWarnCoreVersion('0.5.9')).toBe(true);
+  });
+
+  it('should not warn when core meets or exceeds minimum', () => {
+    expect(shouldWarnCoreVersion('0.6.0')).toBe(false);
+    expect(shouldWarnCoreVersion('0.6.1')).toBe(false);
+    expect(shouldWarnCoreVersion('0.8.1')).toBe(false);
+  });
+
+  it('should handle prerelease versions', () => {
+    expect(shouldWarnCoreVersion('0.6.0-beta.1')).toBe(true);
+    expect(shouldWarnCoreVersion('0.6.1-beta.1')).toBe(false);
+  });
+
+  it('should ignore missing versions', () => {
+    expect(shouldWarnCoreVersion()).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1027,6 +1027,9 @@ importers:
       '@types/picomatch':
         specifier: ^4.0.2
         version: 4.0.2
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@types/vscode':
         specifier: 1.97.0
         version: 1.97.0
@@ -1054,6 +1057,9 @@ importers:
       picomatch:
         specifier: ^4.0.3
         version: 4.0.3
+      semver:
+        specifier: ^7.7.3
+        version: 7.7.3
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -3284,6 +3290,9 @@ packages:
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/sinonjs__fake-timers@8.1.5':
     resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
@@ -9970,6 +9979,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/sarif@2.1.7': {}
+
+  '@types/semver@7.7.1': {}
 
   '@types/sinonjs__fake-timers@8.1.5': {}
 


### PR DESCRIPTION
## Summary

human input:

relax the annoying notification 😅.

---

- Remove the strict version match requirement between extension and `@rstest/core`
- Introduce `MIN_CORE_VERSION` (initially `0.6.0`) as the manual compatibility baseline
- Show a warning only when the local `@rstest/core` version is lower than the minimum required
- Add `semver` dependency for robust version comparison and bundling
- Add unit tests for version checking logic

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
