### PR TITLE
test(browser-mode): guard headed e2e case by display availability

### DIFF
--- a/e2e/browser-mode/basic.test.ts
+++ b/e2e/browser-mode/basic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
-import { runBrowserCli } from './utils';
+import { canRunHeadedBrowser, runBrowserCli } from './utils';
 
 describe('browser mode - basic', () => {
   it('should run DOM tests correctly', async () => {
@@ -37,13 +37,16 @@ describe('browser mode - basic', () => {
     expect(cli.stdout).toContain('/scheduler.html');
   });
 
-  it('should run headed mode without scheduler page and exit with code 0', async () => {
-    const { cli } = await runBrowserCli('basic', {
-      args: ['--browser.headless', 'false', 'tests/dom.test.ts'],
-    });
+  it.runIf(canRunHeadedBrowser)(
+    'should run headed mode without scheduler page and exit with code 0',
+    async () => {
+      const { cli } = await runBrowserCli('basic', {
+        args: ['--browser.headless', 'false', 'tests/dom.test.ts'],
+      });
 
-    await cli.exec;
-    expect(cli.exec.exitCode).toBe(0);
-    expect(cli.stdout).not.toContain('/scheduler.html');
-  });
+      await cli.exec;
+      expect(cli.exec.exitCode).toBe(0);
+      expect(cli.stdout).not.toContain('/scheduler.html');
+    },
+  );
 });

--- a/e2e/browser-mode/utils.ts
+++ b/e2e/browser-mode/utils.ts
@@ -17,6 +17,12 @@ const defaultEnvOverrides: Record<string, string> = {
   GITHUB_ACTIONS: '',
 };
 
+export const canRunHeadedBrowser =
+  process.platform === 'darwin' ||
+  process.platform === 'win32' ||
+  (process.platform === 'linux' &&
+    Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY));
+
 /**
  * Run browser mode CLI with specified fixture
  */


### PR DESCRIPTION
## Summary

to prevent fail like https://github.com/web-infra-dev/rspack/actions/runs/21852746524/job/63063200058.

This PR stabilizes browser-mode e2e execution by conditionally running the headed test only when the environment can actually launch a headed browser. It preserves the original headed-path assertion on macOS, Windows, and display-enabled Linux, while avoiding false negatives on Linux runners without X/Wayland display variables.

**Behavior diff:**

```
+------------------------------+---------------------------------------------+------------------------------------------------------+
| Scope                        | Before                                      | After                                                |
+------------------------------+---------------------------------------------+------------------------------------------------------+
| Headed e2e on Linux no display | Always runs and fails at browser launch      | Skipped via runtime guard                            |
| Headed e2e on mac/win/display Linux | Runs and asserts non-scheduler path behavior | Runs with same assertions and expected exit code     |
+------------------------------+---------------------------------------------+------------------------------------------------------+
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
