### PR TITLE
release: 0.8.2

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "React component testing support for Rstest browser mode",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Browser mode support for Rstest testing framework.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The Rsbuild-based test tool.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Rstest",
   "publisher": "rstack",
   "description": "VS Code extension for Rstest",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Highlights 💡

### Introducing Markdown reporter for agent 🤖

Rstest automatically detects AI coding agent (Claude Code, Cursor, Codex, opencode, etc.) and switches to Markdown output — no configuration needed. 

The structured Markdown format is easier for LLMs to parse and understand compared to traditional terminal output. Each failure includes a one-click repro command so agents can quickly rerun and debug individual test cases. Output is intelligently truncated to stay within context limits even when many tests fail, saving tokens and reducing cost.

For detailed configuration options, see https://rstest.rs/guide/basic/reporters#markdown-reporter.       

https://github.com/user-attachments/assets/6905c08f-b85b-4f25-92f5-6871fe050b5a

### **Introducing Browser mode (experimental)**

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: not update snapshots that were not run on test failure by @9aoy in https://github.com/web-infra-dev/rstest/pull/910
* feat: support filter test by full test name by @9aoy in https://github.com/web-infra-dev/rstest/pull/916
* feat(core): support inspector mode for worker pool by @fi3ework in https://github.com/web-infra-dev/rstest/pull/919
* feat(core): use `md` reporter for AI agent by default by @fi3ework in https://github.com/web-infra-dev/rstest/pull/911
* feat: support test sharding by @9aoy in https://github.com/web-infra-dev/rstest/pull/921
### Bug Fixes 🐞
* fix(e2e): ensure environment variables are truly unset in CLI helper by @fi3ework in https://github.com/web-infra-dev/rstest/pull/909
* fix(vscode): relax @rstest/core version requirement by @fi3ework in https://github.com/web-infra-dev/rstest/pull/914
* fix(browser): fix headless config and enable coverage support by @fi3ework in https://github.com/web-infra-dev/rstest/pull/922
* fix(vscode): Unable to use the “Run Tests in File or Folder” feature by @claneo in https://github.com/web-infra-dev/rstest/pull/920
* fix: exit with code 1 when coverage report generate error by @9aoy in https://github.com/web-infra-dev/rstest/pull/924
* fix(coverage): only apply coverage plugin for main js rule by @9aoy in https://github.com/web-infra-dev/rstest/pull/925
* fix(vscode): stderr logs not written to output by @claneo in https://github.com/web-infra-dev/rstest/pull/926
* fix(reporter): create jUnit output dir tree if needed by @joshuapetryk in https://github.com/web-infra-dev/rstest/pull/927
### Document 📖
* docs: clarify mock behavior in vitest migration guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/912
### Other Changes
* test(e2e): refactor browser snapshot tests for better isolation by @fi3ework in https://github.com/web-infra-dev/rstest/pull/913
* chore: bump browserlist by @fi3ework in https://github.com/web-infra-dev/rstest/pull/923
* test(browser-mode): add comprehensive e2e test coverage by @fi3ework in https://github.com/web-infra-dev/rstest/pull/929
* ci: fix E2E error by @fi3ework in https://github.com/web-infra-dev/rstest/pull/930

## New Contributors
* @joshuapetryk made their first contribution in https://github.com/web-infra-dev/rstest/pull/927

**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.8.1...v0.8.2