### PR TITLE
release: 0.8.5

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "description": "React component testing support for Rstest browser mode",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Browser mode support for Rstest testing framework.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "The Rsbuild-based test tool.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Rstest",
   "publisher": "rstack",
   "description": "VS Code extension for Rstest",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Bug Fixes 🐞
* fix: prevent rpc timeout by @9aoy in https://github.com/web-infra-dev/rstest/pull/961
* fix(browser): register Rstest API before browser setup files by @fi3ework in https://github.com/web-infra-dev/rstest/pull/966
* fix(mockRequire): `__webpack_require__.r` is not a function by @9aoy in https://github.com/web-infra-dev/rstest/pull/965


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.8.4...v0.8.5