### PR TITLE
fix(core): include worker stderr in unexpected-exit summary

### DIFF
--- a/e2e/worker/fixtures/worker.panic.test.ts
+++ b/e2e/worker/fixtures/worker.panic.test.ts
@@ -1,0 +1,9 @@
+import { writeSync } from 'node:fs';
+import { describe, it } from '@rstest/core';
+
+describe('worker panic', () => {
+  it('should crash the worker process', () => {
+    writeSync(2, 'RSTEST_WORKER_PANIC_MARKER\n');
+    process.abort();
+  });
+});

--- a/e2e/worker/index.test.ts
+++ b/e2e/worker/index.test.ts
@@ -25,4 +25,22 @@ describe('test worker behavior', () => {
     // ExperimentalWarning should be suppressed
     expect(cli.log).not.toContain('ExperimentalWarning');
   });
+
+  it('should include worker stderr in summary when worker exits unexpectedly', async () => {
+    const marker = 'RSTEST_WORKER_PANIC_MARKER';
+    const { expectExecFailed, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'worker.panic.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: fixtureDir,
+        },
+      },
+    });
+
+    await expectExecFailed();
+    expect(cli.log).toContain('Worker exited unexpectedly');
+    expect(cli.log).toContain('Maybe related stderr');
+    expect(cli.log).toContain(marker);
+  });
 });

--- a/packages/core/src/pool/forks.ts
+++ b/packages/core/src/pool/forks.ts
@@ -12,11 +12,16 @@ import type {
   Test,
   TestFileResult,
 } from '../types';
