### PR TITLE
chore(deps): upgrade Rslib 0.20 canary version

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@rsbuild/core": "^2.0.0-beta.6",
     "@rsbuild/plugin-react": "^1.4.5",
-    "@rslib/core": "0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/browser": "workspace:*",
     "@rstest/browser-react": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.0-beta.6",
-    "@rslib/core": "^0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*"
   },

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -38,7 +38,7 @@
     }
   },
   "devDependencies": {
-    "@rslib/core": "^0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/core": "workspace:*",
     "typescript": "^5.9.3",
     "tsconfck": "3.1.6",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@rslib/core": "^0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/react": "^19.2.14",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -53,7 +53,7 @@
     "ws": "^8.19.0"
   },
   "devDependencies": {
-    "@rslib/core": "^0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/browser-ui": "workspace:*",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,7 @@
     "@jridgewell/trace-mapping": "0.3.31",
     "@microsoft/api-extractor": "^7.57.6",
     "@rsbuild/plugin-node-polyfill": "^1.4.4",
-    "@rslib/core": "^0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/browser-ui": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@sinonjs/fake-timers": "^15.1.0",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -31,7 +31,7 @@
     "swc-plugin-coverage-instrument": "0.0.32"
   },
   "devDependencies": {
-    "@rslib/core": "^0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/istanbul-lib-coverage": "^2.0.6",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -110,7 +110,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.0-beta.6",
-    "@rslib/core": "^0.19.6",
+    "@rslib/core": "0.20.0-canary-202603101",
     "@rstest/core": "workspace:*",
     "@rstest/coverage-istanbul": "workspace:*",
     "@swc/core": "^1.15.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         version: 2.4.4
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+        version: 1.5.2(@rsbuild/core@2.0.0-canary-20260309140114)(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
       '@rslint/core':
         specifier: ^0.2.1
         version: 0.2.1
@@ -82,13 +82,13 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rslib/core':
-        specifier: 0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/browser':
         specifier: workspace:*
         version: link:../packages/browser
@@ -180,10 +180,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -272,7 +272,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -327,10 +327,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -361,10 +361,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.6(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
+        version: 1.2.6(@rsbuild/core@2.0.0-canary-20260309140114)(@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -389,10 +389,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -423,10 +423,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.6(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
+        version: 1.2.6(@rsbuild/core@2.0.0-canary-20260309140114)(@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -473,7 +473,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -501,16 +501,16 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-babel':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.1.0(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.6(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
+        version: 1.2.6(@rsbuild/core@2.0.0-canary-20260309140114)(@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.29.0)(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.1.2(@babel/core@7.29.0)(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -559,7 +559,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -608,10 +608,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -648,10 +648,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -685,16 +685,16 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-babel':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.1.0(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.6(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
+        version: 1.2.6(@rsbuild/core@2.0.0-canary-20260309140114)(@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.29.0)(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.1.2(@babel/core@7.29.0)(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -718,10 +718,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rslib/core':
-        specifier: ^0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -732,8 +732,8 @@ importers:
   packages/adapter-rslib:
     devDependencies:
       '@rslib/core':
-        specifier: ^0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -769,8 +769,8 @@ importers:
         version: 8.19.0
     devDependencies:
       '@rslib/core':
-        specifier: ^0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/browser-ui':
         specifier: workspace:*
         version: link:../browser-ui
@@ -808,8 +808,8 @@ importers:
   packages/browser-react:
     devDependencies:
       '@rslib/core':
-        specifier: ^0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -855,13 +855,13 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rsbuild/plugin-svgr':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(typescript@5.9.3)
+        version: 1.3.0(@rsbuild/core@2.0.0-canary-20260309140114)(typescript@5.9.3)
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -885,7 +885,7 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@types/chai':
         specifier: ^5.2.3
         version: 5.2.3
@@ -907,16 +907,16 @@ importers:
         version: 7.57.6(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^1.6.0
-        version: 1.6.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.6.0(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.4.4(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.5.0(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rslib/core':
-        specifier: ^0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/browser-ui':
         specifier: workspace:*
         version: link:../browser-ui
@@ -1045,8 +1045,8 @@ importers:
         version: 0.0.32
     devDependencies:
       '@rslib/core':
-        specifier: ^0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1076,10 +1076,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.0-beta.6
-        version: 2.0.0-beta.6(core-js@3.47.0)
+        version: 2.0.0-canary-20260309140114
       '@rslib/core':
-        specifier: ^0.19.6
-        version: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
+        specifier: 0.20.0-canary-202603101
+        version: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1150,13 +1150,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.5.0(@rsbuild/core@2.0.0-canary-20260309140114)
       '@rspress/core':
         specifier: 2.0.3
-        version: 2.0.3(@types/react@19.2.14)(core-js@3.47.0)
+        version: 2.0.3(@types/react@19.2.14)
       '@rspress/plugin-algolia':
         specifier: 2.0.3
-        version: 2.0.3(@rspress/core@2.0.3(@types/react@19.2.14)(core-js@3.47.0))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 2.0.3(@rspress/core@2.0.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@rstack-dev/doc-ui':
         specifier: 1.12.3
         version: 1.12.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1180,13 +1180,13 @@ importers:
         version: 19.2.4(react@19.2.4)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.0.5(@rsbuild/core@2.0.0-canary-20260309140114)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+        version: 1.1.2(@rsbuild/core@2.0.0-canary-20260309140114)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.3
-        version: 1.0.3(@rspress/core@2.0.3(@types/react@19.2.14)(core-js@3.47.0))
+        version: 1.0.3(@rspress/core@2.0.3(@types/react@19.2.14))
       rspress-plugin-sitemap:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1861,24 +1861,6 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@module-federation/error-codes@0.22.0':
-    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
-
-  '@module-federation/runtime-core@0.22.0':
-    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
-
-  '@module-federation/runtime-tools@0.22.0':
-    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
-
-  '@module-federation/runtime@0.22.0':
-    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
-
-  '@module-federation/sdk@0.22.0':
-    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
-
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -2416,11 +2398,6 @@ packages:
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
 
-  '@rsbuild/core@1.7.3':
-    resolution: {integrity: sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w==}
-    engines: {node: '>=18.12.0'}
-    hasBin: true
-
   '@rsbuild/core@2.0.0-beta.3':
     resolution: {integrity: sha512-dfH+Pt2GuF3rWOWGsf5XOhn3Zarvr4DoHwoI1arAsCGvpzoeud3DNGmWPy13tngj0r/YvQRcPTRBCRV4RP5CMw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2431,8 +2408,8 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.0.0-beta.6':
-    resolution: {integrity: sha512-DUBhUzvzj6xlGUAHTTipFskSuZmVEuTX7lGU+ToPuo8n3bsQrWn/UBOEQAd45g66k7QfXadoZ/v7eodQErpvGQ==}
+  '@rsbuild/core@2.0.0-canary-20260309140114':
+    resolution: {integrity: sha512-xVBn15queLoGcqN6ykJ9c35x4HDJei81t8q27naK0IvbUopLPH3X0pGtw7ibEuV6u++42SJEFGE7jnKXVhqhoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2529,9 +2506,9 @@ packages:
   '@rsdoctor/utils@1.5.2':
     resolution: {integrity: sha512-Zdvpp4GdJKgQYXLuILM124YU0peMDebr95k2s5zTTuB2LBkHENf8UdjJs7ijKyoaVYKqxXTBdghekXEFcdo6jQ==}
 
-  '@rslib/core@0.19.6':
-    resolution: {integrity: sha512-/znUZlPX252DhAf2WvzmkZ2rBi85d8TadkABYvWoUGAVGsmFOiX+anDwLOqQ+7m5KsMFzM/SCqB2yEBvAj/T2g==}
-    engines: {node: '>=18.12.0'}
+  '@rslib/core@0.20.0-canary-202603101':
+    resolution: {integrity: sha512-dfCuYPNXtNkcH7Rt/is3jmGO53mS/aCj/Dd3eJf8/wZw2Br7fy442JF4ooNgoiKSlYMKfnuD3PXgdBvnIxWzPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -2576,24 +2553,73 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@1.7.6':
-    resolution: {integrity: sha512-NZ9AWtB1COLUX1tA9HQQvWpTy07NSFfKBU8A6ylWd5KH8AePZztpNgLLAVPTuNO4CZXYpwcoclf8jG/luJcQdQ==}
+  '@rspack-canary/binding-darwin-arm64@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-NOlYp/LFBlROtXpjDFv52BGAAu4dNMvGo3LKu5J/n4dbuS2I+yM/dYoprNmyWPDdbeJIvQRZGuZZYf0/mjvD4g==}
     cpu: [arm64]
     os: [darwin]
+
+  '@rspack-canary/binding-darwin-x64@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-qd6GNAg57P+5GwZ4lKDSdcDaDbnbQ8aXayunlZnkwC+ysG9A4gs8Q9UqU+9+dH5LU0f1pJsaUAxQFMhmnddf1w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack-canary/binding-linux-arm64-gnu@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-RcqTuQnZVUfDSkDkAVVifHu+8XvUEHAXRN2ghHoDrACqclKztvLWU7LXmtEku0XQSgjRopEH0WuJgZua6XBDHw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack-canary/binding-linux-arm64-musl@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-v9JtSx85oM0j8iGMXwEpRqT+J/9jIRWbQzvnb9fKG9XjNl9mKU3/xNbSY28RcbLIEouMSj+WvD/qjFHxnPkrpQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack-canary/binding-linux-x64-gnu@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-mAO+UIZcEq//kMSXdVqrv6oFm16ycWB69hi7JIVKoKLO8qFMnPxEcCvmNCxylSc+2anVDtfxy846tJhZgeP/Tg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack-canary/binding-linux-x64-musl@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-oEiUZLhEoJA7taJ0oHN+9cT3YN/Uw1iW+OmaqLF23l5aKyuDdFIKznqIO8LK9SLb87epLVf73HpH1D4QTMeifQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack-canary/binding-wasm32-wasi@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-yt8d8U9Ill7c4rSMAWU74BjNrosh10Bm1bTz0imqACSqioOWsqJtTeWNV6RVNuYuj3D/gW+LfWeMB1JYprcBNQ==}
+    cpu: [wasm32]
+
+  '@rspack-canary/binding-win32-arm64-msvc@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-NgfKuaoWnMgY+bgMQcM7baCZ0NA6RpX8rH7gGxb3syeNtOEl3MdrS1bXRKeQcAsG2Tv9zE8tLcWNHAHxWjafXA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack-canary/binding-win32-ia32-msvc@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-nNx80tsuzCZPPY9f+0PGoB2r8vvb4nYcc2DOPW+Y0MQ7H+OpMye3I69L/xYrUenAv12i4rEcBnh4xu4N0cRF1w==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack-canary/binding-win32-x64-msvc@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-KkEOwqC516A5tM2B/vnxNrjOo1eCeaUsweZw802osFMo1UWckqy2tdHWQT5WokbaWDK5itTpre32my69WDOPYg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack-canary/binding@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-auGFnCMkLgo/JghhV5Xl6+P5uhMuc16jLB76P3ZvGdDHKGGBxFgOSC4WbpohL77Yh0CJ97yZN1OfeqzC4m4lfw==}
+
+  '@rspack-canary/core@2.0.0-canary-511d0b77-20260309140114':
+    resolution: {integrity: sha512-kJv2OJHo9KzEjshIpWfc6ugyzscd4Q5XMw/xBOelSoX+D9n4Wbu4e5I6TEh1xKHGjUrOkaKZ7qDB3XigDKkKLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
 
   '@rspack/binding-darwin-arm64@2.0.0-beta.0':
     resolution: {integrity: sha512-PPx1+SPEROSvDKmBuCbsE7W9tk07ajPosyvyuafv2wbBI6PW2rNcz62uzpIFS+FTgwwZ5u/06WXRtlD2xW9bKg==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-arm64@2.0.0-beta.3':
-    resolution: {integrity: sha512-QebSomLWlCbFsC0sfDuGqLJtkgyrnr38vrCepWukaAXIY4ANy5QB49LDKdLpVv6bKlC95MpnW37NvSNWY5GMYA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.7.6':
-    resolution: {integrity: sha512-J2g6xk8ZS7uc024dNTGTHxoFzFovAZIRixUG7PiciLKTMP78svbSSWrmW6N8oAsAkzYfJWwQpVgWfFNRHvYxSw==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@2.0.0-beta.0':
@@ -2601,28 +2627,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.0-beta.3':
-    resolution: {integrity: sha512-EysmBq+sz+Ph0bu0gXpU1uuZG9gXgjqY+w3MJel+ieTFyQO3L/R56V32McgssMbheJbYcviDDn7Tz4D+lTvdJA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-linux-arm64-gnu@1.7.6':
-    resolution: {integrity: sha512-eQfcsaxhFrv5FmtaA7+O1F9/2yFDNIoPZzV/ZvqvFz5bBXVc4FAm/1fVpBg8Po/kX1h0chBc7Xkpry3cabFW8w==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.0':
     resolution: {integrity: sha512-nTtYtklRZD4sb2RIFCF9YS8tZ/MjpqIBKVS3YIvdXcfHUdVfmQHTZGtwEuZGg6AxTC5L1hcvkYmTXCG0ok7auw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.3':
-    resolution: {integrity: sha512-iFPj4TQZKewnqWPfTbyk3F8QCBI/Edv7TVSRIPBHRnCM0lvYZl/8IZlUzXSamLvrtDpouF0nUzht/fktoWOhAg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.7.6':
-    resolution: {integrity: sha512-DfQXKiyPIl7i1yECHy4eAkSmlUzzsSAbOjgMuKn7pudsWf483jg0UUYutNgXSlBjc/QSUp7906Cg8oty9OfwPA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2631,28 +2637,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-beta.3':
-    resolution: {integrity: sha512-355mygfCNb0eF/y4HgtJcd0i9csNTG4Z15PCCplIkSAKJpFpkORM2xJb50BqsbhVafYl6AHoBlGWAo9iIzUb/w==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@1.7.6':
-    resolution: {integrity: sha512-NdA+2X3lk2GGrMMnTGyYTzM3pn+zNjaqXqlgKmFBXvjfZqzSsKq3pdD1KHZCd5QHN+Fwvoszj0JFsquEVhE1og==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.0':
     resolution: {integrity: sha512-yx5Fk1gl7lfkvqcjolNLCNeduIs6C2alMsQ/kZ1pLeP5MPquVOYNqs6EcDPIp+fUjo3lZYtnJBiZKK+QosbzYg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@2.0.0-beta.3':
-    resolution: {integrity: sha512-U8a+bcP/tkMyiwiO9XfeRYYO20YPGiZNxWWt7FEsdmRuRAl6M+EmWaJllJFQtKH+GG8IN93pNoVPMvARjLoJOQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.7.6':
-    resolution: {integrity: sha512-rEy6MHKob02t/77YNgr6dREyJ0e0tv1X6Xsg8Z5E7rPXead06zefUbfazj4RELYySWnM38ovZyJAkPx/gOn3VA==}
     cpu: [x64]
     os: [linux]
 
@@ -2661,41 +2647,13 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@2.0.0-beta.3':
-    resolution: {integrity: sha512-g81rqkaqDFRTID2VrHBYeM+xZe8yWov7IcryTrl9RGXXr61s+6Tu/mWyM378PuHOCyMNu7G3blVaSjLvKauG6Q==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-wasm32-wasi@1.7.6':
-    resolution: {integrity: sha512-YupOrz0daSG+YBbCIgpDgzfMM38YpChv+afZpaxx5Ml7xPeAZIIdgWmLHnQ2rts73N2M1NspAiBwV00Xx0N4Vg==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.0.0-beta.0':
     resolution: {integrity: sha512-o6OatnNvb4kCzXbCaomhENGaCsO3naIyAqqErew90HeAwa1lfY3NhRfDLeIyuANQ+xqFl34/R7n8q3ZDx3nd4Q==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.0.0-beta.3':
-    resolution: {integrity: sha512-tzGd8H2oj5F3oR/Hxp+J68zVU/nG+9ndH2KK3/RieVjNAiVNHCR0/ZU9D47s6fnmvWOqAQ1qO8gnVoVLopC4YA==}
-    cpu: [wasm32]
-
-  '@rspack/binding-win32-arm64-msvc@1.7.6':
-    resolution: {integrity: sha512-INj7aVXjBvlZ84kEhSK4kJ484ub0i+BzgnjDWOWM1K+eFYDZjLdAsQSS3fGGXwVc3qKbPIssFfnftATDMTEJHQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.0':
     resolution: {integrity: sha512-neCzVllXzIqM8p8qKb89qV7wyk233gC/V9VrHIKbGeQjAEzpBsk5GOWlFbq5DDL6tivQ+uzYaTrZWm9tb2qxXg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.3':
-    resolution: {integrity: sha512-TZZRSWa34sm5WyoQHwnyBjLJ4w3fcWRYA9ybYjSVWjUU6tVGdMiHiZp+WexUpIETvChLXU1JENNmBg/U7wvZEA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.7.6':
-    resolution: {integrity: sha512-lXGvC+z67UMcw58In12h8zCa9IyYRmuptUBMItQJzu+M278aMuD1nETyGLL7e4+OZ2lvrnnBIcjXN1hfw2yRzw==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@2.0.0-beta.0':
@@ -2703,61 +2661,19 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.3':
-    resolution: {integrity: sha512-VFnfdbJhyl6gNW1VzTyd1ZrHCboHPR7vrOalEsulQRqVNbtDkjm1sqLHtDcLmhTEv0a9r4lli8uubWDwmel8KQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@1.7.6':
-    resolution: {integrity: sha512-zeUxEc0ZaPpmaYlCeWcjSJUPuRRySiSHN23oJ2Xyw0jsQ01Qm4OScPdr0RhEOFuK/UE+ANyRtDo4zJsY52Hadw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.0':
     resolution: {integrity: sha512-dx4zgiAT88EQE7kEUpr7Z9EZAwLnO5FhzWzvd/cDK4bkqYsx+rTklgf/c0EYPBeroXCxlGiMsuC9wHAFNK7sFw==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.0-beta.3':
-    resolution: {integrity: sha512-rwZ6Y3b3oqPj+ZDPPRxr3136HUPKDSlPQa4v7bBOPLDlrFDFOynMIEqDUUi5+8lPaUQ8WWR0aJK4cgcTTT0Siw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding@1.7.6':
-    resolution: {integrity: sha512-/NrEcfo8Gx22hLGysanrV6gHMuqZSxToSci/3M4kzEQtF5cPjfOv5pqeLK/+B6cr56ul/OmE96cCdWcXeVnFjQ==}
-
   '@rspack/binding@2.0.0-beta.0':
     resolution: {integrity: sha512-L6PPqhwZWC2vzwdhBItNPXw+7V4sq+MBDRXLdd8NMqaJSCB5iKdJIbpbEQucST9Nn7V28IYoQTXs6+ol5vWUBA==}
-
-  '@rspack/binding@2.0.0-beta.3':
-    resolution: {integrity: sha512-GSj+d8AlLs1oElhYq32vIN/eAsxWG9jy0EiNgSxWTt5Gdamv87kcvsV4jwfWIjlltdnBIJgey2RnU+hDZlTAvw==}
-
-  '@rspack/core@1.7.6':
-    resolution: {integrity: sha512-Iax6UhrfZqJajA778c1d5DBFbSIqPOSrI34kpNIiNpWd8Jq7mFIa+Z60SQb5ZQDZuUxcCZikjz5BxinFjTkg7Q==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@2.0.0-beta.0':
     resolution: {integrity: sha512-aEqlQQjiXixT5i9S4DFtiAap8ZjF6pOgfY2ALHOizins/QqWyB8dyLxSoXdzt7JixmKcFmHkbL9XahO28BlVUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': '>=0.22.0'
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.0.0-beta.3':
-    resolution: {integrity: sha512-VuLteRIesuyFFTXZaciUY0lwDZiwMc7JcpE8guvjArztDhtpVvlaOcLlVBp/Yza8c/Tk8Dxwe1ARzFL7xG1/0w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
       '@swc/helpers': '>=0.5.1'
     peerDependenciesMeta:
       '@module-federation/runtime-tools':
@@ -4118,9 +4034,6 @@ packages:
 
   core-js-pure@3.48.0:
     resolution: {integrity: sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==}
-
-  core-js@3.47.0:
-    resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -6405,12 +6318,12 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rsbuild-plugin-dts@0.19.6:
-    resolution: {integrity: sha512-ehD3P432VJq6djxfAdWeWSUXPhEAnISlma2EXOSCZSzjerzRrG4H4f6WWw1sxN5qMQXgu5hLPqlUHsFZM9sEIg==}
-    engines: {node: '>=18.12.0'}
+  rsbuild-plugin-dts@0.20.0-canary-202603101:
+    resolution: {integrity: sha512-JwNf1NrkJX0GAkhGg0yp7VNYvrd8JCWDX15mCMiYpzAzDhQRTJmoWE625JQy+aoUJAXHDzO+69kMnibYKYrWKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      '@rsbuild/core': 1.x
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
       '@typescript/native-preview': 7.x
       typescript: ^5
     peerDependenciesMeta:
@@ -8265,31 +8178,6 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@module-federation/error-codes@0.22.0': {}
-
-  '@module-federation/runtime-core@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/runtime-tools@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/webpack-bundler-runtime': 0.22.0
-
-  '@module-federation/runtime@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/runtime-core': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/sdk@0.22.0': {}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -8829,40 +8717,28 @@ snapshots:
 
   '@remix-run/router@1.23.2': {}
 
-  '@rsbuild/core@1.7.3':
-    dependencies:
-      '@rspack/core': 1.7.6(@swc/helpers@0.5.19)
-      '@rspack/lite-tapable': 1.1.0
-      '@swc/helpers': 0.5.19
-      core-js: 3.47.0
-      jiti: 2.6.1
-
-  '@rsbuild/core@2.0.0-beta.3(core-js@3.47.0)':
+  '@rsbuild/core@2.0.0-beta.3':
     dependencies:
       '@rspack/core': 2.0.0-beta.0(@swc/helpers@0.5.19)
       '@swc/helpers': 0.5.19
       jiti: 2.6.1
-    optionalDependencies:
-      core-js: 3.47.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.0.0-beta.6(core-js@3.47.0)':
+  '@rsbuild/core@2.0.0-canary-20260309140114':
     dependencies:
-      '@rspack/core': 2.0.0-beta.3(@swc/helpers@0.5.19)
+      '@rspack/core': '@rspack-canary/core@2.0.0-canary-511d0b77-20260309140114(@swc/helpers@0.5.19)'
       '@swc/helpers': 0.5.19
-    optionalDependencies:
-      core-js: 3.47.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@2.0.0-canary-20260309140114)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -8870,7 +8746,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.0-canary-20260309140114)':
     dependencies:
       acorn: 8.15.0
       browserslist-to-es-version: 1.2.0
@@ -8878,15 +8754,15 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))':
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-canary-20260309140114)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-canary-20260309140114)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8912,37 +8788,37 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
 
-  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.3(core-js@3.47.0))':
+  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.3)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-beta.3
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
       react-refresh: 0.18.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))':
+  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
       react-refresh: 0.18.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))':
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-canary-20260309140114)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
 
-  '@rsbuild/plugin-svgr@1.3.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(typescript@5.9.3)':
+  '@rsbuild/plugin-svgr@1.3.0(@rsbuild/core@2.0.0-canary-20260309140114)(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+      '@rsbuild/core': 2.0.0-canary-20260309140114
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
@@ -8953,21 +8829,21 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-vue-jsx@1.1.2(@babel/core@7.29.0)(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))':
+  '@rsbuild/plugin-vue-jsx@1.1.2(@babel/core@7.29.0)(@rsbuild/core@2.0.0-canary-20260309140114)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
+      '@rsbuild/plugin-babel': 1.1.0(@rsbuild/core@2.0.0-canary-20260309140114)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
       babel-plugin-vue-jsx-hmr: 1.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@1.2.6(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))':
+  '@rsbuild/plugin-vue@1.2.6(@rsbuild/core@2.0.0-canary-20260309140114)(@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
+      '@rsbuild/core': 2.0.0-canary-20260309140114
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -8975,13 +8851,13 @@ snapshots:
 
   '@rsdoctor/client@1.5.2': {}
 
-  '@rsdoctor/core@1.5.2(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
+  '@rsdoctor/core@1.5.2(@rsbuild/core@2.0.0-canary-20260309140114)(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/sdk': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0-canary-20260309140114)
+      '@rsdoctor/graph': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/sdk': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/types': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/utils': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
       browserslist-load-config: 1.0.1
       enhanced-resolve: 5.12.0
       es-toolkit: 1.44.0
@@ -8997,10 +8873,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
+  '@rsdoctor/graph@1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
     dependencies:
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/types': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/utils': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
       es-toolkit: 1.44.0
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -9008,15 +8884,13 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.2(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
+  '@rsdoctor/rspack-plugin@1.5.2(@rsbuild/core@2.0.0-canary-20260309140114)(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
     dependencies:
-      '@rsdoctor/core': 1.5.2(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/sdk': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-    optionalDependencies:
-      '@rspack/core': 1.7.6(@swc/helpers@0.5.19)
+      '@rsdoctor/core': 1.5.2(@rsbuild/core@2.0.0-canary-20260309140114)(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/graph': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/sdk': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/types': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/utils': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
     transitivePeerDependencies:
       - '@rsbuild/core'
       - bufferutil
@@ -9024,12 +8898,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
+  '@rsdoctor/sdk@1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
     dependencies:
       '@rsdoctor/client': 1.5.2
-      '@rsdoctor/graph': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
-      '@rsdoctor/utils': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/graph': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/types': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/utils': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
       safer-buffer: 2.1.2
       socket.io: 4.8.1
       tapable: 2.2.3
@@ -9040,20 +8914,19 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
+  '@rsdoctor/types@1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.2.7
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 1.7.6(@swc/helpers@0.5.19)
       webpack: 5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19))
 
-  '@rsdoctor/utils@1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
+  '@rsdoctor/utils@1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
+      '@rsdoctor/types': 1.5.2(webpack@5.105.2(@swc/core@1.15.13(@swc/helpers@0.5.19)))
       '@types/estree': 1.0.5
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
@@ -9071,15 +8944,17 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)':
+  '@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.7.3
-      rsbuild-plugin-dts: 0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(@rsbuild/core@1.7.3)(typescript@5.9.3)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
+      rsbuild-plugin-dts: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(@rsbuild/core@2.0.0-canary-20260309140114)(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.6(@types/node@22.18.6)
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
+      - core-js
 
   '@rslint/core@0.2.1':
     optionalDependencies:
@@ -9108,63 +8983,73 @@ snapshots:
   '@rslint/win32-x64@0.2.1':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.7.6':
+  '@rspack-canary/binding-darwin-arm64@2.0.0-canary-511d0b77-20260309140114':
     optional: true
+
+  '@rspack-canary/binding-darwin-x64@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding-linux-arm64-gnu@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding-linux-arm64-musl@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding-linux-x64-gnu@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding-linux-x64-musl@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding-wasm32-wasi@2.0.0-canary-511d0b77-20260309140114':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
+  '@rspack-canary/binding-win32-arm64-msvc@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding-win32-ia32-msvc@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding-win32-x64-msvc@2.0.0-canary-511d0b77-20260309140114':
+    optional: true
+
+  '@rspack-canary/binding@2.0.0-canary-511d0b77-20260309140114':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.0.0-canary-511d0b77-20260309140114'
+      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.0.0-canary-511d0b77-20260309140114'
+
+  '@rspack-canary/core@2.0.0-canary-511d0b77-20260309140114(@swc/helpers@0.5.19)':
+    dependencies:
+      '@rspack/binding': '@rspack-canary/binding@2.0.0-canary-511d0b77-20260309140114'
+    optionalDependencies:
+      '@swc/helpers': 0.5.19
 
   '@rspack/binding-darwin-arm64@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-darwin-arm64@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.7.6':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.0-beta.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@1.7.6':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.7.6':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.0-beta.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@1.7.6':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.7.6':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@1.7.6':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.0-beta.0':
@@ -9172,50 +9057,14 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.0-beta.3':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@1.7.6':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.0':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.7.6':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.0-beta.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.7.6':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.0':
     optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.0.0-beta.3':
-    optional: true
-
-  '@rspack/binding@1.7.6':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.7.6
-      '@rspack/binding-darwin-x64': 1.7.6
-      '@rspack/binding-linux-arm64-gnu': 1.7.6
-      '@rspack/binding-linux-arm64-musl': 1.7.6
-      '@rspack/binding-linux-x64-gnu': 1.7.6
-      '@rspack/binding-linux-x64-musl': 1.7.6
-      '@rspack/binding-wasm32-wasi': 1.7.6
-      '@rspack/binding-win32-arm64-msvc': 1.7.6
-      '@rspack/binding-win32-ia32-msvc': 1.7.6
-      '@rspack/binding-win32-x64-msvc': 1.7.6
 
   '@rspack/binding@2.0.0-beta.0':
     optionalDependencies:
@@ -9230,37 +9079,10 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.0
       '@rspack/binding-win32-x64-msvc': 2.0.0-beta.0
 
-  '@rspack/binding@2.0.0-beta.3':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.0-beta.3
-      '@rspack/binding-darwin-x64': 2.0.0-beta.3
-      '@rspack/binding-linux-arm64-gnu': 2.0.0-beta.3
-      '@rspack/binding-linux-arm64-musl': 2.0.0-beta.3
-      '@rspack/binding-linux-x64-gnu': 2.0.0-beta.3
-      '@rspack/binding-linux-x64-musl': 2.0.0-beta.3
-      '@rspack/binding-wasm32-wasi': 2.0.0-beta.3
-      '@rspack/binding-win32-arm64-msvc': 2.0.0-beta.3
-      '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.3
-      '@rspack/binding-win32-x64-msvc': 2.0.0-beta.3
-
-  '@rspack/core@1.7.6(@swc/helpers@0.5.19)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.6
-      '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@swc/helpers': 0.5.19
-
   '@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19)':
     dependencies:
       '@rspack/binding': 2.0.0-beta.0
       '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@swc/helpers': 0.5.19
-
-  '@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19)':
-    dependencies:
-      '@rspack/binding': 2.0.0-beta.3
     optionalDependencies:
       '@swc/helpers': 0.5.19
 
@@ -9272,13 +9094,13 @@ snapshots:
       html-entities: 2.6.0
       react-refresh: 0.18.0
 
-  '@rspress/core@2.0.3(@types/react@19.2.14)(core-js@3.47.0)':
+  '@rspress/core@2.0.3(@types/react@19.2.14)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@rsbuild/core': 2.0.0-beta.3(core-js@3.47.0)
-      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-beta.3(core-js@3.47.0))
-      '@rspress/shared': 2.0.3(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-beta.3
+      '@rsbuild/plugin-react': 1.4.5(@rsbuild/core@2.0.0-beta.3)
+      '@rspress/shared': 2.0.3
       '@shikijs/rehype': 3.21.0
       '@types/unist': 3.0.3
       '@unhead/react': 2.1.7(react@19.2.4)
@@ -9323,11 +9145,11 @@ snapshots:
       - supports-color
       - webpack-hot-middleware
 
-  '@rspress/plugin-algolia@2.0.3(@rspress/core@2.0.3(@types/react@19.2.14)(core-js@3.47.0))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@rspress/plugin-algolia@2.0.3(@rspress/core@2.0.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@docsearch/css': 4.6.0
       '@docsearch/react': 4.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@rspress/core': 2.0.3(@types/react@19.2.14)(core-js@3.47.0)
+      '@rspress/core': 2.0.3(@types/react@19.2.14)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -9336,9 +9158,9 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@rspress/shared@2.0.3(core-js@3.47.0)':
+  '@rspress/shared@2.0.3':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-beta.3
       '@shikijs/rehype': 3.21.0
       gray-matter: 4.0.3
       lodash-es: 4.17.23
@@ -10925,8 +10747,6 @@ snapshots:
       toggle-selection: 1.0.6
 
   core-js-pure@3.48.0: {}
-
-  core-js@3.47.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -13718,37 +13538,37 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-dts@0.19.6(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(@rsbuild/core@1.7.3)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@22.18.6))(@rsbuild/core@2.0.0-canary-20260309140114)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 2.0.0-canary-20260309140114
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.6(@types/node@22.18.6)
       typescript: 5.9.3
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0)):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-canary-20260309140114):
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0)):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-canary-20260309140114):
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
+      '@rsbuild/core': 2.0.0-canary-20260309140114
 
   rslog@1.3.2: {}
 
   rslog@2.0.0: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-beta.3(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-beta.0(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.0-beta.3(@swc/helpers@0.5.19)
+      '@rspack/core': 2.0.0-beta.0(@swc/helpers@0.5.19)
       vue: 3.5.29(typescript@5.9.3)
 
-  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.3(@types/react@19.2.14)(core-js@3.47.0)):
+  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.3(@types/react@19.2.14)):
     dependencies:
-      '@rspress/core': 2.0.3(@types/react@19.2.14)(core-js@3.47.0)
+      '@rspress/core': 2.0.3(@types/react@19.2.14)
 
   rspress-plugin-sitemap@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Upgrade Rslib 0.20 canary version to compatible with Rspack eco CI.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
