### PR TITLE
ci: update rsdoctor-action to latest commit

### DIFF
--- a/.github/workflows/bundle-diff.yml
+++ b/.github/workflows/bundle-diff.yml
@@ -57,7 +57,7 @@ jobs:
           CI: true
 
       - name: Bundle Analysis
-        uses: web-infra-dev/rsdoctor-action@2aaf6eac243da89d3d08618eb65491051874ad5d
+        uses: web-infra-dev/rsdoctor-action@d3a7ae073bc63dcc4a16fba339414cbf4f9c476c
         with:
           file_path: 'packages/*/dist/**/rsdoctor-data.json'
           target_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || 'main' }}


### PR DESCRIPTION
## Summary

### Background

The `rsdoctor-action` version in the bundle-diff workflow was pinned to an older commit hash.

### Implementation

- Updated `web-infra-dev/rsdoctor-action` from `2aaf6eac` to `d3a7ae07`.

### User Impact

None — CI-only change.