### PR TITLE
release: 0.8.4

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "description": "React component testing support for Rstest browser mode",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Browser mode support for Rstest testing framework.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The Rsbuild-based test tool.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Rstest",
   "publisher": "rstack",
   "description": "VS Code extension for Rstest",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(ui): add viewport option by @fi3ework in https://github.com/web-infra-dev/rstest/pull/945
### Performance 🚀
* perf(browser): add lightweight scheduler page for headless mode by @fi3ework in https://github.com/web-infra-dev/rstest/pull/952
### Bug Fixes 🐞
* fix: reorganize the logic of color and remove the forced default values by @fi3ework in https://github.com/web-infra-dev/rstest/pull/946
* fix: setup files run only once with no-isolate by @claneo in https://github.com/web-infra-dev/rstest/pull/947
* fix(browser): unify error reporting and avoid duplicate error messages by @fi3ework in https://github.com/web-infra-dev/rstest/pull/950
* fix: should return the same spy instance when respy by @9aoy in https://github.com/web-infra-dev/rstest/pull/955
* fix(core): include worker stderr in unexpected-exit summary by @fi3ework in https://github.com/web-infra-dev/rstest/pull/956
### Document 📖
* docs: update vitest migration guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/953
* docs(migration): use diff code block by @9aoy in https://github.com/web-infra-dev/rstest/pull/954
* docs: add TypeScript typings guide for custom matchers by @9aoy in https://github.com/web-infra-dev/rstest/pull/957
### Other Changes
* test: drop browser mode test from no-isolate test by @fi3ework in https://github.com/web-infra-dev/rstest/pull/944
* refactor(browser): centralize browser config validation in @rstest/browser by @fi3ework in https://github.com/web-infra-dev/rstest/pull/951
* test(browser-mode): guard headed e2e case by display availability by @fi3ework in https://github.com/web-infra-dev/rstest/pull/958
* chore(deps): bump rspress 2.0 by @9aoy in https://github.com/web-infra-dev/rstest/pull/918
* chore(deps): update dependency axios to v1.13.5 [security] by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/959


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.8.3...v0.8.4