### PR TITLE
fix(core): align color env priority and improve agent detection

### DIFF
--- a/e2e/env/fixtures/forceColor.test.ts
+++ b/e2e/env/fixtures/forceColor.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+it('should receive FORCE_COLOR in worker process', () => {
+  // When FORCE_COLOR=1 is set by the parent, worker should see it
+  expect(process.env.FORCE_COLOR).toBe('1');
+});

--- a/e2e/env/fixtures/noColor.test.ts
+++ b/e2e/env/fixtures/noColor.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from '@rstest/core';
+
+it('should receive FORCE_COLOR=0 when NO_COLOR is set', () => {
+  // When NO_COLOR=1 is set, FORCE_COLOR should be '0' to prevent conflicts
+  // with libraries that only check FORCE_COLOR
+  expect(process.env.FORCE_COLOR).toBe('0');
+  expect(process.env.NO_COLOR).toBe('1');
+});

--- a/e2e/env/index.test.ts
+++ b/e2e/env/index.test.ts
@@ -21,4 +21,50 @@ describe('test environment variables', () => {
 
     await expectExecSuccess();
   });
+
+  it('should pass FORCE_COLOR to worker process when user sets it', async ({
+    onTestFinished,
+  }) => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'forceColor.test.ts'],
+      onTestFinished,
+      // Explicitly unset NO_COLOR to avoid conflicts
+      unsetEnv: ['NO_COLOR'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+          env: {
+            // User explicitly sets FORCE_COLOR=1
+            FORCE_COLOR: '1',
+          },
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
+  it('should set FORCE_COLOR=0 when NO_COLOR is set to prevent conflicts', async ({
+    onTestFinished,
+  }) => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'noColor.test.ts'],
+      onTestFinished,
+      // Explicitly unset FORCE_COLOR to let the default logic handle it
+      unsetEnv: ['FORCE_COLOR'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+          env: {
+            // User sets NO_COLOR=1 to disable colors
+            NO_COLOR: '1',
+          },
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
 });

--- a/e2e/reporter/md.test.ts
+++ b/e2e/reporter/md.test.ts
@@ -6,6 +6,8 @@ import { runRstestCli } from '../scripts';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const UNSET_ENV = ['RSTEST_NO_AGENT'];
+
 const normalizeStdout = (stdout: string) =>
   stdout
     .trimStart()
@@ -25,6 +27,7 @@ describe('md', () => {
       command: 'rstest',
       args: ['run', 'agent-md/index', '-c', './rstest.agentMd.config.ts'],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -124,6 +127,7 @@ describe('md', () => {
         './rstest.agentMd.snapshotMismatch.config.ts',
       ],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -225,6 +229,7 @@ describe('md', () => {
         './rstest.agentMd.console.config.ts',
       ],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -338,6 +343,7 @@ describe('md', () => {
       command: 'rstest',
       args: ['run', 'agent-md/throw', '-c', './rstest.agentMd.throw.config.ts'],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -427,6 +433,7 @@ describe('md', () => {
         './rstest.agentMd.timeout.config.ts',
       ],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -518,6 +525,7 @@ describe('md', () => {
         './rstest.agentMd.truncated.config.ts',
       ],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -694,6 +702,7 @@ describe('md', () => {
       command: 'rstest',
       args: ['run', '-c', './rstest.agentMd.pass.config.ts'],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -762,6 +771,7 @@ describe('md', () => {
       command: 'rstest',
       args: ['run', 'agent-md-pass', '-c', './rstest.agentMd.pass.config.ts'],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -854,6 +864,7 @@ describe('md', () => {
         './rstest.agentMd.unhandled.config.ts',
       ],
       onTestFinished,
+      unsetEnv: UNSET_ENV,
       options: {
         nodeOptions: {
           cwd: __dirname,

--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -35,8 +35,8 @@ async function createSetupPool() {
     isolateWorkers: false,
     env: {
       NODE_ENV: 'test',
-      ...process.env,
       ...getForceColorEnv(),
+      ...process.env,
     },
   };
 

--- a/packages/core/src/core/restart.ts
+++ b/packages/core/src/core/restart.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import type { ChokidarOptions } from 'chokidar';
 import { type CommonOptions, runRest } from '../cli/commands';
 import type { RstestInstance } from '../types';
-import { ansiEnabled, color, isTTY, logger } from '../utils';
+import { color, isColorSupported, isTTY, logger } from '../utils';
 import { createChokidar } from '../utils/watchFiles';
 
 type Cleaner = () => unknown;
@@ -17,7 +17,7 @@ export const onBeforeRestart = (cleaner: Cleaner): void => {
 };
 
 const clearConsole = () => {
-  if (isTTY() && !process.env.DEBUG && ansiEnabled) {
+  if (isTTY() && !process.env.DEBUG && isColorSupported) {
     process.stdout.write('\x1B[H\x1B[2J');
   }
 };

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -220,8 +220,8 @@ export const createPool = async ({
     ],
     env: {
       NODE_ENV: 'test',
-      ...process.env,
       ...getForceColorEnv(),
+      ...process.env,
     },
   });
 

--- a/packages/core/src/utils/agent/detectAgent.ts
+++ b/packages/core/src/utils/agent/detectAgent.ts
@@ -80,6 +80,11 @@ export const KNOWN_AGENTS: {
 };
 
 export function determineAgent(): AgentResult {
+  // Allow explicit opt-out of agent detection (e.g., for self-testing)
+  if (process.env.RSTEST_NO_AGENT === '1') {
+    return { isAgent: false, agent: undefined };
+  }
+
   if (process.env.AI_AGENT) {
     const name = process.env.AI_AGENT.trim();
     if (name) {

--- a/scripts/rstest.setup.ts
+++ b/scripts/rstest.setup.ts
@@ -2,6 +2,10 @@ import path from 'node:path';
 import { expect } from '@rstest/core';
 import { createSnapshotSerializer } from 'path-serializer';
 
+// Prevent the test runner from being detected as an AI agent during self-testing.
+// This ensures consistent behavior regardless of the environment running the tests.
+process.env.RSTEST_NO_AGENT = '1';
+
 // The default path-serializer doesn't normalize pnpm global store paths (e.g.
 // `<HOME>/Library/pnpm/store/.../node_modules/pkg/...`) which makes snapshots
 // OS/host dependent. Keep existing snapshot patterns by mapping those store


### PR DESCRIPTION
## Summary

- **Color Environment Handling**
  - Adjust env merge order in worker pools to ensure user-defined `FORCE_COLOR`/`NO_COLOR` always overrides defaults
  - Refactor `getForceColorEnv` to automatically disable colors in AI agent environments by default
  - Synchronize `FORCE_COLOR=0` when `NO_COLOR=1` is detected to prevent conflicts in downstream tools
- **Agent Detection**
  - Support `RSTEST_NO_AGENT` environment variable to explicitly opt-out of agent detection
  - Simplify repo self-testing setup by using the opt-out flag instead of manually clearing env vars
- **Code Health**
  - Unify color support checks across core modules using `isColorSupported`


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
