### PR TITLE
feat(vscode): add editor diagnostics and clean up failure UI

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
       "background": {
         "activeOnStart": true,
         "beginsPattern": "build started...",
-        "endsPattern": "build complete, watching for changes..."
+        "endsPattern": "build completed, watching for changes..."
       },
       "pattern": {
         "regexp": "build failed in"
@@ -27,7 +27,7 @@
         "background": {
           "activeOnStart": true,
           "beginsPattern": "build started...",
-          "endsPattern": "build complete, watching for changes..."
+          "endsPattern": "build completed, watching for changes..."
         },
         "pattern": {
           "regexp": "build failed in"
@@ -48,7 +48,7 @@
         "background": {
           "activeOnStart": true,
           "beginsPattern": "build started...",
-          "endsPattern": "build complete, watching for changes..."
+          "endsPattern": "build completed, watching for changes..."
         },
         "pattern": {
           "regexp": "build failed in"
@@ -71,7 +71,7 @@
         "background": {
           "activeOnStart": true,
           "beginsPattern": "build started...",
-          "endsPattern": "build complete, watching for changes..."
+          "endsPattern": "build completed, watching for changes..."
         },
         "pattern": {
           "regexp": "build failed in"

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -8,6 +8,7 @@ Rstest is a VS Code extension that discovers, displays, and runs tests in your w
 - Parses test structure to build a nested tree (describe/suite/test)
 - Runs individual tests, suites, or entire files
 - Watches the filesystem and updates the tree on create/change/delete
+- Shows editor diagnostics for failed tests
 
 ## Activation
 
@@ -20,6 +21,15 @@ The extension activates automatically when your workspace contains Rstest config
 | `rstest.rstestPackagePath`     | `string`             | `undefined`                                    | The path to a `package.json` file of a Rstest executable (it's usually inside `node_modules`) in case the extension cannot find it. It will be used to resolve Rstest API paths. This should be used as a last resort fix. Supports `${workspaceFolder}` placeholder. |
 | `rstest.configFileGlobPattern` | `string[]`           | `["**/rstest.config.{mjs,ts,js,cjs,mts,cts}"]` | Glob patterns used to discover config files.                                                                                                                                                                                                                          |
 | `rstest.testCaseCollectMethod` | `"ast" \| "runtime"` | `"ast"`                                        | `"ast"`: Fast, only supports basic test cases. <br /> `"runtime"`: Slow, supports all test cases, including dynamic test generation methods (each/for/extend).                                                                                                        |
+| `rstest.applyDiagnostic`       | `boolean`            | `true`                                         | Show diagnostics in editor and Problems panel for failed tests.                                                                                                                                                                                                       |
+
+### Error lens compatibility
+
+If you use the Error Lens extension and want to avoid duplicated inline diagnostics, add this to your `settings.json`:
+
+- `errorLens.excludeBySource`: `['rstest']`
+
+This extension does not apply this setting automatically.
 
 ## How it works
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -57,6 +57,11 @@
             "Fast, only supports basic test cases.",
             "Slow, supports all test cases, including dynamic test generation methods (each/for/extend)."
           ]
+        },
+        "rstest.applyDiagnostic": {
+          "description": "Show diagnostics in editor and Problems panel for failed tests.",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -14,6 +14,7 @@ const configSchema = v.object({
     v.union([v.literal('ast'), v.literal('runtime')]),
     'ast',
   ),
+  applyDiagnostic: v.fallback(v.boolean(), true),
 });
 
 export type ExtensionConfig = v.InferOutput<typeof configSchema>;

--- a/packages/vscode/src/diagnostics.ts
+++ b/packages/vscode/src/diagnostics.ts
@@ -1,0 +1,102 @@
+import * as vscode from 'vscode';
+
+export type DiagnosticEntry = {
+  uri: vscode.Uri;
+  diagnostic: vscode.Diagnostic;
+};
+
+export class RstestDiagnostics implements vscode.Disposable {
+  private readonly collection =
+    vscode.languages.createDiagnosticCollection('rstest');
+
+  private readonly diagnosticsByProject = new Map<
+    string,
+    Map<vscode.TestItem, DiagnosticEntry[]>
+  >();
+
+  public setForTest(
+    projectKey: string,
+    testItem: vscode.TestItem,
+    diagnostics: DiagnosticEntry[],
+  ) {
+    if (!projectKey) {
+      return;
+    }
+    if (diagnostics.length === 0) {
+      this.clearForTest(projectKey, testItem);
+      return;
+    }
+
+    let projectDiagnostics = this.diagnosticsByProject.get(projectKey);
+    if (!projectDiagnostics) {
+      projectDiagnostics = new Map<vscode.TestItem, DiagnosticEntry[]>();
+      this.diagnosticsByProject.set(projectKey, projectDiagnostics);
+    }
+
+    projectDiagnostics.set(testItem, diagnostics);
+    this.flush();
+  }
+
+  public clearForTest(projectKey: string, testItem: vscode.TestItem) {
+    const projectDiagnostics = this.diagnosticsByProject.get(projectKey);
+    if (!projectDiagnostics) {
+      return;
+    }
+
+    if (projectDiagnostics.delete(testItem)) {
+      if (projectDiagnostics.size === 0) {
+        this.diagnosticsByProject.delete(projectKey);
+      }
+      this.flush();
+    }
+  }
+
+  public clearForProject(projectKey: string) {
+    if (!projectKey) {
+      return;
+    }
+
+    if (this.diagnosticsByProject.delete(projectKey)) {
+      this.flush();
+    }
+  }
+
+  public clear() {
+    this.diagnosticsByProject.clear();
+    this.collection.clear();
+  }
+
+  private flush() {
+    const diagnosticsByFile = new Map<
+      string,
+      { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }
+    >();
+
+    for (const projectDiagnostics of this.diagnosticsByProject.values()) {
+      for (const diagnostics of projectDiagnostics.values()) {
+        for (const entry of diagnostics) {
+          const key = entry.uri.toString();
+          const fileDiagnostics = diagnosticsByFile.get(key);
+          if (fileDiagnostics) {
+            fileDiagnostics.diagnostics.push(entry.diagnostic);
+            continue;
+          }
+          diagnosticsByFile.set(key, {
+            uri: entry.uri,
+            diagnostics: [entry.diagnostic],
+          });
+        }
+      }
+    }
+
+    this.collection.clear();
+    for (const { uri, diagnostics } of diagnosticsByFile.values()) {
+      this.collection.set(uri, diagnostics);
+    }
+  }
+
+  public dispose() {
+    this.clear();
+    this.collection.dispose();
+  }
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import vscode from 'vscode';
+import { RstestDiagnostics } from './diagnostics';
 import { logger } from './logger';
 import { runningWorkers } from './master';
 import { Project, WorkspaceManager } from './project';
@@ -28,6 +29,7 @@ class Rstest {
   private workspaceWatcher?: vscode.Disposable;
   private runProfile!: vscode.TestRunProfile;
   private coverageProfile!: vscode.TestRunProfile;
+  private diagnostics = new RstestDiagnostics();
 
   // Add getter to access the test controller for testing
   get testController() {
@@ -37,6 +39,7 @@ class Rstest {
   constructor(context: vscode.ExtensionContext) {
     this.ctrl = vscode.tests.createTestController('rstest', 'Rstest');
     context.subscriptions.push(this.ctrl);
+    context.subscriptions.push(this.diagnostics);
 
     this.startScanWorkspaces();
     this.setupTestController();
@@ -171,6 +174,7 @@ class Rstest {
       updateSnapshot,
       kind: request.profile?.kind,
       continuous: request.continuous,
+      diagnostics: this.diagnostics,
       createTestRun: () =>
         createTestRun(
           new vscode.TestRunRequest(

--- a/packages/vscode/tests/suite/progress.test.ts
+++ b/packages/vscode/tests/suite/progress.test.ts
@@ -126,6 +126,20 @@ suite('Test Progress Reporting', () => {
 
     assert.equal(failedMessages[3].message, 'after suite');
     assert.equal(failedMessages[4].message, 'after root suite');
+
+    assert.ok(item.uri, 'Progress test item should have a file uri');
+    const diagnostics = vscode.languages.getDiagnostics(item.uri);
+    assert.ok(diagnostics.length > 0, 'Failed run should publish diagnostics');
+    assert.ok(
+      diagnostics.some((diagnostic) => diagnostic.source === 'rstest'),
+      'Diagnostics source should be rstest',
+    );
+    assert.ok(
+      diagnostics.some((diagnostic) =>
+        diagnostic.message.includes('expected 1 to equal 2'),
+      ),
+      'Diagnostics should include assertion error messages',
+    );
   });
 
   test('can run a single test case', async () => {
@@ -163,6 +177,18 @@ suite('Test Progress Reporting', () => {
     assert.equal(passedItems.length, 1);
     assert.equal(passedItems[0]?.label, 'should add two numbers correctly');
     assert.match(output, /1 passed/);
+
+    const progressFileUri = vscode.Uri.file(
+      path.resolve(
+        __dirname,
+        '../../tests/fixtures/workspace-1/test/progress.test.ts',
+      ),
+    );
+    assert.equal(
+      vscode.languages.getDiagnostics(progressFileUri).length,
+      0,
+      'Successful run should clear previous diagnostics',
+    );
   });
 
   test('reports test progress with continuous run', async () => {

--- a/packages/vscode/tests/unit/diagnostics.test.ts
+++ b/packages/vscode/tests/unit/diagnostics.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, rs } from '@rstest/core';
+
+const diagnosticsState = new Map<string, unknown[]>();
+let clearCalls = 0;
+let disposeCalls = 0;
+
+rs.mock('vscode', () => {
+  return {
+    languages: {
+      createDiagnosticCollection: () => ({
+        set: (uri: { toString: () => string }, diagnostics: unknown[]) => {
+          diagnosticsState.set(uri.toString(), diagnostics);
+        },
+        clear: () => {
+          diagnosticsState.clear();
+          clearCalls++;
+        },
+        dispose: () => {
+          disposeCalls++;
+        },
+      }),
+    },
+  };
+});
+
+import { RstestDiagnostics } from '../../src/diagnostics';
+
+const createUri = (path: string) =>
+  ({
+    toString: () => path,
+  }) as any;
+
+const createTestItem = (id: string) =>
+  ({
+    id,
+  }) as any;
+
+const createEntry = (path: string, message: string) =>
+  ({
+    uri: createUri(path),
+    diagnostic: { message },
+  }) as any;
+
+describe('RstestDiagnostics', () => {
+  it('should keep diagnostics for different test items with same id', () => {
+    diagnosticsState.clear();
+    clearCalls = 0;
+
+    const diagnostics = new RstestDiagnostics();
+    const itemA = createTestItem('duplicate-id');
+    const itemB = createTestItem('duplicate-id');
+
+    diagnostics.setForTest('project-a', itemA, [
+      createEntry('file:///a.test.ts', 'error-a'),
+    ]);
+    diagnostics.setForTest('project-a', itemB, [
+      createEntry('file:///a.test.ts', 'error-b'),
+    ]);
+
+    expect(diagnosticsState.get('file:///a.test.ts')).toEqual([
+      { message: 'error-a' },
+      { message: 'error-b' },
+    ]);
+
+    diagnostics.clearForTest('project-a', itemA);
+    expect(diagnosticsState.get('file:///a.test.ts')).toEqual([
+      { message: 'error-b' },
+    ]);
+  });
+
+  it('should clear diagnostics for one project without affecting others', () => {
+    diagnosticsState.clear();
+    clearCalls = 0;
+
+    const diagnostics = new RstestDiagnostics();
+    diagnostics.setForTest('project-a', createTestItem('a'), [
+      createEntry('file:///a.test.ts', 'error-a'),
+      createEntry('file:///stale.test.ts', 'stale-a'),
+    ]);
+    diagnostics.setForTest('project-b', createTestItem('b'), [
+      createEntry('file:///b.test.ts', 'error-b'),
+    ]);
+
+    diagnostics.clearForProject('project-a');
+
+    expect(diagnosticsState.get('file:///a.test.ts')).toBeUndefined();
+    expect(diagnosticsState.get('file:///stale.test.ts')).toBeUndefined();
+    expect(diagnosticsState.get('file:///b.test.ts')).toEqual([
+      { message: 'error-b' },
+    ]);
+  });
+
+  it('should dispose collection safely', () => {
+    diagnosticsState.clear();
+    clearCalls = 0;
+    disposeCalls = 0;
+
+    const diagnostics = new RstestDiagnostics();
+    diagnostics.setForTest('project-a', createTestItem('a'), [
+      createEntry('file:///a.test.ts', 'error-a'),
+    ]);
+    diagnostics.dispose();
+
+    expect(disposeCalls).toBe(1);
+    expect(diagnosticsState.size).toBe(0);
+    expect(clearCalls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

| Before | After |
|--------|-------|
|  <img width="940" height="555" alt="image" src="https://github.com/user-attachments/assets/6da2c4d8-7f54-4b19-a1de-0401bbde5e28" />  |    <img width="955" height="647" alt="Code 2026-02-26 11 47 28" src="https://github.com/user-attachments/assets/ffef629a-e80b-4106-aae9-1d99de8c4412" />   |

This PR introduces editor diagnostics for failed tests, showing squiggles in the editor and entries in the Problems panel. It also cleans up the failure widget by removing noisy compiled stack frames and fixes the preLaunchTask matcher for F5 debugging.
**Behavior diff:**
| Feature | Before | After |
|---------|--------|-------|
| Failed test indicators | Testing badge only | Badge + editor squiggle + Problems entry |
| Failure widget stack | Showed compiled runtime frames (6151.js) | Hidden, only shows actionable message |
| F5 preLaunchTask | Stuck waiting for `build complete...` | Works with `build completed...` pattern |

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
