### PR TITLE
fix(browser-ui): sync case status before results arrive

### DIFF
--- a/packages/browser-ui/src/core/caseMap.test.ts
+++ b/packages/browser-ui/src/core/caseMap.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from '@rstest/core';
 import type { TestInfo } from '@rstest/core/browser-runtime';
 import type { CaseInfo } from '../utils/constants';
-import { buildCollectedCaseMap } from './caseMap';
+import { buildCollectedCaseMap, upsertRunningCase } from './caseMap';
+
+type CollectedCaseInfo = Extract<TestInfo, { type: 'case' }>;
 
 describe('buildCollectedCaseMap', () => {
   it('should flatten collected suites into leaf cases and preserve existing statuses', () => {
@@ -85,6 +87,79 @@ describe('buildCollectedCaseMap', () => {
       status: 'idle',
       filePath: '/tests/example.test.tsx',
       location: { line: 24, column: 5 },
+    });
+  });
+
+  it('should mark an existing collected case as running when case-start arrives', () => {
+    const previousCases: Record<string, CaseInfo> = {
+      'case-1': {
+        id: 'case-1',
+        name: 'renders title',
+        parentNames: ['component', 'header'],
+        fullName: 'component  header  renders title',
+        status: 'idle',
+        filePath: '/tests/example.test.tsx',
+        location: { line: 12, column: 3 },
+      },
+    };
+
+    const test: CollectedCaseInfo = {
+      testId: 'case-1',
+      type: 'case',
+      name: 'renders title',
+      parentNames: ['component', 'header'],
+      testPath: '/tests/example.test.tsx',
+      project: 'browser-react',
+      runMode: 'run',
+    };
+
+    const caseMap = upsertRunningCase({
+      filePath: '/tests/example.test.tsx',
+      test,
+      previousCases,
+    });
+
+    expect(caseMap).toEqual({
+      'case-1': {
+        id: 'case-1',
+        name: 'renders title',
+        parentNames: ['component', 'header'],
+        fullName: 'component  header  renders title',
+        status: 'running',
+        filePath: '/tests/example.test.tsx',
+        location: { line: 12, column: 3 },
+      },
+    });
+  });
+
+  it('should upsert a running case when case-start arrives before file-ready', () => {
+    const test: CollectedCaseInfo = {
+      testId: 'case-2',
+      type: 'case',
+      name: 'renders footer',
+      parentNames: ['component'],
+      testPath: '/tests/example.test.tsx',
+      project: 'browser-react',
+      runMode: 'run',
+      location: { line: 24, column: 5 },
+    };
+
+    const caseMap = upsertRunningCase({
+      filePath: '/tests/example.test.tsx',
+      test,
+      previousCases: {},
+    });
+
+    expect(caseMap).toEqual({
+      'case-2': {
+        id: 'case-2',
+        name: 'renders footer',
+        parentNames: ['component'],
+        fullName: 'component  renders footer',
+        status: 'running',
+        filePath: '/tests/example.test.tsx',
+        location: { line: 24, column: 5 },
+      },
     });
   });
 });

--- a/packages/browser-ui/src/core/caseMap.ts
+++ b/packages/browser-ui/src/core/caseMap.ts
@@ -1,6 +1,39 @@
 import type { TestInfo } from '@rstest/core/browser-runtime';
 import type { CaseInfo } from '../utils/constants';
 
