### PR TITLE
feat(skill): add @rstest/cdp

### DIFF
--- a/e2e/cdp/README.md
+++ b/e2e/cdp/README.md
@@ -1,0 +1,13 @@
+# CDP debug E2E fixtures
+
+This folder hosts fixtures for the `@rstest/cdp` CLI.
+
+**Important:** This CLI is designed to be invoked by AI agents via https://github.com/rstackjs/agent-skills, not for direct human use. The skill definition (`skills/rstest-cdp/SKILL.md`) provides structured guidance for agents to generate plans and interpret results.
+
+This e2e suite exists to keep the CLI contract stable for the skill:
+
+- Plan input (`--plan` file or `-` for stdin)
+- JSON output on stdout (`DebugResult`)
+- Runner output on stderr
+
+The fixtures are intentionally self-contained so the skill can be moved into a different repo without relying on `examples/`.

--- a/e2e/cdp/fixtures/basic-no-debug/package.json
+++ b/e2e/cdp/fixtures/basic-no-debug/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@rstest/tests-cdp-no-debug",
+  "type": "module",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*"
+  }
+}

--- a/e2e/cdp/fixtures/basic-no-debug/rstest.config.ts
+++ b/e2e/cdp/fixtures/basic-no-debug/rstest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  root: __dirname,
+  tools: {
+    rspack: (config) => {
+      config.devtool = 'inline-source-map';
+    },
+  },
+  dev: {
+    writeToDisk: true,
+  },
+});

--- a/e2e/cdp/fixtures/basic-no-debug/src/math.ts
+++ b/e2e/cdp/fixtures/basic-no-debug/src/math.ts
@@ -1,0 +1,13 @@
+export const summarizeScores = (scores: number[]) => {
+  const total = scores.reduce((sum, value) => sum + value, 0);
+  const average = scores.length ? total / scores.length : 0;
+  const weightedTotal = total + average * 0.25;
+  const label = `${scores.length}-scores`;
+
+  return {
+    total,
+    average,
+    weightedTotal,
+    label,
+  };
+};

