### PR TITLE
perf(browser): add lightweight scheduler page for headless mode

### DIFF
--- a/e2e/browser-mode/basic.test.ts
+++ b/e2e/browser-mode/basic.test.ts
@@ -34,14 +34,16 @@ describe('browser mode - basic', () => {
 
     await expectExecSuccess();
     expect(cli.stdout).toMatch(/Test Files.*passed/);
+    expect(cli.stdout).toContain('/scheduler.html');
   });
 
-  it('should exit with code 0 when tests pass', async () => {
+  it('should run headed mode without scheduler page and exit with code 0', async () => {
     const { cli } = await runBrowserCli('basic', {
-      args: ['tests/dom.test.ts'],
+      args: ['--browser.headless', 'false', 'tests/dom.test.ts'],
     });
 
     await cli.exec;
     expect(cli.exec.exitCode).toBe(0);
+    expect(cli.stdout).not.toContain('/scheduler.html');
   });
 });

--- a/packages/browser-ui/rsbuild.config.ts
+++ b/packages/browser-ui/rsbuild.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   source: {
     entry: {
       index: './src/main.tsx',
+      scheduler: './src/scheduler.ts',
     },
   },
   output: {

--- a/packages/browser-ui/src/core/channel.ts
+++ b/packages/browser-ui/src/core/channel.ts
@@ -1,0 +1,81 @@
+import type {
+  BrowserClientMessage,
+  HostRPC,
+  SnapshotRpcRequest,
+  SnapshotRpcResponse,
+} from '../types';
+
+const DISPATCH_MESSAGE_TYPE = '__rstest_dispatch__';
+const SNAPSHOT_RESPONSE_TYPE = '__rstest_snapshot_response__';
+
+type SnapshotRpcHandler = Pick<
+  HostRPC,
+  | 'resolveSnapshotPath'
+  | 'readSnapshotFile'
+  | 'saveSnapshotFile'
+  | 'removeSnapshotFile'
+>;
+
+const canPostMessage = (
+  sourceWindow: MessageEventSource | null,
+): sourceWindow is Window => {
+  return (
+    sourceWindow !== null &&
+    typeof (sourceWindow as Window).postMessage === 'function'
+  );
+};
+
+export const readDispatchMessage = (
+  event: MessageEvent,
+): BrowserClientMessage | null => {
+  if (event.data?.type !== DISPATCH_MESSAGE_TYPE) {
+    return null;
+  }
+  return event.data.payload as BrowserClientMessage;
+};
+
+export const forwardSnapshotRpcRequest = async (
+  rpc: SnapshotRpcHandler | null | undefined,
+  request: SnapshotRpcRequest,
+  sourceWindow: MessageEventSource | null,
+): Promise<void> => {
+  if (!rpc || !canPostMessage(sourceWindow)) {
+    return;
+  }
+
+  const sendResponse = (response: SnapshotRpcResponse) => {
+    sourceWindow.postMessage(
+      { type: SNAPSHOT_RESPONSE_TYPE, payload: response },
+      '*',
+    );
+  };
+
+  try {
+    let result: unknown;
+    switch (request.method) {
+      case 'resolveSnapshotPath':
+        result = await rpc.resolveSnapshotPath(request.args.testPath);
+        break;
+      case 'readSnapshotFile':
+        result = await rpc.readSnapshotFile(request.args.filepath);
+        break;
+      case 'saveSnapshotFile':
+        result = await rpc.saveSnapshotFile(
+          request.args.filepath,
+          request.args.content,
+        );
+        break;
+      case 'removeSnapshotFile':
+        result = await rpc.removeSnapshotFile(request.args.filepath);
+        break;
+      default:
+        result = undefined;
+    }
+    sendResponse({ id: request.id, result });
+  } catch (error) {
+    sendResponse({
+      id: request.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/packages/browser-ui/src/core/runtime.ts
+++ b/packages/browser-ui/src/core/runtime.ts
@@ -1,0 +1,24 @@
+export const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16_000, 30_000];
+
+export const createWebSocketUrl = (wsPort: number): string => {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.hostname}:${wsPort}`;
+};
+
+export const createRunnerUrl = (
+  testFile: string,
+  runnerBase?: string,
+  testNamePattern?: string,
+  cacheBust = false,
+): string => {
+  const base = runnerBase || window.location.origin;
+  const url = new URL('/runner.html', base);
+  url.searchParams.set('testFile', testFile);
+  if (testNamePattern) {
+    url.searchParams.set('testNamePattern', testNamePattern);
+  }
+  if (cacheBust) {
+    url.searchParams.set('t', Date.now().toString());
+  }
+  return url.toString();
+};

--- a/packages/browser-ui/src/scheduler.ts
+++ b/packages/browser-ui/src/scheduler.ts
@@ -1,0 +1,288 @@
+import { type BirpcReturn, createBirpc } from 'birpc';
+import { forwardSnapshotRpcRequest, readDispatchMessage } from './core/channel';
+import {
+  createRunnerUrl,
+  createWebSocketUrl,
+  RECONNECT_DELAYS,
+} from './core/runtime';
+import type {
+  BrowserClientFileResult,
+  BrowserClientMessage,
+  BrowserClientTestResult,
+  BrowserHostConfig,
+  ContainerRPC,
+  FatalPayload,
+  HostRPC,
+  LogPayload,
+  SnapshotRpcRequest,
+  TestFileInfo,
+  TestFileStartPayload,
+} from './types';
+import { getPresetInfo, isDevicePreset } from './utils/viewportPresets';
+
+declare global {
+  interface Window {
+    __RSTEST_BROWSER_OPTIONS__?: BrowserHostConfig;
+  }
+}
+
+type SchedulerRpc = BirpcReturn<HostRPC, ContainerRPC>;
+
+const options = window.__RSTEST_BROWSER_OPTIONS__;
+const debug = options?.debug === true;
+const rpcTimeout = options?.rpcTimeout ?? 30_000;
+
+let rpc: SchedulerRpc | null = null;
+let reconnectAttempt = 0;
+let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
+const iframeMap = new Map<string, HTMLIFrameElement>();
+const fileProjectMap = new Map<string, string>();
+
+const debugLog = (...args: unknown[]) => {
+  if (debug) {
+    console.log('[Scheduler]', ...args);
+  }
+};
+
+const resolveViewport = (
+  testFile: string,
+): { width: number; height: number } | null => {
+  const projectName = fileProjectMap.get(testFile);
+  if (!projectName) {
+    return null;
+  }
+
+  const project = options?.projects.find((item) => item.name === projectName);
+  const viewport = project?.viewport;
+  if (!viewport) {
+    return null;
+  }
+
+  if (typeof viewport === 'string' && isDevicePreset(viewport)) {
+    const preset = getPresetInfo(viewport);
+    return { width: preset.width, height: preset.height };
+  }
+
+  if (
+    typeof viewport === 'object' &&
+    viewport !== null &&
+    typeof viewport.width === 'number' &&
+    typeof viewport.height === 'number'
+  ) {
+    return { width: viewport.width, height: viewport.height };
+  }
+
+  return null;
+};
+
+const postConfig = (frame: HTMLIFrameElement, testFile: string): void => {
+  const projectName = fileProjectMap.get(testFile) || '';
+  frame.contentWindow?.postMessage(
+    {
+      type: 'RSTEST_CONFIG',
+      payload: {
+        ...options,
+        testFile,
+        projectName,
+      },
+    },
+    '*',
+  );
+};
+
+const mountRunner = (testFile: string, testNamePattern?: string): void => {
+  let iframe = iframeMap.get(testFile);
+  if (!iframe) {
+    iframe = document.createElement('iframe');
+    iframe.style.position = 'fixed';
+    iframe.style.left = '0';
+    iframe.style.top = '0';
+    iframe.style.opacity = '0';
+    iframe.style.pointerEvents = 'none';
+    iframe.style.border = '0';
+    iframe.title = `Scheduler runner for ${testFile}`;
+    iframe.dataset.testFile = testFile;
+    iframe.addEventListener('load', () => {
+      postConfig(iframe!, testFile);
+    });
+    document.body.appendChild(iframe);
+    iframeMap.set(testFile, iframe);
+  }
+
+  const viewport = resolveViewport(testFile);
+  if (viewport) {
+    iframe.style.width = `${viewport.width}px`;
+    iframe.style.height = `${viewport.height}px`;
+  } else {
+    iframe.style.width = '100vw';
+    iframe.style.height = '100vh';
+  }
+
+  iframe.src = createRunnerUrl(
+    testFile,
+    options?.runnerUrl,
+    testNamePattern,
+    true,
+  );
+};
+
+const unmountRemovedFiles = (nextFiles: TestFileInfo[]): void => {
+  const nextSet = new Set(nextFiles.map((f) => f.testPath));
+  for (const [testFile, frame] of iframeMap.entries()) {
+    if (!nextSet.has(testFile)) {
+      frame.remove();
+      iframeMap.delete(testFile);
+      fileProjectMap.delete(testFile);
+    }
+  }
+};
+
+const syncFiles = (files: TestFileInfo[]): void => {
+  const previous = new Set(fileProjectMap.keys());
+  unmountRemovedFiles(files);
+  for (const file of files) {
+    fileProjectMap.set(file.testPath, file.projectName);
+  }
+  const added = files.filter((file) => !previous.has(file.testPath));
+  for (const file of added) {
+    mountRunner(file.testPath);
+  }
+};
+
+const forwardClientMessage = async (
+  message: BrowserClientMessage,
+): Promise<void> => {
+  if (!rpc) {
+    return;
+  }
+
+  try {
+    switch (message.type) {
+      case 'file-start':
+        await rpc.onTestFileStart(message.payload as TestFileStartPayload);
+        break;
+      case 'case-result':
+        await rpc.onTestCaseResult(message.payload as BrowserClientTestResult);
+        break;
+      case 'file-complete':
+        await rpc.onTestFileComplete(
+          message.payload as BrowserClientFileResult,
+        );
+        break;
+      case 'log':
+        await rpc.onLog(message.payload as LogPayload);
+        break;
+      case 'fatal':
+        await rpc.onFatal(message.payload as FatalPayload);
+        break;
+      default:
+        break;
+    }
+  } catch (error) {
+    debugLog('failed to forward client message', error);
+  }
+};
+
+const scheduleReconnect = () => {
+  const delay =
+    RECONNECT_DELAYS[Math.min(reconnectAttempt, RECONNECT_DELAYS.length - 1)];
+  reconnectAttempt++;
+  debugLog(`reconnecting in ${delay}ms`);
+  reconnectTimeoutId = setTimeout(() => {
+    void connect().catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      debugLog('reconnect attempt failed', message);
+      scheduleReconnect();
+    });
+  }, delay);
+};
+
+const connect = async (): Promise<void> => {
+  if (!options?.wsPort) {
+    throw new Error('Scheduler requires wsPort in browser options.');
+  }
+
+  if (reconnectTimeoutId) {
+    clearTimeout(reconnectTimeoutId);
+    reconnectTimeoutId = null;
+  }
+
+  const ws = new WebSocket(createWebSocketUrl(options.wsPort));
+
+  await new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`Scheduler websocket timeout after ${rpcTimeout}ms`));
+    }, rpcTimeout);
+
+    ws.addEventListener('open', () => {
+      clearTimeout(timeoutId);
+      resolve();
+    });
+    ws.addEventListener('error', () => {
+      clearTimeout(timeoutId);
+      reject(new Error('Scheduler websocket failed to connect.'));
+    });
+  });
+
+  reconnectAttempt = 0;
+
+  const methods: ContainerRPC = {
+    onTestFileUpdate(testFiles) {
+      debugLog('onTestFileUpdate', testFiles.length);
+      syncFiles(testFiles);
+    },
+    reloadTestFile(testFile, testNamePattern) {
+      debugLog('reloadTestFile', testFile, testNamePattern);
+      mountRunner(testFile, testNamePattern);
+    },
+  };
+
+  rpc = createBirpc<HostRPC, ContainerRPC>(methods, {
+    timeout: rpcTimeout,
+    post(data) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(data));
+      }
+    },
+    on(fn) {
+      ws.addEventListener('message', (event) => {
+        try {
+          fn(JSON.parse(String(event.data)));
+        } catch {
+          // ignore invalid payloads
+        }
+      });
+    },
+  });
+
+  ws.addEventListener('close', () => {
+    debugLog('websocket closed');
+    rpc = null;
+    scheduleReconnect();
+  });
+
+  const files = await rpc.getTestFiles();
+  syncFiles(files);
+};
+
+window.addEventListener('message', (event: MessageEvent) => {
+  const message = readDispatchMessage(event);
+  if (!message) {
+    return;
+  }
+  if (message.type === 'snapshot-rpc-request') {
+    void forwardSnapshotRpcRequest(
+      rpc,
+      message.payload as SnapshotRpcRequest,
+      event.source,
+    );
+    return;
+  }
+  void forwardClientMessage(message);
+});
+
+void connect().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error('[Scheduler] Failed to initialize:', message);
+  scheduleReconnect();
+});


### PR DESCRIPTION
## Summary

perf diff (running under examples/browser-react):

before

```
hyperfine --warmup 3 --runs 50 "pnpm rstest"
Benchmark 1: pnpm rstest
  Time (mean ± σ):      1.326 s ±  0.044 s    [User: 1.444 s, System: 0.392 s]
  Range (min … max):    1.289 s …  1.580 s    50 runs
```

after

```
hyperfine --warmup 3 --runs 50 "pnpm rstest"
Benchmark 1: pnpm rstest
  Time (mean ± σ):     890.5 ms ±  73.7 ms    [User: 1193.6 ms, System: 364.7 ms]
  Range (min … max):   833.8 ms … 1251.4 ms    50 runs
```

This PR introduces a lightweight scheduler page for headless browser runs and avoids loading the full React container UI in that mode. It also consolidates duplicated scheduler/container plumbing by moving shared runtime and channel logic into `@rstest/browser-ui` core helpers with unified RPC types. On the host side, `@rstest/browser` now serves injected `scheduler.html` from browser-ui dist (with fallback), and e2e coverage is updated for both headless and headed paths.

**Behavior diff:**

```
+------------------------+--------------------------------------------+-----------------------------------------------+
| Scope                  | Before                                     | After                                         |
+------------------------+--------------------------------------------+-----------------------------------------------+
| Headless page route    | `/` container page                         | `/scheduler.html` lightweight scheduler page  |
| Scheduler resilience   | single WebSocket attempt                   | reconnect with exponential backoff            |
| Scheduler asset source | browser package client entry               | browser-ui multi-entry dist asset             |
+------------------------+--------------------------------------------+-----------------------------------------------+
```

**Changes:**

- browser-ui scheduler entry and output wiring
  - `scheduler` build entry in rsbuild; emitted `scheduler.html` + JS bundle
- shared browser-ui core runtime/channel helpers
  - runner/websocket URL helpers; reconnect delays; dispatch + snapshot RPC bridge
- RPC/type dedup across container and scheduler
  - shared `HostRPC`/`ContainerRPC` and payload types in `browser-ui/src/types.ts`
- browser host routing and verification updates
  - `/scheduler.html` serve/injection path in `hostController`; e2e assertions for headless vs headed behavior

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
