### PR TITLE
release: 0.9.1

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "React component testing support for Rstest browser mode",
   "license": "MIT",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Browser mode support for Rstest testing framework.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The Rsbuild-based test tool.",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Rstest",
   "publisher": "rstack",
   "description": "VS Code extension for Rstest",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Performance 🚀
* perf: fix cssFilterLoader not working with less / sass plugins by @9aoy in https://github.com/web-infra-dev/rstest/pull/1025
### Bug Fixes 🐞
* fix: `bail` configuration should work with the test file error by @9aoy in https://github.com/web-infra-dev/rstest/pull/997
* fix(core): restore async doMock factory and doUnmock recovery by @fi3ework in https://github.com/web-infra-dev/rstest/pull/998
* fix(e2e): skip headed browser tests on Linux CI without display by @fi3ework in https://github.com/web-infra-dev/rstest/pull/999
* fix:  wasm load error with dynamic import expression by @9aoy in https://github.com/web-infra-dev/rstest/pull/991
* fix: apply default watch ignore options for browser mode by @9aoy in https://github.com/web-infra-dev/rstest/pull/1006
* fix(browser): disable rsbuild hmr outside watch mode by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1010
* fix(watch): cleanup resources on Ctrl+Z exit by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1012
* fix(vscode): prevent hanging test runs on worker failures by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1014
* fix(browser): serialize headed file execution by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1017
* fix(browser): eager compile setup files in watch mode by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1021
* fix: should not exclude dist/ directory when collecting coverage by @9aoy in https://github.com/web-infra-dev/rstest/pull/1022
* fix: handle undefined env values correctly when applying worker runtime env by @9aoy in https://github.com/web-infra-dev/rstest/pull/1024
* fix(browser): support quitting watch mode from the terminal by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1026
### Document 📖
* docs: introduce `rs.mockRequire` and `rs.doMockRequire` APIs by @9aoy in https://github.com/web-infra-dev/rstest/pull/1005
* docs: add global API types tip when migrating from jest by @9aoy in https://github.com/web-infra-dev/rstest/pull/1020
### Other Changes
* chore(deps): update dependency open-editor to v6 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1002
* chore(deps): update actions/checkout digest to de0fac2 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1000
* chore(deps): update dependency rslog to v2 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1003
* chore(deps): update dependency @clack/prompts to v1 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1004
* ci(e2e): enable CI test-case retries by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1011
* chore(deps): update dependency cac to v7 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1007
* chore(deps): update dependency sirv to v3 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1008
* chore(deps): update dependency prettier-plugin-packagejson to v3 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1016
* chore(deps): update dependency check-dependency-version-consistency to v6 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1015
* test: fix MODULE_TYPELESS_PACKAGE_JSON warnings by @9aoy in https://github.com/web-infra-dev/rstest/pull/1018
* test: enable headless mode by default in tests by @9aoy in https://github.com/web-infra-dev/rstest/pull/1019
* chore(deps): update dependency chai to v6 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/512


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.9.0...v0.9.1