### PR TITLE
fix(reporter): create jUnit output dir tree if needed

### DIFF
--- a/packages/core/src/reporter/junit.ts
+++ b/packages/core/src/reporter/junit.ts
@@ -207,8 +207,8 @@ export class JUnitReporter implements Reporter {
     return xmlDeclaration + testsuitesXml + testsuiteXmls + testsuitesEnd;
   }
 
+  /** Create directory tree if not exists */
   async tryMkdir(dirname: string): Promise<void> {
-    // Create directory tree if not exists
     try {
       await fs.mkdir(dirname, { recursive: true });
     } catch (error: any) {


### PR DESCRIPTION
## Summary

Current behavior: junit report file will not be created unless the directory specified in `outputPath` already exists.
This PR changes the behavior so rstest creates the directory structure before writing the file.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