--- a/e2e/cdp/fixtures/basic-no-debug/src/profile.ts
+++ b/e2e/cdp/fixtures/basic-no-debug/src/profile.ts
@@ -1,0 +1,15 @@
+export const formatUser = (name: string, role = 'member') => {
+  const trimmed = name.trim();
+  const [firstName = '', lastName = ''] = trimmed.split(' ');
+  const normalized = `${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
+  const displayName = `${firstName} ${lastName}`.trim();
+
+  return {
+    trimmed,
+    firstName,
+    lastName,
+    normalized,
+    displayName,
+    role,
+  };
+};

--- a/e2e/cdp/fixtures/basic-no-debug/test/combined.test.ts
+++ b/e2e/cdp/fixtures/basic-no-debug/test/combined.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+import { formatUser } from '../src/profile';
+
+describe('combined tests', () => {
+  it('formats user profile', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+
+  it('summarizes scores', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/basic-no-debug/test/math.test.ts
+++ b/e2e/cdp/fixtures/basic-no-debug/test/math.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+
+describe('score summary', () => {
+  it('computes totals', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/basic-no-debug/test/profile.test.ts
+++ b/e2e/cdp/fixtures/basic-no-debug/test/profile.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+import { formatUser } from '../src/profile';
+
+describe('user profile', () => {
+  it('formats display names', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+});

--- a/e2e/cdp/fixtures/basic-no-debug/tsconfig.json
+++ b/e2e/cdp/fixtures/basic-no-debug/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@rstest/core"],
+    "strict": true
+  },
+  "include": ["src", "test", "rstest.config.ts"]
+}

--- a/e2e/cdp/fixtures/basic/package.json
+++ b/e2e/cdp/fixtures/basic/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@rstest/tests-cdp",
+  "type": "module",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*"
+  }
+}

--- a/e2e/cdp/fixtures/basic/rstest.config.ts
+++ b/e2e/cdp/fixtures/basic/rstest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  root: __dirname,
+  tools: {
+    rspack: (config) => {
+      config.devtool = 'inline-source-map';
+    },
+  },
+  dev: {
+    writeToDisk: true,
+  },
+});

--- a/e2e/cdp/fixtures/basic/src/math.ts
+++ b/e2e/cdp/fixtures/basic/src/math.ts
@@ -1,0 +1,13 @@
+export const summarizeScores = (scores: number[]) => {
+  const total = scores.reduce((sum, value) => sum + value, 0);
+  const average = scores.length ? total / scores.length : 0;
+  const weightedTotal = total + average * 0.25;
+  const label = `${scores.length}-scores`;
+
+  return {
+    total,
+    average,
+    weightedTotal,
+    label,
+  };
+};

--- a/e2e/cdp/fixtures/basic/src/profile.ts
+++ b/e2e/cdp/fixtures/basic/src/profile.ts
@@ -1,0 +1,15 @@
+export const formatUser = (name: string, role = 'member') => {
+  const trimmed = name.trim();
+  const [firstName = '', lastName = ''] = trimmed.split(' ');
+  const normalized = `${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
+  const displayName = `${firstName} ${lastName}`.trim();
+
+  return {
+    trimmed,
+    firstName,
+    lastName,
+    normalized,
+    displayName,
+    role,
+  };
+};

--- a/e2e/cdp/fixtures/basic/test/combined.test.ts
+++ b/e2e/cdp/fixtures/basic/test/combined.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+import { formatUser } from '../src/profile';
+
+describe('combined tests', () => {
+  it('formats user profile', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+
+  it('summarizes scores', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/basic/test/math.test.ts
+++ b/e2e/cdp/fixtures/basic/test/math.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+
+describe('score summary', () => {
+  it('computes totals', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/basic/test/profile.test.ts
+++ b/e2e/cdp/fixtures/basic/test/profile.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+import { formatUser } from '../src/profile';
+
+describe('user profile', () => {
+  it('formats display names', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+});

--- a/e2e/cdp/fixtures/basic/tsconfig.json
+++ b/e2e/cdp/fixtures/basic/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@rstest/core"],
+    "strict": true
+  },
+  "include": ["src", "test", "rstest.config.ts"]
+}

--- a/e2e/cdp/fixtures/invalid-line/package.json
+++ b/e2e/cdp/fixtures/invalid-line/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@rstest/tests-cdp-invalid-line",
+  "type": "module",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*"
+  }
+}

--- a/e2e/cdp/fixtures/invalid-line/rstest.config.ts
+++ b/e2e/cdp/fixtures/invalid-line/rstest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  root: __dirname,
+  tools: {
+    rspack: (config) => {
+      config.devtool = 'inline-source-map';
+    },
+  },
+  dev: {
+    writeToDisk: true,
+  },
+});

--- a/e2e/cdp/fixtures/invalid-line/src/math.ts
+++ b/e2e/cdp/fixtures/invalid-line/src/math.ts
@@ -1,0 +1,13 @@
+export const summarizeScores = (scores: number[]) => {
+  const total = scores.reduce((sum, value) => sum + value, 0);
+  const average = scores.length ? total / scores.length : 0;
+  const weightedTotal = total + average * 0.25;
+  const label = `${scores.length}-scores`;
+
+  return {
+    total,
+    average,
+    weightedTotal,
+    label,
+  };
+};

--- a/e2e/cdp/fixtures/invalid-line/src/profile.ts
+++ b/e2e/cdp/fixtures/invalid-line/src/profile.ts
@@ -1,0 +1,15 @@
+export const formatUser = (name: string, role = 'member') => {
+  const trimmed = name.trim();
+  const [firstName = '', lastName = ''] = trimmed.split(' ');
+  const normalized = `${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
+  const displayName = `${firstName} ${lastName}`.trim();
+
+  return {
+    trimmed,
+    firstName,
+    lastName,
+    normalized,
+    displayName,
+    role,
+  };
+};

--- a/e2e/cdp/fixtures/invalid-line/test/combined.test.ts
+++ b/e2e/cdp/fixtures/invalid-line/test/combined.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+import { formatUser } from '../src/profile';
+
+describe('combined tests', () => {
+  it('formats user profile', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+
+  it('summarizes scores', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/invalid-line/test/math.test.ts
+++ b/e2e/cdp/fixtures/invalid-line/test/math.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+
+describe('score summary', () => {
+  it('computes totals', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/invalid-line/test/profile.test.ts
+++ b/e2e/cdp/fixtures/invalid-line/test/profile.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+import { formatUser } from '../src/profile';
+
+describe('user profile', () => {
+  it('formats display names', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+});

--- a/e2e/cdp/fixtures/invalid-line/tsconfig.json
+++ b/e2e/cdp/fixtures/invalid-line/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@rstest/core"],
+    "strict": true
+  },
+  "include": ["src", "test", "rstest.config.ts"]
+}

--- a/e2e/cdp/fixtures/mismatch/package.json
+++ b/e2e/cdp/fixtures/mismatch/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@rstest/tests-cdp-mismatch",
+  "type": "module",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*"
+  }
+}

--- a/e2e/cdp/fixtures/mismatch/rstest.config.ts
+++ b/e2e/cdp/fixtures/mismatch/rstest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  root: __dirname,
+  tools: {
+    rspack: (config) => {
+      config.devtool = 'inline-source-map';
+    },
+  },
+  dev: {
+    writeToDisk: true,
+  },
+});

--- a/e2e/cdp/fixtures/mismatch/src/math.ts
+++ b/e2e/cdp/fixtures/mismatch/src/math.ts
@@ -1,0 +1,13 @@
+export const summarizeScores = (scores: number[]) => {
+  const total = scores.reduce((sum, value) => sum + value, 0);
+  const average = scores.length ? total / scores.length : 0;
+  const weightedTotal = total + average * 0.25;
+  const label = `${scores.length}-scores`;
+
+  return {
+    total,
+    average,
+    weightedTotal,
+    label,
+  };
+};

--- a/e2e/cdp/fixtures/mismatch/src/profile.ts
+++ b/e2e/cdp/fixtures/mismatch/src/profile.ts
@@ -1,0 +1,15 @@
+export const formatUser = (name: string, role = 'member') => {
+  const trimmed = name.trim();
+  const [firstName = '', lastName = ''] = trimmed.split(' ');
+  const normalized = `${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
+  const displayName = `${firstName} ${lastName}`.trim();
+
+  return {
+    trimmed,
+    firstName,
+    lastName,
+    normalized,
+    displayName,
+    role,
+  };
+};

--- a/e2e/cdp/fixtures/mismatch/test/combined.test.ts
+++ b/e2e/cdp/fixtures/mismatch/test/combined.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+import { formatUser } from '../src/profile';
+
+describe('combined tests', () => {
+  it('formats user profile', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+
+  it('summarizes scores', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/mismatch/test/math.test.ts
+++ b/e2e/cdp/fixtures/mismatch/test/math.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+
+describe('score summary', () => {
+  it('computes totals', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/mismatch/test/profile.test.ts
+++ b/e2e/cdp/fixtures/mismatch/test/profile.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+import { formatUser } from '../src/profile';
+
+describe('user profile', () => {
+  it('formats display names', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+});

--- a/e2e/cdp/fixtures/mismatch/tsconfig.json
+++ b/e2e/cdp/fixtures/mismatch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@rstest/core"],
+    "strict": true
+  },
+  "include": ["src", "test", "rstest.config.ts"]
+}

--- a/e2e/cdp/fixtures/multi/package.json
+++ b/e2e/cdp/fixtures/multi/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@rstest/tests-cdp-multi",
+  "type": "module",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@rstest/core": "workspace:*"
+  }
+}

--- a/e2e/cdp/fixtures/multi/rstest.config.ts
+++ b/e2e/cdp/fixtures/multi/rstest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  root: __dirname,
+  tools: {
+    rspack: (config) => {
+      config.devtool = 'inline-source-map';
+    },
+  },
+  dev: {
+    writeToDisk: true,
+  },
+});

--- a/e2e/cdp/fixtures/multi/src/math.ts
+++ b/e2e/cdp/fixtures/multi/src/math.ts
@@ -1,0 +1,13 @@
+export const summarizeScores = (scores: number[]) => {
+  const total = scores.reduce((sum, value) => sum + value, 0);
+  const average = scores.length ? total / scores.length : 0;
+  const weightedTotal = total + average * 0.25;
+  const label = `${scores.length}-scores`;
+
+  return {
+    total,
+    average,
+    weightedTotal,
+    label,
+  };
+};

--- a/e2e/cdp/fixtures/multi/src/profile.ts
+++ b/e2e/cdp/fixtures/multi/src/profile.ts
@@ -1,0 +1,15 @@
+export const formatUser = (name: string, role = 'member') => {
+  const trimmed = name.trim();
+  const [firstName = '', lastName = ''] = trimmed.split(' ');
+  const normalized = `${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
+  const displayName = `${firstName} ${lastName}`.trim();
+
+  return {
+    trimmed,
+    firstName,
+    lastName,
+    normalized,
+    displayName,
+    role,
+  };
+};

--- a/e2e/cdp/fixtures/multi/test/combined.test.ts
+++ b/e2e/cdp/fixtures/multi/test/combined.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+import { formatUser } from '../src/profile';
+
+describe('combined tests', () => {
+  it('formats user profile', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+
+  it('summarizes scores', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/multi/test/math.test.ts
+++ b/e2e/cdp/fixtures/multi/test/math.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@rstest/core';
+import { summarizeScores } from '../src/math';
+
+describe('score summary', () => {
+  it('computes totals', () => {
+    const result = summarizeScores([12, 18, 30]);
+
+    expect(result.total).toBe(60);
+    expect(result.average).toBe(20);
+    expect(result.weightedTotal).toBe(65);
+  });
+});

--- a/e2e/cdp/fixtures/multi/test/profile.test.ts
+++ b/e2e/cdp/fixtures/multi/test/profile.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+import { formatUser } from '../src/profile';
+
+describe('user profile', () => {
+  it('formats display names', () => {
+    const profile = formatUser('Ada Lovelace', 'admin');
+
+    expect(profile.displayName).toBe('Ada Lovelace');
+    expect(profile.normalized).toBe('ada-lovelace');
+  });
+});

--- a/e2e/cdp/fixtures/multi/tsconfig.json
+++ b/e2e/cdp/fixtures/multi/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@rstest/core"],
+    "strict": true
+  },
+  "include": ["src", "test", "rstest.config.ts"]
+}

--- a/e2e/cdp/index.test.ts
+++ b/e2e/cdp/index.test.ts
@@ -1,0 +1,442 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { type Result, x } from 'tinyexec';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface DebugResult {
+  status: 'full_succeed' | 'partial_succeed' | 'failed';
+  exitCode?: number | null;
+  results: Array<{
+    id: string;
+    values: Array<{ expression: string; value: unknown }>;
+  }>;
+  errors: Array<{ taskId?: string; error: string }>;
+  meta?: {
+    runner: {
+      cmd: string;
+      args: string[];
+      cwd: string;
+      env?: Record<string, string>;
+    };
+    forwardedArgs: string[];
+    mappingDiagnostics: Array<{ reason: string }>;
+    pendingTaskIds: string[];
+  };
+}
+
+interface RunCdpDebugOptions {
+  plan: object;
+  cwd: string;
+  debug?: boolean;
+  timeout?: number;
+}
+
+/**
+ * Helper to run rstest-cdp CLI and collect stdout.
+ */
+async function runCdpDebug(options: RunCdpDebugOptions): Promise<DebugResult> {
+  const { plan, cwd, debug = false, timeout = 45_000 } = options;
+  const stdinPayload = JSON.stringify(plan, null, 2);
+
+  const args = [
+    path.resolve(__dirname, '../../packages/skill-cdp/dist/rstest-cdp.cjs'),
+    '--plan',
+    '-',
+  ];
+  if (debug) {
+    args.push('--debug', '1');
+  }
+
+  let stdout = '';
+  const cli = x('node', args, {
+    nodeOptions: { cwd },
+  });
+
+  cli.process?.stdout?.on('data', (chunk) => {
+    stdout += chunk.toString();
+  });
+
+  cli.process?.stdin?.write(stdinPayload);
+  cli.process?.stdin?.end();
+
+  try {
+    await Promise.race([
+      cli,
+      new Promise<Result>((_resolve, reject) => {
+        setTimeout(() => reject(new Error('rstest-cdp timed out.')), timeout);
+      }),
+    ]);
+  } catch (_error) {
+    const details = stdout.trim() ? `\n${stdout}` : '';
+    throw new Error(`rstest-cdp failed.${details}`);
+  }
+
+  return JSON.parse(stdout) as DebugResult;
+}
+
+describe('cdp debug skill', () => {
+  it('evaluates locals via CDP', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures/basic`;
+
+    const build = x('pnpm', ['--filter', '@rstest/cdp', 'build'], {
+      nodeOptions: { cwd: path.resolve(__dirname, '../..') },
+    });
+    await build;
+    if (build.process?.exitCode !== 0) {
+      throw new Error('Failed to build @rstest/cdp.');
+    }
+
+    const profileSourcePath = path.join(fixturesTargetPath, 'src/profile.ts');
+    const plan = {
+      runner: {
+        cmd: 'pnpm',
+        args: [
+          'rstest',
+          'run',
+          '-c',
+          'rstest.config.ts',
+          '--include',
+          'test/profile.test.ts',
+        ],
+        cwd: fixturesTargetPath,
+        env: {
+          FORCE_COLOR: '0',
+        },
+      },
+      tasks: [
+        {
+          description: 'Inspect formatted profile fields',
+          sourcePath: profileSourcePath,
+          line: 7,
+          column: 0,
+          expressions: ['trimmed', 'normalized', 'displayName', 'role'],
+        },
+      ],
+    };
+    const stdinPayload = JSON.stringify(plan, null, 2);
+
+    let stdout = '';
+    const cli = x(
+      'node',
+      [
+        path.resolve(__dirname, '../../packages/skill-cdp/dist/rstest-cdp.cjs'),
+        '--plan',
+        '-',
+        '--debug',
+        '1',
+      ],
+      {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    );
+
+    cli.process?.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    cli.process?.stdin?.write(stdinPayload);
+    cli.process?.stdin?.end();
+
+    try {
+      await Promise.race([
+        cli,
+        new Promise<void>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('rstest-cdp timed out.')), 45_000);
+        }),
+      ]);
+    } catch (_error) {
+      const details = stdout.trim() ? `\n${stdout}` : '';
+      throw new Error(`rstest-cdp failed.${details}`);
+    }
+
+    const result = JSON.parse(stdout) as DebugResult;
+    if (result.status === 'failed') {
+      throw new Error(`rstest-cdp failed.\n${JSON.stringify(result)}`);
+    }
+
+    expect(result.status).toBe('full_succeed');
+    expect(result.meta).toBeTruthy();
+    expect(result.meta?.pendingTaskIds.length).toBe(0);
+
+    expect(result.meta?.forwardedArgs).toContain('--pool.maxWorkers=1');
+    expect(result.meta?.forwardedArgs).toContain(
+      '--pool.execArgv=--inspect-brk=0',
+    );
+
+    const profileResult = result.results.find((item) => item.id === 'task-1');
+    expect(profileResult).toBeTruthy();
+    const values = Object.fromEntries(
+      (profileResult?.values || []).map((entry) => [
+        entry.expression,
+        entry.value,
+      ]),
+    );
+    expect(values.trimmed).toBe('Ada Lovelace');
+    expect(values.normalized).toBe('ada-lovelace');
+    expect(values.displayName).toBe('Ada Lovelace');
+    expect(values.role).toBe('admin');
+  }, 60_000);
+
+  it('omits meta when --debug is not set', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures/basic-no-debug`;
+
+    const build = x('pnpm', ['--filter', '@rstest/cdp', 'build'], {
+      nodeOptions: { cwd: path.resolve(__dirname, '../..') },
+    });
+    await build;
+    if (build.process?.exitCode !== 0) {
+      throw new Error('Failed to build @rstest/cdp.');
+    }
+
+    const profileSourcePath = path.join(fixturesTargetPath, 'src/profile.ts');
+    const plan = {
+      runner: {
+        cmd: 'pnpm',
+        args: [
+          'rstest',
+          'run',
+          '-c',
+          'rstest.config.ts',
+          '--include',
+          'test/profile.test.ts',
+        ],
+        cwd: fixturesTargetPath,
+        env: { FORCE_COLOR: '0' },
+      },
+      tasks: [
+        {
+          description: 'Inspect profile fields without debug',
+          sourcePath: profileSourcePath,
+          line: 7,
+          column: 0,
+          expressions: ['trimmed'],
+        },
+      ],
+    };
+
+    // Run without --debug flag
+    const result = await runCdpDebug({
+      plan,
+      cwd: fixturesTargetPath,
+      debug: false,
+    });
+
+    expect(result.status).toBe('full_succeed');
+    // meta should be undefined when --debug is not set
+    expect(result.meta).toBeUndefined();
+    // results should still be present
+    expect(result.results.length).toBeGreaterThan(0);
+    const profileResult = result.results.find((item) => item.id === 'task-1');
+    expect(profileResult).toBeTruthy();
+    const values = Object.fromEntries(
+      (profileResult?.values || []).map((entry) => [
+        entry.expression,
+        entry.value,
+      ]),
+    );
+    expect(values.trimmed).toBe('Ada Lovelace');
+  }, 60_000);
+
+  it('evaluates multiple breakpoints across files', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures/multi`;
+
+    const build = x('pnpm', ['--filter', '@rstest/cdp', 'build'], {
+      nodeOptions: { cwd: path.resolve(__dirname, '../..') },
+    });
+    await build;
+    if (build.process?.exitCode !== 0) {
+      throw new Error('Failed to build @rstest/cdp.');
+    }
+
+    const profileSourcePath = path.join(fixturesTargetPath, 'src/profile.ts');
+    const mathSourcePath = path.join(fixturesTargetPath, 'src/math.ts');
+    const plan = {
+      runner: {
+        cmd: 'pnpm',
+        args: [
+          'rstest',
+          'run',
+          '-c',
+          'rstest.config.ts',
+          '--include',
+          'test/combined.test.ts',
+        ],
+        cwd: fixturesTargetPath,
+        env: { FORCE_COLOR: '0' },
+      },
+      tasks: [
+        {
+          description: 'Inspect profile fields',
+          sourcePath: profileSourcePath,
+          line: 7,
+          column: 0,
+          expressions: ['trimmed', 'displayName', 'role'],
+        },
+        {
+          description: 'Inspect math fields',
+          sourcePath: mathSourcePath,
+          line: 7,
+          column: 0,
+          expressions: ['total', 'average', 'label'],
+        },
+      ],
+    };
+
+    const result = await runCdpDebug({
+      plan,
+      cwd: fixturesTargetPath,
+      debug: true,
+    });
+
+    if (result.status !== 'full_succeed') {
+      console.error(
+        'Multi-breakpoint test failed:',
+        JSON.stringify(result, null, 2),
+      );
+    }
+    expect(result.status).toBe('full_succeed');
+    expect(result.meta?.pendingTaskIds.length).toBe(0);
+
+    // Verify profile.ts breakpoint result
+    const profileResult = result.results.find((item) => item.id === 'task-1');
+    expect(profileResult).toBeTruthy();
+    const profileValues = Object.fromEntries(
+      (profileResult?.values || []).map((entry) => [
+        entry.expression,
+        entry.value,
+      ]),
+    );
+    expect(profileValues.trimmed).toBe('Ada Lovelace');
+    expect(profileValues.displayName).toBe('Ada Lovelace');
+    expect(profileValues.role).toBe('admin');
+
+    // Verify math.ts breakpoint result
+    const mathResult = result.results.find((item) => item.id === 'task-2');
+    expect(mathResult).toBeTruthy();
+    const mathValues = Object.fromEntries(
+      (mathResult?.values || []).map((entry) => [
+        entry.expression,
+        entry.value,
+      ]),
+    );
+    expect(mathValues.total).toBe(60);
+    expect(mathValues.average).toBe(20);
+    expect(mathValues.label).toBe('3-scores');
+  }, 60_000);
+
+  it('handles non-existent breakpoint line gracefully', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures/invalid-line`;
+
+    const build = x('pnpm', ['--filter', '@rstest/cdp', 'build'], {
+      nodeOptions: { cwd: path.resolve(__dirname, '../..') },
+    });
+    await build;
+    if (build.process?.exitCode !== 0) {
+      throw new Error('Failed to build @rstest/cdp.');
+    }
+
+    const profileSourcePath = path.join(fixturesTargetPath, 'src/profile.ts');
+    const plan = {
+      runner: {
+        cmd: 'pnpm',
+        args: [
+          'rstest',
+          'run',
+          '-c',
+          'rstest.config.ts',
+          '--include',
+          'test/profile.test.ts',
+        ],
+        cwd: fixturesTargetPath,
+        env: { FORCE_COLOR: '0' },
+      },
+      tasks: [
+        {
+          description: 'Breakpoint at non-existent line',
+          sourcePath: profileSourcePath,
+          line: 9999,
+          column: 0,
+          expressions: ['trimmed'],
+        },
+      ],
+    };
+
+    const result = await runCdpDebug({
+      plan,
+      cwd: fixturesTargetPath,
+      debug: true,
+    });
+
+    // The task should remain pending since the breakpoint line doesn't exist
+    expect(result.meta?.pendingTaskIds).toContain('task-1');
+    // No results should be collected for the invalid breakpoint
+    const taskResult = result.results.find((item) => item.id === 'task-1');
+    expect(taskResult).toBeUndefined();
+  }, 60_000);
+
+  it('reports sourcemap mismatch in diagnostics', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures/mismatch`;
+
+    const build = x('pnpm', ['--filter', '@rstest/cdp', 'build'], {
+      nodeOptions: { cwd: path.resolve(__dirname, '../..') },
+    });
+    await build;
+    if (build.process?.exitCode !== 0) {
+      throw new Error('Failed to build @rstest/cdp.');
+    }
+
+    // Use a non-existent source file path that won't match any sourcemap
+    const nonExistentSourcePath = path.join(
+      fixturesTargetPath,
+      'src/non-existent-file.ts',
+    );
+    const plan = {
+      runner: {
+        cmd: 'pnpm',
+        args: [
+          'rstest',
+          'run',
+          '-c',
+          'rstest.config.ts',
+          '--include',
+          'test/profile.test.ts',
+        ],
+        cwd: fixturesTargetPath,
+        env: { FORCE_COLOR: '0' },
+      },
+      tasks: [
+        {
+          description: 'Breakpoint in non-existent file',
+          sourcePath: nonExistentSourcePath,
+          line: 7,
+          column: 0,
+          expressions: ['foo'],
+        },
+      ],
+    };
+
+    const result = await runCdpDebug({
+      plan,
+      cwd: fixturesTargetPath,
+      debug: true,
+    });
+
+    // The task should remain pending since no sourcemap matches
+    expect(result.meta?.pendingTaskIds).toContain('task-1');
+    // mappingDiagnostics should contain info about the mismatch
+    expect(result.meta?.mappingDiagnostics.length).toBeGreaterThan(0);
+    // At least one diagnostic should mention "no match" or similar
+    const hasMismatchDiagnostic = result.meta?.mappingDiagnostics.some(
+      (d) =>
+        d.reason.toLowerCase().includes('no match') ||
+        d.reason.toLowerCase().includes('not found') ||
+        d.reason.toLowerCase().includes('mismatch'),
+    );
+    expect(hasMismatchDiagnostic).toBeTruthy();
+  }, 60_000);
+});

