### PR TITLE
test(e2e): unify timeout time, less flaky

### DIFF
--- a/e2e/projects/coverage.test.ts
+++ b/e2e/projects/coverage.test.ts
@@ -45,7 +45,7 @@ describe('test projects coverage', () => {
     expect(
       fs.existsSync(join(__dirname, 'fixtures/coverage/index.html')),
     ).toBeTruthy();
-  }, 60_000);
+  });
 
   it('should run projects correctly with coverage.include', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
@@ -64,5 +64,5 @@ describe('test projects coverage', () => {
     expect(
       logs.find((log) => log.includes('App1.ts') && log.includes('|')),
     ).toBeTruthy();
-  }, 60_000);
+  });
 });

--- a/e2e/projects/index.test.ts
+++ b/e2e/projects/index.test.ts
@@ -45,7 +45,7 @@ describe('test projects', () => {
       await expectExecFailed();
       // test log print
       expectStderrLog('it is not defined');
-    }, 15_000);
+    });
   });
 
   it('should run project correctly with specified config root', async () => {

--- a/e2e/projects/shard.test.ts
+++ b/e2e/projects/shard.test.ts
@@ -39,7 +39,7 @@ describe('test projects sharding', () => {
     expect(
       logs.some((log) => log.includes('packages/node/test/mockFs.test.ts')),
     ).toBeFalsy();
-  }, 30000);
+  });
 
   it('should run the second shard of 2', async () => {
     const { cli, expectExecSuccess, expectLog } = await runRstestCli({
@@ -75,7 +75,7 @@ describe('test projects sharding', () => {
     expectLog('packages/client/test/node.test.ts', logs);
     expectLog('packages/node/test/index.test.ts', logs);
     expectLog('packages/node/test/mockFs.test.ts', logs);
-  }, 30000);
+  });
 
   it('should run failed on an empty shard', async () => {
     const { expectExecFailed, expectLog, expectStderrLog } = await runRstestCli(

--- a/e2e/vue/jsx.test.ts
+++ b/e2e/vue/jsx.test.ts
@@ -19,5 +19,5 @@ describe('vue jsx', () => {
     });
 
     await expectExecSuccess();
-  }, 20000);
+  });
 });

--- a/e2e/vue/sfc.test.ts
+++ b/e2e/vue/sfc.test.ts
@@ -19,6 +19,5 @@ describe('vue sfc', () => {
     });
 
     await expectExecSuccess();
-    // fix timeout in CI
-  }, 20000);
+  });
 });


### PR DESCRIPTION
## Summary

use the unified timeout config for E2E test, less flaky, and only reserve the case specific timeout for timeout related cases.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
