### PR TITLE
docs: add mocking guide

### DIFF
--- a/website/docs/en/guide/basic/_meta.json
+++ b/website/docs/en/guide/basic/_meta.json
@@ -2,6 +2,7 @@
   "cli",
   "configure-rstest",
   "test-filter",
+  "mock",
   "snapshot",
   "projects",
   "reporters",

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -1,0 +1,257 @@
+---
+description: Mock functions, object methods, ESM modules, and CommonJS modules in Rstest, and distinguish mock state from module state.
+---
+
+# Mocking
+
+Mocking lets you replace dependencies in tests, control return values, and assert how functions or modules are called. Rstest provides different mocking APIs for functions, object methods, ESM modules, CommonJS modules, and object trees.
+
+## Mock modules
+
+If a dependency is loaded through the module system, you can choose different APIs based on the module type and mocking behavior.
+
+### Mock ESM modules
+
+If a dependency is loaded through `import`, you can use [rstest.mock()](/api/runtime-api/rstest/mock-modules#rsmock) or [rstest.doMock()](/api/runtime-api/rstest/mock-modules#rsdomock).
+
+#### Use `rstest.mock()`
+
+`rstest.mock()` is hoisted to the top of the file. It is useful when the dependency should be replaced before the module under test runs.
+
+```ts title="user-service.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { loadUserName } from './user-service';
+import { fetchUser } from './api';
+
+rstest.mock('./api', () => ({
+  fetchUser: rstest.fn().mockResolvedValue({ id: '1', name: 'Alice' }),
+}));
+
+test('returns the fetched user name', async () => {
+  await expect(loadUserName('1')).resolves.toBe('Alice');
+  expect(fetchUser).toHaveBeenCalledWith('1');
+});
+```
+
+#### Use `rstest.doMock()`
+
+Note that `rstest.doMock()` is not hoisted and only takes effect after it runs. It is useful when earlier `import` statements should keep the real implementation and later ones should use the mock.
+
+```ts title="feature.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { readFeatureFlag } from './feature';
+
+test('only mocks later imports', async () => {
+  expect(readFeatureFlag()).toBe('real');
+
+  rstest.doMock('./feature', () => ({
+    readFeatureFlag: () => 'mocked',
+  }));
+
+  const { readFeatureFlag: mockedReadFeatureFlag } = await import('./feature');
+  expect(mockedReadFeatureFlag()).toBe('mocked');
+});
+```
+
+### Mock CommonJS modules
+
+If a dependency is loaded through `require()`, you can use [rstest.mockRequire()](/api/runtime-api/rstest/mock-modules#rsmockrequire) or [rstest.doMockRequire()](/api/runtime-api/rstest/mock-modules#rsdomockrequire).
+
+#### Use `rstest.mockRequire()`
+
+`rstest.mockRequire()` is hoisted to the top of the file. It is useful for file-level mocking of CommonJS modules.
+
+```js title="math.test.cjs"
+const { expect, rstest, test } = require('@rstest/core');
+const { sum } = require('./math.cjs');
+
+rstest.mockRequire('./math.cjs', () => ({
+  sum: (a, b) => a + b + 100,
+}));
+
+test('mocks a CommonJS module loaded with require', () => {
+  expect(sum(1, 2)).toBe(103);
+});
+```
+
+#### Use `rstest.doMockRequire()`
+
+Note that `rstest.doMockRequire()` is not hoisted and only affects later `require()` calls.
+
+Note that this distinction matters when a package exposes both ESM and CommonJS entries. Mocking the ESM entry does not automatically affect the CommonJS entry, and vice versa.
+
+### Auto-mock modules
+
+If you want to replace the module's function exports with mock functions first and then configure only selected exports in the test, you can use `{ mock: true }`.
+
+```ts title="math.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { add } from './math';
+
+rstest.mock('./math', { mock: true });
+
+test('overrides one export', () => {
+  rstest.mocked(add).mockReturnValue(100);
+  expect(add(1, 2)).toBe(100);
+});
+```
+
+### Spy on a whole module
+
+If you want to keep the real implementation and still assert calls, you can use `{ spy: true }`.
+
+```ts title="calculator.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { add, calculate } from './calculator';
+
+rstest.mock('./calculator', { spy: true });
+
+test('tracks the internal call to add', () => {
+  expect(calculate(1, 2)).toBe(3);
+  expect(add).toHaveBeenCalledWith(1, 2);
+});
+```
+
+### Partially mock modules
+
+If you want one export to keep the real implementation and another export to be replaced, you can use [importActual](/api/runtime-api/rstest/mock-modules#rsimportactual).
+
+```ts title="date-utils.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import * as actualDateUtils from './date-utils' with { rstest: 'importActual' };
+import { formatDate, parseDate } from './date-utils';
+
+rstest.mock('./date-utils', () => ({
+  ...actualDateUtils,
+  formatDate: rstest.fn().mockReturnValue('2026-03-19'),
+}));
+
+test('keeps parseDate real', () => {
+  expect(formatDate(new Date())).toBe('2026-03-19');
+  expect(parseDate('2026-03-19')).toBeInstanceOf(Date);
+});
+```
+
+Note that factory functions are hoisted, so they should not read values that are initialized later in the same file.
+
+### Reuse manual mocks from `__mocks__`
+
+If multiple tests reuse the same fake implementation, you can place it in `__mocks__` and load it without passing a factory.
+
+```txt
+src/
+  api.ts
+  __mocks__/
+    api.ts
+tests/
+  user-service.test.ts
+```
+
+```ts title="user-service.test.ts"
+import { rstest } from '@rstest/core';
+
+rstest.mock('../src/api');
+```
+
+### Reset module state
+
+If you want later `import` or `require()` calls to return the original module again, you can use these APIs:
+
+- [rstest.unmock()](/api/runtime-api/rstest/mock-modules#rsunmock) / [rstest.doUnmock()](/api/runtime-api/rstest/mock-modules#rsdounmock): stop mocking a module.
+- [rstest.resetModules()](/api/runtime-api/rstest/mock-modules#rsresetmodules): clear the module cache so the next import or require evaluates the module again.
+
+Note that `rstest.resetModules()` does not cancel module mocking. To cancel module mocking, use `rstest.unmock()` or `rstest.doUnmock()`.
+
+For the full API and more examples, see [Mock modules](/api/runtime-api/rstest/mock-modules).
+
+## Mock functions
+
+If a dependency is passed in as a callback or injected implementation, you can use [rstest.fn()](/api/runtime-api/rstest/mock-functions#rstestfn) to create a mock function.
+
+```ts title="user.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+
+test('passes the selected id to the callback', () => {
+  const onSelect = rstest.fn();
+
+  onSelect('user-1');
+
+  expect(onSelect).toHaveBeenCalledTimes(1);
+  expect(onSelect).toHaveBeenCalledWith('user-1');
+});
+```
+
+You can also override behavior through mock instance methods, for example by returning a different value for one call:
+
+```ts
+const fetchUser = rstest.fn(async (id: string) => ({ id, role: 'guest' }));
+
+fetchUser.mockResolvedValueOnce({ id: '1', role: 'admin' });
+```
+
+For the full API and more examples, see [Mock functions](/api/runtime-api/rstest/mock-functions) and [MockInstance](/api/runtime-api/rstest/mock-instance).
+
+## Spy on existing methods
+
+If you want to keep the real object and still track calls or temporarily override behavior, you can use [rstest.spyOn()](/api/runtime-api/rstest/mock-functions#rstestspyon).
+
+```ts title="logger.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+
+test('logs a warning when validation fails', () => {
+  const warn = rstest
+    .spyOn(console, 'warn')
+    .mockImplementation(() => undefined);
+
+  console.warn('invalid payload');
+
+  expect(warn).toHaveBeenCalledWith('invalid payload');
+  warn.mockRestore();
+});
+```
+
+This pattern is commonly used with globals such as `console` and `Date`, as well as shared objects that already exist in the test.
+
+## Deep-mock objects
+
+If a dependency already exists in memory and you want to convert nested methods into mocks, you can use [rstest.mockObject()](/api/runtime-api/rstest/mock-functions#rstestmockobject).
+
+```ts title="service.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+
+test('mocks nested methods', async () => {
+  const service = rstest.mockObject({
+    user: {
+      fetch: async (id: string) => ({ id, name: 'real' }),
+    },
+    version: 'v1',
+  });
+
+  service.user.fetch.mockResolvedValue({ id: '1', name: 'mocked' });
+
+  expect(service.version).toBe('v1');
+  await expect(service.user.fetch('1')).resolves.toEqual({
+    id: '1',
+    name: 'mocked',
+  });
+});
+```
+
+If you want to keep the original nested implementations while still recording calls, you can pass `{ spy: true }`.
+
+For the full API and more examples, see [Mock functions](/api/runtime-api/rstest/mock-functions) and [MockInstance](/api/runtime-api/rstest/mock-instance).
+
+## Clear mock state
+
+If you need to clear call history or reset mock implementations, you can use these APIs:
+
+- [clearMocks](/config/test/clear-mocks): clear call history before each test.
+- [resetMocks](/config/test/reset-mocks): clear call history and reset mock implementations.
+- [restoreMocks](/config/test/restore-mocks): restore spied descriptors on real objects.
+
+For manual cleanup, the corresponding APIs are `rstest.clearAllMocks()`, `rstest.resetAllMocks()`, and `rstest.restoreAllMocks()`.
+
+## Further reading
+
+- [Mock functions](/api/runtime-api/rstest/mock-functions)
+- [Mock modules](/api/runtime-api/rstest/mock-modules)

--- a/website/docs/zh/guide/basic/_meta.json
+++ b/website/docs/zh/guide/basic/_meta.json
@@ -2,6 +2,7 @@
   "cli",
   "configure-rstest",
   "test-filter",
+  "mock",
   "snapshot",
   "projects",
   "reporters",

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -1,0 +1,257 @@
+---
+description: 使用 Rstest mock 函数、对象方法、ESM 模块、CommonJS 模块，并区分 mock 状态和模块状态。
+---
+
+# Mocking
+
+Mocking 用于在测试中替换依赖、控制返回值，并断言函数或模块的调用行为。Rstest 提供了多组 mock API，分别适用于函数、对象方法、ESM 模块、CommonJS 模块和对象树。
+
+## Mock 模块
+
+如果依赖是通过模块系统加载的，可以根据模块类型和 mock 方式选择不同的 API。
+
+### Mock ESM 模块
+
+如果依赖是通过 `import` 加载的，可以使用 [rstest.mock()](/api/runtime-api/rstest/mock-modules#rsmock) 或 [rstest.doMock()](/api/runtime-api/rstest/mock-modules#rsdomock)。
+
+#### 使用 `rstest.mock()`
+
+`rstest.mock()` 会被提升到文件顶部，适用于在被测模块执行前就替换依赖的场景。
+
+```ts title="user-service.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { loadUserName } from './user-service';
+import { fetchUser } from './api';
+
+rstest.mock('./api', () => ({
+  fetchUser: rstest.fn().mockResolvedValue({ id: '1', name: 'Alice' }),
+}));
+
+test('returns the fetched user name', async () => {
+  await expect(loadUserName('1')).resolves.toBe('Alice');
+  expect(fetchUser).toHaveBeenCalledWith('1');
+});
+```
+
+#### 使用 `rstest.doMock()`
+
+需要注意的是，`rstest.doMock()` 不会被提升，只会在执行之后生效。它适用于前面的 `import` 保持真实实现，后面的再切换成 mock 的场景。
+
+```ts title="feature.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { readFeatureFlag } from './feature';
+
+test('only mocks later imports', async () => {
+  expect(readFeatureFlag()).toBe('real');
+
+  rstest.doMock('./feature', () => ({
+    readFeatureFlag: () => 'mocked',
+  }));
+
+  const { readFeatureFlag: mockedReadFeatureFlag } = await import('./feature');
+  expect(mockedReadFeatureFlag()).toBe('mocked');
+});
+```
+
+### Mock CommonJS 模块
+
+如果依赖是通过 `require()` 加载的，可以使用 [rstest.mockRequire()](/api/runtime-api/rstest/mock-modules#rsmockrequire) 或 [rstest.doMockRequire()](/api/runtime-api/rstest/mock-modules#rsdomockrequire)。
+
+#### 使用 `rstest.mockRequire()`
+
+`rstest.mockRequire()` 会被提升到文件顶部，适用于 CommonJS 模块的文件级 mock 设置。
+
+```js title="math.test.cjs"
+const { expect, rstest, test } = require('@rstest/core');
+const { sum } = require('./math.cjs');
+
+rstest.mockRequire('./math.cjs', () => ({
+  sum: (a, b) => a + b + 100,
+}));
+
+test('mocks a CommonJS module loaded with require', () => {
+  expect(sum(1, 2)).toBe(103);
+});
+```
+
+#### 使用 `rstest.doMockRequire()`
+
+需要注意的是，`rstest.doMockRequire()` 不会被提升，只会影响后续的 `require()` 调用。
+
+需要注意的是，如果一个包同时提供 ESM 和 CJS 入口，这个区分尤其重要。mock ESM 入口并不会自动影响 CJS 入口，反过来也一样。
+
+### 自动 mock 模块
+
+如果你希望先把模块中的函数导出替换成 mock 函数，再由测试补充少数导出的行为，可以使用 `{ mock: true }`。
+
+```ts title="math.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { add } from './math';
+
+rstest.mock('./math', { mock: true });
+
+test('overrides one export', () => {
+  rstest.mocked(add).mockReturnValue(100);
+  expect(add(1, 2)).toBe(100);
+});
+```
+
+### Spy 整个模块
+
+如果你希望保留真实实现，同时提供调用断言能力，可以使用 `{ spy: true }`。
+
+```ts title="calculator.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import { add, calculate } from './calculator';
+
+rstest.mock('./calculator', { spy: true });
+
+test('tracks the internal call to add', () => {
+  expect(calculate(1, 2)).toBe(3);
+  expect(add).toHaveBeenCalledWith(1, 2);
+});
+```
+
+### 部分 mock 模块
+
+如果你要做部分 mock，让一个导出保留真实实现、另一个导出被替换，可以使用 [importActual](/api/runtime-api/rstest/mock-modules#rsimportactual)。
+
+```ts title="date-utils.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+import * as actualDateUtils from './date-utils' with { rstest: 'importActual' };
+import { formatDate, parseDate } from './date-utils';
+
+rstest.mock('./date-utils', () => ({
+  ...actualDateUtils,
+  formatDate: rstest.fn().mockReturnValue('2026-03-19'),
+}));
+
+test('keeps parseDate real', () => {
+  expect(formatDate(new Date())).toBe('2026-03-19');
+  expect(parseDate('2026-03-19')).toBeInstanceOf(Date);
+});
+```
+
+需要注意的是，由于 factory 会被提升，factory 内不应该访问同文件中稍后才初始化的值。
+
+### 复用 `__mocks__` 里的手写 mock
+
+如果多个测试会复用同一个 fake 实现，可以把它放进 `__mocks__` 目录，并在不传 factory 的情况下直接加载。
+
+```txt
+src/
+  api.ts
+  __mocks__/
+    api.ts
+tests/
+  user-service.test.ts
+```
+
+```ts title="user-service.test.ts"
+import { rstest } from '@rstest/core';
+
+rstest.mock('../src/api');
+```
+
+### 重置模块状态
+
+如果你希望后续的 `import` 或 `require()` 返回原始模块，可以使用下面这些 API：
+
+- [rstest.unmock()](/api/runtime-api/rstest/mock-modules#rsunmock) / [rstest.doUnmock()](/api/runtime-api/rstest/mock-modules#rsdounmock)：停止 mock 某个模块。
+- [rstest.resetModules()](/api/runtime-api/rstest/mock-modules#rsresetmodules)：清空模块缓存，让下一次 import 或 require 重新执行模块。
+
+需要注意的是，`rstest.resetModules()` 不会取消模块 mock。如果你要取消模块 mock，需要使用 `rstest.unmock()` 或 `rstest.doUnmock()`。
+
+关于完整 API 和更多示例，可以参考 [Mock modules](/api/runtime-api/rstest/mock-modules)。
+
+## Mock 函数
+
+如果依赖是以回调或注入实现的形式传入的，可以使用 [rstest.fn()](/api/runtime-api/rstest/mock-functions#rstestfn) 创建 mock 函数。
+
+```ts title="user.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+
+test('passes the selected id to the callback', () => {
+  const onSelect = rstest.fn();
+
+  onSelect('user-1');
+
+  expect(onSelect).toHaveBeenCalledTimes(1);
+  expect(onSelect).toHaveBeenCalledWith('user-1');
+});
+```
+
+你也可以通过 mock 实例方法覆盖行为，例如为某一次调用返回不同的结果：
+
+```ts
+const fetchUser = rstest.fn(async (id: string) => ({ id, role: 'guest' }));
+
+fetchUser.mockResolvedValueOnce({ id: '1', role: 'admin' });
+```
+
+关于完整 API 和更多示例，可以参考 [Mock functions](/api/runtime-api/rstest/mock-functions) 和 [MockInstance](/api/runtime-api/rstest/mock-instance)。
+
+## Spy 现有方法
+
+如果你希望保留真实对象，同时跟踪调用或临时覆盖行为，可以使用 [rstest.spyOn()](/api/runtime-api/rstest/mock-functions#rstestspyon)。
+
+```ts title="logger.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+
+test('logs a warning when validation fails', () => {
+  const warn = rstest
+    .spyOn(console, 'warn')
+    .mockImplementation(() => undefined);
+
+  console.warn('invalid payload');
+
+  expect(warn).toHaveBeenCalledWith('invalid payload');
+  warn.mockRestore();
+});
+```
+
+这类写法常用于 `console`、`Date` 这类全局对象，以及测试里已经存在的共享对象。
+
+## 深度 mock 对象
+
+如果依赖已经存在于内存中，并且你希望把嵌套方法转换成 mock，可以使用 [rstest.mockObject()](/api/runtime-api/rstest/mock-functions#rstestmockobject)。
+
+```ts title="service.test.ts"
+import { expect, rstest, test } from '@rstest/core';
+
+test('mocks nested methods', async () => {
+  const service = rstest.mockObject({
+    user: {
+      fetch: async (id: string) => ({ id, name: 'real' }),
+    },
+    version: 'v1',
+  });
+
+  service.user.fetch.mockResolvedValue({ id: '1', name: 'mocked' });
+
+  expect(service.version).toBe('v1');
+  await expect(service.user.fetch('1')).resolves.toEqual({
+    id: '1',
+    name: 'mocked',
+  });
+});
+```
+
+如果你希望保留嵌套方法的原始实现，同时记录调用，可以传入 `{ spy: true }`。
+
+关于完整 API 和更多示例，可以参考 [Mock functions](/api/runtime-api/rstest/mock-functions) 和 [MockInstance](/api/runtime-api/rstest/mock-instance)。
+
+## 清理 mock 状态
+
+如果你要处理调用记录残留或 mock 实现残留，可以使用下面这些 API：
+
+- [clearMocks](/config/test/clear-mocks)：每个测试前清空调用记录。
+- [resetMocks](/config/test/reset-mocks)：清空调用记录并重置 mock 实现。
+- [restoreMocks](/config/test/restore-mocks)：恢复真实对象上被 spy 的描述符。
+
+如果你想手动调用，对应的 API 是 `rstest.clearAllMocks()`、`rstest.resetAllMocks()` 和 `rstest.restoreAllMocks()`。
+
+## 延伸阅读
+
+- [Mock functions](/api/runtime-api/rstest/mock-functions)
+- [Mock modules](/api/runtime-api/rstest/mock-modules)


### PR DESCRIPTION
## Summary

### Background
Rstest had API-level mock docs and scattered examples, but no basic guide that explained mocking workflows in one place.

### Implementation
- Added new English and Chinese `Mocking` guide pages under `guide/basic`.
- Organized module mocking by ESM/CommonJS usage, hoisted and non-hoisted behavior, partial mocks, manual mocks, and module reset APIs.
- Added sidebar entries and linked the relevant runtime API documentation from the new guide.

### User Impact
Users now have a task-oriented mocking guide in both languages instead of piecing behavior together from API references and migration docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation was not run locally because this environment does not provide `node`, `npx`, or `pnpm`. This PR is created as a draft for that reason.
