### PR TITLE
chore: enforce noNamespaceImport with targeted exceptions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -64,7 +64,8 @@
         "noConfusingVoidType": "off"
       },
       "performance": {
-        "noDelete": "off"
+        "noDelete": "off",
+        "noNamespaceImport": "error"
       },
       "correctness": {
         "useHookAtTopLevel": "off"
@@ -88,6 +89,16 @@
         "rules": {
           "style": {
             "useFilenamingConvention": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["e2e/mock/**"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noNamespaceImport": "off"
           }
         }
       }

--- a/e2e/browser-mode/fixtures/browser-react/tests/rstest.setup.ts
+++ b/e2e/browser-mode/fixtures/browser-react/tests/rstest.setup.ts
@@ -1,4 +1,5 @@
 import { expect } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: jest-dom matchers are consumed as a matcher namespace.
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 
 void jestDomMatchers;

--- a/e2e/dom/fixtures/test/setup.ts
+++ b/e2e/dom/fixtures/test/setup.ts
@@ -1,4 +1,5 @@
 import { expect } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: jest-dom matchers are consumed as a matcher namespace.
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 
 expect.extend(jestDomMatchers);

--- a/e2e/projects/fixtures-shard/packages/client/test/setup.ts
+++ b/e2e/projects/fixtures-shard/packages/client/test/setup.ts
@@ -1,4 +1,5 @@
 import { expect } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: jest-dom matchers are consumed as a matcher namespace.
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 
 expect.extend(jestDomMatchers);

--- a/e2e/projects/fixtures/packages/client/test/setup.ts
+++ b/e2e/projects/fixtures/packages/client/test/setup.ts
@@ -1,4 +1,5 @@
 import { expect } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: jest-dom matchers are consumed as a matcher namespace.
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 
 expect.extend(jestDomMatchers);

--- a/e2e/spy/spyOn.test.ts
+++ b/e2e/spy/spyOn.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, rstest } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: this test verifies spyOn behavior against a module namespace.
 import * as utils from './fixtures/util';
 
 describe('test spyOn', () => {

--- a/e2e/wasm/index.test.ts
+++ b/e2e/wasm/index.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: this test exercises the generated WASM module namespace.
 import * as wasm from './src/factorial.wasm';
 
 test('WASM factorial', async () => {

--- a/examples/react-rsbuild/test/rstest.setup.ts
+++ b/examples/react-rsbuild/test/rstest.setup.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: jest-dom matchers are consumed as a matcher namespace.
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 import { cleanup } from '@testing-library/react';
 

--- a/examples/react/test/rstest.setup.ts
+++ b/examples/react/test/rstest.setup.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect } from '@rstest/core';
+// biome-ignore lint/performance/noNamespaceImport: jest-dom matchers are consumed as a matcher namespace.
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 import { cleanup } from '@testing-library/react';
 

--- a/packages/browser-react/src/act.ts
+++ b/packages/browser-react/src/act.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 let activeActs = 0;
 

--- a/packages/browser-react/src/pure.tsx
+++ b/packages/browser-react/src/pure.tsx
@@ -1,6 +1,6 @@
 import type { JSXElementConstructor, ReactNode } from 'react';
-import * as React from 'react';
-import * as ReactDOMClient from 'react-dom/client';
+import React from 'react';
+import { createRoot as createReactRoot } from 'react-dom/client';
 import { act } from './act';
 
 // ===== Types =====
@@ -70,7 +70,7 @@ const config: RenderConfiguration = {
 // ===== Internal Helpers =====
 
 function createRoot(container: HTMLElement): ReactRoot {
-  const root = ReactDOMClient.createRoot(container);
+  const root = createReactRoot(container);
   return {
     render: (element: ReactNode) => root.render(element),
     unmount: () => root.unmount(),

--- a/packages/browser-ui/src/components/Resizable.tsx
+++ b/packages/browser-ui/src/components/Resizable.tsx
@@ -1,5 +1,5 @@
 import { Splitter, type SplitterProps } from 'antd';
-import * as React from 'react';
+import React from 'react';
 
 type ResizablePanelGroupProps = Omit<SplitterProps, 'children'> & {
   children: React.ReactNode;

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -30,7 +30,7 @@ import {
 import { type BirpcReturn, createBirpc } from 'birpc';
 import openEditor from 'open-editor';
 import { basename, dirname, join, normalize, relative, resolve } from 'pathe';
-import * as picomatch from 'picomatch';
+import picomatch from 'picomatch';
 import sirv from 'sirv';
 import { type WebSocket, WebSocketServer } from 'ws';
 import { getHeadlessConcurrency } from './concurrency';

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -5,6 +5,7 @@
  */
 
 // Re-export @rsbuild/core for @rstest/browser to avoid duplicate dependency
+// biome-ignore lint/performance/noNamespaceImport: this package re-exports the module namespace as a compatibility surface.
 import * as rsbuild from '@rsbuild/core';
 export { rsbuild };
 

--- a/packages/core/src/cli/init/browser/create.ts
+++ b/packages/core/src/cli/init/browser/create.ts
@@ -1,5 +1,15 @@
 import path from 'node:path';
-import * as p from '@clack/prompts';
+import {
+  cancel,
+  confirm,
+  intro,
+  isCancel,
+  log,
+  note,
+  outro,
+  select,
+  spinner,
+} from '@clack/prompts';
 import { color, determineAgent } from '../../../utils';
 import { detectProject } from './detect';
 import type { BrowserProvider, Framework } from './templates';
@@ -159,7 +169,7 @@ async function createInteractive(
   const effectiveFramework: Framework =
     framework === 'react' ? 'react' : 'vanilla';
 
-  p.intro(color.bgCyan(color.black(' rstest init browser ')));
+  intro(color.bgCyan(color.black(' rstest init browser ')));
 
   // Step 1: Show detection results
   const detectionLines: string[] = [];
@@ -177,17 +187,17 @@ async function createInteractive(
   );
   detectionLines.push(`${color.green('✓')} Test directory: ${testDir}/`);
 
-  p.note(detectionLines.join('\n'), 'Detecting project...');
+  note(detectionLines.join('\n'), 'Detecting project...');
 
   // Show agent hint if running in AI agent environment
   if (isAgent) {
-    p.log.info(
+    log.info(
       `AI Agent detected. For non-interactive mode, run:\n  ${color.cyan('npx rstest init browser --yes')}`,
     );
   }
 
   // Step 2: Choose browser provider (only playwright supported for now)
-  const providerSelection = await p.select({
+  const providerSelection = await select({
     message: 'Choose a browser provider (so far, only Playwright)',
     options: [
       {
@@ -198,8 +208,8 @@ async function createInteractive(
     ],
   });
 
-  if (p.isCancel(providerSelection)) {
-    p.cancel('Operation cancelled.');
+  if (isCancel(providerSelection)) {
+    cancel('Operation cancelled.');
     process.exit(0);
   }
 
@@ -224,21 +234,21 @@ async function createInteractive(
     `   - Add "test:browser" script`,
     `   - Add devDependencies: ${color.dim(depsList)}`,
   ];
-  p.note(previewLines.join('\n'), 'Changes to be made');
+  note(previewLines.join('\n'), 'Changes to be made');
 
   // Step 4: Confirm
-  const confirmed = await p.confirm({
+  const confirmed = await confirm({
     message: 'Proceed with these changes?',
     initialValue: true,
   });
 
-  if (p.isCancel(confirmed) || !confirmed) {
-    p.cancel('Operation cancelled.');
+  if (isCancel(confirmed) || !confirmed) {
+    cancel('Operation cancelled.');
     process.exit(0);
   }
 
   // Step 5: Generate files
-  const s = p.spinner();
+  const s = spinner();
   s.start('Creating files...');
 
   const createdFiles = await generateFiles(cwd, projectInfo, provider);
@@ -248,7 +258,7 @@ async function createInteractive(
   // Show created files
   const fileLines = createdFiles.map((f) => `${color.green('✓')} Created ${f}`);
   fileLines.push(`${color.green('✓')} Updated package.json`);
-  p.note(fileLines.join('\n'), 'Files');
+  note(fileLines.join('\n'), 'Files');
 
   // Step 6: Show next steps
   const nextStepsLines = [
@@ -262,9 +272,9 @@ async function createInteractive(
     `   ${color.cyan(getRunCommand(agent))}`,
   ];
 
-  p.note(nextStepsLines.join('\n'), 'Next steps');
+  note(nextStepsLines.join('\n'), 'Next steps');
 
-  p.outro(color.green('Done! Happy testing with Rstest!'));
+  outro(color.green('Done! Happy testing with Rstest!'));
 }
 
 /**

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -28,7 +28,13 @@ import {
   JestExtend,
   setState,
 } from '@vitest/expect';
-import * as chai from 'chai';
+import {
+  assert,
+  config as chaiConfig,
+  expect as chaiExpect,
+  use,
+  util,
+} from 'chai';
 import type {
   Assertion,
   ChaiConfig,
@@ -41,9 +47,10 @@ import { createExpectPoll } from './poll';
 import { SnapshotPlugin } from './snapshot';
 
 export { GLOBAL_EXPECT };
+export { assert } from 'chai';
 
 export function setupChaiConfig(config: ChaiConfig): void {
-  Object.assign(chai.config, config);
+  Object.assign(chaiConfig, config);
 }
 
 export function createExpect({
@@ -53,15 +60,15 @@ export function createExpect({
   workerState: WorkerState;
   getCurrentTest: () => TestCase | undefined;
 }): RstestExpect {
-  chai.use(JestExtend);
-  chai.use(JestChaiExpect);
-  chai.use(SnapshotPlugin(workerState));
-  chai.use(JestAsymmetricMatchers);
+  use(JestExtend);
+  use(JestChaiExpect);
+  use(SnapshotPlugin(workerState));
+  use(JestAsymmetricMatchers);
 
   const expect = ((value: any, message?: string): Assertion => {
     const { assertionCalls } = getState(expect);
     setState({ assertionCalls: assertionCalls + 1 }, expect);
-    const assert = chai.expect(value, message) as unknown as Assertion;
+    const assert = chaiExpect(value, message) as unknown as Assertion;
     const _test = getCurrentTest();
     if (_test) {
       // @ts-expect-error internal
@@ -69,7 +76,7 @@ export function createExpect({
     }
     return assert;
   }) as RstestExpect;
-  Object.assign(expect, chai.expect);
+  Object.assign(expect, chaiExpect);
   Object.assign(expect, (globalThis as any)[ASYMMETRIC_MATCHERS_OBJECT]);
 
   expect.getState = () => getState<MatcherState>(expect);
@@ -93,7 +100,7 @@ export function createExpect({
   );
 
   // @ts-expect-error chai.expect.extend untyped
-  expect.extend = (matchers) => chai.expect.extend(expect, matchers);
+  expect.extend = (matchers) => chaiExpect.extend(expect, matchers);
   expect.addEqualityTesters = (customTesters) =>
     addCustomEqualityTesters(customTesters);
 
@@ -112,9 +119,7 @@ export function createExpect({
   };
 
   expect.unreachable = (message?: string) => {
-    chai.assert.fail(
-      `expected ${message ? `"${message}" ` : ''}not to be reached`,
-    );
+    assert.fail(`expected ${message ? `"${message}" ` : ''}not to be reached`);
   };
 
   function assertions(expected: number) {
@@ -146,12 +151,10 @@ export function createExpect({
     });
   }
 
-  chai.util.addMethod(expect, 'assertions', assertions);
-  chai.util.addMethod(expect, 'hasAssertions', hasAssertions);
+  util.addMethod(expect, 'assertions', assertions);
+  util.addMethod(expect, 'hasAssertions', hasAssertions);
 
   expect.extend(customMatchers);
 
   return expect;
 }
-
-export { assert } from 'chai';

--- a/packages/core/src/runtime/api/poll.ts
+++ b/packages/core/src/runtime/api/poll.ts
@@ -17,7 +17,7 @@
  * copies or substantial portions of the Software.
  */
 import type { Assertion } from '@vitest/expect';
-import * as chai from 'chai';
+import { Assertion as ChaiAssertion, util } from 'chai';
 import type { RstestExpect, TestCase } from '../../types';
 import { getRealTimers } from '../util';
 
@@ -53,9 +53,7 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
     // biome-ignore lint/style/noParameterAssign: reassigning
     fn = fn.bind(assertion);
     // TODO: flag rstest
-    const test = chai.util.flag(assertion, 'vitest-test') as
-      | TestCase
-      | undefined;
+    const test = util.flag(assertion, 'vitest-test') as TestCase | undefined;
     if (!test) {
       throw new Error('expect.poll() must be called inside a test');
     }
@@ -64,7 +62,7 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
         const assertionFunction = Reflect.get(target, key, receiver);
 
         if (typeof assertionFunction !== 'function') {
-          return assertionFunction instanceof chai.Assertion
+          return assertionFunction instanceof ChaiAssertion
             ? proxy
             : assertionFunction;
         }
@@ -89,22 +87,22 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
               // TODO: use timeout manager
               const check = async () => {
                 try {
-                  chai.util.flag(assertion, '_name', key);
+                  util.flag(assertion, '_name', key);
                   const obj = await fn();
-                  chai.util.flag(assertion, 'object', obj);
+                  util.flag(assertion, 'object', obj);
                   resolve(await assertionFunction.call(assertion, ...args));
                   clearTimeout(intervalId);
                   clearTimeout(timeoutId);
                 } catch (err) {
                   lastError = err;
-                  if (!chai.util.flag(assertion, '_isLastPollAttempt')) {
+                  if (!util.flag(assertion, '_isLastPollAttempt')) {
                     intervalId = getRealTimers().setTimeout!(check, interval);
                   }
                 }
               };
               timeoutId = getRealTimers().setTimeout!(() => {
                 clearTimeout(intervalId);
-                chai.util.flag(assertion, '_isLastPollAttempt', true);
+                util.flag(assertion, '_isLastPollAttempt', true);
                 const rejectWithCause = (cause: any) => {
                   reject(
                     copyStackTrace(
@@ -125,8 +123,8 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
           test.onFinished ??= [];
           test.onFinished.push(() => {
             if (!awaited) {
-              const negated = chai.util.flag(assertion, 'negate') ? 'not.' : '';
-              const name = chai.util.flag(assertion, '_poll.element')
+              const negated = util.flag(assertion, 'negate') ? 'not.' : '';
+              const name = util.flag(assertion, '_poll.element')
                 ? 'element(locator)'
                 : 'poll(assertion)';
               const assertionString = `expect.${name}.${negated}${String(key)}()`;

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -1,23 +1,34 @@
-import * as v from 'valibot';
+import {
+  array,
+  boolean,
+  fallback,
+  type InferOutput,
+  literal,
+  object,
+  optional,
+  parse,
+  string,
+  union,
+} from 'valibot';
 import vscode from 'vscode';
 
 // Centralized configuration types for the extension.
 // Add new keys here to extend configuration in a type-safe way.
-const configSchema = v.object({
+const configSchema = object({
   // The path to a package.json file of a Rstest executable.
   // Used as a last resort if the extension cannot auto-detect @rstest/core.
-  rstestPackagePath: v.fallback(v.optional(v.string()), undefined),
-  configFileGlobPattern: v.fallback(v.array(v.string()), [
+  rstestPackagePath: fallback(optional(string()), undefined),
+  configFileGlobPattern: fallback(array(string()), [
     '**/rstest.config.{mjs,ts,js,cjs,mts,cts}',
   ]),
-  testCaseCollectMethod: v.fallback(
-    v.union([v.literal('ast'), v.literal('runtime')]),
+  testCaseCollectMethod: fallback(
+    union([literal('ast'), literal('runtime')]),
     'ast',
   ),
-  applyDiagnostic: v.fallback(v.boolean(), true),
+  applyDiagnostic: fallback(boolean(), true),
 });
 
-export type ExtensionConfig = v.InferOutput<typeof configSchema>;
+export type ExtensionConfig = InferOutput<typeof configSchema>;
 
 // Type-safe getter for a single config value
 export function getConfigValue<K extends keyof ExtensionConfig>(
@@ -25,7 +36,7 @@ export function getConfigValue<K extends keyof ExtensionConfig>(
   scope?: vscode.ConfigurationScope | null,
 ): ExtensionConfig[K] {
   const value = vscode.workspace.getConfiguration('rstest', scope).get(key);
-  return v.parse(configSchema.entries[key], value) as ExtensionConfig[K];
+  return parse(configSchema.entries[key], value) as ExtensionConfig[K];
 }
 
 // Convenience to get a full, normalized config object at the given scope.

--- a/packages/vscode/src/diagnostics.ts
+++ b/packages/vscode/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 export type DiagnosticEntry = {
   uri: vscode.Uri;

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import type { TestInfo } from '@rstest/core';
 import picomatch from 'picomatch';
 import { glob } from 'tinyglobby';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import { watchConfigValue } from './config';
 import { logger } from './logger';
 import { RstestApi } from './master';

--- a/packages/vscode/tests/runTest.ts
+++ b/packages/vscode/tests/runTest.ts
@@ -1,4 +1,4 @@
-import * as path from 'node:path';
+import path from 'node:path';
 import { runTests } from '@vscode/test-electron';
 
 async function main() {

--- a/packages/vscode/tests/suite/index.test.ts
+++ b/packages/vscode/tests/suite/index.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'node:assert';
-import * as vscode from 'vscode';
+import assert from 'node:assert';
+import vscode from 'vscode';
 import { getProjectItems, toLabelTree } from './helpers';
 
 suite('Extension Test Suite', () => {

--- a/packages/vscode/tests/suite/progress.test.ts
+++ b/packages/vscode/tests/suite/progress.test.ts
@@ -1,7 +1,7 @@
-import * as assert from 'node:assert';
+import assert from 'node:assert';
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import { delay, getTestItemByLabels, waitFor } from './helpers';
 
 suite('Test Progress Reporting', () => {

--- a/packages/vscode/tests/suite/runtimeList.test.ts
+++ b/packages/vscode/tests/suite/runtimeList.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import { getTestItemByLabels, toLabelTree, waitFor } from './helpers';
 
 suite('Runtime list suite', () => {

--- a/packages/vscode/tests/suite/workspace.test.ts
+++ b/packages/vscode/tests/suite/workspace.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import { toLabelTree, waitFor } from './helpers';
 
 suite('Workspace discover suite', () => {

--- a/packages/vscode/tests/unit/diagnostics.test.ts
+++ b/packages/vscode/tests/unit/diagnostics.test.ts
@@ -5,7 +5,7 @@ let clearCalls = 0;
 let disposeCalls = 0;
 
 rs.mock('vscode', () => {
-  return {
+  const vscode = {
     languages: {
       createDiagnosticCollection: () => ({
         set: (uri: { toString: () => string }, diagnostics: unknown[]) => {
@@ -20,6 +20,11 @@ rs.mock('vscode', () => {
         },
       }),
     },
+  };
+
+  return {
+    ...vscode,
+    default: vscode,
   };
 });
 

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,4 +1,4 @@
-import * as path from 'node:path';
+import path from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { defineConfig } from '@rspress/core';
 import { pluginAlgolia } from '@rspress/plugin-algolia';


### PR DESCRIPTION
## Summary

human input:

LLM sometimes intent to write namespace import syntax, adding a lint to maintain consistent code style.

---

- enable Biome `performance/noNamespaceImport` and rewrite safe namespace imports across core, browser, browser-ui, browser-react, vscode, and website code
- keep mock-sensitive `e2e/mock/**` cases under a directory override and use inline suppressions for intentional namespace imports such as `jest-dom` setup, `spyOn`, WASM modules, and the `@rsbuild/core` compatibility re-export
- update the VS Code test mock shape to support default `vscode` imports and verify the workspace lint, typecheck, build, test, examples, e2e, and VS Code suites still pass