### PR TITLE
feat: add unmockRequire / doUnmockRequire API

### DIFF
--- a/e2e/mock/tests/doUnmockRequire.test.ts
+++ b/e2e/mock/tests/doUnmockRequire.test.ts
@@ -1,0 +1,15 @@
+import { expect, rs, test } from '@rstest/core';
+
+test('doUnmockRequire restores the original CommonJS module', () => {
+  rs.doMockRequire('../src/increment', () => ({
+    increment: (num: number) => num + 100,
+  }));
+
+  const { increment: mockedIncrement } = require('../src/increment');
+  expect(mockedIncrement(1)).toBe(101);
+
+  rs.doUnmockRequire('../src/increment');
+
+  const { increment } = require('../src/increment');
+  expect(increment(1)).toBe(2);
+});

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -56,6 +56,15 @@ __webpack_require__.rstest_unmock = (id) => {
 __webpack_require__.rstest_do_unmock = __webpack_require__.rstest_unmock;
 //#endregion
 
+//#region rs.unmockRequire
+__webpack_require__.rstest_unmock_require = __webpack_require__.rstest_unmock;
+//#endregion
+
+//#region rs.doUnmockRequire
+__webpack_require__.rstest_do_unmock_require =
+  __webpack_require__.rstest_do_unmock;
+//#endregion
+
 //#region rs.requireActual
 __webpack_require__.rstest_require_actual =
   __webpack_require__.rstest_import_actual = (id) => {

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -146,6 +146,8 @@ export const createRstestUtilities: (
     doMockRequire: () => undefined,
     unmock: () => undefined,
     doUnmock: () => undefined,
+    unmockRequire: () => undefined,
+    doUnmockRequire: () => undefined,
     importMock: () => {
       // The actual implementation is managed by the built-in Rstest plugin.
       return Promise.resolve({} as any);

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -451,9 +451,19 @@ export interface RstestUtilities {
   unmock: (path: string) => void;
 
   /**
+   * Removes CommonJS require module from the mocked registry.
+   */
+  unmockRequire: (path: string) => void;
+
+  /**
    * Removes module from the mocked registry, not hoisted.
    */
   doUnmock: (path: string) => void;
+
+  /**
+   * Removes CommonJS require module from the mocked registry, not hoisted.
+   */
+  doUnmockRequire: (path: string) => void;
 
   /**
    * Imports a module with all of its properties (including nested properties) mocked.

--- a/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
@@ -296,6 +296,50 @@ test('doMockRequire only affects later require calls', () => {
 });
 ```
 
+## rs.unmockRequire
+
+- **Type**: `(path: string) => void`
+
+Cancels the mock implementation for modules loaded through `require()`. Like `rs.mockRequire`, this call is hoisted to the top of the file.
+
+Use this API when you want later `require()` calls to load the original CommonJS module again.
+
+```ts title="src/math.test.cjs"
+const { sum } = require('./math.cjs');
+
+rs.mockRequire('./math.cjs', () => ({
+  sum: (a, b) => a + b + 100,
+}));
+
+rs.unmockRequire('./math.cjs');
+
+test('unmockRequire restores the original CommonJS module', () => {
+  expect(sum(1, 2)).toBe(3);
+});
+```
+
+## rs.doUnmockRequire
+
+- **Type**: `(path: string) => void`
+
+Same as `rs.unmockRequire`, but it is not hoisted. Only later `require()` calls will load the original module again.
+
+```ts title="src/math.test.cjs"
+test('doUnmockRequire only affects later require calls', () => {
+  rs.doMockRequire('./math.cjs', () => ({
+    sum: (a, b) => a + b + 100,
+  }));
+
+  const { sum: mockedSum } = require('./math.cjs');
+  expect(mockedSum(1, 2)).toBe(103);
+
+  rs.doUnmockRequire('./math.cjs');
+
+  const { sum } = require('./math.cjs');
+  expect(sum(1, 2)).toBe(3);
+});
+```
+
 ## rs.hoisted
 
 - **Type**: `<T = unknown>(fn: () => T) => T`
@@ -417,5 +461,5 @@ Same as `rs.unmock`, but it is not hoisted to the top of the file. The next impo
 Clears the cache of all modules. This allows modules to be re-executed when re-imported. This is useful for isolating the state of modules shared between different tests.
 
 :::warning
-Does not reset mocked modules. To clear mocked modules, use [`rs.unmock`](#rsunmock) or [`rs.doUnmock`](#rsdounmock).
+Does not reset mocked modules. To clear mocked modules, use [`rs.unmock`](#rsunmock), [`rs.doUnmock`](#rsdounmock), [`rs.unmockRequire`](#rsunmockrequire), or [`rs.doUnmockRequire`](#rsdounmockrequire).
 :::

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -157,10 +157,11 @@ rstest.mock('../src/api');
 
 If you want later `import` or `require()` calls to return the original module again, you can use these APIs:
 
-- [rstest.unmock()](/api/runtime-api/rstest/mock-modules#rsunmock) / [rstest.doUnmock()](/api/runtime-api/rstest/mock-modules#rsdounmock): stop mocking a module.
+- [rstest.unmock()](/api/runtime-api/rstest/mock-modules#rsunmock) / [rstest.doUnmock()](/api/runtime-api/rstest/mock-modules#rsdounmock): stop mocking an `import`-based module.
+- [rstest.unmockRequire()](/api/runtime-api/rstest/mock-modules#rsunmockrequire) / [rstest.doUnmockRequire()](/api/runtime-api/rstest/mock-modules#rsdounmockrequire): stop mocking a `require()`-based module.
 - [rstest.resetModules()](/api/runtime-api/rstest/mock-modules#rsresetmodules): clear the module cache so the next import or require evaluates the module again.
 
-Note that `rstest.resetModules()` does not cancel module mocking. To cancel module mocking, use `rstest.unmock()` or `rstest.doUnmock()`.
+Note that `rstest.resetModules()` does not cancel module mocking. To cancel module mocking, use the matching `unmock` API for the way the module is loaded.
 
 For the full API and more examples, see [Mock modules](/api/runtime-api/rstest/mock-modules).
 

--- a/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
@@ -298,6 +298,50 @@ test('doMockRequire 只影响后续 require 调用', () => {
 });
 ```
 
+## rs.unmockRequire
+
+- **类型：** `(path: string) => void`
+
+取消通过 `require()` 加载模块的 mock 实现。和 `rs.mockRequire` 一样，这个调用会被提升到文件顶部。
+
+当你希望后续的 `require()` 重新加载原始 CommonJS 模块时，使用这个 API。
+
+```ts title="src/math.test.cjs"
+const { sum } = require('./math.cjs');
+
+rs.mockRequire('./math.cjs', () => ({
+  sum: (a, b) => a + b + 100,
+}));
+
+rs.unmockRequire('./math.cjs');
+
+test('unmockRequire 恢复原始 CommonJS 模块', () => {
+  expect(sum(1, 2)).toBe(3);
+});
+```
+
+## rs.doUnmockRequire
+
+- **类型：** `(path: string) => void`
+
+与 `rs.unmockRequire` 相同，但不会被提升。只有后续的 `require()` 调用才会重新加载原始模块。
+
+```ts title="src/math.test.cjs"
+test('doUnmockRequire 只影响后续 require 调用', () => {
+  rs.doMockRequire('./math.cjs', () => ({
+    sum: (a, b) => a + b + 100,
+  }));
+
+  const { sum: mockedSum } = require('./math.cjs');
+  expect(mockedSum(1, 2)).toBe(103);
+
+  rs.doUnmockRequire('./math.cjs');
+
+  const { sum } = require('./math.cjs');
+  expect(sum(1, 2)).toBe(3);
+});
+```
+
 ## rs.hoisted
 
 - **类型：** `<T = unknown>(fn: () => T) => T`
@@ -419,5 +463,5 @@ it('test', async () => {
 清除所有模块的缓存。这允许在重新导入时重新执行模块。这在隔离不同测试中共享的模块的状态时非常有用。
 
 :::warning
-不会重置被 mock 的 modules。要清除 mock 的模块，请使用 [`rs.unmock`](#rsunmock) 或 [`rs.doUnmock`](#rsdounmock) 。
+不会重置被 mock 的 modules。要清除 mock 的模块，请使用 [`rs.unmock`](#rsunmock)、[`rs.doUnmock`](#rsdounmock)、[`rs.unmockRequire`](#rsunmockrequire) 或 [`rs.doUnmockRequire`](#rsdounmockrequire)。
 :::

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -157,10 +157,11 @@ rstest.mock('../src/api');
 
 如果你希望后续的 `import` 或 `require()` 返回原始模块，可以使用下面这些 API：
 
-- [rstest.unmock()](/api/runtime-api/rstest/mock-modules#rsunmock) / [rstest.doUnmock()](/api/runtime-api/rstest/mock-modules#rsdounmock)：停止 mock 某个模块。
+- [rstest.unmock()](/api/runtime-api/rstest/mock-modules#rsunmock) / [rstest.doUnmock()](/api/runtime-api/rstest/mock-modules#rsdounmock)：停止 mock 通过 `import` 加载的模块。
+- [rstest.unmockRequire()](/api/runtime-api/rstest/mock-modules#rsunmockrequire) / [rstest.doUnmockRequire()](/api/runtime-api/rstest/mock-modules#rsdounmockrequire)：停止 mock 通过 `require()` 加载的模块。
 - [rstest.resetModules()](/api/runtime-api/rstest/mock-modules#rsresetmodules)：清空模块缓存，让下一次 import 或 require 重新执行模块。
 
-需要注意的是，`rstest.resetModules()` 不会取消模块 mock。如果你要取消模块 mock，需要使用 `rstest.unmock()` 或 `rstest.doUnmock()`。
+需要注意的是，`rstest.resetModules()` 不会取消模块 mock。要取消模块 mock，需要根据模块的加载方式选择对应的 `unmock` API。
 
 关于完整 API 和更多示例，可以参考 [Mock modules](/api/runtime-api/rstest/mock-modules)。
 


### PR DESCRIPTION
## Summary
add rs.unmockRequire / rs.doUnmockRequire API.

## rs.unmockRequire

- **Type**: `(path: string) => void`

Cancels the mock implementation for modules loaded through `require()`. Like `rs.mockRequire`, this call is hoisted to the top of the file.

Use this API when you want later `require()` calls to load the original CommonJS module again.

```ts title="src/math.test.cjs"
const { sum } = require('./math.cjs');

rs.mockRequire('./math.cjs', () => ({
  sum: (a, b) => a + b + 100,
}));

rs.unmockRequire('./math.cjs');

test('unmockRequire restores the original CommonJS module', () => {
  expect(sum(1, 2)).toBe(3);
});
```

## rs.doUnmockRequire

- **Type**: `(path: string) => void`

Same as `rs.unmockRequire`, but it is not hoisted. Only later `require()` calls will load the original module again.

```ts title="src/math.test.cjs"
test('doUnmockRequire only affects later require calls', () => {
  rs.doMockRequire('./math.cjs', () => ({
    sum: (a, b) => a + b + 100,
  }));

  const { sum: mockedSum } = require('./math.cjs');
  expect(mockedSum(1, 2)).toBe(103);

  rs.doUnmockRequire('./math.cjs');

  const { sum } = require('./math.cjs');
  expect(sum(1, 2)).toBe(3);
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