--- a/packages/skill-cdp/AGENTS.md
+++ b/packages/skill-cdp/AGENTS.md
@@ -1,0 +1,129 @@
+## @rstest/cdp (agent-invoked CLI)
+
+This package ships a CDP debug CLI designed for AI agents.
+Treat it as a portable artifact: deterministic, easy to invoke via `npx`, minimal surface area.
+
+How it is used:
+
+- External agent generates a Plan JSON and calls: `npx @rstest/cdp --plan <path|->`
+- This repo focuses on keeping the CLI contract stable; the skill runbook lives elsewhere
+
+Skill definition (external):
+
+- https://github.com/rstackjs/agent-skills (skills/rstest-cdp)
+
+## Project structure (start here)
+
+- Entrypoint: `packages/skill-cdp/src/cli.ts`
+- CLI orchestration + output writing: `packages/skill-cdp/src/index.ts`
+- Plan parsing/validation + runner args normalization: `packages/skill-cdp/src/plan.ts`
+- CDP session + sourcemap mapping + breakpoint resolution: `packages/skill-cdp/src/session.ts`
+- Generated plan JSON Schema (do not edit): `packages/skill-cdp/schema/plan.schema.json`
+- Schema generator: `packages/skill-cdp/scripts/genPlanSchema.mts`
+
+## Output contract (do not break)
+
+- stdout: a single JSON `DebugResult` (machine-readable)
+  - Core fields: `ok`, `results`, `errors` (always present)
+  - `meta` field: diagnostic info, only included with `--debug` flag
+- stderr: runner output + optional debug logs (`--debug`)
+- stable ordering, explicit timeouts, no randomness
+
+## Do
+
+- Keep diffs small and localized to `packages/skill-cdp/`.
+- Prefer file-scoped commands for fast feedback.
+- Treat input from files / CDP / subprocess as `unknown`, then validate/narrow.
+- Keep the CLI deterministic (timeouts explicit, stable ordering).
+- Rebuild after changes; do not edit `dist/*` by hand.
+
+## Don't
+
+- Don't print non-JSON to stdout (breaks callers).
+- Don't add heavy dependencies without approval.
+- Don't do repo-wide rewrites unless explicitly requested.
+
+## Commands (development)
+
+File-scoped checks preferred.
+
+```bash
+# Typecheck
+pnpm --filter @rstest/cdp typecheck
+
+# Build (bundle output in dist/)
+pnpm --filter @rstest/cdp build
+
+# Watch build
+pnpm --filter @rstest/cdp dev
+
+# Regenerate plan JSON schema (committed artifact)
+pnpm --filter @rstest/cdp gen:schema
+
+# Lint / format (file-scoped)
+pnpm biome check --write 'packages/skill-cdp/src/index.ts'
+pnpm prettier --write 'packages/skill-cdp/src/index.ts'
+```
+
+## Tests
+
+This package relies on workspace E2E tests.
+
+```bash
+# Run a single E2E test (recommended)
+pnpm rstest 'e2e/cdp/index.test.ts'
+
+# Full suites (slower)
+pnpm test
+pnpm e2e
+```
+
+If CLI flags or JSON output shape change, update `e2e/cdp/index.test.ts`.
+
+## Running the CLI locally
+
+```bash
+pnpm --filter @rstest/cdp build
+
+# Plan from file
+npx @rstest/cdp --plan '/abs/path/to/plan.json'
+
+# Plan from stdin
+npx @rstest/cdp --plan -
+```
+
+Or directly:
+
+```bash
+node 'packages/skill-cdp/dist/rstest-cdp.cjs' --plan '/abs/path/to/plan.json'
+```
+
+## Safety / permissions
+
+Allowed without asking:
+
+- Read/list files
+- Run: `pnpm --filter @rstest/cdp build|dev|typecheck|gen:schema`
+- Run: `pnpm rstest 'e2e/cdp/index.test.ts'`
+- Run format/lint on specific files
+
+Ask first:
+
+- Adding/removing dependencies
+- Running full workspace builds if not necessary
+- Deleting files / changing permissions / running network-heavy tasks
+- Git push / publishing
+
+## Pre-PR checklist
+
+```bash
+pnpm biome check --write 'packages/skill-cdp/src/index.ts'
+pnpm --filter @rstest/cdp typecheck
+pnpm rstest 'e2e/cdp/index.test.ts'
+pnpm --filter @rstest/cdp build
+```
+
+## When stuck
+
+- Propose a short plan and ask 1 targeted question.
+- Prefer minimal, reversible changes over speculative refactors.

--- a/packages/skill-cdp/README.md
+++ b/packages/skill-cdp/README.md
@@ -1,0 +1,105 @@
+# @rstest/cdp
+
+[CDP](https://chromedevtools.github.io/devtools-protocol/)-based debugger CLI for rstest, designed for use by [rstackjs/agent-skills](https://github.com/rstackjs/agent-skills).
+
+**Important:** This CLI is intended to be invoked by AI agents, not for direct human use. Agents use the skill definition to generate plans and interpret results automatically.
+
+This package provides a command-line tool that helps debug Rstest test cases by:
+
+- Running a single test file in a single worker under the Node inspector (CDP)
+- Setting sourcemap-mapped breakpoints via instrumentation breakpoints (handles timing/race conditions)
+- Evaluating expressions to inspect intermediate variables
+
+**Note:** Browser mode debugging is not supported yet.
+
+## Usage
+
+```bash
+# Read plan from a file
+npx @rstest/cdp --plan plan.json
+
+# Read plan from stdin (using heredoc)
+npx @rstest/cdp --plan - <<'EOF'
+{
+  "runner": {
+    "cmd": "pnpm",
+    "args": ["rstest", "run", "--include", "test/example.test.ts"],
+    "cwd": "/path/to/project"
+  },
+  "tasks": [
+    {
+      "sourcePath": "/path/to/project/src/example.ts",
+      "line": 42,
+      "column": 0,
+      "expressions": ["value", "typeof value"]
+    }
+  ]
+}
+EOF
+
+# Enable debug mode for diagnostic info (includes meta in output + stderr logs)
+npx @rstest/cdp --debug --plan plan.json
+```
+
+### CLI args
+
+| Option                      | Description                                              |
+| --------------------------- | -------------------------------------------------------- |
+| `-p, --plan <path>`         | Path to plan JSON file (or `-` for stdin). **Required.** |
+| `--output <path>`           | Write JSON output to file (or `-` for stdout).           |
+| `--breakpoint-timeout <ms>` | Timeout for resolving breakpoints (default: `20000`).    |
+| `--inactivity-timeout <ms>` | Timeout between breakpoint hits (default: `40000`).      |
+| `--debug`                   | Enable debug logging.                                    |
+
+## Output
+
+The CLI outputs a JSON `DebugResult` to stdout:
+
+```json
+{
+  "ok": true,
+  "results": [
+    {
+      "id": "task-1",
+      "sourcePath": "src/example.ts",
+      "line": 42,
+      "column": 0,
+      "values": [{ "expression": "value", "value": "hello", "type": "string" }]
+    }
+  ],
+  "errors": []
+}
+```
+
+With `--debug`, additional diagnostic metadata is included:
+
+```json
+{
+  "ok": true,
+  "results": [...],
+  "errors": [],
+  "meta": {
+    "runner": { ... },
+    "forwardedArgs": [...],
+    "pendingTaskIds": [],
+    "mappingDiagnostics": [...]
+  }
+}
+```
+
+## Commands (for development)
+
+```bash
+pnpm --filter @rstest/cdp build
+pnpm --filter @rstest/cdp dev
+pnpm --filter @rstest/cdp gen:schema
+pnpm --filter @rstest/cdp typecheck
+```
+
+## Plan schema
+
+The plan JSON Schema is generated from Valibot schemas and committed to this repository at [./schema/plan.schema.json](./schema/plan.schema.json). Skill definitions can reference this schema.
+
+## Related
+
+- Skill definition: maintained at [rstackjs/agent-skills](https://github.com/rstackjs/agent-skills).

--- a/packages/skill-cdp/package.json
+++ b/packages/skill-cdp/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@rstest/cdp",
+  "version": "0.1.0",
+  "description": "CDP-based debugger CLI for rstest, used by agent-skills.",
+  "type": "module",
+  "bin": "./dist/rstest-cdp.cjs",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib build",
+    "postbuild": "pnpm run gen:schema",
+    "dev": "rslib build --watch",
+    "gen:schema": "node --experimental-strip-types ./scripts/genPlanSchema.mts && prettier -w ./schema/plan.schema.json",
+    "prepare": "pnpm run gen:schema",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@jridgewell/trace-mapping": "0.3.31",
+    "@rslib/core": "^0.19.0",
+    "@rstest/tsconfig": "workspace:*",
+    "@valibot/to-json-schema": "^1.2.0",
+    "@types/ws": "^8.18.1",
+    "cac": "^6.7.14",
+    "json-rpc-2.0": "^1.7.1",
+    "valibot": "^1.2.0",
+    "ws": "^8.18.3"
+  },
+  "engines": {
+    "node": ">=18.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rstest",
+    "directory": "packages/skill-cdp"
+  }
+}

