### PR TITLE
docs: add global API types tip when migrating from jest

### DIFF
--- a/website/docs/en/guide/migration/jest.mdx
+++ b/website/docs/en/guide/migration/jest.mdx
@@ -80,6 +80,16 @@ export default defineConfig({
 });
 ```
 
+To enable TypeScript to properly recognize the global APIs, add the `@rstest/core/globals` type declaration in your `tsconfig.json`:
+
+```ts title='tsconfig.json'
+{
+  "compilerOptions": {
+    "types": ["@rstest/core/globals"]
+  }
+}
+```
+
 ### Code transformation
 
 Rstest uses `swc` for code transformation by default, which is different from Jest's `babel-jest`. Most of the time, you don't need to change anything. And you can configure your swc options through [tools.swc](/config/build/tools#toolsswc).

--- a/website/docs/zh/guide/migration/jest.mdx
+++ b/website/docs/zh/guide/migration/jest.mdx
@@ -80,6 +80,16 @@ export default defineConfig({
 });
 ```
 
+为了让 TypeScript 正确识别这些全局 API，请在 `tsconfig.json` 中添加 `@rstest/core/globals` 类型声明：
+
+```ts title='tsconfig.json'
+{
+  "compilerOptions": {
+    "types": ["@rstest/core/globals"]
+  }
+}
+```
+
 ### 代码转换
 
 Rstest 默认使用 `swc` 进行代码转换，这与 Jest 的 `babel-jest` 不同。大多数情况下，你不需要做任何更改。你可以通过 [tools.swc](/config/build/tools#toolsswc) 配置你的 swc 选项。


### PR DESCRIPTION
## Summary

add global API types tip when migrating from jest.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