+type CollectedCaseInfo = Extract<TestInfo, { type: 'case' }>;
+
+const createCaseInfo = ({
+  filePath,
+  test,
+  status,
+  previousCase,
+}: {
+  filePath: string;
+  test: {
+    testId: string;
+    name: string;
+    parentNames?: string[];
+    testPath?: string;
+    location?: CaseInfo['location'];
+  };
+  status: CaseInfo['status'];
+  previousCase?: CaseInfo;
+}): CaseInfo => {
+  const parentNames = (test.parentNames ?? []).filter(Boolean);
+  const fullName = [...parentNames, test.name].join('  ') || test.name;
+
+  return {
+    id: test.testId,
+    name: test.name,
+    parentNames,
+    fullName,
+    status,
+    filePath: test.testPath || previousCase?.filePath || filePath,
+    location: test.location ?? previousCase?.location,
+  };
+};
+
 export const buildCollectedCaseMap = ({
   filePath,
   tests,
@@ -20,19 +53,14 @@ export const buildCollectedCaseMap = ({
       return;
     }
 
-    const parentNames = (test.parentNames ?? []).filter(Boolean);
-    const fullName = [...parentNames, test.name].join('  ') || test.name;
     const previous = previousCases[test.testId];
 
-    nextFile[test.testId] = {
-      id: test.testId,
-      name: test.name,
-      parentNames,
-      fullName,
+    nextFile[test.testId] = createCaseInfo({
+      filePath,
+      test,
       status: previous?.status ?? 'idle',
-      filePath: test.testPath || filePath,
-      location: test.location,
-    };
+      previousCase: previous,
+    });
   };
 
   for (const test of tests) {
@@ -40,4 +68,26 @@ export const buildCollectedCaseMap = ({
   }
 
   return nextFile;
+};
+
+export const upsertRunningCase = ({
+  filePath,
+  test,
+  previousCases,
+}: {
+  filePath: string;
+  test: CollectedCaseInfo;
+  previousCases: Record<string, CaseInfo>;
+}): Record<string, CaseInfo> => {
+  const previous = previousCases[test.testId];
+
+  return {
+    ...previousCases,
+    [test.testId]: createCaseInfo({
+      filePath,
+      test,
+      status: 'running',
+      previousCase: previous,
+    }),
+  };
 };

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -20,7 +20,7 @@ import {
   isStaleBrowserRpcRequest,
   readBrowserRpcRequest,
 } from './core/browserRpc';
-import { buildCollectedCaseMap } from './core/caseMap';
+import { buildCollectedCaseMap, upsertRunningCase } from './core/caseMap';
 import { forwardDispatchRpcRequest, readDispatchMessage } from './core/channel';
 import { createRunId, createRunnerUrl } from './core/runtime';
 import { useRpc } from './hooks/useRpc';
@@ -31,6 +31,7 @@ import type {
   BrowserHostConfig,
   FatalPayload,
   LogPayload,
+  TestCaseStartPayload,
   TestFileInfo,
   TestFileReadyPayload,
 } from './types';
@@ -384,6 +385,24 @@ const BrowserRunner: React.FC<{
     [],
   );
 
+  const syncStartedCase = useCallback(
+    (filePath: string, payload: TestCaseStartPayload) => {
+      setCaseMap((prev) => {
+        const prevFile = prev[filePath] ?? {};
+
+        return {
+          ...prev,
+          [filePath]: upsertRunningCase({
+            filePath,
+            test: payload,
+            previousCases: prevFile,
+          }),
+        };
+      });
+    },
+    [],
+  );
+
   const handleRerunFile = useCallback(
     (file: string) => {
       setActive(file);
@@ -513,6 +532,17 @@ const BrowserRunner: React.FC<{
           }
         }
 
+        if (
+          dispatchRequest.namespace === DISPATCH_NAMESPACE_RUNNER &&
+          dispatchRequest.method === 'case-start'
+        ) {
+          const payload = dispatchRequest.args as TestCaseStartPayload;
+
+          if (typeof payload?.testPath === 'string' && payload.testId) {
+            syncStartedCase(payload.testPath, payload);
+          }
+        }
+
         const browserRpcRequest = readBrowserRpcRequest(dispatchRequest);
 
         if (browserRpcRequest) {
@@ -553,6 +583,7 @@ const BrowserRunner: React.FC<{
     rpc,
     runIdByTestFile,
     syncCollectedCases,
+    syncStartedCase,
   ]);
 
   // Computed values - case level statistics

--- a/packages/browser-ui/src/types.ts
+++ b/packages/browser-ui/src/types.ts
@@ -60,6 +60,8 @@ export type TestFileReadyPayload = {
   tests: TestInfo[];
 };
 
+export type TestCaseStartPayload = Extract<TestInfo, { type: 'case' }>;
+
 export type LogPayload = Extract<
   ProtocolBrowserClientMessage,
   { type: 'log' }


### PR DESCRIPTION
## Summary

### Background
The browser UI only reflected a test case after `case-result`, so collected cases could stay hidden or look idle while execution had already started.

### Implementation
- Added shared case-map helpers that preserve collected metadata and upsert running cases from `case-start` events.
- Wired the browser UI message handler to sync `case-start` dispatches before the first result arrives.
- Expanded case-map tests to cover both updating collected cases and `case-start` arriving before `file-ready`.

### User Impact
Browser-mode users see running cases in the sidebar as soon as execution starts.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).