### PR TITLE
perf(core): split monolithic worker bundle into lazy-loaded chunks

### DIFF
--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -20,6 +20,7 @@
 import {
   ASYMMETRIC_MATCHERS_OBJECT,
   addCustomEqualityTesters,
+  type ChaiPlugin,
   customMatchers,
   GLOBAL_EXPECT,
   getState,
@@ -44,7 +45,6 @@ import type {
   WorkerState,
 } from '../../types';
 import { createExpectPoll } from './poll';
-import { SnapshotPlugin } from './snapshot';
 
 export { assert } from 'chai';
 export { GLOBAL_EXPECT };
@@ -56,13 +56,17 @@ export function setupChaiConfig(config: ChaiConfig): void {
 export function createExpect({
   getCurrentTest,
   workerState,
+  snapshotPlugin,
 }: {
   workerState: WorkerState;
   getCurrentTest: () => TestCase | undefined;
+  snapshotPlugin?: ChaiPlugin;
 }): RstestExpect {
   use(JestExtend);
   use(JestChaiExpect);
-  use(SnapshotPlugin(workerState));
+  if (snapshotPlugin) {
+    use(snapshotPlugin);
+  }
   use(JestAsymmetricMatchers);
 
   const expect = ((value: any, message?: string): Assertion => {

--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -25,7 +25,10 @@ export const createRstestRuntime = async (
   };
   api: Rstest;
 }> => {
-  const { runner, api: runnerAPI } = createRunner({ workerState });
+  const [{ runner, api: runnerAPI }, { SnapshotPlugin }] = await Promise.all([
+    Promise.resolve(createRunner({ workerState })),
+    import(/* webpackChunkName: "snapshot" */ './snapshot'),
+  ]);
 
   if (workerState.runtimeConfig.chaiConfig) {
     setupChaiConfig(workerState.runtimeConfig.chaiConfig);
@@ -34,6 +37,7 @@ export const createRstestRuntime = async (
   const expect: RstestExpect = createExpect({
     workerState,
     getCurrentTest: () => runner.getCurrentTest(),
+    snapshotPlugin: SnapshotPlugin(workerState),
   });
 
   Object.defineProperty(globalThis, GLOBAL_EXPECT, {

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -7,7 +7,7 @@ import type {
   WorkerState,
 } from '../../types';
 import { getRealTimers } from '../util';
-import { type FakeTimerInstallOpts, FakeTimers } from './fakeTimers';
+import type { FakeTimerInstallOpts } from './fakeTimers';
 import { mockObject as mockObjectImpl } from './mockObject';
 import { initSpy } from './spy';
 
@@ -58,7 +58,11 @@ export const createRstestUtilities: (
     PropertyDescriptor | undefined
   >();
 
-  let _timers: FakeTimers;
+  const { FakeTimers } = await import(
+    /* webpackChunkName: "fake-timers" */ './fakeTimers'
+  );
+
+  let _timers: InstanceType<typeof FakeTimers>;
 
   let originalConfig: undefined | RuntimeConfig;
 


### PR DESCRIPTION
## Benchmark

tested in Rstest self codebase.

unit test

```
hyperfine --warmup 8 --runs 30 \
  --command-name 'perf' "cd '/Users/bytedance/Projects/worktrees/tree/dev1' && pnpm test" \
  --command-name 'baseline' "cd '/Users/bytedance/Projects/rstest' && pnpm test"
Benchmark 1: perf
  Time (mean ± σ):      1.175 s ±  0.017 s    [User: 5.662 s, System: 1.356 s]
  Range (min … max):    1.144 s …  1.210 s    30 runs
 
Benchmark 2: baseline
  Time (mean ± σ):      1.235 s ±  0.052 s    [User: 6.133 s, System: 1.375 s]
  Range (min … max):    1.192 s …  1.451 s    30 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  perf ran
    1.05 ± 0.05 times faster than baseline
```

sliced E2E test (exclude noisy cases like browser mode)

```
hyperfine --warmup 3 --runs 10 \
  --command-name 'dev1-e2e-slice' "cd '/Users/bytedance/Projects/worktrees/tree/dev1/e2e' && pnpm test test-api lifecycle projects" \
  --command-name 'rstest-e2e-slice' "cd '/Users/bytedance/Projects/rstest/e2e' && pnpm test test-api lifecycle projects"
Benchmark 1: dev1-e2e-slice
  Time (mean ± σ):      8.484 s ±  1.379 s    [User: 39.350 s, System: 13.961 s]
  Range (min … max):    7.376 s … 12.163 s    10 runs
 
Benchmark 2: rstest-e2e-slice
  Time (mean ± σ):      9.081 s ±  0.384 s    [User: 45.145 s, System: 14.580 s]
  Range (min … max):    8.854 s … 10.146 s    10 runs
 
Summary
  dev1-e2e-slice ran
    1.07 ± 0.18 times faster than rstest-e2e-slice
```

## Summary

### Background

The Worker process loaded a single monolithic 742KB chunk (`1949.js`) at startup, containing all runtime dependencies including snapshot utilities and fake timers — even when they weren't needed for every test run. This added unnecessary parse/compile overhead to Worker initialization.

### Implementation

- Convert `SnapshotPlugin` from a static import to a dynamic `import()` in `createRstestRuntime()`, parallelized with `createRunner()` via `Promise.all`
- Convert `FakeTimers` from a static import to a dynamic `import()` in `createRstestUtilities()`
- Make `snapshotPlugin` an optional parameter on `createExpect()` (passed from `createRstestRuntime` after dynamic load)
- Add a `vendor-assertion` splitChunks cache group to extract chai/@vitest/expect/spy/utils into a stable-named chunk for better V8 compile cache reuse

### User Impact

Reduced Worker startup overhead by deferring ~165KB of code (snapshot + fake-timers) to first use. The stable `vendor-assertion.js` chunk name improves V8 compile cache hit rate across rebuilds.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).