### PR TITLE
fix(browser): serialize headed file execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ cd e2e && pnpm rstest browser-mode/config.test.ts
 
 Note: Always lint and typecheck updated files. Use project-wide commands sparingly.
 
+When validating changes through `examples/` or `e2e/`, remember that package source edits will not take effect until the affected workspace package is rebuilt first (for example `pnpm --filter @rstest/browser build`).
+
 ## Do
 
 - Use ESM-first: `.mjs` for runtime loaders, `.ts` for typed utilities

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,19 @@
+# E2E tests
+
+Integration and end-to-end coverage for Rstest features.
+
+## Do
+
+- Prefer reusing an existing fixture when the new scenario can be expressed by extending it with a small, focused test file.
+- Add a new fixture only when the scenario truly needs different config, dependencies, or file layout.
+- Keep fixtures minimal and representative of the behavior under test.
+- Prefer targeted e2e runs over full suites while iterating.
+
+## Don't
+
+- Don't create near-duplicate fixtures just to add one extra test case.
+- Don't expand fixture scope beyond the behavior the e2e is meant to cover.
+
+## Validation
+
+- Rebuild affected workspace packages before validating through `e2e/` fixtures when source edits need packaged output.

--- a/e2e/browser-mode/fixtures/locator-api/tests/headedConcurrencySmoke.test.ts
+++ b/e2e/browser-mode/fixtures/locator-api/tests/headedConcurrencySmoke.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@rstest/core';
+
+/**
+ * Keeps a second test file ahead of the locator-based file so headed mode exercises
+ * multi-file scheduling instead of the single-file happy path.
+ */
+test('headed concurrency smoke', () => {
+  expect(1).toBe(1);
+});

--- a/e2e/browser-mode/locatorApi.test.ts
+++ b/e2e/browser-mode/locatorApi.test.ts
@@ -6,19 +6,26 @@ describe('browser mode - locator api', () => {
     const { expectExecSuccess, cli } = await runBrowserCli('locator-api');
 
     await expectExecSuccess();
+    expect(cli.stdout).toContain('headedConcurrencySmoke.test.ts');
+    expect(cli.stdout).toContain('locatorApi.test.ts');
+    expect(cli.stdout).toMatch(/Test Files.*2.*passed/);
     expect(cli.stdout).toMatch(/Tests.*passed/);
   });
 
   it.skipIf(!canRunHeadedBrowser)(
-    'should run locator API tests in headed mode without scheduler page',
+    'should keep locator API working across multiple files in headed mode',
     async () => {
       const { expectExecSuccess, cli } = await runBrowserCli('locator-api', {
         args: ['--browser.headless', 'false'],
       });
 
       await expectExecSuccess();
+      expect(cli.stdout).toContain('headedConcurrencySmoke.test.ts');
+      expect(cli.stdout).toContain('locatorApi.test.ts');
+      expect(cli.stdout).toMatch(/Test Files.*2.*passed/);
       expect(cli.stdout).toMatch(/Tests.*passed/);
       expect(cli.stdout).not.toContain('/scheduler.html');
+      expect(cli.stdout).not.toContain('test timed out');
     },
   );
 });

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -213,6 +213,7 @@ const BrowserRunner: React.FC<{
         testFile,
         testNamePattern,
       );