+import { createWorkerStderrCapture } from './stderrCapture';
+import { parseWorkerMetaMessage, type WorkerMetaMessage } from './workerMeta';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function createChannel(rpcMethods: RuntimeRPC) {
+function createChannel(
+  rpcMethods: RuntimeRPC,
+  onWorkerMeta?: (message: WorkerMetaMessage) => void,
+) {
   const emitter = new EventEmitter();
   const cleanup = () => emitter.removeAllListeners();
 
@@ -26,6 +31,11 @@ function createChannel(rpcMethods: RuntimeRPC) {
       emitter.on(events.message, callback);
     },
     postMessage: (message: any) => {
+      const workerMeta = parseWorkerMetaMessage(message);
+      if (workerMeta) {
+        onWorkerMeta?.(workerMeta);
+        return;
+      }
       emitter.emit(events.response, message);
     },
   };
@@ -81,25 +91,46 @@ export const createForksPool = (poolOptions: {
   };
 
   const pool = new Tinypool(options);
+  const stderrCapture = createWorkerStderrCapture(pool);
+  let nextTaskId = 0;
 
   return {
     name: 'forks',
     runTest: async ({ options, rpcMethods }: RunWorkerOptions) => {
-      const { channel, cleanup } = createChannel(rpcMethods);
+      const taskId = ++nextTaskId;
+      stderrCapture.createTask(taskId);
+      const { channel, cleanup } = createChannel(rpcMethods, ({ pid }) => {
+        stderrCapture.bindTaskToPid(taskId, pid);
+      });
       try {
         return await pool.run(options, { channel });
+      } catch (err) {
+        await stderrCapture.enhanceWorkerExitError(taskId, err);
+        throw err;
       } finally {
         cleanup();
+        stderrCapture.clearTask(taskId);
       }
     },
     collectTests: async ({ options, rpcMethods }: RunWorkerOptions) => {
-      const { channel, cleanup } = createChannel(rpcMethods);
+      const taskId = ++nextTaskId;
+      stderrCapture.createTask(taskId);
+      const { channel, cleanup } = createChannel(rpcMethods, ({ pid }) => {
+        stderrCapture.bindTaskToPid(taskId, pid);
+      });
       try {
         return await pool.run(options, { channel });
+      } catch (err) {
+        await stderrCapture.enhanceWorkerExitError(taskId, err);
+        throw err;
       } finally {
         cleanup();
+        stderrCapture.clearTask(taskId);
       }
     },
-    close: () => pool.destroy(),
+    close: async () => {
+      stderrCapture.cleanup();
+      await pool.destroy();
+    },
   };
 };

--- a/packages/core/src/pool/stderrCapture.ts
+++ b/packages/core/src/pool/stderrCapture.ts
@@ -1,0 +1,328 @@
+import type { ChildProcess } from 'node:child_process';
+import type { Tinypool } from 'tinypool';
+
+const MAX_CAPTURED_STDERR_BYTES = 128 * 1024;
+const STDERR_SETTLE_MAX_WAIT = 200;
+const WORKER_EXIT_ERROR = 'Worker exited unexpectedly';
+const MAX_STDERR_MESSAGE_BYTES = 64 * 1024;
+
+interface StderrChunk {
+  bytes: number;
+  seq: number;
+  text: string;
+}
+
+interface WorkerStderrState {
+  bytes: number;
+  chunks: StderrChunk[];
+  seq: number;
+}
+
+interface TaskBinding {
+  pid: number;
+  startSeq: number;
+}
+
+interface Deferred<T> {
+  settled: boolean;
+  resolve: (value: T) => void;
+  promise: Promise<T>;
+}
+
+interface WorkerStderrCapture {
+  createTask: (taskId: number) => void;
+  bindTaskToPid: (taskId: number, pid: number) => void;
+  clearTask: (taskId: number) => void;
+  enhanceWorkerExitError: (taskId: number, err: unknown) => Promise<void>;
+  cleanup: () => void;
+}
+
+const createDeferred = <T>(): Deferred<T> => {
+  let resolvePromise: (value: T) => void = () => undefined;
+
+  const deferred: Deferred<T> = {
+    settled: false,
+    resolve(value) {
+      if (deferred.settled) {
+        return;
+      }
+      deferred.settled = true;
+      resolvePromise(value);
+    },
+    promise: new Promise<T>((resolve) => {
+      resolvePromise = resolve;
+    }),
+  };
+
+  return deferred;
+};
+
+const withTimeout = <T>(
+  promise: Promise<T>,
+  timeout: number,
+): Promise<T | undefined> => {
+  return new Promise((resolve) => {
+    let finished = false;
+    const timer = setTimeout(() => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      resolve(undefined);
+    }, timeout);
+    timer.unref();
+
+    void promise.then(
+      (value) => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        clearTimeout(timer);
+        resolve(undefined);
+      },
+    );
+  });
+};
+
+const formatCapturedStderr = (text: string): string => {
+  const bytes = Buffer.byteLength(text);
+  if (bytes <= MAX_STDERR_MESSAGE_BYTES) {
+    return text;
+  }
+
+  const half = Math.floor(MAX_STDERR_MESSAGE_BYTES / 2);
+  const head = text.slice(0, half);
+  const tail = text.slice(-half);
+  const hiddenBytes = bytes - Buffer.byteLength(head) - Buffer.byteLength(tail);
+
+  return `${head}\n\n... [truncated ${hiddenBytes} bytes of stderr] ...\n\n${tail}`;
+};
+
+const getChildProcessByPid = (
+  pool: Tinypool,
+  pid: number,
+): ChildProcess | undefined => {
+  for (const worker of pool.threads) {
+    const childProcess = (worker as { process?: ChildProcess }).process;
+    if (childProcess?.pid === pid) {
+      return childProcess;
+    }
+  }
+
+  return undefined;
+};
+
+export const createWorkerStderrCapture = (
+  pool: Tinypool,
+): WorkerStderrCapture => {
+  const workerStates = new Map<number, WorkerStderrState>();
+  const taskBindings = new Map<number, TaskBinding>();
+  const taskBindingWaiters = new Map<number, Deferred<TaskBinding>>();
+  const workerCloseWaiters = new Map<number, Deferred<void>>();
+  const trackedWorkers = new Map<
+    number,
+    {
+      onData: (chunk: Buffer | string) => void;
+      stream: NodeJS.ReadableStream;
+    }
+  >();
+
+  const getWorkerState = (pid: number): WorkerStderrState => {
+    let state = workerStates.get(pid);
+    if (!state) {
+      state = {
+        bytes: 0,
+        chunks: [],
+        seq: 0,
+      };
+      workerStates.set(pid, state);
+    }
+    return state;
+  };
+
+  const appendStderr = (pid: number, text: string): void => {
+    if (!text) {
+      return;
+    }
+
+    const state = getWorkerState(pid);
+    const bytes = Buffer.byteLength(text);
+
+    state.seq += 1;
+    state.bytes += bytes;
+    state.chunks.push({
+      bytes,
+      seq: state.seq,
+      text,
+    });
+
+    while (state.bytes > MAX_CAPTURED_STDERR_BYTES && state.chunks.length > 0) {
+      const dropped = state.chunks.shift();
+      if (dropped) {
+        state.bytes -= dropped.bytes;
+      }
+    }
+  };
+
+  /**
+   * HACK: tinypool currently pipes child-process stderr directly to the parent process,
+   * so crash output (for example native panic logs) bypasses rstest summary rendering.
+   * A cleaner long-term fix is intercepting stderr in tinypool's pipe path:
+   * https://github.com/tinylibs/tinypool/blob/abc247f85cba0309e3f1e5655db1837a2a1c2483/src/runtime/process-worker.ts#L40
+   */
+  const attachWorker = (pid: number): void => {
+    if (trackedWorkers.has(pid)) {
+      return;
+    }
+
+    const childProcess = getChildProcessByPid(pool, pid);
+    const stderr = childProcess?.stderr;
+    if (!childProcess || !stderr) {
+      return;
+    }
+
+    const closeWaiter = createDeferred<void>();
+    workerCloseWaiters.set(pid, closeWaiter);
+
+    const onData = (chunk: Buffer | string) => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString();
+      appendStderr(pid, text);
+    };
+
+    stderr.on('data', onData);
+    trackedWorkers.set(pid, {
+      onData,
+      stream: stderr,
+    });
+
+    const detachTrackedWorker = () => {
+      const tracked = trackedWorkers.get(pid);
+      if (!tracked) {
+        return;
+      }
+      tracked.stream.off('data', tracked.onData);
+      trackedWorkers.delete(pid);
+    };
+
+    childProcess.once('close', () => {
+      detachTrackedWorker();
+      closeWaiter.resolve(undefined);
+    });
+  };
+
+  const bindTaskToPid = (taskId: number, pid: number): void => {
+    attachWorker(pid);
+
+    const binding: TaskBinding = {
+      pid,
+      startSeq: getWorkerState(pid).seq,
+    };
+
+    taskBindings.set(taskId, binding);
+    taskBindingWaiters.get(taskId)?.resolve(binding);
+  };
+
+  const waitForTaskBinding = async (
+    taskId: number,
+  ): Promise<TaskBinding | undefined> => {
+    const binding = taskBindings.get(taskId);
+    if (binding) {
+      return binding;
+    }
+
+    const waiter = taskBindingWaiters.get(taskId);
+    if (!waiter) {
+      return undefined;
+    }
+
+    return withTimeout(waiter.promise, STDERR_SETTLE_MAX_WAIT);
+  };
+
+  const waitForWorkerClose = async (pid: number): Promise<void> => {
+    attachWorker(pid);
+    const waiter = workerCloseWaiters.get(pid);
+    if (!waiter) {
+      return;
+    }
+    await withTimeout(waiter.promise, STDERR_SETTLE_MAX_WAIT);
+  };
+
+  const getTaskStderr = (taskId: number): string => {
+    const binding = taskBindings.get(taskId);
+    if (!binding) {
+      return '';
+    }
+
+    const state = workerStates.get(binding.pid);
+    if (!state || state.chunks.length === 0) {
+      return '';
+    }
+
+    return state.chunks
+      .filter((chunk) => chunk.seq > binding.startSeq)
+      .map((chunk) => chunk.text)
+      .join('')
+      .trim();
+  };
+
+  const enhanceWorkerExitError = async (
+    taskId: number,
+    err: unknown,
+  ): Promise<void> => {
+    if (!(err instanceof Error) || !err.message.includes(WORKER_EXIT_ERROR)) {
+      return;
+    }
+
+    const binding =
+      taskBindings.get(taskId) ?? (await waitForTaskBinding(taskId));
+    if (!binding) {
+      return;
+    }
+
+    await waitForWorkerClose(binding.pid);
+    const stderr = formatCapturedStderr(getTaskStderr(taskId));
+    if (stderr.length > 0) {
+      err.message += `\n\nMaybe related stderr:\n${stderr}`;
+    }
+  };
+
+  const createTask = (taskId: number): void => {
+    if (!taskBindingWaiters.has(taskId)) {
+      taskBindingWaiters.set(taskId, createDeferred<TaskBinding>());
+    }
+  };
+
+  const clearTask = (taskId: number): void => {
+    taskBindings.delete(taskId);
+    taskBindingWaiters.delete(taskId);
+  };
+
+  const cleanup = (): void => {
+    for (const { onData, stream } of trackedWorkers.values()) {
+      stream.off('data', onData);
+    }
+
+    trackedWorkers.clear();
+    workerStates.clear();
+    taskBindings.clear();
+    taskBindingWaiters.clear();
+    workerCloseWaiters.clear();
+  };
+
+  return {
+    createTask,
+    bindTaskToPid,
+    clearTask,
+    enhanceWorkerExitError,
+    cleanup,
+  };
+};

