### PR TITLE
docs: clarify single-value include glob behavior

### DIFF
--- a/packages/core/tests/coverage/include.test.ts
+++ b/packages/core/tests/coverage/include.test.ts
@@ -94,6 +94,16 @@ describe('getIncludedFiles', () => {
     expect(await glob(['**/*.d.ts'])).toMatchInlineSnapshot('[]');
   });
 
+  it('should not treat single-value braces as an extension alternation', async () => {
+    expect(await glob(['**/*.{ts}'])).toMatchInlineSnapshot('[]');
+    expect(await glob(['**/*.ts'])).toMatchInlineSnapshot(`
+      [
+        "apps/a.ts",
+        "apps/dist/a.ts",
+      ]
+    `);
+  });
+
   it('should exclude test and spec files by default', async () => {
     expect(await glob(['**/*.{test,spec}.*'])).toMatchInlineSnapshot('[]');
   });

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -110,6 +110,8 @@ A list of glob patterns that should be included for coverage collection.
 
 By default, rstest will only collect coverage for files that are tested. If you want to include untested files in the coverage report, you can use the `include` option to specify the files or patterns to include.
 
+Note that you should use standard glob syntax here. For a single extension, write `src/**/*.ts` instead of `src/**/*.{ts}`. Single-value braces are treated literally by the underlying glob libraries, so `src/**/*.{ts}` will not match `.ts` files.
+
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
 

--- a/website/docs/en/config/test/include.mdx
+++ b/website/docs/en/config/test/include.mdx
@@ -68,3 +68,5 @@ export default defineConfig({
 +  include: ['**/index.test.ts'],
 });
 ```
+
+It should be noted that for a single extension you should write `**/*.ts` instead of `**/*.{ts}`. The underlying glob libraries treat single-value braces literally, so `**/*.{ts}` will not match `.ts` files.

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -110,6 +110,8 @@ import { PackageManagerTabs } from '@theme';
 
 默认情况下，Rstest 会收集已测试文件的覆盖率。如果你希望在覆盖率报告中包含未测试的文件，可以使用 `include` 选项指定要包含的文件或模式。
 
+需要注意的是，这里应使用标准 glob 语法。匹配单个扩展名时，请写 `src/**/*.ts`，不要写 `src/**/*.{ts}`。底层 glob 库会把单元素花括号按字面量处理，因此 `src/**/*.{ts}` 不会匹配 `.ts` 文件。
+
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
 

--- a/website/docs/zh/config/test/include.mdx
+++ b/website/docs/zh/config/test/include.mdx
@@ -68,3 +68,5 @@ export default defineConfig({
 +  include: ['**/index.test.ts'],
 });
 ```
+
+需要注意的是，单个扩展名应直接写成 `**/*.ts`，不要写成 `**/*.{ts}`。底层 glob 库会把单元素花括号按字面量处理，因此 `**/*.{ts}` 不会匹配 `.ts` 文件。


### PR DESCRIPTION
## Summary

Users can reasonably assume that `**/*.{ts}` is equivalent to `**/*.ts`, but the underlying glob libraries treat single-value braces literally. That makes coverage and include patterns with `.{ts}` easy to misconfigure.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
