### PR TITLE
docs: introduce `rs.mockRequire` and `rs.doMockRequire` APIs

### DIFF
--- a/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
@@ -246,6 +246,55 @@ it('test', async () => {
 });
 ```
 
+## rs.mockRequire
+
+- **Type**: `<T = unknown>(moduleName: string, factoryOrOptions?: (() => T) | { spy: true } | { mock: true }) => void`
+
+Mocks modules loaded through CommonJS `require()`. Like `rs.mock`, this API is hoisted to the top of the current module.
+
+Use this API when the target module is consumed via `require()` instead of `import`.
+
+:::tip
+Difference from `rs.mock` in dual packages (one ESM entry and one CJS entry):
+
+- `rs.mock()` mocks the **ESM entry** (used by `import`)
+- `rs.mockRequire()` mocks the **CJS entry** (used by `require()`)
+
+If your code path uses `require()`, prefer `rs.mockRequire()` to avoid mocking the wrong entry.
+:::
+
+```ts title="src/math.test.cjs"
+const { sum } = require('./math.cjs');
+
+rs.mockRequire('./math.cjs', () => ({
+  sum: (a, b) => a + b + 100,
+}));
+
+test('mock cjs module with require', () => {
+  expect(sum(1, 2)).toBe(103);
+});
+```
+
+## rs.doMockRequire
+
+- **Type**: `<T = unknown>(moduleName: string, factoryOrOptions?: (() => T) | { spy: true } | { mock: true }) => void`
+
+Similar to `rs.mockRequire`, but it is **not hoisted**. The mock is applied only after `rs.doMockRequire` is executed, and only affects subsequent `require()` calls.
+
+```ts title="src/math.test.cjs"
+test('doMockRequire only affects later require calls', () => {
+  const { sum } = require('./math.cjs');
+  expect(sum(1, 2)).toBe(3);
+
+  rs.doMockRequire('./math.cjs', () => ({
+    sum: (a, b) => a + b + 100,
+  }));
+
+  const { sum: mockedSum } = require('./math.cjs');
+  expect(mockedSum(1, 2)).toBe(103);
+});
+```
+
 ## rs.hoisted
 
 - **Type**: `<T = unknown>(fn: () => T) => T`

--- a/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
@@ -246,6 +246,55 @@ it('test', async () => {
 });
 ```
 
+## rs.mockRequire
+
+- **类型：** `<T = unknown>(moduleName: string, factoryOrOptions?: (() => T) | { spy: true } | { mock: true }) => void`
+
+用于 mock 通过 CommonJS `require()` 加载的模块。和 `rs.mock` 一样，这个 API 会被提升（hoisted）到当前模块顶部。
+
+当目标模块是通过 `require()` 消费时，应使用这个 API。
+
+:::tip
+与 `rs.mock` 在 dual package（同时提供 ESM entry 与 CJS entry）场景的区别：
+
+- `rs.mock()` mock 的是 **ESM entry**（`import` 使用）
+- `rs.mockRequire()` mock 的是 **CJS entry**（`require()` 使用）
+
+如果你的代码路径走的是 `require()`，优先使用 `rs.mockRequire()`，避免 mock 到错误的 entry。
+:::
+
+```ts title="src/math.test.cjs"
+const { sum } = require('./math.cjs');
+
+rs.mockRequire('./math.cjs', () => ({
+  sum: (a, b) => a + b + 100,
+}));
+
+test('使用 require mock cjs 模块', () => {
+  expect(sum(1, 2)).toBe(103);
+});
+```
+
+## rs.doMockRequire
+
+- **类型：** `<T = unknown>(moduleName: string, factoryOrOptions?: (() => T) | { spy: true } | { mock: true }) => void`
+
+与 `rs.mockRequire` 类似，但它**不会被提升**。只有在执行 `rs.doMockRequire` 之后，后续的 `require()` 才会应用 mock。
+
+```ts title="src/math.test.cjs"
+test('doMockRequire 只影响后续 require 调用', () => {
+  const { sum } = require('./math.cjs');
+  expect(sum(1, 2)).toBe(3);
+
+  rs.doMockRequire('./math.cjs', () => ({
+    sum: (a, b) => a + b + 100,
+  }));
+
+  const { sum: mockedSum } = require('./math.cjs');
+  expect(mockedSum(1, 2)).toBe(103);
+});
+```
+
 ## rs.hoisted
 
 - **类型：** `<T = unknown>(fn: () => T) => T`


### PR DESCRIPTION
## Summary

Introduce `rs.mockRequire` and `rs.doMockRequire` APIs.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
