### PR TITLE
perf: pre-filter test projects to avoid unnecessary builds

### DIFF
--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -73,6 +73,7 @@ const collectNodeTests = async ({
     globTestSourceEntries,
     setupFiles,
     globalSetupFiles,
+    nodeProjects,
   );
 
   const { getRsbuildStats, closeServer } = await createRsbuildServer({

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -11,6 +11,7 @@ import path from 'pathe';
 import type {
   EntryInfo,
   NormalizedProjectConfig,
+  ProjectContext,
   RstestContext,
 } from '../types';
 import { isDebug } from '../utils';
@@ -65,6 +66,11 @@ export const prepareRsbuild = async (
   globTestSourceEntries: (name: string) => Promise<Record<string, string>>,
   setupFiles: Record<string, Record<string, string>>,
   globalSetupFiles: Record<string, Record<string, string>>,
+  /**
+   * Explicit list of node-mode projects to include in the Rsbuild instance.
+   * When provided, only these projects will be compiled.
+   */
+  targetNodeProjects?: ProjectContext[],
 ): Promise<RsbuildInstance> => {
   const {
     command,
@@ -72,9 +78,11 @@ export const prepareRsbuild = async (
   } = context;
 
   // Filter out browser mode projects - this rsbuild is for node mode only
-  const projects = context.projects.filter(
-    (project) => !project.normalizedConfig.browser.enabled,
-  );
+  const projects = targetNodeProjects?.length
+    ? targetNodeProjects
+    : context.projects.filter(
+        (project) => !project.normalizedConfig.browser.enabled,
+      );
   const debugMode = isDebug();
 
   RsbuildLogger.level = debugMode ? 'verbose' : 'error';

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -142,7 +142,24 @@ export async function runTests(context: Rstest): Promise<void> {
   let browserProjectsToRun = browserProjects;
   let nodeProjectsToRun = nodeProjects;
 
-  if (shard) {
+  // In non-watch mode, proactively skip projects with no test files to avoid unnecessary builds
+  if (!isWatchMode) {
+    // Populate entries cache for all projects
+    await Promise.all(
+      allProjects.map((p) => globTestSourceEntries(p.environmentName)),
+    );
+
+    const hasEntries = (env: string) =>
+      Object.keys(entriesCache.get(env)?.entries || {}).length > 0;
+
+    browserProjectsToRun = browserProjects.filter((p) =>
+      hasEntries(p.environmentName),
+    );
+    nodeProjectsToRun = nodeProjects.filter((p) =>
+      hasEntries(p.environmentName),
+    );
+  } else if (shard) {
+    // In watch mode with sharding, only run projects that have sharded entries
     browserProjectsToRun = browserProjects.filter((p) => {
       return (
         Object.keys(entriesCache.get(p.environmentName)?.entries || {}).length >
@@ -232,6 +249,7 @@ export async function runTests(context: Rstest): Promise<void> {
     globTestSourceEntries,
     setupFiles,
     globalSetupFiles,
+    projects,
   );
 
   const { getRsbuildStats, closeServer } = await createRsbuildServer({


### PR DESCRIPTION
## Summary

Pre-filter test projects to avoid unnecessary project builds. This is especially helpful when test file filters are applied.
before:
<img width="1280" height="343" alt="image" src="https://github.com/user-attachments/assets/6096bc3c-cb0f-4020-a3b1-3dce91be834e" />
after:
<img width="1231" height="393" alt="image" src="https://github.com/user-attachments/assets/c238923c-79ed-4b00-9ccb-c3864bf8a464" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
