### PR TITLE
ci: enhance test workflow to include coverage reporting and upload to…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage to Canyon
         if: github.event_name == 'pull_request'
-        uses: canyon-project/canyon-action@v1.0.26
+        uses: canyon-project/canyon-action@v1.0.27
         with:
           coverage-file: coverage/coverage-final.json
           canyon-url: https://app.canyonjs.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage to Canyon
         if: github.event_name == 'pull_request'
-        uses: canyon-project/canyon-action@v1.0.24
+        uses: canyon-project/canyon-action@v1.0.25
         with:
           coverage-file: coverage/coverage-final.json
           canyon-url: https://app.canyonjs.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
           coverage-file: coverage/coverage-final.json
           canyon-url: https://app.canyonjs.io
           instrument-cwd: ${{ github.workspace }}
+          only-changes: false
 
       - name: Run Examples Test
         run: pnpm run test:examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,15 @@ jobs:
         run: pnpm run typecheck
 
       - name: Run Test
-        run: pnpm run test
+        run: pnpm run test --coverage
+
+      - name: Upload coverage to Canyon
+        if: github.event_name == 'pull_request'
+        uses: canyon-project/canyon-action@v1.0.24
+        with:
+          coverage-file: coverage/coverage-final.json
+          canyon-url: https://app.canyonjs.io
+          instrument-cwd: ${{ github.workspace }}
 
       - name: Run Examples Test
         run: pnpm run test:examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage to Canyon
         if: github.event_name == 'pull_request'
-        uses: canyon-project/canyon-action@v1.0.27
+        uses: canyon-project/canyon-action@v1.0.28
         with:
           coverage-file: coverage/coverage-final.json
           canyon-url: https://app.canyonjs.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage to Canyon
         if: github.event_name == 'pull_request'
-        uses: canyon-project/canyon-action@v1.0.25
+        uses: canyon-project/canyon-action@v1.0.26
         with:
           coverage-file: coverage/coverage-final.json
           canyon-url: https://app.canyonjs.io


### PR DESCRIPTION
Add Canyon Action for PR Coverage Reporting

Introduce canyon-action in GitHub Actions to collect and upload coverage artifacts from PR pipelines to https://app.canyonjs.io/
.

This enables diff coverage analysis for changed code in PRs, helping ensure code quality and prevent untested changes from being merged.

## Summary
<img width="983" height="717" alt="截屏2026-03-20 18 06 07" src="https://github.com/user-attachments/assets/01f97569-150e-4a19-96e4-2c2d382e1046" />

<img width="1008" height="508" alt="截屏2026-03-20 18 04 44" src="https://github.com/user-attachments/assets/414b288c-711d-4643-8ee9-912138323137" />

## Related Links
https://github.com/web-infra-dev/rstest/actions/runs/23337871773
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
