### PR TITLE
docs: add `migrate-to-rstest` skill to migration guide

### DIFF
--- a/website/docs/en/guide/migration/jest.mdx
+++ b/website/docs/en/guide/migration/jest.mdx
@@ -2,6 +2,16 @@
 
 Rstest is designed to be Jest-compatible, making migration from Jest projects straightforward. Here's how to migrate your Jest project to Rstest:
 
+## Using Agent Skills
+
+If you are using a Coding Agent that supports Skills, install the [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) skill to help with the upgrade process from Jest to Rstest.
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rstest
+```
+
+After installation, let the Coding Agent guide you through the upgrade.
+
 ## Installation and setup
 
 First, you need to install Rstest as a development dependency.

--- a/website/docs/en/guide/migration/vitest.mdx
+++ b/website/docs/en/guide/migration/vitest.mdx
@@ -2,6 +2,16 @@
 
 If you are using the Rstack toolchain (Rsbuild / Rslib / Rspack, etc.), migrating to Rstest gives you a more consistent development experience.
 
+## Using Agent Skills
+
+If you are using a Coding Agent that supports Skills, install the [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) skill to help with the upgrade process from Vitest to Rstest.
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rstest
+```
+
+After installation, let the Coding Agent guide you through the upgrade.
+
 ## Install dependencies
 
 First, you need to install the Rstest dependency.

--- a/website/docs/zh/guide/migration/jest.mdx
+++ b/website/docs/zh/guide/migration/jest.mdx
@@ -2,6 +2,16 @@
 
 Rstest 提供兼容 Jest 的 API，这使得从 Jest 项目迁移变得简单。以下是如何将你的 Jest 项目迁移到 Rstest：
 
+## 使用 Agent Skills
+
+如果你在使用支持 Skills 的 Coding Agent，可以安装 [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) 技能来辅助完成从 Jest 到 Rstest 的迁移。
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rstest
+```
+
+安装后，让 Coding Agent 协助完成升级即可。
+
 ## 安装依赖
 
 首先，你需要安装 Rstest 依赖。

--- a/website/docs/zh/guide/migration/vitest.mdx
+++ b/website/docs/zh/guide/migration/vitest.mdx
@@ -2,6 +2,16 @@
 
 如果你正在使用 Rstack 工具链（Rsbuild / Rslib / Rspack 等），迁移到 Rstest 可以带来更一致的开发体验。
 
+## 使用 Agent Skills
+
+如果你在使用支持 Skills 的 Coding Agent，可以安装 [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) 技能来辅助完成从 Vitest 到 Rstest 的迁移。
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rstest
+```
+
+安装后，让 Coding Agent 协助完成升级即可。
+
 ## 安装依赖
 
 首先，你需要安装 Rstest 依赖。


### PR DESCRIPTION
## Summary

Add `migrate-to-rstest` skill to Jest / Vitest migration guide.

https://github.com/rstackjs/agent-skills#migrate-to-rstest
## Related Links
close https://github.com/web-infra-dev/rstest/issues/362
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
