### PR TITLE
ci: skip no-isolate e2e on Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,8 @@ jobs:
         run: cd e2e && pnpm test:commonjs
 
       - name: E2E Test (No Isolate)
+        # Node 20 is flaky here because reused no-isolate workers can hit upstream vm native crashes.
+        if: matrix.node_version != '20'
         shell: bash
         run: |
           cd e2e


### PR DESCRIPTION
## Summary

- skip `E2E Test (No Isolate)` on Node 20 in the e2e matrix
- add an inline workflow note explaining that the Node 20 no-isolate job is flaky because reused workers can hit upstream `vm` native crashes

## Why

We traced the flaky `No Isolate` failures down to native worker crashes on Node 20 in CI, rather than normal JavaScript test failures. The crash only reproduced in the reused-worker no-isolate path, and newer Node versions are not currently showing the same issue.

Skipping this matrix entry keeps the rest of the Node 20 e2e coverage while removing the flaky path from CI.

## Details

- keep regular e2e coverage on Node 20
- keep `No Isolate` coverage on newer Node versions
- document the Node 20 skip reason inline in `.github/workflows/test.yml`