### PR TITLE
fix(core): move federation external bypass into federation plugin

### DIFF
--- a/packages/core/src/core/plugins/external.ts
+++ b/packages/core/src/core/plugins/external.ts
@@ -3,7 +3,7 @@ import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import type { RstestContext } from '../../types';
 import { ADDITIONAL_NODE_BUILTINS, castArray } from '../../utils';
 
-const autoExternalNodeModules: (
+const createAutoExternalNodeModules: (
   outputModule: boolean,
   federation: boolean,
 ) => (
@@ -13,9 +13,11 @@ const autoExternalNodeModules: (
     result?: Rspack.ExternalItemValue,
     type?: Rspack.ExternalsType,
   ) => void,
-) => void =
-  (outputModule, federation) =>
-  ({ context, request, dependencyType, getResolve }, callback) => {
+) => void = (outputModule, federation) =>
+  function autoExternalNodeModules(
+    { context, request, dependencyType, getResolve },
+    callback,
+  ) {
     if (!request) {
       return callback();
     }
@@ -117,7 +119,7 @@ export const pluginExternal: (context: RstestContext) => RsbuildPlugin = (
           output: {
             externals:
               testEnvironment.name === 'node'
-                ? [autoExternalNodeModules(outputModule, federation)]
+                ? [createAutoExternalNodeModules(outputModule, federation)]
                 : undefined,
           },
           tools: {

--- a/packages/core/src/core/plugins/federation.ts
+++ b/packages/core/src/core/plugins/federation.ts
@@ -99,17 +99,17 @@ export const shouldKeepBundledForFederation = (
   return false;
 };
 
-function federationExternalBypass(
+const createFederationExternalBypass = (
   remoteNames: Set<string>,
-): (
+): ((
   data: Rspack.ExternalItemFunctionData,
   callback: (
     err?: Error,
     result?: Rspack.ExternalItemValue,
     type?: Rspack.ExternalsType,
   ) => void,
-) => void {
-  return ({ request }, callback) => {
+) => void) => {
+  return function federationExternalBypass({ request }, callback) {
     if (!request || !shouldKeepBundledForFederation(request, remoteNames)) {
       return callback();
     }
@@ -117,7 +117,7 @@ function federationExternalBypass(
     // `false` means: stop evaluating remaining externals and keep bundled.
     return callback(undefined, false);
   };
-}
+};
 
 /**
  * Enable Rstest's Module Federation compatibility mode for the current Rsbuild
@@ -160,7 +160,7 @@ export const federation = (): RsbuildPlugin => ({
             );
             rspackConfig.externals = castArray(rspackConfig.externals) || [];
             rspackConfig.externals.unshift(
-              federationExternalBypass(federationRemoteNames),
+              createFederationExternalBypass(federationRemoteNames),
             );
 
             if (rspackConfig.plugins) {


### PR DESCRIPTION
## Summary

move federation external bypass into federation plugin.
- Move federation-specific external bypass logic from pluginExternal to federation plugin.
- Use `callback(undefined, false)` in federation external function so Rspack skips remaining externals and bundles matching federation requests.
- Keep `pluginExternal` focused on generic Node external behavior.
- Preserve the federation resolve-fail fallback in `pluginExternal`.

## Related Links

https://github.com/web-infra-dev/rstest/pull/842

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
