### PR TITLE
fix: handle undefined env values correctly when applying worker runtime env

### DIFF
--- a/e2e/env/fixtures/index.test.ts
+++ b/e2e/env/fixtures/index.test.ts
@@ -3,3 +3,7 @@ import { expect, it } from '@rstest/core';
 it('should get environment variables correctly', () => {
   expect(process.env.printLogger).toBe('true');
 });
+
+it('should get environment variables correctly', () => {
+  expect(process.env.aa).toBeTypeOf('undefined');
+});

--- a/e2e/env/fixtures/rstest.config.ts
+++ b/e2e/env/fixtures/rstest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   env: {
     printLogger: 'true',
+    aa: undefined,
   },
 });

--- a/e2e/projects/fixtures/packages/client/rstest.config.ts
+++ b/e2e/projects/fixtures/packages/client/rstest.config.ts
@@ -10,6 +10,9 @@ export default defineProject({
       testEnvironment: 'jsdom',
       setupFiles: ['./test/setup.ts'],
       exclude: ['test/node.test.ts'],
+      env: {
+        aaaa: undefined,
+      },
     },
     {
       root: __dirname,

--- a/e2e/projects/fixtures/packages/client/test/index.test.ts
+++ b/e2e/projects/fixtures/packages/client/test/index.test.ts
@@ -1,3 +1,4 @@
 it('should add two numbers correctly', () => {
   expect(1 + 1).toBe(2);
+  expect(process.env.aaaa).toBeTypeOf('undefined');
 });

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -49,7 +49,13 @@ let isTeardown = false;
 
 const setupEnv = (env?: Partial<NodeJS.ProcessEnv>) => {
   if (env) {
-    Object.assign(process.env, env);
+    Object.entries(env).forEach(([key, value]) => {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    });
   }
 };
 


### PR DESCRIPTION
## Summary

handle undefined env values correctly when applying worker runtime env.

In Node.js, assigning `undefined` to `process.env` coerces it to the string `"undefined"`.
As a result, `process.env.aaaa` became a string instead of being absent/undefined.

<img width="1714" height="1210" alt="image" src="https://github.com/user-attachments/assets/00feb17c-e787-4332-afd0-988e2c127a78" />
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