+      setActive(testFile);
       return new Promise<void>((resolve, reject) => {
         const previousPending = pendingReloadsRef.current.get(testFile);
         if (previousPending) {
@@ -310,7 +311,9 @@ const BrowserRunner: React.FC<{
     setRunIdByTestFile((prev) => {
       const next: Record<string, string> = {};
       for (const file of testFiles) {
-        next[file.testPath] = prev[file.testPath] ?? createRunId();
+        if (prev[file.testPath]) {
+          next[file.testPath] = prev[file.testPath]!;
+        }
       }
       return next;
     });
@@ -331,6 +334,21 @@ const BrowserRunner: React.FC<{
       return prev;
     });
   }, [testFiles]);
+
+  useEffect(() => {
+    if (!rpc || !connected) {
+      return;
+    }
+
+    void rpc
+      .onRunnerFramesReady(testFiles.map((file) => file.testPath))
+      .catch((error) => {
+        logger.debug(
+          '[Container RPC] Failed to notify runner frames ready:',
+          error,
+        );
+      });
+  }, [rpc, connected, testFiles]);
 
   const mapCaseStatus = useCallback(
     (status?: BrowserClientTestResult['status']): CaseStatus => {
@@ -765,9 +783,6 @@ const BrowserRunner: React.FC<{
                 (() => {
                   const isActive = fileInfo.testPath === active;
                   const runId = runIdByTestFile[fileInfo.testPath];
-                  if (!runId) {
-                    return null;
-                  }
                   const selection =
                     viewportByProject[fileInfo.projectName] ??
                     selectionFromConfig(
@@ -776,6 +791,9 @@ const BrowserRunner: React.FC<{
                   const onLoad = (
                     event: React.SyntheticEvent<HTMLIFrameElement>,
                   ) => {
+                    if (!runId) {
+                      return;
+                    }
                     const frame = event.currentTarget;
                     const frameRunId = readRunIdFromFrame(frame) ?? runId;
                     if (frame.contentWindow) {
@@ -823,13 +841,17 @@ const BrowserRunner: React.FC<{
                         <iframe
                           data-test-file={fileInfo.testPath}
                           title={`Test runner for ${getDisplayName(fileInfo.testPath)}`}
-                          src={createRunnerUrl(
-                            fileInfo.testPath,
-                            options.runnerUrl,
-                            undefined,
-                            false,
-                            runId,
-                          )}
+                          src={
+                            runId
+                              ? createRunnerUrl(
+                                  fileInfo.testPath,
+                                  options.runnerUrl,
+                                  undefined,
+                                  false,
+                                  runId,
+                                )
+                              : 'about:blank'
+                          }
                           className="block h-full w-full border-0"
                           style={{ background: token.colorBgContainer }}
                           onLoad={onLoad}

--- a/packages/browser-ui/src/types.ts
+++ b/packages/browser-ui/src/types.ts
@@ -67,6 +67,7 @@ export type BrowserClientMessage =
 export type HostRPC = {
   rerunTest: (testFile: string, testNamePattern?: string) => Promise<void>;
   getTestFiles: () => Promise<TestFileInfo[]>;
+  onRunnerFramesReady: (testFiles: string[]) => Promise<void>;
   onTestFileStart: (payload: TestFileStartPayload) => Promise<void>;
   onTestCaseResult: (payload: BrowserClientTestResult) => Promise<void>;
   onTestFileComplete: (payload: BrowserClientFileResult) => Promise<void>;

--- a/packages/browser/src/headedSerialTaskQueue.ts
+++ b/packages/browser/src/headedSerialTaskQueue.ts
@@ -1,0 +1,19 @@
+export type HeadedSerialTask = () => Promise<void>;
+
+/**
+ * Serializes headed browser file execution so only one task runs at a time.
+ * The queue keeps draining even if an earlier task rejects.
+ */
+export const createHeadedSerialTaskQueue = () => {
+  let queue: Promise<void> = Promise.resolve();
+
+  const enqueue = (task: HeadedSerialTask): Promise<void> => {
+    const next = queue.then(task);
+    queue = next.catch(() => {});
+    return next;
+  };
+
+  return {
+    enqueue,
+  };
+};

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -38,6 +38,7 @@ import {
   createHostDispatchRouter,
   type HostDispatchRouterOptions,
 } from './dispatchCapabilities';
+import { createHeadedSerialTaskQueue } from './headedSerialTaskQueue';
 import { createHeadlessLatestRerunScheduler } from './headlessLatestRerunScheduler';
 import { attachHeadlessRunnerTransport } from './headlessTransport';
 import type {
@@ -156,6 +157,7 @@ type TestCaseStartPayload = ReporterHookArg<'onTestCaseStart'>;
 type HostRpcMethods = {
   rerunTest: (testFile: string, testNamePattern?: string) => Promise<void>;
   getTestFiles: () => Promise<TestFileInfo[]>;
+  onRunnerFramesReady: (testFiles: string[]) => Promise<void>;
   // Test result callbacks from container
   onTestFileStart: (payload: TestFileStartPayload) => Promise<void>;
   onTestCaseResult: (payload: TestResult) => Promise<void>;
@@ -2501,13 +2503,98 @@ export const runBrowserController = async (
     return result;
   }
 
-  let completedTests = 0;
+  let currentTestFiles = allTestFiles;
+  const RUNNER_FRAMES_READY_TIMEOUT_MS = 30_000;
+  let currentRunnerFramesSignature: string | null = null;
+  const runnerFramesWaiters = new Map<string, Set<() => void>>();
 
-  // Promise that resolves when all tests complete
-  let resolveAllTests: (() => void) | undefined;
-  const allTestsPromise = new Promise<void>((resolve) => {
-    resolveAllTests = resolve;
-  });
+  const createTestFilesSignature = (testFiles: readonly string[]): string => {
+    return JSON.stringify(testFiles.map((testFile) => normalize(testFile)));
+  };
+
+  const markRunnerFramesReady = (testFiles: string[]): void => {
+    const signature = createTestFilesSignature(testFiles);
+    currentRunnerFramesSignature = signature;
+    const waiters = runnerFramesWaiters.get(signature);
+    if (!waiters) {
+      return;
+    }
+    runnerFramesWaiters.delete(signature);
+    for (const waiter of waiters) {
+      waiter();
+    }
+  };
+
+  const waitForRunnerFramesReady = async (
+    testFiles: readonly string[],
+  ): Promise<void> => {
+    const signature = createTestFilesSignature(testFiles);
+    if (currentRunnerFramesSignature === signature) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const waiters =
+        runnerFramesWaiters.get(signature) ?? new Set<() => void>();
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const cleanup = () => {
+        const currentWaiters = runnerFramesWaiters.get(signature);
+        if (!currentWaiters) {
+          return;
+        }
+        currentWaiters.delete(onReady);
+        if (currentWaiters.size === 0) {
+          runnerFramesWaiters.delete(signature);
+        }
+      };
+
+      const onReady = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        cleanup();
+        resolve();
+      };
+
+      timeoutId = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `Timed out waiting for headed runner frames to be ready for ${testFiles.length} file(s).`,
+          ),
+        );
+      }, RUNNER_FRAMES_READY_TIMEOUT_MS);
+
+      waiters.add(onReady);
+      runnerFramesWaiters.set(signature, waiters);
+
+      if (currentRunnerFramesSignature === signature) {
+        onReady();
+      }
+    });
+  };
+
+  const getTestFileInfo = (testFile: string): TestFileInfo => {
+    const normalizedTestFile = normalize(testFile);
+    const fileInfo = currentTestFiles.find(
+      (file) => file.testPath === normalizedTestFile,
+    );
+    if (!fileInfo) {
+      throw new Error(`Unknown browser test file: ${JSON.stringify(testFile)}`);
+    }
+    return fileInfo;
+  };
+
+  const getHeadedPerFileTimeoutMs = (file: TestFileInfo): number => {
+    const projectRuntime = projectRuntimeConfigs.find(
+      (project) => project.name === file.projectName,
+    );
+    return (
+      (projectRuntime?.runtimeConfig.testTimeout ?? maxTestTimeoutForRpc) +
+      30_000
+    );
+  };
 
   // Open a container page for user to view (reuse in watch mode)
   let containerContext: BrowserProviderContext;
@@ -2553,6 +2640,40 @@ export const runBrowserController = async (
   activeContainerPage = containerPage;
 
   const dispatchRouter = createDispatchRouter();
+  const headedReloadQueue = createHeadedSerialTaskQueue();
+  let enqueueHeadedReload = async (
+    _file: TestFileInfo,
+    _testNamePattern?: string,
+  ): Promise<void> => {
+    throw new Error('Headed reload queue is not initialized');
+  };
+
+  const reloadTestFileWithTimeout = async (
+    file: TestFileInfo,
+    testNamePattern?: string,
+  ): Promise<void> => {
+    const timeoutMs = getHeadedPerFileTimeoutMs(file);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      await Promise.race([
+        rpcManager.reloadTestFile(file.testPath, testNamePattern),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(
+              new Error(
+                `Headed test execution timeout after ${timeoutMs / 1000}s for ${file.testPath}.`,
+              ),
+            );
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  };
 
   // Create RPC methods that can access test state variables
   const createRpcMethods = (): HostRpcMethods => ({
@@ -2565,10 +2686,13 @@ export const runBrowserController = async (
           `\nRe-running test: ${displayPath}${testNamePattern ? ` (pattern: ${testNamePattern})` : ''}\n`,
         ),
       );
-      await rpcManager.reloadTestFile(testFile, testNamePattern);
+      await enqueueHeadedReload(getTestFileInfo(testFile), testNamePattern);
     },
     async getTestFiles() {
-      return allTestFiles;
+      return currentTestFiles;
+    },
+    async onRunnerFramesReady(testFiles: string[]) {
+      markRunnerFramesReady(testFiles);
     },
     async onTestFileStart(payload: TestFileStartPayload) {
       await handleTestFileStart(payload);
@@ -2578,20 +2702,12 @@ export const runBrowserController = async (
     },
     async onTestFileComplete(payload: TestFileResult) {
       await handleTestFileComplete(payload);
-
-      completedTests++;
-      if (completedTests >= allTestFiles.length && resolveAllTests) {
-        resolveAllTests();
-      }
     },
     async onLog(payload: LogPayload) {
       await handleLog(payload);
     },
     async onFatal(payload: FatalPayload) {
       await handleFatal(payload);
-      if (resolveAllTests) {
-        resolveAllTests();
-      }
     },
     async dispatch(request: BrowserDispatchRequest) {
       // Headed/container path now shares the same dispatch contract as headless.
@@ -2633,31 +2749,33 @@ export const runBrowserController = async (
     );
   }
 
-  // Wait for all tests to complete
-  // Calculate total timeout based on config: max testTimeout * file count + buffer
-  const maxTestTimeout = Math.max(
-    ...browserProjects.map((p) => p.normalizedConfig.testTimeout ?? 5000),
-  );
-  const totalTimeoutMs = maxTestTimeout * allTestFiles.length + 30_000;
-
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const testTimeout = new Promise<void>((resolve) => {
-    timeoutId = setTimeout(() => {
-      logger.log(
-        color.yellow(
-          `\nTest execution timeout after ${totalTimeoutMs / 1000}s. ` +
-            `Completed: ${completedTests}/${allTestFiles.length}\n`,
-        ),
-      );
-      resolve();
-    }, totalTimeoutMs);
-  });
+  enqueueHeadedReload = async (
+    file: TestFileInfo,
+    testNamePattern?: string,
+  ): Promise<void> => {
+    return headedReloadQueue.enqueue(async () => {
+      if (fatalError) {
+        return;
+      }
+      await reloadTestFileWithTimeout(file, testNamePattern);
+    });
+  };
 
   const testStart = Date.now();
-  await Promise.race([allTestsPromise, testTimeout]);
+  try {
+    await waitForRunnerFramesReady(
+      currentTestFiles.map((file) => file.testPath),
+    );
 
-  if (timeoutId) {
-    clearTimeout(timeoutId);
+    for (const file of currentTestFiles) {
+      await enqueueHeadedReload(file);
+      if (fatalError) {
+        break;
+      }
+    }
+  } catch (error) {
+    fatalError = fatalError ?? toError(error);
+    ensureProcessExitCode(1);
   }
 
   const testTime = Date.now() - testStart;
@@ -2682,7 +2800,11 @@ export const runBrowserController = async (
           context.updateReporterResultState([], [], deletedTestPaths);
         }
         watchContext.lastTestFiles = rerunPlan.currentTestFiles;
-        await rpcManager.notifyTestFileUpdate(rerunPlan.currentTestFiles);
+        currentTestFiles = rerunPlan.currentTestFiles;
+        await rpcManager.notifyTestFileUpdate(currentTestFiles);
+        await waitForRunnerFramesReady(
+          currentTestFiles.map((file) => file.testPath),
+        );
       }
 
       if (rerunPlan.normalizedAffectedTestFiles.length > 0) {
@@ -2699,7 +2821,7 @@ export const runBrowserController = async (
 
         try {
           for (const testFile of rerunPlan.normalizedAffectedTestFiles) {
-            await rpcManager.reloadTestFile(testFile);
+            await enqueueHeadedReload(getTestFileInfo(testFile));
           }
         } catch (error) {
           rerunError = toError(error);

--- a/packages/browser/tests/headedSerialTaskQueue.test.ts
+++ b/packages/browser/tests/headedSerialTaskQueue.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, rstest } from '@rstest/core';
+import { createHeadedSerialTaskQueue } from '../src/headedSerialTaskQueue';
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+const createDeferred = (): Deferred => {
+  let resolve = () => {};
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+describe('headed serial task queue', () => {
+  it('should run enqueued tasks strictly in order', async () => {
+    const queue = createHeadedSerialTaskQueue();
+    const firstGate = createDeferred();
+    const steps: string[] = [];
+
+    const first = queue.enqueue(async () => {
+      steps.push('first:start');
+      await firstGate.promise;
+      steps.push('first:end');
+    });
+
+    const second = queue.enqueue(async () => {
+      steps.push('second:start');
+      steps.push('second:end');
+    });
+
+    await Promise.resolve();
+    expect(steps).toEqual(['first:start']);
+
+    firstGate.resolve();
+    await first;
+    await second;
+
+    expect(steps).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+
+  it('should continue draining after a task failure', async () => {
+    const queue = createHeadedSerialTaskQueue();
+    const onSettled = rstest.fn();
+
+    const first = queue.enqueue(async () => {
+      throw new Error('boom');
+    });
+
+    const second = queue.enqueue(async () => {
+      onSettled('second');
+    });
+
+    await expect(first).rejects.toThrow('boom');
+    await second;
+
+    expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(onSettled).toHaveBeenCalledWith('second');
+  });
+});


### PR DESCRIPTION
## Summary

Headed browser test execution previously ran all test files in parallel by
firing reloads concurrently and waiting on a single shared "all tests done"
promise. This PR replaces that approach with a `HeadedSerialTaskQueue` that
runs one file at a time, waits for iframe frames to be ready before starting,
and applies a per-file timeout instead of a single global timeout.

**Behavior diff:**

```plaintext
+------------------+----------------------------------------------+--------------------------------------------+
|  Aspect          |  Before                                      |  After                                     |
+------------------+----------------------------------------------+--------------------------------------------+
|  Execution order |  All files reloaded concurrently             |  Files run one-at-a-time via serial queue  |
|  Readiness sync  |  No frame-ready handshake; races possible    |  Host waits for onRunnerFramesReady RPC    |
|  Timeout scope   |  One global timeout (max × file count + 30s) |  Per-file timeout (testTimeout + 30s)      |
|  iframe src      |  Always set to runner URL                    |  Set to about:blank until runId is known   |
+------------------+----------------------------------------------+--------------------------------------------+
```

**Changes:**

- `headedSerialTaskQueue.ts` — new module; serial promise queue that keeps
  draining on individual task failures
- `hostController.ts` — `waitForRunnerFramesReady` / `markRunnerFramesReady`
  handshake; per-file `reloadTestFileWithTimeout`; `enqueueHeadedReload`
  replaces direct `rpcManager.reloadTestFile` calls; watch-mode rerun also
  uses the queue
- `browser-ui/main.tsx` — notifies host via `onRunnerFramesReady` once frames
  are mounted; defers iframe `src` to `about:blank` until `runId` is assigned;
  `setActive` called immediately on rerun trigger
- `HostRPC` / `HostRpcMethods` — new `onRunnerFramesReady` method added to
  both the UI-side type and the host RPC handler