### PR TITLE
fix(browser): keep lazyCompilation and hmr enabled

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -542,12 +542,12 @@ export const createBrowserLazyCompilationConfig = (
   };
 };
 
-export const createBrowserRsbuildDevConfig = (isWatchMode: boolean) => {
+export const createBrowserRsbuildDevConfig = (_isWatchMode: boolean) => {
   return {
     writeToDisk: isDebug(),
-    // Disable HMR in non-watch mode (tests run once and exit).
-    // Aligns with node mode behavior (packages/core/src/core/rsbuild.ts).
-    hmr: isWatchMode,
+    // Keep HMR enabled in browser mode even for one-shot runs.
+    // lazyCompilation depends on HMR runtime wiring for async import chains.
+    hmr: true,
     client: {
       logLevel: 'error' as const,
     },
@@ -1280,9 +1280,8 @@ const createBrowserRuntime = async ({
               tools: {
                 rspack: (rspackConfig) => {
                   rspackConfig.mode = 'development';
-                  rspackConfig.lazyCompilation = isWatchMode
-                    ? createBrowserLazyCompilationConfig(setupFiles)
-                    : false;
+                  rspackConfig.lazyCompilation =
+                    createBrowserLazyCompilationConfig(setupFiles);
                   rspackConfig.plugins = rspackConfig.plugins || [];
                   rspackConfig.plugins.push(virtualManifestPlugin);
 

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -104,10 +104,10 @@ describe('browser config resolution', () => {
     expect(browserConfig.strictPort).toBe(true);
   });
 
-  it('should disable HMR in non-watch mode and keep error-only client log', () => {
+  it('should enable HMR in non-watch mode and keep error-only client log', () => {
     const devConfig = createBrowserRsbuildDevConfig(false);
 
-    expect(devConfig.hmr).toBe(false);
+    expect(devConfig.hmr).toBe(true);
     expect(devConfig.client.logLevel).toBe('error');
   });
 


### PR DESCRIPTION
## Summary

### Background

In browser mode, deeply nested runtime `import()` chains depend on lazy compilation to avoid eager bundling and startup regressions. Keeping lazy compilation active also requires HMR runtime wiring to remain enabled.

### Implementation

- Keep `rspackConfig.mode = 'development'` for browser runtime behavior.
- Set browser `hmr` to always `true` in `createBrowserRsbuildDevConfig`.
- Always apply `createBrowserLazyCompilationConfig(setupFiles)` instead of gating it by Rstest watch mode.
- Update host controller tests to assert that non-watch browser runs also keep HMR enabled.

### User Impact

Browser mode preserves lazy loading behavior for deep async imports in both watch and non-watch runs, avoiding non-watch performance regressions.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).