--- a/packages/core/src/pool/workerMeta.ts
+++ b/packages/core/src/pool/workerMeta.ts
@@ -1,0 +1,51 @@
+const WORKER_META_MESSAGE_TYPE = 'rstest:worker-meta';
+const WORKER_META_MESSAGE_VERSION = 1;
+const WORKER_META_MESSAGE_NAMESPACE = 'rstest';
+
+export interface WorkerMetaMessage {
+  pid: number;
+}
+
+interface WorkerMetaEnvelope {
+  __rstest_internal__: typeof WORKER_META_MESSAGE_NAMESPACE;
+  payload: WorkerMetaMessage;
+  type: typeof WORKER_META_MESSAGE_TYPE;
+  version: typeof WORKER_META_MESSAGE_VERSION;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+export const createWorkerMetaMessage = (pid: number): WorkerMetaEnvelope => {
+  return {
+    __rstest_internal__: WORKER_META_MESSAGE_NAMESPACE,
+    payload: {
+      pid,
+    },
+    type: WORKER_META_MESSAGE_TYPE,
+    version: WORKER_META_MESSAGE_VERSION,
+  };
+};
+
+export const parseWorkerMetaMessage = (
+  message: unknown,
+): WorkerMetaMessage | undefined => {
+  if (!isRecord(message)) {
+    return undefined;
+  }
+
+  if (
+    message.__rstest_internal__ === WORKER_META_MESSAGE_NAMESPACE &&
+    message.type === WORKER_META_MESSAGE_TYPE &&
+    message.version === WORKER_META_MESSAGE_VERSION &&
+    isRecord(message.payload) &&
+    typeof message.payload.pid === 'number'
+  ) {
+    return {
+      pid: message.payload.pid,
+    };
+  }
+
+  return undefined;
+};

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -9,6 +9,7 @@ import type {
 import './setup';
 import { install } from 'source-map-support';
 import { createCoverageProvider } from '../../coverage';
+import { createWorkerMetaMessage } from '../../pool/workerMeta';
 import { globalApis } from '../../utils/constants';
 import { undoSerializableConfig } from '../../utils/helper';
 import { color } from '../../utils/logger';
@@ -282,6 +283,10 @@ const runInPool = async (
     }
   | TestFileResult
 > => {
+  if (typeof process.send === 'function') {
+    process.send(createWorkerMetaMessage(process.pid));
+  }
+
   isTeardown = false;
   const {
     entryInfo: { distPath, testPath },


### PR DESCRIPTION
## Summary

supersede https://github.com/web-infra-dev/rstest/pull/949.

This PR fixes missing diagnostics when a child worker crashes (for example, rspack panic) under tinypool `child_process` mode. It captures worker `stderr` at the pool layer, binds output to the active task via worker meta messages, and appends relevant logs to the summary error. The implementation avoids renderer/global `stderr` monkey-patching and adds e2e coverage for the crash path.

**Behavior diff:**

```
+------------------------+------------------------------------------+--------------------------------------------------+
| Area                   | Before                                   | After                                            |
+------------------------+------------------------------------------+--------------------------------------------------+
| Worker crash summary   | only "Worker exited unexpectedly"        | includes "Maybe related stderr" with crash logs |
| Stderr attribution     | no task-scoped stderr binding            | task->pid binding via structured worker meta     |
| Regression coverage    | no panic-specific e2e assertion          | panic fixture + summary assertions added         |
+------------------------+------------------------------------------+--------------------------------------------------+
```

**Changes:**
- pool-level stderr capture module
  - new `packages/core/src/pool/stderrCapture.ts` with ring buffer, truncation, close-wait timeout
- structured worker meta channel
  - new `packages/core/src/pool/workerMeta.ts`; worker emits meta in `packages/core/src/runtime/worker/index.ts`
- forks pool error enrichment
  - `packages/core/src/pool/forks.ts` parses worker meta and appends captured stderr on unexpected worker exit
- e2e crash-path validation
  - new `e2e/worker/fixtures/worker.panic.test.ts` and assertions in `e2e/worker/index.test.ts`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