--- a/packages/skill-cdp/rslib.config.ts
+++ b/packages/skill-cdp/rslib.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'cjs',
+      dts: false,
+      bundle: true,
+      syntax: ['node 18.12.0'],
+      output: {
+        filename: {
+          js: '[name].cjs',
+        },
+      },
+      source: {
+        define: {
+          // `ws` optionally loads native addons (`bufferutil`, `utf-8-validate`).
+          // We don't ship them in the bundled script, so disable those code paths.
+          'process.env.WS_NO_BUFFER_UTIL': JSON.stringify('1'),
+          'process.env.WS_NO_UTF_8_VALIDATE': JSON.stringify('1'),
+        },
+        entry: {
+          'rstest-cdp': './src/cli.ts',
+        },
+      },
+    },
+  ],
+});

--- a/packages/skill-cdp/schema/plan.schema.json
+++ b/packages/skill-cdp/schema/plan.schema.json
@@ -1,0 +1,98 @@
+{
+  "type": "object",
+  "properties": {
+    "runner": {
+      "type": "object",
+      "properties": {
+        "cmd": {
+          "type": "string",
+          "description": "Runner command. Example: \"pnpm\"."
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Runner arguments. Example: [\"rstest\", \"run\", ...]."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "Working directory for the runner process."
+        },
+        "env": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Environment variables passed to the runner. Default: {}."
+        }
+      },
+      "required": ["cmd", "args", "cwd"],
+      "description": "Runner configuration used to execute the test command."
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Task id. If omitted, the CLI assigns \"task-<n>\"."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable task description."
+          },
+          "sourcePath": {
+            "type": "string",
+            "description": "Absolute source file path in the runner workspace. Used for sourcemap mapping."
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based line number in the source file."
+          },
+          "column": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "0-based column number in the source file. Default: 0."
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Expressions to evaluate on the paused call frame when this breakpoint is hit."
+          },
+          "hitLimit": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Stop after this many hits. Default: 1."
+          },
+          "condition": {
+            "type": "string",
+            "description": "Conditional breakpoint expression (evaluated by the debugger). The breakpoint pauses only when this evaluates to a truthy value."
+          },
+          "order": {
+            "type": "integer",
+            "description": "Optional ordering hint (lower values run first)."
+          },
+          "hits": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Internal hit counter. Default: 0."
+          }
+        },
+        "required": ["sourcePath", "line"]
+      },
+      "minItems": 1,
+      "description": "List of breakpoint tasks. Must be non-empty."
+    }
+  },
+  "required": ["runner", "tasks"],
+  "description": "Plan JSON passed to the CLI via --plan <path|->.",
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/skill-cdp/scripts/genPlanSchema.mts
+++ b/packages/skill-cdp/scripts/genPlanSchema.mts
@@ -1,0 +1,15 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { toJsonSchema } from '@valibot/to-json-schema';
+import { PlanInputSchema } from '../src/schema.ts';
+
+const outDir = path.resolve(import.meta.dirname, '../schema');
+const outFile = path.join(outDir, 'plan.schema.json');
+
+await mkdir(outDir, { recursive: true });
+
+const schema = toJsonSchema(PlanInputSchema, { target: 'draft-07' });
+await writeFile(outFile, `${JSON.stringify(schema, null, 2)}\n`, 'utf8');
+
+process.stderr.write(`Wrote ${outFile}\n`);

