### PR TITLE
fix(browser): remove default process shim while keep env stubbing support

### DIFF
--- a/e2e/browser-mode/env.test.ts
+++ b/e2e/browser-mode/env.test.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('browser mode - env', () => {
-  it('should inject env into browser runtime via process shim', async () => {
+  it('should inject env into browser runtime without process shim', async () => {
     const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
       args: ['run'],

--- a/e2e/browser-mode/fixtures/env/rstest.config.ts
+++ b/e2e/browser-mode/fixtures/env/rstest.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
   env: {
     RSTEST_E2E_ENV_FOO: 'bar',
     RSTEST_E2E_ENV_EMPTY: '',
-    // In browser mode, env is proxied into a process shim.
-    // Setting a key to undefined should remove it from process.env.
+    // In browser mode, env is injected into runtime env store.
+    // Setting a key to undefined should remove it from the store.
     RSTEST_E2E_ENV_UNSET: undefined,
   },
 });

--- a/e2e/browser-mode/fixtures/env/tests/env.test.ts
+++ b/e2e/browser-mode/fixtures/env/tests/env.test.ts
@@ -1,14 +1,34 @@
-import { describe, expect, it } from '@rstest/core';
+import { describe, expect, it, rstest } from '@rstest/core';
 
 describe('browser env injection', () => {
-  it('should expose process.env in browser and apply env changes', () => {
+  it('should apply env changes without injecting global process', () => {
     // Browser client ensures global alias exists for libraries expecting Node globals.
     expect((globalThis as any).global).toBe(globalThis);
 
-    expect(typeof (globalThis as any).process).toBe('object');
+    expect((globalThis as any).process).toBeUndefined();
+    expect((globalThis as any).__RSTEST_ENV__).toBeUndefined();
+    expect(Object.hasOwn(globalThis, '__RSTEST_ENV__')).toBe(false);
+
     expect(process.env.RSTEST_E2E_ENV_FOO).toBe('bar');
     expect(process.env.RSTEST_E2E_ENV_EMPTY).toBe('');
     expect(process.env.RSTEST_E2E_ENV_UNSET).toBeUndefined();
     expect(Object.hasOwn(process.env, 'RSTEST_E2E_ENV_UNSET')).toBe(false);
+
+    const originalFoo = process.env.RSTEST_E2E_ENV_FOO;
+
+    rstest.stubEnv('RSTEST_E2E_ENV_FOO', 'changed');
+    rstest.stubEnv('RSTEST_E2E_ENV_DYNAMIC', 'dynamic');
+
+    expect(process.env.RSTEST_E2E_ENV_FOO).toBe('changed');
+    expect(process.env.RSTEST_E2E_ENV_DYNAMIC).toBe('dynamic');
+
+    rstest.stubEnv('RSTEST_E2E_ENV_DYNAMIC', undefined);
+
+    expect(process.env.RSTEST_E2E_ENV_DYNAMIC).toBeUndefined();
+
+    rstest.unstubAllEnvs();
+
+    expect(process.env.RSTEST_E2E_ENV_FOO).toBe(originalFoo);
+    expect(process.env.RSTEST_E2E_ENV_DYNAMIC).toBeUndefined();
   });
 });

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -975,6 +975,12 @@ const createBrowserRuntime = async ({
               resolve: {
                 alias: rstestInternalAliases,
               },
+              source: {
+                define: {
+                  'process.env': 'globalThis[Symbol.for("rstest.env")]',
+                  'import.meta.env': 'globalThis[Symbol.for("rstest.env")]',
+                },
+              },
               output: {
                 target: 'web',
                 // Enable source map for inline snapshot support

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -105,7 +105,7 @@ const applyCommonOptions = (cli: CAC) => {
     )
     .option(
       '--unstubEnvs',
-      'Restores all `process.env` values that were changed with `rstest.stubEnv` before every test',
+      'Restores all runtime env values that were changed with `rstest.stubEnv` before every test',
     )
     .option(
       '--includeTaskLocation',

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -368,7 +368,7 @@ export interface RstestConfig {
    */
   unstubGlobals?: boolean;
   /**
-   * Restores all `process.env` values that were changed with `rstest.stubEnv` before every test.
+   * Restores all runtime env values that were changed with `rstest.stubEnv` before every test.
    * @default false
    */
   unstubEnvs?: boolean;

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -469,12 +469,13 @@ export interface RstestUtilities {
   resetModules: () => RstestUtilities;
 
   /**
-   * Changes the value of environmental variable on `process.env`.
+   * Changes the value of an environment variable in the current runtime env store.
+   * Uses `process.env` in Node.js and runtime env store in browser mode.
    */
   stubEnv: (name: string, value: string | undefined) => RstestUtilities;
 
   /**
-   * Restores all `process.env` values that were changed with `rstest.stubEnv`.
+   * Restores all env values that were changed with `rstest.stubEnv`.
    */
   unstubAllEnvs: () => RstestUtilities;
 


### PR DESCRIPTION
## Summary

Removes the automatic injection of a `process` object shim in browser mode, eliminating global namespace pollution. Replaces the string-keyed `__RSTEST_ENV__` with a Symbol-based store (`Symbol.for('rstest.env')`) to hold environment variables, while ensuring `rstest.stubEnv()` continues to work seamlessly.

**Behavior diff:**
| Aspect | Before | After |
|--------|--------|-------|
| Global `process` | Injected with `env/argv/version/cwd/platform/nextTick` | `undefined` by default |
| Env store key | `globalThis.__RSTEST_ENV__` (string) | `globalThis[Symbol.for('rstest.env')]` |
| `process.env` access | Direct property access on shim | Compiled to Symbol store via `source.define` |
| Global pollution | Visible string key `__RSTEST_ENV__` | No visible string keys added |

**Changes:**
- Replace `ensureProcessEnv` with `ensureRuntimeEnv` using `Symbol.for('rstest.env')` as the canonical store
- Update `stubEnv`/`unstubAllEnvs` to resolve env target from Symbol store first, fallback to `process.env` in Node
- Configure Rsbuild `source.define` to rewrite `process.env` and `import.meta.env` to the Symbol store
- Update E2E assertions to verify no global `process` and no `__RSTEST_ENV__` string key
- Revise CLI help text and type documentation to reference "runtime env" instead of "process.env"

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
