### PR TITLE
fix(browser): move headed reload completion out of birpc

### DIFF
--- a/packages/browser-ui/src/hooks/useRpc.ts
+++ b/packages/browser-ui/src/hooks/useRpc.ts
@@ -1,7 +1,12 @@
 import { type BirpcReturn, createBirpc } from 'birpc';
 import { useEffect, useRef, useState } from 'react';
 import { createWebSocketUrl, RECONNECT_DELAYS } from '../core/runtime';
-import type { ContainerRPC, HostRPC, TestFileInfo } from '../types';
+import type {
+  ContainerRPC,
+  HostRPC,
+  ReloadTestFileAck,
+  TestFileInfo,
+} from '../types';
 import { logger } from '../utils/logger';
 
 export type RpcState = {
@@ -20,7 +25,7 @@ export const useRpc = (
   onReloadTestFile?: (
     testFile: string,
     testNamePattern?: string,
-  ) => Promise<void>,
+  ) => Promise<ReloadTestFileAck>,
 ): RpcState => {
   const [rpc, setRpc] = useState<BirpcReturn<HostRPC, ContainerRPC> | null>(
     null,
@@ -49,6 +54,7 @@ export const useRpc = (
     }
 
     let ws: WebSocket | null = null;
+    let birpc: BirpcReturn<HostRPC, ContainerRPC> | null = null;
     let reconnectAttempt = 0;
     let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let isMounted = true;
@@ -58,6 +64,10 @@ export const useRpc = (
 
       ws = new WebSocket(createWebSocketUrl(wsPort));
       activeWsRef.current = ws;
+      const messageHandlers = new WeakMap<
+        (data: any) => void,
+        (event: MessageEvent<string>) => void
+      >();
 
       const methods: ContainerRPC = {
         onTestFileUpdate(files: TestFileInfo[]) {
@@ -70,7 +80,10 @@ export const useRpc = (
             testFile,
             testNamePattern,
           );
-          await onReloadTestFileRef.current?.(testFile, testNamePattern);
+          if (!onReloadTestFileRef.current) {
+            throw new Error('reloadTestFile handler is not available');
+          }
+          return onReloadTestFileRef.current(testFile, testNamePattern);
         },
       };
 
@@ -81,7 +94,8 @@ export const useRpc = (
         reconnectAttempt = 0; // Reset reconnect counter on successful connection
         setConnected(true);
 
-        const birpc = createBirpc<HostRPC, ContainerRPC>(methods, {
+        birpc = createBirpc<HostRPC, ContainerRPC>(methods, {
+          timeout: -1,
           post: (data) => {
             if (ws?.readyState === WebSocket.OPEN) {
               ws.send(JSON.stringify(data));
@@ -89,7 +103,7 @@ export const useRpc = (
           },
           on: (fn) => {
             if (!ws) return;
-            ws.onmessage = (event) => {
+            const handler = (event: MessageEvent<string>) => {
               try {
                 const data = JSON.parse(event.data);
                 fn(data);
@@ -97,6 +111,15 @@ export const useRpc = (
                 // ignore invalid messages
               }
             };
+            messageHandlers.set(fn, handler);
+            ws.addEventListener('message', handler);
+          },
+          off: (fn) => {
+            if (!ws) return;
+            const handler = messageHandlers.get(fn);
+            if (!handler) return;
+            ws.removeEventListener('message', handler);
+            messageHandlers.delete(fn);
           },
         });
         setRpc(birpc);
@@ -128,6 +151,7 @@ export const useRpc = (
         if (!isMounted) return;
 
         logger.debug('[Container] WebSocket disconnected');
+        birpc?.$close(new Error('Container WebSocket disconnected'));
         setRpc(null);
         setConnected(false);
 
@@ -162,6 +186,7 @@ export const useRpc = (
       if (reconnectTimeoutId) {
         clearTimeout(reconnectTimeoutId);
       }
+      birpc?.$close(new Error('Container RPC disposed'));
       if (ws) {
         ws.close();
       }

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -4,13 +4,7 @@ import {
   RSTEST_CONFIG_MESSAGE_TYPE,
 } from '@rstest/browser/protocol';
 import { App as AntdApp, theme as antdTheme, ConfigProvider } from 'antd';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { EmptyPreviewOverlay } from './components/EmptyPreviewOverlay';
 import { PreviewHeader } from './components/PreviewHeader';
@@ -74,6 +68,18 @@ const findRunnerFrameByTestPath = (
   ).find((frame) => frame.dataset.testFile === testPath);
 };
 
+const findRunnerFrameBySource = (
+  source: MessageEventSource | null,
+): HTMLIFrameElement | undefined => {
+  if (!source) {
+    return undefined;
+  }
+
+  return Array.from(
+    document.querySelectorAll<HTMLIFrameElement>('iframe[data-test-file]'),
+  ).find((frame) => frame.contentWindow === source);
+};
+
 // ============================================================================
 // App Component
 // ============================================================================
@@ -95,15 +101,6 @@ const BrowserRunner: React.FC<{
   >({});
   const [openFiles, setOpenFiles] = useState<string[]>([]);
   const [filterText, setFilterText] = useState<string>('');
-  const pendingReloadsRef = useRef<
-    Map<
-      string,
-      {
-        resolve: () => void;
-        reject: (error: Error) => void;
-      }
-    >
-  >(new Map());
   const [runIdByTestFile, setRunIdByTestFile] = useState<
     Record<string, string>
   >({});
@@ -214,54 +211,43 @@ const BrowserRunner: React.FC<{
         testNamePattern,
       );
       setActive(testFile);
-      return new Promise<void>((resolve, reject) => {
-        const previousPending = pendingReloadsRef.current.get(testFile);
-        if (previousPending) {
-          previousPending.reject(
-            new Error(
-              `Reload for "${testFile}" was superseded by a newer request.`,
-            ),
-          );
-        }
-        pendingReloadsRef.current.set(testFile, { resolve, reject });
+      const iframe = document.querySelector<HTMLIFrameElement>(
+        `iframe[data-test-file="${testFile}"]`,
+      );
+      logger.debug('[Container] Found iframe:', iframe);
+      if (!iframe) {
+        throw new Error(
+          `Cannot reload test file "${testFile}": iframe not found`,
+        );
+      }
 
-        const iframe = document.querySelector<HTMLIFrameElement>(
-          `iframe[data-test-file="${testFile}"]`,
-        );
-        logger.debug('[Container] Found iframe:', iframe);
-        if (!iframe) {
-          pendingReloadsRef.current.delete(testFile);
-          reject(
-            new Error(
-              `Cannot reload test file "${testFile}": iframe not found`,
-            ),
-          );
-          return;
+      const nextRunId = createRunId();
+      setRunIdByTestFile((prev) => ({
+        ...prev,
+        [testFile]: nextRunId,
+      }));
+      setStatusMap((prev) => ({ ...prev, [testFile]: 'running' }));
+      setCaseMap((prev) => {
+        const prevFile = prev[testFile] ?? {};
+        const updatedCases: Record<string, CaseInfo> = {};
+        for (const [key, caseInfo] of Object.entries(prevFile)) {
+          updatedCases[key] = { ...caseInfo, status: 'running' };
         }
-        const nextRunId = createRunId();
-        setRunIdByTestFile((prev) => ({
-          ...prev,
-          [testFile]: nextRunId,
-        }));
-        setStatusMap((prev) => ({ ...prev, [testFile]: 'running' }));
-        setCaseMap((prev) => {
-          const prevFile = prev[testFile] ?? {};
-          const updatedCases: Record<string, CaseInfo> = {};
-          for (const [key, caseInfo] of Object.entries(prevFile)) {
-            updatedCases[key] = { ...caseInfo, status: 'running' };
-          }
-          return { ...prev, [testFile]: updatedCases };
-        });
-        const newSrc = createRunnerUrl(
-          testFile,
-          options.runnerUrl,
-          testNamePattern,
-          false,
-          nextRunId,
-        );
-        logger.debug('[Container] Setting iframe.src to:', newSrc);
-        iframe.src = newSrc;
+        return { ...prev, [testFile]: updatedCases };
       });
+      const newSrc = createRunnerUrl(
+        testFile,
+        options.runnerUrl,
+        testNamePattern,
+        false,
+        nextRunId,
+      );
+      logger.debug('[Container] Setting iframe.src to:', newSrc);
+      iframe.src = newSrc;
+
+      return {
+        runId: nextRunId,
+      };
     },
     [options.runnerUrl],
   );
@@ -271,21 +257,6 @@ const BrowserRunner: React.FC<{
     options?.wsPort,
     handleReloadTestFile,
   );
-
-  useEffect(() => {
-    return () => {
-      if (pendingReloadsRef.current.size === 0) {
-        return;
-      }
-      const unmountError = new Error(
-        'Browser runner unmounted before reload completed',
-      );
-      for (const pending of pendingReloadsRef.current.values()) {
-        pending.reject(unmountError);
-      }
-      pendingReloadsRef.current.clear();
-    };
-  }, []);
 
   // Consolidated effect for handling testFiles changes
   // Handles statusMap, caseMap, openFiles initialization and cleanup
@@ -458,6 +429,11 @@ const BrowserRunner: React.FC<{
         const payload = message.payload as BrowserClientFileResult;
         const testPath = payload.testPath;
         if (typeof testPath === 'string') {
+          const frame = findRunnerFrameBySource(event.source);
+          const fallbackFrame = frame ?? findRunnerFrameByTestPath(testPath);
+          const runId =
+            (fallbackFrame ? readRunIdFromFrame(fallbackFrame) : undefined) ??
+            runIdByTestFile[testPath];
           const passed = payload.status === 'pass' || payload.status === 'skip';
           setStatusMap((prev) => ({
             ...prev,
@@ -483,26 +459,15 @@ const BrowserRunner: React.FC<{
             }
             return { ...prev, [testPath]: newCases };
           });
-          const pending = pendingReloadsRef.current.get(testPath);
-          if (pending) {
-            pendingReloadsRef.current.delete(testPath);
-            pending.resolve();
-          }
-          rpc?.onTestFileComplete(payload);
+          rpc?.onTestFileComplete({
+            ...payload,
+            runId,
+          });
         }
       } else if (message.type === 'fatal') {
         const payload = message.payload as FatalPayload;
         if (active) {
           setStatusMap((prev) => ({ ...prev, [active]: 'fail' }));
-        }
-        if (pendingReloadsRef.current.size > 0) {
-          const fatalError = new Error(
-            payload.message || 'Browser runner fatal',
-          );
-          for (const pending of pendingReloadsRef.current.values()) {
-            pending.reject(fatalError);
-          }
-          pendingReloadsRef.current.clear();
         }
         rpc?.onFatal(payload);
       } else if (message.type === 'log') {
@@ -544,7 +509,7 @@ const BrowserRunner: React.FC<{
     };
     window.addEventListener('message', listener);
     return () => window.removeEventListener('message', listener);
-  }, [active, upsertCase, mapCaseStatus, rpc]);
+  }, [active, upsertCase, mapCaseStatus, rpc, runIdByTestFile]);
 
   // Computed values - case level statistics
   const caseCounts = useMemo(() => {

--- a/packages/browser-ui/src/types.ts
+++ b/packages/browser-ui/src/types.ts
@@ -36,6 +36,7 @@ export type BrowserClientFileResult = {
   status: TestFileResult['status'];
   name: TestFileResult['name'];
   testPath: TestFileResult['testPath'];
+  runId?: string;
   parentNames?: TestFileResult['parentNames'];
   location?: {
     line: number;
@@ -78,9 +79,16 @@ export type HostRPC = {
   ) => Promise<BrowserDispatchResponse>;
 };
 
+export type ReloadTestFileAck = {
+  runId: string;
+};
+
 export type ContainerRPC = {
   onTestFileUpdate: (testFiles: TestFileInfo[]) => void;
-  reloadTestFile: (testFile: string, testNamePattern?: string) => Promise<void>;
+  reloadTestFile: (
+    testFile: string,
+    testNamePattern?: string,
+  ) => Promise<ReloadTestFileAck>;
 };
 
 export type {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -157,6 +157,33 @@ type TestFileReadyPayload = ReporterHookArg<'onTestFileReady'>;
 type TestSuiteStartPayload = ReporterHookArg<'onTestSuiteStart'>;
 type TestSuiteResultPayload = ReporterHookArg<'onTestSuiteResult'>;
 type TestCaseStartPayload = ReporterHookArg<'onTestCaseStart'>;
+type ReloadTestFileAck = {
+  runId: string;
+};
+type HeadedTestFileCompletePayload = TestFileResult & {
+  runId?: string;
+};
+
+type DeferredPromise<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const createDeferredPromise = <T>(): DeferredPromise<T> => {
+  let resolve!: DeferredPromise<T>['resolve'];
+  let reject!: DeferredPromise<T>['reject'];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+};
 
 /** RPC methods exposed by the host (server) to the container (client) */
 type HostRpcMethods = {
@@ -166,7 +193,7 @@ type HostRpcMethods = {
   // Test result callbacks from container
   onTestFileStart: (payload: TestFileStartPayload) => Promise<void>;
   onTestCaseResult: (payload: TestResult) => Promise<void>;
-  onTestFileComplete: (payload: TestFileResult) => Promise<void>;
+  onTestFileComplete: (payload: HeadedTestFileCompletePayload) => Promise<void>;
   onLog: (payload: LogPayload) => Promise<void>;
   onFatal: (payload: FatalPayload) => Promise<void>;
   // Generic dispatch endpoint used by runner RPC requests.
@@ -178,7 +205,10 @@ type HostRpcMethods = {
 /** RPC methods exposed by the container (client) to the host (server) */
 type ContainerRpcMethods = {
   onTestFileUpdate: (testFiles: TestFileInfo[]) => Promise<void>;
-  reloadTestFile: (testFile: string, testNamePattern?: string) => Promise<void>;
+  reloadTestFile: (
+    testFile: string,
+    testNamePattern?: string,
+  ) => Promise<ReloadTestFileAck>;
 };
 
 type ContainerRpc = BirpcReturn<ContainerRpcMethods, HostRpcMethods>;
@@ -196,16 +226,27 @@ class ContainerRpcManager {
   private ws: WebSocket | null = null;
   private rpc: ContainerRpc | null = null;
   private methods: HostRpcMethods;
+  private onDisconnect?: (error: Error) => void;
+  private detachActiveSocketListeners: (() => void) | null = null;
 
-  constructor(wss: WebSocketServer, methods: HostRpcMethods) {
+  constructor(
+    wss: WebSocketServer,
+    methods: HostRpcMethods,
+    onDisconnect?: (error: Error) => void,
+  ) {
     this.wss = wss;
     this.methods = methods;
+    this.onDisconnect = onDisconnect;
     this.setupConnectionHandler();
   }
 
   /** Update the RPC methods (used when starting a new test run) */
-  updateMethods(methods: HostRpcMethods): void {
+  updateMethods(
+    methods: HostRpcMethods,
+    onDisconnect?: (error: Error) => void,
+  ): void {
     this.methods = methods;
+    this.onDisconnect = onDisconnect;
     // Re-create birpc with new methods if already connected
     if (this.ws && this.ws.readyState === this.ws.OPEN) {
       this.attachWebSocket(this.ws);
@@ -223,35 +264,68 @@ class ContainerRpcManager {
   }
 
   private attachWebSocket(ws: WebSocket): void {
+    this.detachActiveSocketListeners?.();
+    if (this.rpc && !this.rpc.$closed) {
+      this.rpc.$close(new Error('Container RPC transport reattached'));
+    }
     this.ws = ws;
+    const messageHandlers = new WeakMap<
+      (data: any) => void,
+      (message: any) => void
+    >();
 
     this.rpc = createBirpc<ContainerRpcMethods, HostRpcMethods>(this.methods, {
+      timeout: -1,
       post: (data) => {
         if (ws.readyState === ws.OPEN) {
           ws.send(JSON.stringify(data));
         }
       },
       on: (fn) => {
-        ws.on('message', (message) => {
+        const handler = (message: any) => {
           try {
             const data = JSON.parse(message.toString());
             fn(data);
           } catch {
             // ignore invalid messages
           }
-        });
+        };
+        messageHandlers.set(fn, handler);
+        ws.on('message', handler);
+      },
+      off: (fn) => {
+        const handler = messageHandlers.get(fn);
+        if (!handler) {
+          return;
+        }
+        ws.off('message', handler);
+        messageHandlers.delete(fn);
       },
     });
 
-    ws.on('close', () => {
+    const handleClose = () => {
       // Only clear if this is still the active connection
       // This prevents a race condition when a new connection is established
       // before the old one's close event fires
       if (this.ws === ws) {
         this.ws = null;
-        this.rpc = null;
       }
-    });
+      this.detachActiveSocketListeners?.();
+      this.detachActiveSocketListeners = null;
+      if (this.rpc && !this.rpc.$closed) {
+        const disconnectError = new Error(
+          'Browser UI WebSocket disconnected before reload completed',
+        );
+        this.rpc.$close(disconnectError);
+        this.onDisconnect?.(disconnectError);
+      }
+      this.rpc = null;
+    };
+
+    ws.on('close', handleClose);
+    this.detachActiveSocketListeners = () => {
+      ws.off('close', handleClose);
+    };
   }
 
   /** Check if a container is currently connected */
@@ -278,16 +352,15 @@ class ContainerRpcManager {
   async reloadTestFile(
     testFile: string,
     testNamePattern?: string,
-  ): Promise<void> {
+  ): Promise<ReloadTestFileAck> {
     logger.debug(
       `[Browser UI] reloadTestFile called, rpc: ${this.rpc ? 'exists' : 'null'}, ws: ${this.ws ? 'exists' : 'null'}`,
     );
     if (!this.rpc) {
-      logger.debug('[Browser UI] RPC not available, skipping reloadTestFile');
-      return;
+      throw new Error('Browser UI RPC not available for reloadTestFile');
     }
     logger.debug(`[Browser UI] Calling reloadTestFile: ${testFile}`);
-    await this.rpc.reloadTestFile(testFile, testNamePattern);
+    return this.rpc.reloadTestFile(testFile, testNamePattern);
   }
 }
 
@@ -2706,11 +2779,82 @@ export const runBrowserController = async (
 
   const dispatchRouter = createDispatchRouter();
   const headedReloadQueue = createHeadedSerialTaskQueue();
+  const pendingHeadedReloads = new Map<
+    string,
+    {
+      runId: string;
+      deferred: DeferredPromise<void>;
+    }
+  >();
   let enqueueHeadedReload = async (
     _file: TestFileInfo,
     _testNamePattern?: string,
   ): Promise<void> => {
     throw new Error('Headed reload queue is not initialized');
+  };
+
+  const rejectPendingHeadedReload = (
+    testPath: string,
+    error: Error,
+    runId?: string,
+  ): void => {
+    const pending = pendingHeadedReloads.get(testPath);
+    if (!pending) {
+      return;
+    }
+    if (runId && pending.runId !== runId) {
+      return;
+    }
+    pendingHeadedReloads.delete(testPath);
+    pending.deferred.reject(error);
+  };
+
+  const rejectAllPendingHeadedReloads = (error: Error): void => {
+    for (const [testPath, pending] of pendingHeadedReloads) {
+      pendingHeadedReloads.delete(testPath);
+      pending.deferred.reject(error);
+    }
+  };
+
+  const registerPendingHeadedReload = (
+    testPath: string,
+    runId: string,
+  ): Promise<void> => {
+    const previousPending = pendingHeadedReloads.get(testPath);
+    if (previousPending) {
+      previousPending.deferred.reject(
+        new Error(
+          `Reload for "${testPath}" was superseded by a newer request.`,
+        ),
+      );
+      pendingHeadedReloads.delete(testPath);
+    }
+
+    const deferred = createDeferredPromise<void>();
+    pendingHeadedReloads.set(testPath, {
+      runId,
+      deferred,
+    });
+
+    return deferred.promise;
+  };
+
+  const resolvePendingHeadedReload = (
+    testPath: string,
+    runId?: string,
+  ): void => {
+    const pending = pendingHeadedReloads.get(testPath);
+    if (!pending) {
+      return;
+    }
+    if (runId && pending.runId !== runId) {
+      logger.debug(
+        `[Browser UI] Ignoring stale file-complete for ${testPath}. current=${pending.runId}, incoming=${runId}`,
+      );
+      return;
+    }
+    pendingHeadedReloads.delete(testPath);
+    pending.deferred.resolve();
   };
 
   const reloadTestFileWithTimeout = async (
@@ -2719,10 +2863,19 @@ export const runBrowserController = async (
   ): Promise<void> => {
     const timeoutMs = getHeadedPerFileTimeoutMs(file);
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let reloadAck: ReloadTestFileAck | undefined;
 
     try {
+      reloadAck = await rpcManager.reloadTestFile(
+        file.testPath,
+        testNamePattern,
+      );
+      const completionPromise = registerPendingHeadedReload(
+        file.testPath,
+        reloadAck.runId,
+      );
       await Promise.race([
-        rpcManager.reloadTestFile(file.testPath, testNamePattern),
+        completionPromise,
         new Promise<never>((_, reject) => {
           timeoutId = setTimeout(() => {
             reject(
@@ -2733,6 +2886,15 @@ export const runBrowserController = async (
           }, timeoutMs);
         }),
       ]);
+    } catch (error) {
+      if (reloadAck?.runId) {
+        rejectPendingHeadedReload(
+          file.testPath,
+          toError(error),
+          reloadAck.runId,
+        );
+      }
+      throw error;
     } finally {
       if (timeoutId) {
         clearTimeout(timeoutId);
@@ -2765,13 +2927,26 @@ export const runBrowserController = async (
     async onTestCaseResult(payload: TestResult) {
       await handleTestCaseResult(payload);
     },
-    async onTestFileComplete(payload: TestFileResult) {
-      await handleTestFileComplete(payload);
+    async onTestFileComplete(payload: HeadedTestFileCompletePayload) {
+      try {
+        await handleTestFileComplete(payload);
+        resolvePendingHeadedReload(payload.testPath, payload.runId);
+      } catch (error) {
+        rejectPendingHeadedReload(
+          payload.testPath,
+          toError(error),
+          payload.runId,
+        );
+        throw error;
+      }
     },
     async onLog(payload: LogPayload) {
       await handleLog(payload);
     },
     async onFatal(payload: FatalPayload) {
+      const error = new Error(payload.message);
+      error.stack = payload.stack;
+      rejectAllPendingHeadedReloads(error);
       await handleFatal(payload);
     },
     async dispatch(request: BrowserDispatchRequest) {
@@ -2786,14 +2961,18 @@ export const runBrowserController = async (
   if (isWatchMode && runtime.rpcManager) {
     rpcManager = runtime.rpcManager;
     // Update methods with new test state (caseResults, completedTests, etc.)
-    rpcManager.updateMethods(createRpcMethods());
+    rpcManager.updateMethods(createRpcMethods(), rejectAllPendingHeadedReloads);
     // Reattach if we have an existing WebSocket
     const existingWs = rpcManager.currentWebSocket;
     if (existingWs) {
       rpcManager.reattach(existingWs);
     }
   } else {
-    rpcManager = new ContainerRpcManager(wss, createRpcMethods());
+    rpcManager = new ContainerRpcManager(
+      wss,
+      createRpcMethods(),
+      rejectAllPendingHeadedReloads,
+    );
 
     if (isWatchMode) {
       runtime.rpcManager = rpcManager;


### PR DESCRIPTION
## Summary
- move headed `reloadTestFile` to an ack-style RPC so the host owns file completion tracking instead of keeping a long-lived birpc promise open for the full test run
- disable host/container birpc transport timeouts and close pending calls on WebSocket teardown so browser lifecycle timeouts stay under the host scheduler's control
- forward `runId` with headed file completion events and guard against stale completions during reruns and reconnects

## Validation
- pnpm --filter @rstest/core build
- pnpm --filter @rstest/browser build
- pnpm --filter @rstest/browser-ui build
- pnpm --filter @rstest/browser typecheck
- pnpm --filter @rstest/browser-ui typecheck
- pnpm biome check 'packages/browser/src/hostController.ts' 'packages/browser-ui/src/hooks/useRpc.ts' 'packages/browser-ui/src/main.tsx' 'packages/browser-ui/src/types.ts'
- node 'packages/core/bin/rstest.js' run --browser.headless false 'tests/dom.test.ts' (cwd: e2e/browser-mode/fixtures/basic)
- node 'packages/core/bin/rstest.js' run --browser.headless false (cwd: e2e/browser-mode/fixtures/locator-api)
- node 'packages/core/bin/rstest.js' run --browser.headless false (cwd: e2e/browser-mode/fixtures/viewport)
- manual headed verification with a temporary 65s browser test to confirm `reloadTestFile` no longer fails at birpc's 60s default timeout