--- a/packages/skill-cdp/src/cdp.ts
+++ b/packages/skill-cdp/src/cdp.ts
@@ -1,0 +1,170 @@
+import { createJSONRPCErrorResponse, JSONRPCClient } from 'json-rpc-2.0';
+import WebSocket from 'ws';
+import type { CdpClient, EvaluatedValue } from './types';
+
+const REQUEST_TIMEOUT_MS = 60_000;
+
+// ============================================================================
+// CDP Client
+// ============================================================================
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * CDP protocol doesn't use JSON-RPC 2.0's `jsonrpc` field.
+ * Strip it to avoid protocol errors.
+ */
+const stripJsonRpcField = (payload: unknown): unknown => {
+  if (Array.isArray(payload)) {
+    return payload.map((item) => stripJsonRpcField(item));
+  }
+  if (!isObject(payload) || !('jsonrpc' in payload)) return payload;
+  const { jsonrpc: _, ...rest } = payload;
+  return rest;
+};
+
+export const createCdpClient = async (wsUrl: string): Promise<CdpClient> => {
+  const socket = new WebSocket(wsUrl);
+
+  const client = new JSONRPCClient<void>((payload) => {
+    const raw = JSON.stringify(stripJsonRpcField(payload));
+    return new Promise<void>((resolve, reject) => {
+      socket.send(raw, (error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  const requester = client.timeout(REQUEST_TIMEOUT_MS, (id) =>
+    createJSONRPCErrorResponse(id, -32000, 'CDP request timed out.'),
+  );
+
+  const listeners = new Map<string, (params: unknown) => void>();
+
+  socket.on('message', (raw) => {
+    let message: unknown;
+    try {
+      message = JSON.parse(raw.toString());
+    } catch (error) {
+      client.rejectAllPendingRequests(
+        `Invalid CDP message: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      socket.close();
+      return;
+    }
+    if (!isObject(message)) return;
+
+    // Response to a request
+    if ('id' in message) {
+      client.receive(
+        message as unknown as Parameters<typeof client.receive>[0],
+      );
+      return;
+    }
+
+    // Event notification
+    const method = message.method;
+    if (typeof method === 'string') {
+      listeners.get(method)?.(message.params);
+    }
+  });
+
+  socket.on('error', (error) => {
+    client.rejectAllPendingRequests(
+      error instanceof Error ? error.message : String(error),
+    );
+  });
+
+  socket.on('close', () => {
+    client.rejectAllPendingRequests('CDP websocket closed.');
+  });
+
+  // Wait for connection
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', () => resolve());
+    socket.once('error', (err) => reject(err));
+  });
+
+  return {
+    send: (method, params = {}) =>
+      Promise.resolve(requester.request(method, params, undefined)),
+    on: (method, handler) =>
+      listeners.set(method, handler as (params: unknown) => void),
+    close: () => {
+      client.rejectAllPendingRequests('CDP client closed.');
+      socket.close();
+    },
+  };
+};
+
+// ============================================================================
+// Expression Evaluation
+// ============================================================================
+
+type RemoteObject = {
+  type?: string;
+  subtype?: string;
+  value?: unknown;
+  description?: string;
+  objectId?: string;
+};
+
+type PropertyDescriptor = {
+  name?: string;
+  value?: RemoteObject;
+};
+
+/**
+ * Evaluate expressions on a paused call frame.
+ * For objects, fetches shallow properties to provide useful debug output.
+ */
+export const evaluateExpressions = async ({
+  cdp,
+  callFrameId,
+  expressions,
+}: {
+  cdp: CdpClient;
+  callFrameId: string;
+  expressions: string[];
+}): Promise<EvaluatedValue[]> => {
+  return Promise.all(
+    expressions.map(async (expression) => {
+      const result = await cdp.send<{ result?: RemoteObject }>(
+        'Debugger.evaluateOnCallFrame',
+        { callFrameId, expression },
+      );
+      const payload = result?.result;
+      let value = payload?.value;
+      const type = payload?.type;
+      const subtype = payload?.subtype;
+      const preview = payload?.description;
+
+      // For objects without a primitive value, fetch shallow properties
+      if (value === undefined && payload?.objectId) {
+        try {
+          const properties = await cdp.send<{ result?: PropertyDescriptor[] }>(
+            'Runtime.getProperties',
+            { objectId: payload.objectId, ownProperties: true },
+          );
+          const shallow: Record<string, unknown> = {};
+          for (const prop of properties?.result || []) {
+            if (!prop?.name || prop?.value == null) continue;
+            const propVal = prop.value;
+            shallow[prop.name] =
+              propVal.value ?? propVal.description ?? propVal.type;
+          }
+          value = shallow;
+        } catch {
+          value = preview;
+        }
+      }
+
+      return {
+        expression,
+        value,
+        type,
+        subtype,
+        preview,
+      } satisfies EvaluatedValue;
+    }),
+  );
+};

--- a/packages/skill-cdp/src/cli.ts
+++ b/packages/skill-cdp/src/cli.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runCli } from './index';
+
+void runCli();

--- a/packages/skill-cdp/src/index.ts
+++ b/packages/skill-cdp/src/index.ts
@@ -1,0 +1,210 @@
+import type { ChildProcess } from 'node:child_process';
+import { cac } from 'cac';
+import {
+  createOutputWriter,
+  loadPlan,
+  normalizeRunnerArgs,
+  parseCliOptions,
+  spawnRunner,
+  waitForInspectorUrl,
+} from './plan';
+import { createCdpClient, DebugSession } from './session';
+import type { CdpClient, DebugResult, RunnerConfig } from './types';
+
+/** Wait for child process to exit with timeout */
+const waitForExit = (
+  child: ChildProcess,
+  timeoutMs = 5000,
+): Promise<number | null> => {
+  return new Promise((resolve) => {
+    if (child.exitCode != null) {
+      resolve(child.exitCode);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      child.off('exit', onExit);
+      resolve(null);
+    }, timeoutMs);
+    const onExit = (code: number | null) => {
+      clearTimeout(timeout);
+      resolve(code);
+    };
+    child.once('exit', onExit);
+  });
+};
+
+// ============================================================================
+// CLI Argument Parsing
+// ============================================================================
+
+type ParsedArgs = {
+  options: Record<string, unknown>;
+  positional: string[];
+  shouldExit: boolean;
+};
+
+const parseArgs = (argv: string[]): ParsedArgs => {
+  const cli = cac('rstest-cdp');
+
+  cli.option('-p, --plan <path>', 'Path to plan JSON file (or "-" for stdin)');
+  cli.option(
+    '--output <path>',
+    'Write JSON output to file (or "-" for stdout)',
+  );
+  cli.option(
+    '--breakpoint-timeout <ms>',
+    'Timeout for resolving breakpoints (default: 20000)',
+  );
+  cli.option(
+    '--inactivity-timeout <ms>',
+    'Timeout between breakpoint hits (default: 40000)',
+  );
+  cli.option('--debug', 'Enable debug logging');
+
+  cli.help();
+  cli.globalCommand.allowUnknownOptions();
+
+  // Normalize `--plan -` and `--output -` so stdin/stdout markers survive parsing
+  // (cac/mri may drop standalone `-` tokens)
+  const normalizedArgv: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token) continue;
+    if ((token === '--plan' || token === '-p') && argv[i + 1] === '-') {
+      normalizedArgv.push('--plan=-');
+      i += 1;
+      continue;
+    }
+    if (token === '--output' && argv[i + 1] === '-') {
+      normalizedArgv.push('--output=-');
+      i += 1;
+      continue;
+    }
+    normalizedArgv.push(token);
+  }
+
+  const parsed = cli.parse(normalizedArgv, { run: false });
+
+  if (parsed.options.help) {
+    cli.outputHelp();
+    return { options: {}, positional: [], shouldExit: true };
+  }
+
+  return {
+    options: parsed.options as Record<string, unknown>,
+    positional: Array.from(parsed.args),
+    shouldExit: false,
+  };
+};
+
+// ============================================================================
+// Main Entry Point
+// ============================================================================
+
+export const runCli = async (): Promise<void> => {
+  const parsedArgs = parseArgs(process.argv);
+  if (parsedArgs.shouldExit) return;
+
+  const options = parseCliOptions(parsedArgs.options);
+  const output = createOutputWriter(options.outputPath);
+
+  const debugLog = (...args: unknown[]) => {
+    if (options.debug) {
+      console.error('[rstest-cdp]', ...args);
+    }
+  };
+
+  /** Write failure result and clean up */
+  const writeFailure = (error: string, runner?: RunnerConfig): void => {
+    const failure: DebugResult = {
+      status: 'failed',
+      results: [],
+      errors: [{ error }],
+      // Only include meta in debug mode when runner info is available
+      ...(options.debug &&
+        runner && {
+          meta: {
+            runner,
+            forwardedArgs: [runner.cmd, ...runner.args],
+            pendingTaskIds: [],
+            mappingDiagnostics: [],
+          },
+        }),
+    };
+    output.write(failure);
+  };
+
+  let child: ChildProcess | null = null;
+  let cdp: CdpClient | null = null;
+  let isCleaningUp = false;
+
+  /** Cleanup resources on exit */
+  const cleanup = async () => {
+    if (isCleaningUp) return;
+    isCleaningUp = true;
+    cdp?.close();
+    if (child && child.exitCode == null) {
+      child.kill('SIGTERM');
+      await waitForExit(child);
+    }
+  };
+
+  // Handle termination signals
+  const onSignal = () => {
+    debugLog('received termination signal, cleaning up...');
+    cleanup().then(() => process.exit(1));
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+
+  try {
+    const plan = await loadPlan(options.planPath);
+
+    // Normalize runner args (enforce single worker, inspector, etc.)
+    const normalizedRunner = normalizeRunnerArgs(plan.runner.args);
+    if (normalizedRunner.error) {
+      writeFailure(normalizedRunner.error, plan.runner);
+      return;
+    }
+    plan.runner.args = normalizedRunner.args;
+
+    const tasks = plan.tasks;
+
+    if (!tasks.length) {
+      writeFailure('No tasks matched the filter.', plan.runner);
+      return;
+    }
+
+    // Spawn runner process
+    child = spawnRunner(plan.runner);
+
+    // Forward runner output to stderr so stdout stays valid JSON
+    child.stdout?.on('data', (chunk) => process.stderr.write(chunk));
+    child.stderr?.on('data', (chunk) => process.stderr.write(chunk));
+
+    // Wait for inspector to be ready
+    const wsUrl = await waitForInspectorUrl(child);
+    debugLog('inspector url', wsUrl);
+
+    // Connect CDP and start debug session
+    cdp = await createCdpClient(wsUrl);
+
+    const session = new DebugSession({
+      plan,
+      options,
+      tasks,
+      cdp,
+      runnerProcess: child,
+      output,
+      debugLog,
+    });
+    session.start();
+
+    child.on('exit', (code) => session.onRunnerExit(code));
+    await session.enableAndRun();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeFailure(message);
+    await cleanup();
+  }
+};

--- a/packages/skill-cdp/src/plan.ts
+++ b/packages/skill-cdp/src/plan.ts
@@ -1,0 +1,305 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as v from 'valibot';
+import { PlanInputSchema } from './schema';
+import type { DebugResult, Plan, RunnerConfig, TaskDefinition } from './types';
+
+// ============================================================================
+// CLI Options
+// ============================================================================
+
+export type CliOptions = {
+  planPath?: string;
+  outputPath?: string;
+  breakpointTimeout?: number;
+  inactivityTimeout?: number;
+  debug: boolean;
+};
+
+const readStringOption = (
+  options: Record<string, unknown>,
+  keys: string[],
+): string | undefined => {
+  for (const key of keys) {
+    const value = options[key];
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' && Number.isFinite(value))
+      return String(value);
+  }
+  return undefined;
+};
+
+const readBooleanOption = (
+  options: Record<string, unknown>,
+  keys: string[],
+): boolean => {
+  for (const key of keys) {
+    const value = options[key];
+    if (typeof value === 'boolean') return value;
+    if (value === '1' || value === 'true') return true;
+    if (value === '0' || value === 'false') return false;
+  }
+  return false;
+};
+
+const readNumberOption = (
+  options: Record<string, unknown>,
+  keys: string[],
+): number | undefined => {
+  for (const key of keys) {
+    const value = options[key];
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    }
+  }
+  return undefined;
+};
+
+export const parseCliOptions = (
+  options: Record<string, unknown>,
+): CliOptions => ({
+  planPath: readStringOption(options, ['plan', 'p']),
+  outputPath: readStringOption(options, ['output']),
+  breakpointTimeout: readNumberOption(options, ['breakpointTimeout']),
+  inactivityTimeout: readNumberOption(options, ['inactivityTimeout']),
+  debug: readBooleanOption(options, ['debug']),
+});
+
+// ============================================================================
+// Plan Loading
+// ============================================================================
+
+const readStdin = async (): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => {
+      buffer += chunk;
+    });
+    process.stdin.on('end', () => resolve(buffer));
+    process.stdin.on('error', reject);
+  });
+};
+
+export const loadPlan = async (planPath?: string): Promise<Plan> => {
+  if (!planPath) {
+    throw new Error('Missing required --plan <path>');
+  }
+  const content =
+    planPath === '-'
+      ? await readStdin()
+      : await fs.promises.readFile(path.resolve(planPath), 'utf-8');
+  if (!content.trim()) {
+    throw new Error(
+      planPath === '-'
+        ? 'Empty plan received on stdin.'
+        : 'Plan file is empty.',
+    );
+  }
+  const parsed = v.safeParse(PlanInputSchema, JSON.parse(content) as unknown);
+  if (!parsed.success) {
+    const messages = (
+      parsed.issues as Array<{
+        message?: string;
+        path?: Array<{ key?: string | number }>;
+      }>
+    )
+      .map((issue) => {
+        const keyPath = (issue.path ?? [])
+          .map((item) => item?.key)
+          .filter(
+            (key): key is string | number =>
+              typeof key === 'string' || typeof key === 'number',
+          )
+          .map(String)
+          .join('.');
+        const message = issue.message ?? 'Invalid value.';
+        return keyPath ? `${keyPath}: ${message}` : message;
+      })
+      .filter(Boolean);
+
+    throw new Error(
+      messages.length
+        ? `Invalid plan schema.\n${messages.join('\n')}`
+        : 'Invalid plan schema.',
+    );
+  }
+
+  return normalizePlan(parsed.output);
+};
+
+const normalizePlan = (plan: v.InferOutput<typeof PlanInputSchema>): Plan => {
+  const runner: RunnerConfig = {
+    cmd: plan.runner.cmd,
+    args: [...plan.runner.args],
+    cwd: plan.runner.cwd,
+    env: plan.runner.env ?? {},
+  };
+
+  const tasks: TaskDefinition[] = plan.tasks.map(
+    (task: (typeof plan.tasks)[number], index: number) => {
+      const providedId = typeof task.id === 'string' ? task.id.trim() : '';
+      const id = providedId || `task-${index + 1}`;
+      return {
+        ...task,
+        id,
+        // Derived defaults.
+        order: Number.isFinite(task.order) ? task.order : index,
+        hits: Number.isFinite(task.hits) ? task.hits : 0,
+      };
+    },
+  );
+
+  return { runner, tasks };
+};
+
+// ============================================================================
+// Runner Args Normalization
+// ============================================================================
+
+export type NormalizedRunnerArgs = { args: string[]; error?: string };
+
+/**
+ * Normalize runner args to ensure:
+ * - Exactly one `--include <file>` is present
+ * - Debug-related flags are stripped (will be re-added with correct values)
+ * - Single worker mode is enforced for deterministic debugging
+ */
+export const normalizeRunnerArgs = (args: string[]): NormalizedRunnerArgs => {
+  const normalized: string[] = [];
+  let includeCount = 0;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const value = args[i];
+    if (!value) continue;
+
+    // Count --include occurrences
+    if (value === '--include') {
+      const next = args[i + 1];
+      if (!next || next.startsWith('-')) {
+        return {
+          args: normalized,
+          error: 'Runner args must include exactly one "--include <file>".',
+        };
+      }
+      includeCount += 1;
+      normalized.push(value, next);
+      i += 1;
+      continue;
+    }
+    if (value.startsWith('--include=')) {
+      includeCount += 1;
+      normalized.push(value);
+      continue;
+    }
+
+    // Strip flags that will be overridden
+    if (
+      value === '--pool.maxWorkers' ||
+      value === '--pool.execArgv' ||
+      value === '--maxWorkers'
+    ) {
+      i += 1; // Skip next argument (the value)
+      continue;
+    }
+    if (
+      value.startsWith('--pool.maxWorkers=') ||
+      value.startsWith('--pool.execArgv=') ||
+      value.startsWith('--maxWorkers=')
+    ) {
+      continue;
+    }
+
+    // Strip inspect flags (will use --inspect-brk=0 via pool.execArgv)
+    if (value === '--inspect' || value === '--inspect-brk') {
+      const next = args[i + 1];
+      if (next && !next.startsWith('-')) i += 1;
+      continue;
+    }
+    if (value.startsWith('--inspect=') || value.startsWith('--inspect-brk=')) {
+      continue;
+    }
+
+    normalized.push(value);
+  }
+
+  if (includeCount !== 1) {
+    return {
+      args: normalized,
+      error:
+        includeCount === 0
+          ? 'Runner args must include exactly one "--include <file>".'
+          : 'Runner args must include exactly one "--include <file>" (multiple provided).',
+    };
+  }
+
+  // Force single worker and inspector for deterministic debugging
+  normalized.push('--pool.maxWorkers=1');
+  normalized.push('--pool.execArgv=--inspect-brk=0');
+
+  return { args: normalized };
+};
+
+// ============================================================================
+// Runner Process
+// ============================================================================
+
+export const spawnRunner = (runner: RunnerConfig): ChildProcess => {
+  return spawn(runner.cmd, runner.args, {
+    cwd: runner.cwd,
+    env: { ...process.env, ...runner.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+};
+
+export const waitForInspectorUrl = (child: ChildProcess): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    let output = '';
+    const onData = (data: Buffer) => {
+      output += data.toString();
+      const match = output.match(/Debugger listening on (ws:\/\/[^\s]+)/);
+      if (match?.[1]) {
+        child.stderr?.off('data', onData);
+        child.stdout?.off('data', onData);
+        resolve(match[1]);
+      }
+    };
+    child.stderr?.on('data', onData);
+    child.stdout?.on('data', onData);
+    child.on('exit', (code) => {
+      reject(new Error(`Runner exited before inspector ready (code: ${code})`));
+    });
+  });
+};
+
+// ============================================================================
+// Output Writer
+// ============================================================================
+
+export type OutputWriter = {
+  write(output: DebugResult): void;
+};
+
+export const createOutputWriter = (outputPath?: string): OutputWriter => {
+  const resolvedPath =
+    typeof outputPath === 'string' && outputPath !== '-'
+      ? path.resolve(outputPath)
+      : null;
+
+  return {
+    write: (output) => {
+      const payload = JSON.stringify(output, null, 2);
+      if (resolvedPath) {
+        fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+        fs.writeFileSync(resolvedPath, payload, 'utf-8');
+        return;
+      }
+      console.log(payload);
+    },
+  };
+};

--- a/packages/skill-cdp/src/schema.ts
+++ b/packages/skill-cdp/src/schema.ts
@@ -1,0 +1,146 @@
+import * as v from 'valibot';
+
+/**
+ * Plan schema (SSoT) for `--plan` input.
+ *
+ * Notes:
+ * - `tasks[].id` is optional on input; the CLI will assign `task-<n>`.
+ * - Some fields are derived at runtime (e.g. `order` defaults to task index).
+ */
+
+export type RunnerConfigInput = {
+  cmd: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+};
+
+export type RunnerConfigOutput = {
+  cmd: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+};
+
+export const RunnerConfigSchema: v.GenericSchema<
+  RunnerConfigInput,
+  RunnerConfigOutput
+> = v.object({
+  cmd: v.pipe(v.string(), v.description('Runner command. Example: "pnpm".')),
+  args: v.pipe(
+    v.array(v.string()),
+    v.description('Runner arguments. Example: ["rstest", "run", ...].'),
+  ),
+  cwd: v.pipe(
+    v.string(),
+    v.description('Working directory for the runner process.'),
+  ),
+  env: v.pipe(
+    v.fallback(v.optional(v.record(v.string(), v.string())), {}),
+    v.description('Environment variables passed to the runner. Default: {}.'),
+  ),
+});
+
+export type TaskDefinitionInput = {
+  id?: string;
+  description?: string;
+  sourcePath: string;
+  line: number;
+  column?: number;
+  expressions?: string[];
+  hitLimit?: number;
+  condition?: string;
+  order?: number;
+  hits?: number;
+};
+
+export type TaskDefinitionOutput = {
+  id?: string;
+  description?: string;
+  sourcePath: string;
+  line: number;
+  column?: number;
+  expressions?: string[];
+  hitLimit?: number;
+  condition?: string;
+  order?: number;
+  hits?: number;
+};
+
+export const TaskDefinitionInputSchema: v.GenericSchema<
+  TaskDefinitionInput,
+  TaskDefinitionOutput
+> = v.object({
+  id: v.pipe(
+    v.optional(v.string()),
+    v.description('Task id. If omitted, the CLI assigns "task-<n>".'),
+  ),
+  description: v.pipe(
+    v.optional(v.string()),
+    v.description('Human-readable task description.'),
+  ),
+  sourcePath: v.pipe(
+    v.string(),
+    v.description(
+      'Absolute source file path in the runner workspace. Used for sourcemap mapping.',
+    ),
+  ),
+  // 1-based
+  line: v.pipe(
+    v.pipe(v.number(), v.integer(), v.minValue(1)),
+    v.description('1-based line number in the source file.'),
+  ),
+  // 0-based
+  column: v.pipe(
+    v.fallback(v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))), 0),
+    v.description('0-based column number in the source file. Default: 0.'),
+  ),
+  expressions: v.pipe(
+    v.optional(v.array(v.string())),
+    v.description(
+      'Expressions to evaluate on the paused call frame when this breakpoint is hit.',
+    ),
+  ),
+  hitLimit: v.pipe(
+    v.fallback(v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))), 1),
+    v.description('Stop after this many hits. Default: 1.'),
+  ),
+  condition: v.pipe(
+    v.optional(v.string()),
+    v.description(
+      'Conditional breakpoint expression (evaluated by the debugger). The breakpoint pauses only when this evaluates to a truthy value.',
+    ),
+  ),
+  order: v.pipe(
+    v.optional(v.pipe(v.number(), v.integer())),
+    v.description('Optional ordering hint (lower values run first).'),
+  ),
+  hits: v.pipe(
+    v.fallback(v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))), 0),
+    v.description('Internal hit counter. Default: 0.'),
+  ),
+});
+
+export type PlanInput = {
+  runner: RunnerConfigInput;
+  tasks: TaskDefinitionInput[];
+};
+
+export type PlanOutput = {
+  runner: RunnerConfigOutput;
+  tasks: TaskDefinitionOutput[];
+};
+
+export const PlanInputSchema: v.GenericSchema<PlanInput, PlanOutput> = v.pipe(
+  v.object({
+    runner: v.pipe(
+      RunnerConfigSchema,
+      v.description('Runner configuration used to execute the test command.'),
+    ),
+    tasks: v.pipe(
+      v.pipe(v.array(TaskDefinitionInputSchema), v.nonEmpty()),
+      v.description('List of breakpoint tasks. Must be non-empty.'),
+    ),
+  }),
+  v.description('Plan JSON passed to the CLI via --plan <path|->.'),
+);

--- a/packages/skill-cdp/src/session.ts
+++ b/packages/skill-cdp/src/session.ts
@@ -1,0 +1,440 @@
+import type { ChildProcess } from 'node:child_process';
+import { createCdpClient, evaluateExpressions } from './cdp';
+import type { CliOptions, OutputWriter } from './plan';
+import { resolveBreakpoint } from './sourcemap';
+import type {
+  CdpClient,
+  DebugResult,
+  DebugStatus,
+  ExecutionError,
+  MappingDiagnostics,
+  Plan,
+  TaskDefinition,
+} from './types';
+import {
+  DEFAULT_BREAKPOINT_RESOLVE_TIMEOUT_MS,
+  DEFAULT_INACTIVITY_TIMEOUT_MS,
+  MAX_DEBUG_MAPPING,
+  MAX_DEBUG_SCRIPTS,
+  MAX_MAPPING_DIAGNOSTICS,
+} from './types';
+
+// ============================================================================
+// Debug Session
+// ============================================================================
+
+const readWorkspacePath = (filePath: string, rootPath: string) =>
+  filePath.replace(rootPath, '').replace(/^\//, '').replace(/\\/g, '/');
+
+export type DebugSessionContext = {
+  plan: Plan;
+  options: CliOptions;
+  tasks: TaskDefinition[];
+  cdp: CdpClient;
+  runnerProcess: ChildProcess;
+  output: OutputWriter;
+  debugLog: (...args: unknown[]) => void;
+};
+
+type DebuggerScriptParsedParams = { scriptId: string; url?: string };
+type DebuggerPausedParams = {
+  callFrames?: Array<{ callFrameId: string }>;
+  hitBreakpoints?: string[];
+  reason?: string;
+  data?: { scriptId?: string; url?: string };
+};
+
+export class DebugSession {
+  private readonly plan: Plan;
+  private readonly options: CliOptions;
+  private readonly cdp: CdpClient;
+  private readonly runnerProcess: ChildProcess;
+  private readonly output: OutputWriter;
+  private readonly debugLog: (...args: unknown[]) => void;
+
+  private readonly remaining: TaskDefinition[];
+  private readonly results: DebugResult['results'] = [];
+  private readonly errors: ExecutionError[] = [];
+  private readonly mappingDiagnostics: MappingDiagnostics[] = [];
+
+  private readonly scripts = new Set<string>();
+  private readonly triedScripts = new Set<string>();
+  private readonly breakpoints = new Map<string, TaskDefinition>();
+
+  private finished = false;
+  private breakpointTimeout: ReturnType<typeof setTimeout> | null = null;
+  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private pausedOnce = false;
+
+  private scriptCount = 0;
+
+  /**
+   * Map of scriptId -> Promise that resolves when the script has been processed
+   * for breakpoint resolution. This is used to coordinate between scriptParsed
+   * and instrumentation pause events, which can fire in either order.
+   */
+  private readonly scriptProcessed = new Map<string, Promise<void>>();
+  private readonly scriptProcessedResolvers = new Map<string, () => void>();
+
+  /**
+   * Get or create a Promise for tracking when a script has been processed.
+   * This method is safe to call from either onScriptParsed or onPaused,
+   * regardless of which fires first.
+   */
+  private getOrCreateScriptPromise(scriptId: string): Promise<void> {
+    const existing = this.scriptProcessed.get(scriptId);
+    if (existing) {
+      return existing;
+    }
+    let resolver: () => void;
+    const promise = new Promise<void>((resolve) => {
+      resolver = resolve;
+    });
+    this.scriptProcessed.set(scriptId, promise);
+    this.scriptProcessedResolvers.set(scriptId, resolver!);
+    return promise;
+  }
+
+  /**
+   * Mark a script as processed (resolve its Promise).
+   * If the Promise doesn't exist yet, create it first then resolve.
+   */
+  private markScriptProcessed(scriptId: string): void {
+    // Ensure the Promise exists (in case onPaused hasn't created it yet)
+    if (!this.scriptProcessed.has(scriptId)) {
+      this.getOrCreateScriptPromise(scriptId);
+    }
+    const resolver = this.scriptProcessedResolvers.get(scriptId);
+    if (resolver) {
+      resolver();
+    }
+  }
+
+  constructor(ctx: DebugSessionContext) {
+    this.plan = ctx.plan;
+    this.options = ctx.options;
+    this.cdp = ctx.cdp;
+    this.runnerProcess = ctx.runnerProcess;
+    this.output = ctx.output;
+    this.debugLog = ctx.debugLog;
+    this.remaining = [...ctx.tasks];
+  }
+
+  /** Start listening for CDP events and set up timeout */
+  start(): void {
+    this.cdp.on<DebuggerScriptParsedParams>(
+      'Debugger.scriptParsed',
+      (params) => void this.onScriptParsed(params),
+    );
+    this.cdp.on<DebuggerPausedParams>(
+      'Debugger.paused',
+      (params) => void this.onPaused(params),
+    );
+
+    const breakpointTimeoutMs =
+      this.options.breakpointTimeout ?? DEFAULT_BREAKPOINT_RESOLVE_TIMEOUT_MS;
+    this.breakpointTimeout = setTimeout(() => {
+      if (!this.breakpoints.size && this.remaining.length) {
+        this.errors.push({ error: 'No breakpoints resolved for tasks.' });
+        this.finalize(this.runnerProcess.exitCode);
+        this.cdp.close();
+      }
+    }, breakpointTimeoutMs);
+  }
+
+  /** Enable debugger and start execution */
+  async enableAndRun(): Promise<void> {
+    await this.cdp.send('Runtime.enable');
+    await this.cdp.send('Debugger.enable');
+    // Set instrumentation breakpoint to pause before each script execution
+    // This ensures we can set breakpoints before the script runs
+    try {
+      await this.cdp.send('Debugger.setInstrumentationBreakpoint', {
+        instrumentation: 'beforeScriptExecution',
+      });
+      this.debugLog('instrumentation breakpoint set: beforeScriptExecution');
+    } catch (error) {
+      this.debugLog(
+        'failed to set instrumentation breakpoint:',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    await this.cdp.send('Runtime.runIfWaitingForDebugger');
+  }
+
+  /** Handle runner process exit */
+  onRunnerExit(code: number | null): void {
+    if (!this.finished) {
+      this.finalize(code);
+    }
+    this.cdp.close();
+  }
+
+  // --------------------------------------------------------------------------
+  // Private methods
+  // --------------------------------------------------------------------------
+
+  private finalize(exitCode: number | null): void {
+    if (this.finished) return;
+    this.finished = true;
+    this.clearTimers();
+
+    // Determine status based on results and remaining tasks
+    let status: DebugStatus;
+    if (this.results.length === 0) {
+      status = 'failed';
+    } else if (this.remaining.length === 0) {
+      status = 'full_succeed';
+    } else {
+      status = 'partial_succeed';
+    }
+
+    const output: DebugResult = {
+      status,
+      exitCode,
+      results: this.results,
+      errors: this.errors,
+      // Only include meta in debug mode - it's diagnostic info not needed for normal use
+      ...(this.options.debug && {
+        meta: {
+          runner: this.plan.runner,
+          forwardedArgs: [this.plan.runner.cmd, ...this.plan.runner.args],
+          pendingTaskIds: this.remaining.map((t) => t.id),
+          mappingDiagnostics: this.mappingDiagnostics,
+        },
+      }),
+    };
+    this.output.write(output);
+
+    if (status === 'failed' && this.runnerProcess.exitCode == null) {
+      this.runnerProcess.kill('SIGTERM');
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.breakpointTimeout) {
+      clearTimeout(this.breakpointTimeout);
+      this.breakpointTimeout = null;
+    }
+    if (this.inactivityTimer) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
+  }
+
+  private resetInactivityTimer(): void {
+    if (this.inactivityTimer) clearTimeout(this.inactivityTimer);
+    const inactivityTimeoutMs =
+      this.options.inactivityTimeout ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+    this.inactivityTimer = setTimeout(() => {
+      this.errors.push({ error: 'Timeout waiting for breakpoint hits.' });
+      this.finalize(this.runnerProcess.exitCode);
+      this.cdp.close();
+    }, inactivityTimeoutMs);
+  }
+
+  private async onScriptParsed(
+    params: DebuggerScriptParsedParams,
+  ): Promise<void> {
+    if (!params?.scriptId || this.scripts.has(params.scriptId)) return;
+    this.scripts.add(params.scriptId);
+    this.scriptCount += 1;
+
+    if (this.options.debug && this.scriptCount <= MAX_DEBUG_SCRIPTS) {
+      this.debugLog('scriptParsed', params.scriptId, params.url || '');
+    }
+
+    // Skip internal Node.js scripts
+    if (params.url?.startsWith('node:')) {
+      this.markScriptProcessed(params.scriptId);
+      return;
+    }
+
+    const tasksToResolve = this.remaining.filter(
+      (task) => !this.triedScripts.has(`${params.scriptId}:${task.id}`),
+    );
+
+    await Promise.all(
+      tasksToResolve.map(async (task) => {
+        this.triedScripts.add(`${params.scriptId}:${task.id}`);
+        const resolution = await resolveBreakpoint({
+          cdp: this.cdp,
+          scriptId: params.scriptId,
+          url: params.url,
+          task,
+          rootDir: this.plan.runner.cwd,
+        });
+
+        if (this.mappingDiagnostics.length < MAX_MAPPING_DIAGNOSTICS) {
+          this.mappingDiagnostics.push(resolution.diagnostics);
+        }
+
+        if (!resolution.location) {
+          if (
+            this.options.debug &&
+            this.mappingDiagnostics.length <= MAX_DEBUG_MAPPING
+          ) {
+            this.debugLog('mapping', resolution.diagnostics);
+          }
+          return;
+        }
+
+        try {
+          const result = await this.cdp.send<{ breakpointId: string }>(
+            'Debugger.setBreakpoint',
+            {
+              location: resolution.location,
+              ...(task.condition ? { condition: task.condition } : {}),
+            },
+          );
+          this.breakpoints.set(result.breakpointId, task);
+          this.debugLog(
+            `breakpoint set for ${task.id} at ${resolution.location.scriptId}`,
+            `${resolution.location.lineNumber}:${resolution.location.columnNumber}`,
+          );
+          if (this.breakpointTimeout) {
+            clearTimeout(this.breakpointTimeout);
+            this.breakpointTimeout = null;
+          }
+        } catch (error) {
+          this.errors.push({
+            taskId: task.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }),
+    );
+
+    // Mark this script as processed so instrumentation pause can resume
+    this.markScriptProcessed(params.scriptId);
+  }
+
+  private async onPaused(params: DebuggerPausedParams): Promise<void> {
+    // Skip if session already finished (WebSocket may be closing/closed)
+    if (this.finished) {
+      this.debugLog('onPaused skipped (session finished)');
+      return;
+    }
+
+    this.debugLog('onPaused', {
+      reason: params.reason,
+      pausedOnce: this.pausedOnce,
+      hitBreakpoints: params.hitBreakpoints,
+      breakpointCount: this.breakpoints.size,
+      breakpointIds: Array.from(this.breakpoints.keys()),
+      data: params.data,
+    });
+
+    // Handle instrumentation breakpoints (beforeScriptExecution)
+    // These fire before each script runs, giving us a chance to set breakpoints
+    if (params.reason === 'instrumentation') {
+      const scriptId = params.data?.scriptId;
+      if (scriptId) {
+        // Wait for the scriptParsed handler to finish processing this script
+        // This ensures breakpoints are set before the script executes
+        // Note: getOrCreateScriptPromise handles the race condition where
+        // onPaused may fire before onScriptParsed
+        const processedPromise = this.getOrCreateScriptPromise(scriptId);
+        await processedPromise;
+        // Check again after await - session may have finished while waiting
+        if (this.finished) {
+          this.debugLog('onPaused skipped after wait (session finished)');
+          return;
+        }
+        this.debugLog('script processed, resuming', scriptId);
+      }
+      // After all breakpoints are set, disable instrumentation to avoid performance hit
+      if (this.breakpoints.size >= this.remaining.length) {
+        try {
+          await this.cdp.send('Debugger.removeInstrumentationBreakpoint', {
+            instrumentation: 'beforeScriptExecution',
+          });
+          this.debugLog('instrumentation breakpoint removed');
+        } catch (error) {
+          this.debugLog(
+            'failed to remove instrumentation breakpoint:',
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      }
+      try {
+        await this.cdp.send('Debugger.resume');
+      } catch (error) {
+        this.debugLog(
+          'failed to resume after instrumentation:',
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      return;
+    }
+
+    // First pause (from --inspect-brk): just resume, instrumentation breakpoint will handle the rest
+    if (!this.pausedOnce) {
+      this.pausedOnce = true;
+      this.debugLog('first pause resume (instrumentation enabled)');
+      await this.cdp.send('Debugger.resume');
+      if (this.breakpoints.size) this.resetInactivityTimer();
+      return;
+    }
+
+    this.resetInactivityTimer();
+
+    const frame = params.callFrames?.[0];
+    const hitBreakpointId = params.hitBreakpoints?.[0];
+    this.debugLog('breakpoint hit check', { frame: !!frame, hitBreakpointId });
+    if (!frame || !hitBreakpointId) {
+      await this.cdp.send('Debugger.resume');
+      return;
+    }
+
+    const task = this.breakpoints.get(hitBreakpointId);
+    if (!task) {
+      await this.cdp.send('Debugger.resume');
+      return;
+    }
+
+    // Determine expressions to evaluate
+    const expressions = task.expressions?.length ? task.expressions : [];
+    if (!expressions.length) {
+      this.errors.push({ taskId: task.id, error: 'No expressions specified.' });
+      await this.cdp.send('Debugger.resume');
+      return;
+    }
+
+    // Evaluate and record result
+    const evaluated = await evaluateExpressions({
+      cdp: this.cdp,
+      callFrameId: frame.callFrameId,
+      expressions,
+    });
+
+    this.results.push({
+      id: task.id,
+      description: task.description,
+      sourcePath: readWorkspacePath(task.sourcePath, this.plan.runner.cwd),
+      line: task.line,
+      column: task.column ?? 0,
+      values: evaluated,
+    });
+
+    // Track hits and remove completed tasks
+    task.hits = (task.hits ?? 0) + 1;
+    if (task.hits >= (task.hitLimit ?? 1)) {
+      const index = this.remaining.findIndex((t) => t.id === task.id);
+      if (index >= 0) this.remaining.splice(index, 1);
+      this.breakpoints.forEach((value, key) => {
+        if (value.id === task.id) this.breakpoints.delete(key);
+      });
+    }
+
+    await this.cdp.send('Debugger.resume');
+    if (!this.remaining.length) {
+      this.finalize(this.runnerProcess.exitCode);
+      this.cdp.close();
+    }
+  }
+}
+
+// Re-export for index.ts
+export { createCdpClient };

--- a/packages/skill-cdp/src/sourcemap.ts
+++ b/packages/skill-cdp/src/sourcemap.ts
@@ -1,0 +1,210 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  GREATEST_LOWER_BOUND,
+  generatedPositionFor,
+  LEAST_UPPER_BOUND,
+  TraceMap,
+} from '@jridgewell/trace-mapping';
+import type { CdpClient, MappingDiagnostics, TaskDefinition } from './types';
+
+// ============================================================================
+// Source Map Resolution
+// ============================================================================
+
+const INLINE_SOURCEMAP_REGEX =
+  /\/\/[#@]\s*sourceMappingURL=data:application\/json(?:;charset=[^;]+)?;base64,([^\s]+)/;
+const FILE_SOURCEMAP_REGEX = /\/\/[#@]\s*sourceMappingURL=([^\s]+)/;
+
+const normalizePath = (value: string) => value.replace(/\\/g, '/');
+
+/**
+ * Normalize source paths from sourcemaps.
+ * Handles webpack/rspack prefixes like:
+ * - webpack:///./src/foo.ts
+ * - webpack://<project>/./src/foo.ts
+ */
+const normalizeMapSourcePath = (value: string) => {
+  if (!value) return '';
+  if (value.startsWith('file://')) {
+    try {
+      return normalizePath(fileURLToPath(value));
+    } catch {
+      // fall through
+    }
+  }
+  let source = normalizePath(value);
+  source = source.replace(/^[a-zA-Z]+:\/\/\/+/, '');
+  const firstSlash = source.indexOf('/');
+  if (firstSlash >= 0) source = source.slice(firstSlash + 1);
+  source = source.replace(/^\.(\/|\\)/, '');
+  return source;
+};
+
+const matchesSource = (source: string, target: string, rootDir?: string) => {
+  const sourceValue = normalizeMapSourcePath(source);
+  const targetValue = normalizePath(target);
+  const targetRelative = rootDir
+    ? normalizePath(path.relative(rootDir, targetValue))
+    : '';
+  const candidates = [targetValue, targetRelative].filter(Boolean);
+  const targetBase = path.posix.basename(targetValue);
+
+  return (
+    candidates.some(
+      (c) =>
+        sourceValue === c || sourceValue.endsWith(c) || c.endsWith(sourceValue),
+    ) ||
+    (targetBase && sourceValue.endsWith(`/${targetBase}`)) ||
+    sourceValue === targetBase
+  );
+};
+
+/** Try line and adjacent lines to handle minification offset */
+const hintTaskLines = (task: TaskDefinition) =>
+  [task.line, task.line - 1, task.line + 1].filter((v) => v > 0);
+
+const parseSourceMap = (source: string, scriptUrl?: string) => {
+  // Inline base64 sourcemap
+  const inlineMatch = source.match(INLINE_SOURCEMAP_REGEX);
+  if (inlineMatch?.[1]) {
+    const json = Buffer.from(inlineMatch[1], 'base64').toString('utf-8');
+    return JSON.parse(json);
+  }
+  // External sourcemap file
+  const fileMatch = source.match(FILE_SOURCEMAP_REGEX);
+  if (!fileMatch?.[1] || !scriptUrl?.startsWith('file://')) return null;
+  const scriptPath = fileURLToPath(scriptUrl);
+  const mapPath = path.resolve(path.dirname(scriptPath), fileMatch[1]);
+  return JSON.parse(readFileSync(mapPath, 'utf-8'));
+};
+
+export type BreakpointResolution = {
+  location: {
+    scriptId: string;
+    lineNumber: number;
+    columnNumber: number;
+  } | null;
+  diagnostics: MappingDiagnostics;
+};
+
+export const resolveBreakpoint = async ({
+  cdp,
+  scriptId,
+  url,
+  task,
+  rootDir,
+}: {
+  cdp: CdpClient;
+  scriptId: string;
+  url?: string;
+  task: TaskDefinition;
+  rootDir?: string;
+}): Promise<BreakpointResolution> => {
+  try {
+    const { scriptSource } = await cdp.send<{ scriptSource: string }>(
+      'Debugger.getScriptSource',
+      { scriptId },
+    );
+    const sourceMap = parseSourceMap(scriptSource, url);
+    if (!sourceMap) {
+      return {
+        location: null,
+        diagnostics: {
+          scriptId,
+          url,
+          taskId: task.id,
+          reason: 'no-sourcemap',
+          hasSourceMapComment: FILE_SOURCEMAP_REGEX.test(scriptSource),
+        },
+      };
+    }
+
+    const traceMap = new TraceMap(sourceMap);
+    const matchedSource = traceMap.sources.find(
+      (s) => s && matchesSource(s, task.sourcePath, rootDir),
+    );
+    if (!matchedSource) {
+      return {
+        location: null,
+        diagnostics: {
+          scriptId,
+          url,
+          taskId: task.id,
+          reason: 'source-mismatch',
+          sourcesSample: traceMap.sources
+            .filter((s): s is string => Boolean(s))
+            .slice(0, 3),
+        },
+      };
+    }
+
+    // Try multiple column/line combinations to find a valid mapping
+    const columns = [task.column ?? 0, 0, Math.max((task.column ?? 0) - 1, 0)];
+    let generated: { line: number; column: number } | null = null;
+
+    outer: for (const col of columns) {
+      for (const line of hintTaskLines(task)) {
+        const primary = generatedPositionFor(traceMap, {
+          source: matchedSource,
+          line,
+          column: col,
+          bias: GREATEST_LOWER_BOUND,
+        });
+        const fallback = generatedPositionFor(traceMap, {
+          source: matchedSource,
+          line,
+          column: col,
+          bias: LEAST_UPPER_BOUND,
+        });
+        const resolved = primary?.line ? primary : fallback;
+        if (resolved?.line) {
+          generated = { line: resolved.line, column: resolved.column };
+          break outer;
+        }
+      }
+    }
+
+    if (!generated?.line || generated.column == null) {
+      return {
+        location: null,
+        diagnostics: {
+          scriptId,
+          url,
+          taskId: task.id,
+          reason: 'generated-position-missing',
+          matchedSource,
+        },
+      };
+    }
+
+    return {
+      location: {
+        scriptId,
+        lineNumber: generated.line - 1, // CDP uses 0-based line numbers
+        columnNumber: generated.column,
+      },
+      diagnostics: {
+        scriptId,
+        url,
+        taskId: task.id,
+        reason: 'ok',
+        matchedSource,
+        generatedLine: generated.line,
+        generatedColumn: generated.column,
+      },
+    };
+  } catch (error) {
+    return {
+      location: null,
+      diagnostics: {
+        scriptId,
+        url,
+        taskId: task.id,
+        reason: 'script-error',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+};

--- a/packages/skill-cdp/src/types.ts
+++ b/packages/skill-cdp/src/types.ts
@@ -1,0 +1,126 @@
+// ============================================================================
+// Types
+// ============================================================================
+
+export type Plan = {
+  runner: RunnerConfig;
+  tasks: TaskDefinition[];
+};
+
+export type RunnerConfig = {
+  cmd: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+};
+
+export type TaskDefinition = {
+  id: string;
+  description?: string;
+  sourcePath: string;
+  /** 1-based line number */
+  line: number;
+  /** 0-based column number */
+  column?: number;
+  expressions?: string[];
+  hitLimit?: number;
+  condition?: string;
+  order?: number;
+  hits?: number;
+};
+
+export type TaskResult = {
+  id: string;
+  description?: string;
+  sourcePath: string;
+  line: number;
+  column: number;
+  values: EvaluatedValue[];
+};
+
+export type EvaluatedValue = {
+  expression: string;
+  value: unknown;
+  type?: string;
+  subtype?: string;
+  preview?: string;
+};
+
+export type MappingDiagnostics = {
+  scriptId: string;
+  url?: string;
+  taskId: string;
+  reason:
+    | 'ok'
+    | 'no-sourcemap'
+    | 'source-mismatch'
+    | 'generated-position-missing'
+    | 'script-error';
+  hasSourceMapComment?: boolean;
+  sourcesSample?: string[];
+  matchedSource?: string;
+  generatedLine?: number;
+  generatedColumn?: number;
+  error?: string;
+};
+
+export type ExecutionError = {
+  taskId?: string;
+  error: string;
+};
+
+/**
+ * - 'full_succeed': All tasks completed (all hitLimits reached)
+ * - 'partial_succeed': Some results collected, but not all tasks completed
+ * - 'failed': No results collected (e.g., no breakpoints resolved, runner crashed)
+ */
+export type DebugStatus = 'full_succeed' | 'partial_succeed' | 'failed';
+
+export type DebugResult = {
+  status: DebugStatus;
+  /** Runner exit code (null if killed or not exited) */
+  exitCode?: number | null;
+  results: TaskResult[];
+  errors: ExecutionError[];
+  /** Diagnostic metadata, only included in debug mode */
+  meta?: {
+    runner: RunnerConfig;
+    forwardedArgs: string[];
+    pendingTaskIds: string[];
+    mappingDiagnostics: MappingDiagnostics[];
+  };
+};
+
+export type CdpClient = {
+  send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<T>;
+  on<TParams = unknown>(
+    method: string,
+    handler: (params: TParams) => void,
+  ): void;
+  close(): void;
+};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Grace period before first resume to allow breakpoints to be set */
+export const DEFAULT_FIRST_PAUSE_GRACE_MS = 4_000;
+
+/** Timeout for resolving at least one breakpoint */
+export const DEFAULT_BREAKPOINT_RESOLVE_TIMEOUT_MS = 20_000;
+
+/** Timeout between breakpoint hits before giving up */
+export const DEFAULT_INACTIVITY_TIMEOUT_MS = 40_000;
+
+/** Maximum mapping diagnostics to record (prevents memory bloat) */
+export const MAX_MAPPING_DIAGNOSTICS = 50;
+
+/** Maximum scripts to log in debug mode */
+export const MAX_DEBUG_SCRIPTS = 10;
+
+/** Maximum mapping diagnostics to log in debug mode */
+export const MAX_DEBUG_MAPPING = 10;

--- a/packages/skill-cdp/tsconfig.json
+++ b/packages/skill-cdp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@rstest/tsconfig/base",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true,
+    "isolatedDeclarations": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,36 @@ importers:
 
   e2e/build/runtimeImport: {}
 
+  e2e/cdp/fixtures/basic:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
+
+  e2e/cdp/fixtures/basic-no-debug:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
+
+  e2e/cdp/fixtures/invalid-line:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
+
+  e2e/cdp/fixtures/mismatch:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
+
+  e2e/cdp/fixtures/multi:
+    devDependencies:
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
+
   e2e/cli:
     devDependencies:
       '@rstest/core':
@@ -997,6 +1027,36 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/skill-cdp:
+    devDependencies:
+      '@jridgewell/trace-mapping':
+        specifier: 0.3.31
+        version: 0.3.31
+      '@rslib/core':
+        specifier: ^0.19.0
+        version: 0.19.0(@microsoft/api-extractor@7.55.2(@types/node@22.18.6))(typescript@5.9.3)
+      '@rstest/tsconfig':
+        specifier: workspace:*
+        version: link:../../scripts/tsconfig
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      '@valibot/to-json-schema':
+        specifier: ^1.2.0
+        version: 1.5.0(valibot@1.2.0(typescript@5.9.3))
+      cac:
+        specifier: ^6.7.14
+        version: 6.7.14
+      json-rpc-2.0:
+        specifier: ^1.7.1
+        version: 1.7.1
+      valibot:
+        specifier: ^1.2.0
+        version: 1.2.0(typescript@5.9.3)
+      ws:
+        specifier: ^8.18.3
+        version: 8.18.3
 
   packages/vscode:
     devDependencies:
@@ -3342,6 +3402,11 @@ packages:
     peerDependencies:
       react: '>=18.3.1'
 
+  '@valibot/to-json-schema@1.5.0':
+    resolution: {integrity: sha512-GE7DmSr1C2UCWPiV0upRH6mv0cCPsqYGs819fb6srCS1tWhyXrkGGe+zxUiwzn/L1BOfADH4sNjY/YHCuP8phQ==}
+    peerDependencies:
+      valibot: ^1.2.0
+
   '@vercel/oidc@3.0.3':
     resolution: {integrity: sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==}
     engines: {node: '>= 20'}
@@ -5204,6 +5269,9 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -10029,6 +10097,10 @@ snapshots:
       react: 19.2.3
       unhead: 2.0.19
 
+  '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.2.0(typescript@5.9.3)
+
   '@vercel/oidc@3.0.3': {}
 
   '@vitest/expect@3.2.4':
@@ -12201,6 +12273,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-rpc-2.0@1.7.1: {}
 
   json-schema-traverse@1.0.0: {}
 


### PR DESCRIPTION
## Summary

human input:

introducing `@rstest/cdp-debug` package to let agent use skill by `npx @rstest/cdp-debug --plan '/abs/path/to/plan.json'` to set breakpoint at source file position (leverage sourcemap inference to dist file) and read the variable throw CDP while test is running.  skip the `log -> build -> find log` (sometimes agent even don't know the loop, lol) loop while testing.

TODO:

- [ ] local release package
- [ ] add skill to https://github.com/rstackjs/agent-skills

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
