### PR TITLE
fix(browser): unify error reporting and avoid duplicate error messages

### DIFF
--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -65,8 +65,13 @@ export async function runTests(context: Rstest): Promise<void> {
       skipOnTestRunEnd: false,
     });
 
-    // Generate coverage reports for browser-only tests
-    if (coverage.enabled && browserResult?.results) {
+    // Generate coverage reports for browser-only tests when execution produced test results.
+    // Skip coverage on early startup failures surfaced via unhandledErrors.
+    if (
+      coverage.enabled &&
+      browserResult?.results.length &&
+      !browserResult.unhandledErrors?.length
+    ) {
       const coverageProvider = await createCoverageProvider(
         coverage,
         context.rootPath,
@@ -420,6 +425,9 @@ export async function runTests(context: Rstest): Promise<void> {
     }
     if (shouldUnifyReporter && browserResult?.testResults) {
       testResults.push(...browserResult.testResults);
+    }
+    if (shouldUnifyReporter && browserResult?.unhandledErrors) {
+      errors.push(...browserResult.unhandledErrors);
     }
 
     context.updateReporterResultState(

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -44,30 +44,16 @@ export class DefaultReporter implements Reporter {
     this.projectConfigs = projectConfigs ?? new Map();
     this.options = options;
     this.testState = testState;
-    // Note: StatusRenderer is created lazily in onTestFileStart() to avoid
-    // intercepting stdout/stderr too early. This ensures that errors occurring
-    // before tests start (e.g., Playwright browser not installed) are visible
-    // and not cleared by WindowRenderer's TTY control sequences.
-  }
-
-  /**
-   * Lazily create StatusRenderer on first test file start.
-   * This avoids intercepting stdout/stderr before tests actually begin,
-   * ensuring early errors (like missing Playwright browsers) remain visible.
-   */
-  private ensureStatusRenderer(): void {
-    if (this.statusRenderer) return;
-    if (isTTY() || this.options.logger) {
+    if (isTTY() || options.logger) {
       this.statusRenderer = new StatusRenderer(
-        this.rootPath,
-        this.testState,
-        this.options.logger,
+        rootPath,
+        testState,
+        options.logger,
       );
     }
   }
 
   onTestFileStart(): void {
-    this.ensureStatusRenderer();
     this.statusRenderer?.onTestFileStart();
   }
 

--- a/packages/core/src/types/browser.ts
+++ b/packages/core/src/types/browser.ts
@@ -33,4 +33,6 @@ export interface BrowserTestRunResult {
   };
   /** Whether the test run had failures */
   hasFailure: boolean;
+  /** Errors that occurred before/outside test execution (e.g., browser launch failure) */
+  unhandledErrors?: Error[];
 }


### PR DESCRIPTION
## Summary

credits to https://github.com/web-infra-dev/rstest/pull/891#issuecomment-3860925398. @claneo 

This change fixes browser-mode error reporting so early failures are no longer lost or printed twice.  
We now route startup/runtime failures through a single `unhandledErrors -> onTestRunEnd` path, which keeps reporting consistent.  
It also merges browser unhandled errors into the unified reporter flow in mixed node+browser runs.  
As a result, users get one clear summary error output with correct failure exit behavior.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
