### PR TITLE
fix(browser): avoid log out deleting virtual module

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -716,6 +716,11 @@ const htmlTemplate = `<!DOCTYPE html>
 </html>
 `;
 
+// Workaround for noisy "removed ..." logs caused by VirtualModulesPlugin.
+// Rsbuild suppresses the removed-file log if all removed paths include "virtual":
+// https://github.com/web-infra-dev/rsbuild/blob/1258fa9dba5c321a4629b591a6dadbd2e26c6963/packages/core/src/createCompiler.ts#L73-L76
+const VIRTUAL_MANIFEST_FILENAME = 'virtual-manifest.ts';
+
 // ============================================================================
 // Browser Runtime Lifecycle
 // ============================================================================
@@ -1296,8 +1301,8 @@ export const runBrowserController = async (
             'browser',
             Date.now().toString(),
           );
-  const manifestPath = join(tempDir, 'manifest.ts');
 
+  const manifestPath = join(tempDir, VIRTUAL_MANIFEST_FILENAME);
   const manifestSource = generateManifestModule({
     manifestPath,
     entries: projectEntries,
@@ -1769,8 +1774,8 @@ export const listBrowserTests = async (
     'browser',
     `list-${Date.now()}`,
   );
-  const manifestPath = join(tempDir, 'manifest.ts');
 
+  const manifestPath = join(tempDir, VIRTUAL_MANIFEST_FILENAME);
   const manifestSource = generateManifestModule({
     manifestPath,
     entries: projectEntries,


### PR DESCRIPTION
## Summary

| Before | After |
|--------|-------|
|   <img width="439" height="206" alt="Warp 2026-02-04 17 02 25" src="https://github.com/user-attachments/assets/4bc8132a-843d-4a68-a7fa-46114e9f4f6f" />     |   <img width="487" height="211" alt="Warp 2026-02-04 17 02 19" src="https://github.com/user-attachments/assets/39ab47b1-0ffe-4700-9c01-a5b1120d91a1" />     |

ref https://github.com/web-infra-dev/rspack/issues/11694.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
