### PR TITLE
fix: error messages not displayed due to stream interception

### DIFF
--- a/packages/core/src/reporter/windowedRenderer.ts
+++ b/packages/core/src/reporter/windowedRenderer.ts
@@ -53,7 +53,7 @@ export class WindowRenderer {
   private windowHeight = 0;
   private finished = false;
   private readonly cleanups: (() => void)[] = [];
-  private exitHandler = () => {
+  private readonly exitHandler = () => {
     this.finish();
   };
 


### PR DESCRIPTION
## Summary

fix error messages not displayed due to stream interception
before:
<img width="753" height="116" alt="image" src="https://github.com/user-attachments/assets/a1108d79-bc42-4f42-b561-1c46a4b0b605" />

after:
<img width="757" height="252" alt="image" src="https://github.com/user-attachments/assets/3c1a4b34-a651-4cc6-98c1-264459a24703" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
