### PR TITLE
test(core): use unique temp file paths in extends config tests

### DIFF
--- a/packages/core/tests/extends.test.ts
+++ b/packages/core/tests/extends.test.ts
@@ -1,19 +1,27 @@
+import { randomUUID } from 'node:crypto';
 import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { beforeEach, describe, expect, it } from '@rstest/core';
+import { afterEach, describe, expect, it } from '@rstest/core';
 import { loadConfig } from '../src/config';
 
 describe('Config Extends Mechanism', () => {
-  const testConfigPath = join(__dirname, 'test-temp-extends.config.ts');
+  let testConfigPath: string;
 
-  beforeEach(() => {
-    // Clean up any existing test config
-    if (existsSync(testConfigPath)) {
+  // Rsbuild's loadConfig cache-busts with `?t=${Date.now()}` on native import().
+  // Millisecond resolution can collide between sequential tests reusing the same
+  // file path, causing Node.js to return a stale cached module. A random suffix
+  // per test guarantees a unique path and avoids the cache hit entirely.
+  const createConfigPath = () =>
+    join(__dirname, `test-temp-extends-${randomUUID()}.config.ts`);
+
+  afterEach(() => {
+    if (testConfigPath && existsSync(testConfigPath)) {
       unlinkSync(testConfigPath);
     }
   });
 
   it('should handle extends with direct config object', async () => {
+    testConfigPath = createConfigPath();
     const testConfigContent = `
 import { defineConfig } from '@rstest/core';
 
@@ -42,6 +50,7 @@ export default defineConfig({
   });
 
   it('should handle extends with extend config function', async () => {
+    testConfigPath = createConfigPath();
     const testConfigContent = `
 import { defineConfig } from '@rstest/core';
 
@@ -76,6 +85,7 @@ export default defineConfig({
   });
 
   it('should merge extends config with local config', async () => {
+    testConfigPath = createConfigPath();
     const testConfigContent = `
 import { defineConfig } from '@rstest/core';
 
@@ -103,6 +113,7 @@ export default defineConfig({
   });
 
   it('should handle extends without projects field', async () => {
+    testConfigPath = createConfigPath();
     const testConfigContent = `
 import { defineConfig } from '@rstest/core';
 
@@ -127,6 +138,7 @@ export default defineConfig({
   });
 
   it('should handle extends as array', async () => {
+    testConfigPath = createConfigPath();
     const testConfigContent = `
 import { defineConfig } from '@rstest/core';
 
@@ -176,6 +188,7 @@ export default defineConfig({
   });
 
   it('should pass the original local config to every extends function in arrays', async () => {
+    testConfigPath = createConfigPath();
     const testConfigContent = `
 import { defineConfig } from '@rstest/core';
 


### PR DESCRIPTION
## Summary

### Background

The `extends.test.ts` unit tests are flaky on CI (macOS and Windows). Rsbuild's `loadConfig` cache-busts native `import()` using `?t=${Date.now()}`, which has millisecond resolution. Sequential tests that reuse the same temp config file path can collide when two `loadConfig` calls land in the same millisecond, causing Node.js to return the previous test's cached module.

### Implementation

- Generate a unique config file path per test case via `crypto.randomUUID()` instead of sharing a single fixed path.
- Switch cleanup from `beforeEach` to `afterEach` since paths are now created inside each test.

### User Impact

None — test-only change.

## Related Links

- Observed in [#1079](https://github.com/web-infra-dev/rstest/pull/1079) CI:
  - [Attempt 1 — ut (macos-14)](https://github.com/web-infra-dev/rstest/actions/runs/23329710956/job/67858599715) (`config.globals` → `undefined`)
  - [Attempt 2 — ut (macos-14)](https://github.com/web-infra-dev/rstest/actions/runs/23329710956/job/67862206679) (`config.testEnvironment` → `'happy-dom'` instead of `'jsdom'`)

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).