### PR TITLE
test(browser-mode): add comprehensive e2e test coverage

### DIFF
--- a/e2e/browser-mode/entryOverride.test.ts
+++ b/e2e/browser-mode/entryOverride.test.ts
@@ -1,0 +1,24 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('browser mode - entry override', () => {
+  it('should not execute user rsbuild entry (rstest controls entry)', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures', 'entry-override'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).not.toContain('USER_ENTRY_SHOULD_NOT_RUN');
+  });
+});

--- a/e2e/browser-mode/env.test.ts
+++ b/e2e/browser-mode/env.test.ts
@@ -1,0 +1,23 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('browser mode - env', () => {
+  it('should inject env into browser runtime via process shim', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures', 'env'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+});

--- a/e2e/browser-mode/fixtures/entry-override/rstest.config.ts
+++ b/e2e/browser-mode/fixtures/entry-override/rstest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS } from '../ports';
+
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS['entry-override'],
+  },
+  include: ['tests/**/*.test.ts'],
+  // Intentionally keep './src/index.ts' in this fixture.
+  // If browser mode does not override rsbuild entry, rsbuild may detect and
+  // execute it as the default entry (and it will throw).
+});

--- a/e2e/browser-mode/fixtures/entry-override/src/index.ts
+++ b/e2e/browser-mode/fixtures/entry-override/src/index.ts
@@ -1,0 +1,1 @@
+throw new Error('USER_ENTRY_SHOULD_NOT_RUN');

--- a/e2e/browser-mode/fixtures/entry-override/tests/smoke.test.ts
+++ b/e2e/browser-mode/fixtures/entry-override/tests/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('browser entry override', () => {
+  it('should run tests normally', () => {
+    expect(typeof document).toBe('object');
+  });
+});

--- a/e2e/browser-mode/fixtures/env/rstest.config.ts
+++ b/e2e/browser-mode/fixtures/env/rstest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS } from '../ports';
+
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS.env,
+  },
+  include: ['tests/**/*.test.ts'],
+  env: {
+    RSTEST_E2E_ENV_FOO: 'bar',
+    RSTEST_E2E_ENV_EMPTY: '',
+    // In browser mode, env is proxied into a process shim.
+    // Setting a key to undefined should remove it from process.env.
+    RSTEST_E2E_ENV_UNSET: undefined,
+  },
+});

--- a/e2e/browser-mode/fixtures/env/tests/env.test.ts
+++ b/e2e/browser-mode/fixtures/env/tests/env.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('browser env injection', () => {
+  it('should expose process.env in browser and apply env changes', () => {
+    // Browser client ensures global alias exists for libraries expecting Node globals.
+    expect((globalThis as any).global).toBe(globalThis);
+
+    expect(typeof (globalThis as any).process).toBe('object');
+    expect(process.env.RSTEST_E2E_ENV_FOO).toBe('bar');
+    expect(process.env.RSTEST_E2E_ENV_EMPTY).toBe('');
+    expect(process.env.RSTEST_E2E_ENV_UNSET).toBeUndefined();
+    expect(Object.hasOwn(process.env, 'RSTEST_E2E_ENV_UNSET')).toBe(false);
+  });
+});

--- a/e2e/browser-mode/fixtures/list/rstest.config.ts
+++ b/e2e/browser-mode/fixtures/list/rstest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS } from '../ports';
+
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS.list,
+  },
+  include: ['tests/**/*.test.ts'],
+  testTimeout: 30000,
+});

--- a/e2e/browser-mode/fixtures/list/tests/a.test.ts
+++ b/e2e/browser-mode/fixtures/list/tests/a.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('browser list', () => {
+  it('should include this test in list', () => {
+    // This test should be collected by `rstest list` (browser collect mode)
+    expect(true).toBe(true);
+  });
+
+  it.skip('should NOT be listed (skip)', () => {
+    // skipped
+  });
+
+  it.todo('should NOT be listed (todo)');
+});

--- a/e2e/browser-mode/fixtures/list/tests/b.test.ts
+++ b/e2e/browser-mode/fixtures/list/tests/b.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from '@rstest/core';
+
+describe('browser list nested', () => {
+  describe('nested', () => {
+    it('should include nested test', () => {
+      // This test should be collected by `rstest list` (browser collect mode)
+    });
+  });
+});

--- a/e2e/browser-mode/fixtures/no-tests/rstest.config.ts
+++ b/e2e/browser-mode/fixtures/no-tests/rstest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS } from '../ports';
+
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS['no-tests'],
+  },
+  // Intentionally points to a non-existing directory to cover the
+  // "No test files found" branch in browser mode.
+  include: ['tests/**/*.test.ts'],
+});

--- a/e2e/browser-mode/fixtures/ports.ts
+++ b/e2e/browser-mode/fixtures/ports.ts
@@ -1,6 +1,10 @@
 export const BROWSER_PORTS = {
   basic: 5180,
   'browser-react': 5202,
+  list: 5204,
+  'no-tests': 5206,
+  'entry-override': 5208,
+  env: 5212,
   config: 5184,
   console: 5192,
   'browser-coverage': 5200,

--- a/e2e/browser-mode/list.test.ts
+++ b/e2e/browser-mode/list.test.ts
@@ -1,0 +1,41 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import pathe from 'pathe';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('browser mode - list (collect mode)', () => {
+  it('should list browser tests without executing them', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['list'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures', 'list'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const lines = cli.stdout
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => pathe.normalize(l));
+
+    // Basic sanity: list should include our browser test cases
+    expect(lines.join('\n')).toContain(
+      'tests/a.test.ts > browser list > should include this test in list',
+    );
+    expect(lines.join('\n')).toContain(
+      'tests/b.test.ts > browser list nested > nested > should include nested test',
+    );
+
+    // Skip/todo tests should not be listed
+    expect(lines.join('\n')).not.toContain('should NOT be listed (skip)');
+    expect(lines.join('\n')).not.toContain('should NOT be listed (todo)');
+  });
+});

--- a/e2e/browser-mode/noTests.test.ts
+++ b/e2e/browser-mode/noTests.test.ts
@@ -1,0 +1,39 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('browser mode - no tests', () => {
+  it('should exit with code 1 by default when no tests found', async () => {
+    const { cli, expectExecFailed } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures', 'no-tests'),
+        },
+      },
+    });
+
+    await expectExecFailed();
+    expect(cli.stdout).toContain('No test files found, exiting with code 1.');
+  });
+
+  it('should exit with code 0 when passWithNoTests flag is enabled', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--passWithNoTests'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures', 'no-tests'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).toContain('No test files found, exiting with code 0.');
+  });
+});


### PR DESCRIPTION
## Summary

- Add E2E tests for entry override configuration
- Add E2E tests for environment variable handling
- Add E2E tests for test listing functionality
- Add E2E tests for no-tests scenario

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
