### PR TITLE
fix(browser): register Rstest API before browser setup files

### DIFF
--- a/e2e/browser-mode/fixtures/setup-files/setup.ts
+++ b/e2e/browser-mode/fixtures/setup-files/setup.ts
@@ -1,8 +1,17 @@
+import { beforeEach } from '@rstest/core';
+
 // Setup file that runs before all tests
 (globalThis as Record<string, unknown>).__SETUP_EXECUTED__ = true;
 (globalThis as Record<string, unknown>).__SETUP_TIMESTAMP__ = Date.now();
+(globalThis as Record<string, unknown>).__SETUP_BEFORE_EACH_COUNT__ = 0;
 
 // Add a custom matcher or global utility
 (globalThis as Record<string, unknown>).__customHelper__ = (value: string) => {
   return value.toUpperCase();
 };
+
+beforeEach(() => {
+  const globals = globalThis as Record<string, unknown>;
+  globals.__SETUP_BEFORE_EACH_COUNT__ =
+    (globals.__SETUP_BEFORE_EACH_COUNT__ as number) + 1;
+});

--- a/e2e/browser-mode/fixtures/setup-files/tests/index.test.ts
+++ b/e2e/browser-mode/fixtures/setup-files/tests/index.test.ts
@@ -5,6 +5,9 @@ describe('setup files', () => {
     expect((globalThis as Record<string, unknown>).__SETUP_EXECUTED__).toBe(
       true,
     );
+    expect(
+      (globalThis as Record<string, unknown>).__SETUP_BEFORE_EACH_COUNT__,
+    ).toBe(1);
   });
 
   it('should have setup timestamp', () => {
@@ -12,6 +15,9 @@ describe('setup files', () => {
       .__SETUP_TIMESTAMP__ as number;
     expect(typeof timestamp).toBe('number');
     expect(timestamp).toBeLessThanOrEqual(Date.now());
+    expect(
+      (globalThis as Record<string, unknown>).__SETUP_BEFORE_EACH_COUNT__,
+    ).toBe(2);
   });
 
   it('should have custom helper from setup', () => {
@@ -20,5 +26,8 @@ describe('setup files', () => {
     ) => string;
     expect(typeof helper).toBe('function');
     expect(helper('hello')).toBe('HELLO');
+    expect(
+      (globalThis as Record<string, unknown>).__SETUP_BEFORE_EACH_COUNT__,
+    ).toBe(3);
   });
 });

--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -426,12 +426,13 @@ const run = async () => {
     return;
   }
 
-  // 1. Load setup files for this project
-  for (const loadSetup of currentSetupLoaders) {
-    await loadSetup();
-  }
+  const loadSetupFiles = async (): Promise<void> => {
+    for (const loadSetup of currentSetupLoaders) {
+      await loadSetup();
+    }
+  };
 
-  // 2. Determine which test files to run
+  // 1. Determine which test files to run
   let testKeysToRun: string[];
 
   if (targetTestFile) {
@@ -478,6 +479,9 @@ const run = async () => {
       }
 
       try {
+        // Load setup files for this project after runtime is ready.
+        await loadSetupFiles();
+
         // Load the test file dynamically (registers tests without running)
         await currentTestContext.loadTest(key);
 
@@ -512,7 +516,7 @@ const run = async () => {
     return;
   }
 
-  // 3. Run tests for each file
+  // 2. Run tests for each file
   for (const key of testKeysToRun) {
     const testPath = toAbsolutePath(key, currentProject.projectRoot);
 
@@ -573,6 +577,9 @@ const run = async () => {
     });
 
     try {
+      // Load setup files for this project after runtime is ready.
+      await loadSetupFiles();
+
       // Record script URLs before loading the test file
       const beforeScripts = getScriptUrls();
 


### PR DESCRIPTION
## Summary

Fixes #964 by aligning browser-mode setup execution order with worker runtime semantics.

- In browser client entry, setup files are now loaded **after** `createRstestRuntime` so `globalThis.RSTEST_API` is already available.
- Applied the same order in both `run` and `collect` modes.
- Added e2e regression coverage for using `beforeEach` from `@rstest/core` inside browser setup files.

## Why

Previously browser mode loaded setup files before runtime initialization, so calling `beforeEach`/other Rstest APIs inside setup could throw:

`Rstest API '<name>' is not registered yet`.

## Verification

- `cd e2e && pnpm rstest browser-mode/setup.test.ts`
- `cd e2e && pnpm rstest browser-mode/list.test.ts`
- `pnpm --filter @rstest/browser typecheck`
