### PR TITLE
fix: reorganize the logic of color and remove the forced default values

### DIFF
--- a/e2e/env/fixtures/defaultColor.test.ts
+++ b/e2e/env/fixtures/defaultColor.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from '@rstest/core';
+
+it('should not set FORCE_COLOR when no color env is set by user', () => {
+  // When neither FORCE_COLOR nor NO_COLOR is set by the user,
+  // rstest should not intervene - let child processes decide (like vitest)
+  expect(process.env.FORCE_COLOR).toBeUndefined();
+  expect(process.env.NO_COLOR).toBeUndefined();
+});

--- a/e2e/env/fixtures/noColor.test.ts
+++ b/e2e/env/fixtures/noColor.test.ts
@@ -1,8 +1,9 @@
 import { expect, it } from '@rstest/core';
 
-it('should receive FORCE_COLOR=0 when NO_COLOR is set', () => {
-  // When NO_COLOR=1 is set, FORCE_COLOR should be '0' to prevent conflicts
-  // with libraries that only check FORCE_COLOR
-  expect(process.env.FORCE_COLOR).toBe('0');
+it('should pass through NO_COLOR when user sets it', () => {
+  // When NO_COLOR=1 is set by user, rstest should pass it through
+  // without adding extra env vars (like vitest)
   expect(process.env.NO_COLOR).toBe('1');
+  // FORCE_COLOR should not be set by rstest when user controls color via NO_COLOR
+  expect(process.env.FORCE_COLOR).toBeUndefined();
 });

--- a/e2e/env/index.test.ts
+++ b/e2e/env/index.test.ts
@@ -45,14 +45,14 @@ describe('test environment variables', () => {
     await expectExecSuccess();
   });
 
-  it('should set FORCE_COLOR=0 when NO_COLOR is set to prevent conflicts', async ({
+  it('should pass through NO_COLOR when user sets it', async ({
     onTestFinished,
   }) => {
     const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'noColor.test.ts'],
       onTestFinished,
-      // Explicitly unset FORCE_COLOR to let the default logic handle it
+      // Explicitly unset FORCE_COLOR to test that rstest doesn't add it
       unsetEnv: ['FORCE_COLOR'],
       options: {
         nodeOptions: {
@@ -61,6 +61,25 @@ describe('test environment variables', () => {
             // User sets NO_COLOR=1 to disable colors
             NO_COLOR: '1',
           },
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
+  it('should not set FORCE_COLOR when no color env is set by user', async ({
+    onTestFinished,
+  }) => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'defaultColor.test.ts'],
+      onTestFinished,
+      // Unset both color envs to test default behavior (like vitest)
+      unsetEnv: ['FORCE_COLOR', 'NO_COLOR'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
         },
       },
     });

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -31,28 +31,20 @@ export const isDebug = (): boolean => {
 };
 
 export const getForceColorEnv = (): {
-  FORCE_COLOR?: '0' | '1';
+  FORCE_COLOR?: '0';
   NO_COLOR?: '1';
 } => {
-  // User env should always win; we only provide defaults for child processes.
-  if (process.env.FORCE_COLOR !== undefined) {
-    return {};
-  }
+  // In agent environments, disable colors for stable output
+  // (unless user explicitly set color env vars)
+  const userSetColorEnv =
+    process.env.FORCE_COLOR !== undefined || process.env.NO_COLOR !== undefined;
 
-  const noColorEnabled = process.env.NO_COLOR === '1';
-
-  // In agent environments, prefer stable plain output by default.
-  const isAgent = determineAgent().isAgent;
-
-  if (noColorEnabled) {
-    return { FORCE_COLOR: '0' };
-  }
-
-  if (isAgent || !isColorSupported) {
+  if (determineAgent().isAgent && !userSetColorEnv) {
     return { NO_COLOR: '1', FORCE_COLOR: '0' };
   }
 
-  return { FORCE_COLOR: '1' };
+  // Otherwise, don't intervene - let child processes decide (like vitest)
+  return {};
 };
 
 /**


### PR DESCRIPTION
## Summary

Simplify color environment variable handling to align with vitest's behavior.

## New Color Logic

The new `getForceColorEnv()` logic is straightforward:

1. **Agent environments**: Disable colors by setting `NO_COLOR=1` and `FORCE_COLOR=0` (unless user explicitly set color env vars)
2. **All other cases**: Don't intervene - let child processes decide based on their own environment detection

This is consistent with how vitest handles color env vars - it simply passes through `process.env` without forcing any color settings.

## Why prebundle Previously Passed (Accidentally)

In the original implementation (before the agent detection changes), rstest **always** set `FORCE_COLOR=1` for worker processes:

```javascript
// Old behavior
env: {
  ...process.env,
  FORCE_COLOR: process.env.NO_COLOR === '1' ? '0' : '1',  // Always set!
}
```

This caused prebundle's chalk color test to pass because rstest was forcing colors on, even in non-TTY CI environments. However, this was not intentional behavior - the test was relying on a side effect rather than explicitly requesting color output.

When running the same test with vitest, it fails for the same reason - vitest doesn't force `FORCE_COLOR=1` either.

## Breaking Change for Downstream

Projects that relied on rstest automatically setting `FORCE_COLOR=1` need to explicitly enable colors in their tests if needed:

```javascript
// Before: worked accidentally
const message = chalk.red('test');
expect(message).toContain('\x1b['); // relied on rstest setting FORCE_COLOR=1

// After: explicit is better
rs.stubEnv('FORCE_COLOR', '1');
const message = chalk.red('test');
expect(message).toContain('\x1b[');
```

## Related Links

- [ ] revert https://github.com/rstackjs/prebundle/pull/49.
- [ ] https://github.com/rstackjs/rslog/pull/60 directly shall pass.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
