### PR TITLE
fix(browser): eager compile setup files in watch mode

### DIFF
--- a/e2e/browser-mode/browserReact.test.ts
+++ b/e2e/browser-mode/browserReact.test.ts
@@ -11,6 +11,7 @@ describe('browser mode - @rstest/browser-react', () => {
     expect(cli.stdout).toContain('renderHook.test.tsx');
     expect(cli.stdout).toContain('cleanup.test.tsx');
     expect(cli.stdout).toContain('testingLibraryDom.test.tsx');
+    expect(cli.stdout).toContain('setupImport.test.tsx');
 
     // Verify tests passed
     expect(cli.stdout).toMatch(/Tests.*passed/);

--- a/e2e/browser-mode/fixtures/browser-react/rstest.config.ts
+++ b/e2e/browser-mode/fixtures/browser-react/rstest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     port: BROWSER_PORTS['browser-react'],
   },
   include: ['tests/**/*.test.tsx'],
+  setupFiles: ['./tests/rstest.setup.ts'],
   testTimeout: 30000,
 });

--- a/e2e/browser-mode/fixtures/browser-react/tests/rstest.setup.ts
+++ b/e2e/browser-mode/fixtures/browser-react/tests/rstest.setup.ts
@@ -1,0 +1,5 @@
+import { expect } from '@rstest/core';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+
+void jestDomMatchers;
+expect.extend({});

--- a/e2e/browser-mode/fixtures/browser-react/tests/setupImport.test.tsx
+++ b/e2e/browser-mode/fixtures/browser-react/tests/setupImport.test.tsx
@@ -1,0 +1,8 @@
+import { describe, expect, it } from '@rstest/core';
+import '@testing-library/react';
+
+describe('browser react setup import', () => {
+  it('loads testing library react after setup files', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/e2e/browser-mode/watch.test.ts
+++ b/e2e/browser-mode/watch.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
 import treeKill from 'tree-kill';
 import { prepareFixtures, runRstestCli } from '../scripts';
+import { runBrowserWatchCli } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -238,6 +239,24 @@ describe('browser mode - watch', () => {
       if (process.platform !== 'win32') {
         throw err;
       }
+    }
+  }, 30_000);
+
+  it('should not emit HMR fallback warning when setup files are eager compiled', async () => {
+    const { cli } = await runBrowserWatchCli('browser-react');
+
+    await cli.waitForStdout('Duration');
+    expect(cli.stdout).toContain('setupImport.test.tsx');
+    expect(cli.stdout).not.toContain(
+      'HMR update failed, performing full reload',
+    );
+    expect(cli.stdout).not.toContain('is not accepted');
+
+    const pid = cli.exec.process?.pid;
+    if (pid) {
+      treeKill(pid, 'SIGKILL');
+    } else {
+      cli.exec.kill();
     }
   }, 30_000);
 });

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -409,6 +409,40 @@ const applyDefaultWatchOptions = (
     rspackConfig.watchOptions.ignored.push(rspackConfig.output.path);
 };
 
