### PR TITLE
fix(e2e): skip headed browser tests on Linux CI without display

### DIFF
--- a/e2e/browser-mode/locatorApi.test.ts
+++ b/e2e/browser-mode/locatorApi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
-import { runBrowserCli } from './utils';
+import { canRunHeadedBrowser, runBrowserCli } from './utils';
 
 describe('browser mode - locator api', () => {
   it('should run locator API tests correctly', async () => {
@@ -9,13 +9,16 @@ describe('browser mode - locator api', () => {
     expect(cli.stdout).toMatch(/Tests.*passed/);
   });
 
-  it('should run locator API tests in headed mode without scheduler page', async () => {
-    const { expectExecSuccess, cli } = await runBrowserCli('locator-api', {
-      args: ['--browser.headless', 'false'],
-    });
+  it.skipIf(!canRunHeadedBrowser)(
+    'should run locator API tests in headed mode without scheduler page',
+    async () => {
+      const { expectExecSuccess, cli } = await runBrowserCli('locator-api', {
+        args: ['--browser.headless', 'false'],
+      });
 
-    await expectExecSuccess();
-    expect(cli.stdout).toMatch(/Tests.*passed/);
-    expect(cli.stdout).not.toContain('/scheduler.html');
-  });
+      await expectExecSuccess();
+      expect(cli.stdout).toMatch(/Tests.*passed/);
+      expect(cli.stdout).not.toContain('/scheduler.html');
+    },
+  );
 });

--- a/e2e/browser-mode/viewport.test.ts
+++ b/e2e/browser-mode/viewport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
-import { runBrowserCli } from './utils';
+import { canRunHeadedBrowser, runBrowserCli } from './utils';
 
 describe('browser mode - viewport', () => {
   it('should apply viewport config to runner iframe', async () => {
@@ -14,13 +14,16 @@ describe('browser mode - viewport', () => {
     expect(cli.stdout).toMatch(/Tests.*passed/);
   });
 
-  it('should apply viewport config in headed mode without scheduler page', async () => {
-    const { expectExecSuccess, cli } = await runBrowserCli('viewport', {
-      args: ['--browser.headless', 'false'],
-    });
+  it.skipIf(!canRunHeadedBrowser)(
+    'should apply viewport config in headed mode without scheduler page',
+    async () => {
+      const { expectExecSuccess, cli } = await runBrowserCli('viewport', {
+        args: ['--browser.headless', 'false'],
+      });
 
-    await expectExecSuccess();
-    expect(cli.stdout).toMatch(/Tests.*passed/);
-    expect(cli.stdout).not.toContain('/scheduler.html');
-  });
+      await expectExecSuccess();
+      expect(cli.stdout).toMatch(/Tests.*passed/);
+      expect(cli.stdout).not.toContain('/scheduler.html');
+    },
+  );
 });


### PR DESCRIPTION
## Problem

`viewport.test.ts` and `locatorApi.test.ts` have test cases that pass `--browser.headless false`, forcing headed mode. These fail on Linux CI (e.g. ecosystem-ci on Ubuntu) because there is no X Server / `$DISPLAY`.

## Fix

Gate the headed-mode test cases with the existing `canRunHeadedBrowser` check from `e2e/browser-mode/utils.ts`, so they are automatically skipped when no display server is available (Linux without `DISPLAY`/`WAYLAND_DISPLAY`). macOS and Windows are unaffected.

### Changes
- `e2e/browser-mode/viewport.test.ts`: `it.skipIf(!canRunHeadedBrowser)` on the headed test case
- `e2e/browser-mode/locatorApi.test.ts`: `it.skipIf(!canRunHeadedBrowser)` on the headed test case