### PR TITLE
fix: apply default watch ignore options for browser mode

### DIFF
--- a/packages/browser/src/config.ts
+++ b/packages/browser/src/config.ts
@@ -1,0 +1,31 @@
+import type { Rspack } from '@rstest/core';
+
+const castArray = <T>(arr?: T | T[]): T[] => {
+  if (arr === undefined) {
+    return [];
+  }
+  return Array.isArray(arr) ? arr : [arr];
+};
+
+export const applyDefaultWatchOptions = (
+  rspackConfig: Rspack.Configuration,
+  isWatchMode: boolean,
+) => {
+  rspackConfig.watchOptions ??= {};
+
+  if (!isWatchMode) {
+    rspackConfig.watchOptions.ignored = '**/**';
+    return;
+  }
+
+  rspackConfig.watchOptions.ignored = castArray(
+    rspackConfig.watchOptions.ignored || [],
+  ) as string[];
+
+  if (rspackConfig.watchOptions.ignored.length === 0) {
+    rspackConfig.watchOptions.ignored.push('**/.git', '**/node_modules');
+  }
+
+  rspackConfig.output?.path &&
+    rspackConfig.watchOptions.ignored.push(rspackConfig.output.path);
+};

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -33,6 +33,7 @@ import * as picomatch from 'picomatch';
 import sirv from 'sirv';
 import { type WebSocket, WebSocketServer } from 'ws';
 import { getHeadlessConcurrency } from './concurrency';
+import { applyDefaultWatchOptions } from './config';
 import {
   createHostDispatchRouter,
   type HostDispatchRouterOptions,
@@ -1096,6 +1097,8 @@ const createBrowserRuntime = async ({
                   };
                   rspackConfig.plugins = rspackConfig.plugins || [];
                   rspackConfig.plugins.push(virtualManifestPlugin);
+
+                  applyDefaultWatchOptions(rspackConfig, isWatchMode);
 
                   // Extract and merge sourcemaps from pre-built @rstest/core files
                   // This preserves the sourcemap chain for inline snapshot support

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,8 @@ export function defineProject(config: RstestProjectConfigExport) {
   return config;
 }
 
+export type { Rspack } from '@rsbuild/core';
+
 export type {
   Assertion,
   DescribeAPI as Describe,


### PR DESCRIPTION
## Summary

Apply default watch ignore options for browser mode. fix unexpected hot update when `dev.writeToDisk: true`

<img width="1876" height="1090" alt="image" src="https://github.com/user-attachments/assets/7b4eb285-67a0-4589-bc4a-493c6813e7dd" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