+type LazyCompilationModule = {
+  nameForCondition?: () => string | null | undefined;
+};
+
+type BrowserLazyCompilationConfig = {
+  imports: true;
+  entries: false;
+  test?: (module: LazyCompilationModule) => boolean;
+};
+
+export const createBrowserLazyCompilationConfig = (
+  setupFiles: string[],
+): BrowserLazyCompilationConfig => {
+  const eagerSetupFiles = new Set(
+    setupFiles.map((filePath) => normalize(filePath)),
+  );
+
+  if (eagerSetupFiles.size === 0) {
+    return {
+      imports: true,
+      entries: false,
+    };
+  }
+
+  return {
+    imports: true,
+    entries: false,
+    test(module: LazyCompilationModule) {
+      const filePath = module.nameForCondition?.();
+      return !filePath || !eagerSetupFiles.has(normalize(filePath));
+    },
+  };
+};
+
 export const createBrowserRsbuildDevConfig = (isWatchMode: boolean) => {
   return {
     // Disable HMR in non-watch mode (tests run once and exit).
@@ -1107,6 +1141,12 @@ const createBrowserRuntime = async ({
             }
 
             const userRsbuildConfig = project.normalizedConfig;
+            const setupFiles = Object.values(
+              getSetupFiles(
+                project.normalizedConfig.setupFiles,
+                project.rootPath,
+              ),
+            );
             // Merge order: current config -> userConfig -> rstest required config (highest priority)
             const merged = mergeEnvironmentConfig(config, userRsbuildConfig, {
               resolve: {
@@ -1128,10 +1168,8 @@ const createBrowserRuntime = async ({
               tools: {
                 rspack: (rspackConfig) => {
                   rspackConfig.mode = 'development';
-                  rspackConfig.lazyCompilation = {
-                    imports: true,
-                    entries: false,
-                  };
+                  rspackConfig.lazyCompilation =
+                    createBrowserLazyCompilationConfig(setupFiles);
                   rspackConfig.plugins = rspackConfig.plugins || [];
                   rspackConfig.plugins.push(virtualManifestPlugin);
 

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@rstest/core';
 import type { ProjectContext, Rstest } from '@rstest/core/browser';
-import { createBrowserRsbuildDevConfig } from '../src/hostController';
+import {
+  createBrowserLazyCompilationConfig,
+  createBrowserRsbuildDevConfig,
+} from '../src/hostController';
 
 /**
  * Create a mock context for testing browser config resolution.
@@ -113,5 +116,36 @@ describe('browser config resolution', () => {
 
     expect(devConfig.hmr).toBe(true);
     expect(devConfig.client.logLevel).toBe('error');
+  });
+
+  it('should keep setup files out of lazy compilation', () => {
+    const lazyCompilation = createBrowserLazyCompilationConfig([
+      '/project/tests/rstest.setup.ts',
+    ]);
+
+    expect(lazyCompilation.imports).toBe(true);
+    expect(lazyCompilation.entries).toBe(false);
+    expect(
+      lazyCompilation.test?.({
+        nameForCondition: () => '/project/tests/rstest.setup.ts',
+      }),
+    ).toBe(false);
+    expect(
+      lazyCompilation.test?.({
+        nameForCondition: () => '/project/tests/example.test.tsx',
+      }),
+    ).toBe(true);
+  });
+
+  it('should normalize setup file paths before filtering lazy compilation', () => {
+    const lazyCompilation = createBrowserLazyCompilationConfig([
+      '/project/tests/rstest.setup.ts',
+    ]);
+
+    expect(
+      lazyCompilation.test?.({
+        nameForCondition: () => '/project/tests/../tests/rstest.setup.ts',
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

In browser watch mode, configuring `setupFiles` alongside test files that import heavy libraries (e.g. `@testing-library/react`) triggers an HMR fallback reload with a noisy console warning. The root cause is that `lazyCompilation` was applied uniformly to all modules — when a setup file's lazy proxy activates, the resulting chunk graph update propagates through an `entry.ts` boundary that has no `module.hot.accept()` handler, causing Rspack HMR to abort and fall back. This PR excludes resolved setup file paths from `lazyCompilation.test` so they are compiled eagerly, while test files remain lazy (preserving O(1) initial compile time).

**Behavior diff:**

```
watch mode + setupFiles:   HMR fallback warning on startup  →  clean start, no warning
test files (no setupFiles): lazy compilation unchanged       →  unchanged
```

**Changes:**

- `createBrowserLazyCompilationConfig(setupFiles)` — new helper that builds the `lazyCompilation` config with a `test` predicate excluding setup file paths
  - no-op (no `test` field) when `setupFiles` is empty, preserving existing behavior
- `createBrowserRuntime` — resolves setup files before building the merged Rsbuild config and passes them into the new helper
- e2e regression: `browser-react` fixture extended with `setupFiles` + a test importing `@testing-library/react`; `watch.test.ts` asserts no HMR warning on startup
- unit tests for `createBrowserLazyCompilationConfig` covering empty, single, and cross-platform path cases
