### PR TITLE
fix(core): pin pool worker node runtime to parent execPath

### DIFF
--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -22,6 +22,7 @@ const __dirname = dirname(__filename);
 function createSetupPool() {
   const options: Options = {
     runtime: 'child_process',
+    execPath: process.execPath,
     filename: resolve(__dirname, './globalSetupWorker.js'),
     execArgv: [
       ...process.execArgv,

--- a/packages/core/src/pool/forks.ts
+++ b/packages/core/src/pool/forks.ts
@@ -93,6 +93,7 @@ export const createForksPool = (poolOptions: {
 
   const options: Options = {
     runtime: 'child_process',
+    execPath: process.execPath,
     filename: resolve(__dirname, './worker.js'),
     env,
     execArgv,

--- a/packages/core/tests/core/globalSetupExecPath.test.ts
+++ b/packages/core/tests/core/globalSetupExecPath.test.ts
@@ -1,0 +1,65 @@
+var tinypoolRunMock: ReturnType<typeof rs.fn>;
+var tinypoolDestroyMock: ReturnType<typeof rs.fn>;
+var tinypoolConstructorMock: ReturnType<typeof rs.fn>;
+
+function getTinypoolRunMock() {
+  if (!tinypoolRunMock) {
+    tinypoolRunMock = rs.fn(async () => ({ success: false }));
+  }
+
+  return tinypoolRunMock;
+}
+
+function getTinypoolDestroyMock() {
+  if (!tinypoolDestroyMock) {
+    tinypoolDestroyMock = rs.fn(async () => undefined);
+  }
+
+  return tinypoolDestroyMock;
+}
+
+function getTinypoolConstructorMock() {
+  if (!tinypoolConstructorMock) {
+    tinypoolConstructorMock = rs.fn(() => {
+      return {
+        run: getTinypoolRunMock(),
+        destroy: getTinypoolDestroyMock(),
+        threads: [],
+      };
+    });
+  }
+
+  return tinypoolConstructorMock;
+}
+
+rs.mock('tinypool', () => ({
+  Tinypool: getTinypoolConstructorMock(),
+}));
+
+import { runGlobalSetup } from '../../src/core/globalSetup';
+
+describe('runGlobalSetup', () => {
+  beforeEach(() => {
+    tinypoolConstructorMock?.mockClear();
+    tinypoolRunMock?.mockClear();
+    tinypoolDestroyMock?.mockClear();
+  });
+
+  it('should pin global setup worker execPath to the current Node runtime', async () => {
+    await runGlobalSetup({
+      globalSetupEntries: [],
+      assetFiles: {},
+      sourceMaps: {},
+      interopDefault: false,
+      outputModule: false,
+    });
+
+    expect(tinypoolConstructorMock).toHaveBeenCalledTimes(1);
+    expect(tinypoolConstructorMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        runtime: 'child_process',
+        execPath: process.execPath,
+      }),
+    );
+  });
+});

--- a/packages/core/tests/pool/forksExecPath.test.ts
+++ b/packages/core/tests/pool/forksExecPath.test.ts
@@ -1,0 +1,45 @@
+var tinypoolConstructorMock: ReturnType<typeof rs.fn>;
+
+function getTinypoolConstructorMock() {
+  if (!tinypoolConstructorMock) {
+    tinypoolConstructorMock = rs.fn(() => ({
+      run: rs.fn(),
+      destroy: rs.fn(),
+      threads: [],
+    }));
+  }
+
+  return tinypoolConstructorMock;
+}
+
+rs.mock('tinypool', () => ({
+  Tinypool: getTinypoolConstructorMock(),
+}));
+
+import { createForksPool } from '../../src/pool/forks';
+
+describe('createForksPool', () => {
+  beforeEach(() => {
+    tinypoolConstructorMock.mockClear();
+  });
+
+  it('should pin worker execPath to the current Node runtime', () => {
+    const pool = createForksPool({
+      env: {},
+      execArgv: [],
+      isolate: true,
+      maxWorkers: 1,
+      minWorkers: 1,
+    });
+
+    expect(tinypoolConstructorMock).toHaveBeenCalledTimes(1);
+    expect(tinypoolConstructorMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        runtime: 'child_process',
+        execPath: process.execPath,
+      }),
+    );
+
+    return pool.close();
+  });
+});


### PR DESCRIPTION
## Problem
`rstest` worker pools did not explicitly pin `execPath`, so worker runtime selection could drift based on environment/PATH resolution.
That can cause parent/worker Node-version divergence and runtime-specific failures.

## Root Cause
Both pool creation points relied on implicit process spawning defaults instead of forcing workers to use the parent process’ Node binary.

## Fix
Set `execPath: process.execPath` in both pool constructors:
- Forks pool
- Global setup pool

## Files Changed
- `packages/core/src/pool/forks.ts`
- `packages/core/src/core/globalSetup.ts`
- `packages/core/tests/pool/forksExecPath.test.ts`
- `packages/core/tests/core/globalSetupExecPath.test.ts`

## Verification
1. Added regression tests first to assert both pools pass `execPath: process.execPath`.
2. Confirmed red -> green:
- With fix removed: new tests fail.
- With fix restored: new tests pass.
3. Latest run:
- `pnpm test packages/core/tests/pool/forksExecPath.test.ts packages/core/tests/core/globalSetupExecPath.test.ts`
- Result: `2 passed, 0 failed`.
