### PR TITLE
fix(browser-ui): show collected cases before first result

### DIFF
--- a/packages/browser-ui/src/core/caseMap.test.ts
+++ b/packages/browser-ui/src/core/caseMap.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from '@rstest/core';
+import type { TestInfo } from '@rstest/core/browser-runtime';
+import type { CaseInfo } from '../utils/constants';
+import { buildCollectedCaseMap } from './caseMap';
+
+describe('buildCollectedCaseMap', () => {
+  it('should flatten collected suites into leaf cases and preserve existing statuses', () => {
+    const previousCases: Record<string, CaseInfo> = {
+      'case-1': {
+        id: 'case-1',
+        name: 'renders title',
+        parentNames: ['component', 'header'],
+        fullName: 'component  header  renders title',
+        status: 'running',
+        filePath: '/tests/example.test.tsx',
+      },
+    };
+
+    const tests: TestInfo[] = [
+      {
+        testId: 'suite-1',
+        type: 'suite',
+        name: 'component',
+        parentNames: [],
+        testPath: '/tests/example.test.tsx',
+        project: 'browser-react',
+        runMode: 'run',
+        tests: [
+          {
+            testId: 'suite-2',
+            type: 'suite',
+            name: 'header',
+            parentNames: ['component'],
+            testPath: '/tests/example.test.tsx',
+            project: 'browser-react',
+            runMode: 'run',
+            tests: [
+              {
+                testId: 'case-1',
+                type: 'case',
+                name: 'renders title',
+                parentNames: ['component', 'header'],
+                testPath: '/tests/example.test.tsx',
+                project: 'browser-react',
+                runMode: 'run',
+                location: { line: 12, column: 3 },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        testId: 'case-2',
+        type: 'case',
+        name: 'renders footer',
+        parentNames: [],
+        testPath: '/tests/example.test.tsx',
+        project: 'browser-react',
+        runMode: 'run',
+        location: { line: 24, column: 5 },
+      },
+    ];
+
+    const caseMap = buildCollectedCaseMap({
+      filePath: '/tests/example.test.tsx',
+      tests,
+      previousCases,
+    });
+
+    expect(Object.keys(caseMap)).toEqual(['case-1', 'case-2']);
+    expect(caseMap['case-1']).toEqual({
+      id: 'case-1',
+      name: 'renders title',
+      parentNames: ['component', 'header'],
+      fullName: 'component  header  renders title',
+      status: 'running',
+      filePath: '/tests/example.test.tsx',
+      location: { line: 12, column: 3 },
+    });
+    expect(caseMap['case-2']).toEqual({
+      id: 'case-2',
+      name: 'renders footer',
+      parentNames: [],
+      fullName: 'renders footer',
+      status: 'idle',
+      filePath: '/tests/example.test.tsx',
+      location: { line: 24, column: 5 },
+    });
+  });
+});

--- a/packages/browser-ui/src/core/caseMap.ts
+++ b/packages/browser-ui/src/core/caseMap.ts
@@ -1,0 +1,43 @@
+import type { TestInfo } from '@rstest/core/browser-runtime';
+import type { CaseInfo } from '../utils/constants';
+
+export const buildCollectedCaseMap = ({
+  filePath,
+  tests,
+  previousCases,
+}: {
+  filePath: string;
+  tests: TestInfo[];
+  previousCases: Record<string, CaseInfo>;
+}): Record<string, CaseInfo> => {
+  const nextFile: Record<string, CaseInfo> = {};
+
+  const visit = (test: TestInfo) => {
+    if (test.type === 'suite') {
+      for (const child of test.tests) {
+        visit(child);
+      }
+      return;
+    }
+
+    const parentNames = (test.parentNames ?? []).filter(Boolean);
+    const fullName = [...parentNames, test.name].join('  ') || test.name;
+    const previous = previousCases[test.testId];
+
+    nextFile[test.testId] = {
+      id: test.testId,
+      name: test.name,
+      parentNames,
+      fullName,
+      status: previous?.status ?? 'idle',
+      filePath: test.testPath || filePath,
+      location: test.location,
+    };
+  };
+
+  for (const test of tests) {
+    visit(test);
+  }
+
+  return nextFile;
+};

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -1,4 +1,5 @@
 import {
+  DISPATCH_NAMESPACE_RUNNER,
   DISPATCH_RESPONSE_TYPE,
   DISPATCH_RPC_REQUEST_TYPE,
   RSTEST_CONFIG_MESSAGE_TYPE,
@@ -19,6 +20,7 @@ import {
   isStaleBrowserRpcRequest,
   readBrowserRpcRequest,
 } from './core/browserRpc';
+import { buildCollectedCaseMap } from './core/caseMap';
 import { forwardDispatchRpcRequest, readDispatchMessage } from './core/channel';
 import { createRunId, createRunnerUrl } from './core/runtime';
 import { useRpc } from './hooks/useRpc';
@@ -30,6 +32,7 @@ import type {
   FatalPayload,
   LogPayload,
   TestFileInfo,
+  TestFileReadyPayload,
 } from './types';
 import type {
   CaseInfo,
@@ -362,6 +365,25 @@ const BrowserRunner: React.FC<{
     [mapCaseStatus],
   );
 
+  const syncCollectedCases = useCallback(
+    (filePath: string, payload: TestFileReadyPayload) => {
+      setCaseMap((prev) => {
+        const prevFile = prev[filePath] ?? {};
+        const nextFile = buildCollectedCaseMap({
+          filePath,
+          tests: payload.tests,
+          previousCases: prevFile,
+        });
+
+        return {
+          ...prev,
+          [filePath]: nextFile,
+        };
+      });
+    },
+    [],
+  );
+
   const handleRerunFile = useCallback(
     (file: string) => {
       setActive(file);
@@ -476,6 +498,21 @@ const BrowserRunner: React.FC<{
       } else if (message.type === DISPATCH_RPC_REQUEST_TYPE) {
         // Unified RPC path for snapshot and future runner-side capabilities.
         const dispatchRequest = message.payload as BrowserDispatchRequest;
+
+        if (
+          dispatchRequest.namespace === DISPATCH_NAMESPACE_RUNNER &&
+          dispatchRequest.method === 'file-ready'
+        ) {
+          const payload = dispatchRequest.args as TestFileReadyPayload;
+
+          if (
+            typeof payload?.testPath === 'string' &&
+            Array.isArray(payload.tests)
+          ) {
+            syncCollectedCases(payload.testPath, payload);
+          }
+        }
+
         const browserRpcRequest = readBrowserRpcRequest(dispatchRequest);
 
         if (browserRpcRequest) {
@@ -509,7 +546,14 @@ const BrowserRunner: React.FC<{
     };
     window.addEventListener('message', listener);
     return () => window.removeEventListener('message', listener);
-  }, [active, upsertCase, mapCaseStatus, rpc, runIdByTestFile]);
+  }, [
+    active,
+    upsertCase,
+    mapCaseStatus,
+    rpc,
+    runIdByTestFile,
+    syncCollectedCases,
+  ]);
 
   // Computed values - case level statistics
   const caseCounts = useMemo(() => {

--- a/packages/browser-ui/src/types.ts
+++ b/packages/browser-ui/src/types.ts
@@ -9,7 +9,11 @@ import type {
   TestFileInfo,
 } from '@rstest/browser/protocol';
 
-import type { TestFileResult, TestResult } from '@rstest/core/browser-runtime';
+import type {
+  TestFileResult,
+  TestInfo,
+  TestResult,
+} from '@rstest/core/browser-runtime';
 
 /**
  * Browser UI types
@@ -50,6 +54,11 @@ export type TestFileStartPayload = Extract<
   ProtocolBrowserClientMessage,
   { type: 'file-start' }
 >['payload'];
+
+export type TestFileReadyPayload = {
+  testPath: string;
+  tests: TestInfo[];
+};
 
 export type LogPayload = Extract<
   ProtocolBrowserClientMessage,


### PR DESCRIPTION
## Summary

### Background
The browser sidebar only populated test cases after the first `case-result` or final file result, so running files briefly showed `No test cases reported yet` even after collection had already completed.

### Implementation
- consume runner `file-ready` dispatch messages in the browser UI and project the collected `TestInfo[]` tree into the sidebar immediately
- extract the collect-to-`caseMap` projection into a pure helper to keep the runtime path small and make the behavior easy to test
- add a unit test covering nested suites, leaf-case flattening, and preservation of previously known case status

### User Impact
Browser watch runs now show collected test cases in the sidebar before the first test result arrives.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

## Testing

- `pnpm exec rstest 'packages/browser-ui/src/core/caseMap.test.ts' 'packages/browser-ui/src/core/browserRpc.test.ts' 'packages/browser-ui/src/core/channel.test.ts'`
- `pnpm --filter @rstest/browser-ui typecheck`