### PR TITLE
fix: rspack peerDependencies version

### DIFF
--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -28,8 +28,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@rspack/cli": ">=2.0.0",
-    "@rspack/core": ">=2.0.0",
+    "@rspack/cli": ">=2.0.0-0",
+    "@rspack/core": ">=2.0.0-0",
     "@rstest/core": ">=0.7.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

fix rspack peerDependencies version
<img width="1203" height="369" alt="image" src="https://github.com/user-attachments/assets/37718a64-f805-4125-87ec-4807596c4895" />


## Related Links
https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/23131482091/job/67185637630

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
