### PR TITLE
fix(vscode): Unable to use the “Run Tests in File or Folder” feature

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,7 +22,17 @@
       "type": "npm",
       "script": "dev",
       "path": "packages/core",
-      "problemMatcher": "$rslib-watch",
+      "problemMatcher": {
+        "owner": "rslib",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "build started...",
+          "endsPattern": "build complete, watching for changes..."
+        },
+        "pattern": {
+          "regexp": "build failed in"
+        }
+      },
       "isBackground": true,
       "group": {
         "kind": "build"
@@ -33,7 +43,17 @@
       "type": "npm",
       "script": "dev",
       "path": "packages/coverage-istanbul",
-      "problemMatcher": "$rslib-watch",
+      "problemMatcher": {
+        "owner": "rslib",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "build started...",
+          "endsPattern": "build complete, watching for changes..."
+        },
+        "pattern": {
+          "regexp": "build failed in"
+        }
+      },
       "isBackground": true,
       "dependsOn": ["core dev"],
       "dependsOrder": "parallel",
@@ -46,7 +66,17 @@
       "type": "npm",
       "script": "watch:local",
       "path": "packages/vscode",
-      "problemMatcher": "$rslib-watch",
+      "problemMatcher": {
+        "owner": "rslib",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "build started...",
+          "endsPattern": "build complete, watching for changes..."
+        },
+        "pattern": {
+          "regexp": "build failed in"
+        }
+      },
       "isBackground": true,
       "group": {
         "kind": "build",

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -190,7 +190,8 @@ export class Project implements vscode.Disposable {
         this.testItem = this.testController.createTestItem(
           this.configFileUri.toString(),
           path.relative(this.workspaceFolder.uri.path, this.configFileUri.path),
-          this.configFileUri,
+          // Do not set `uri`, so that VSCode’s “Run Tests” works correctly.
+          // https://github.com/microsoft/vscode/blob/3b42759b8b501e68106c72b5683dcc114ed789e1/src/vs/workbench/contrib/testing/common/testService.ts#L278-L280
         );
         testData.set(this.testItem, this);
       }


### PR DESCRIPTION
## Summary

This pr fixes `No tests found in the selected file or folder` error.

The uri of a test item must either be unset or be the parent uri of its children.

https://github.com/microsoft/vscode/blob/3b42759b8b501e68106c72b5683dcc114ed789e1/src/vs/workbench/contrib/testing/common/testService.ts#L278-L280

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
