### PR TITLE
fix: `bail` configuration should work with the test file error

### DIFF
--- a/packages/core/src/core/stateManager.ts
+++ b/packages/core/src/core/stateManager.ts
@@ -63,7 +63,13 @@ export class TestStateManager {
   getCountOfFailedTests(): number {
     const testResults: TestResult[] = Array.from(this.runningModules.values())
       .flatMap(({ results }) => results)
-      .concat(this.testModules.flatMap((mod) => mod.results));
+      .concat(
+        this.testModules.flatMap((mod) =>
+          mod.results.length > 0
+            ? mod.results
+            : [{ status: mod.status } as TestResult],
+        ),
+      );
 
     return testResults.filter((t) => t.status === 'fail').length;
   }


### PR DESCRIPTION
## Summary

`bail` configuration should work with the test file error.

<img width="593" height="275" alt="image" src="https://github.com/user-attachments/assets/a2b67e4e-17ea-4abd-a953-a71dc87b061c" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
