### PR TITLE
perf(worker): lazy-load coverage provider to reduce worker startup overhead

### DIFF
--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -9,7 +9,6 @@ import type {
 import './setup';
 import type { FileCoverageData } from 'istanbul-lib-coverage';
 import { install } from 'source-map-support';
-import { createCoverageProvider } from '../../coverage';
 import { createWorkerMetaMessage } from '../../pool/workerMeta';
 import { globalApis } from '../../utils/constants';
 import { color } from '../../utils/logger';
@@ -426,10 +425,16 @@ const runInPool = async (
       };
     }
     // Initialize coverage collector if coverage is enabled
-    const coverageProvider = await createCoverageProvider(
-      options.context.runtimeConfig.coverage || {},
-      options.context.rootPath,
-    );
+    let coverageProvider: Awaited<
+      ReturnType<typeof import('../../coverage').createCoverageProvider>
+    > | null = null;
+    if (options.context.runtimeConfig.coverage?.enabled) {
+      const { createCoverageProvider } = await import('../../coverage');
+      coverageProvider = await createCoverageProvider(
+        options.context.runtimeConfig.coverage,
+        options.context.rootPath,
+      );
+    }
     if (coverageProvider) {
       coverageProvider.init();
     }


### PR DESCRIPTION
## Summary

### Background

Every worker process statically imports the coverage module chain (`7704.js` → `4411.js`), loading ~108KB of picomatch/glob code at startup — even when coverage is disabled (the common case).

### Implementation

- Changed `createCoverageProvider` from a top-level static `import` to a dynamic `import()` guarded by `coverage.enabled`.
- This removes `7704.js` (1.6KB) and its transitive dependency `4411.js` (106KB) from every worker's static import chain. These chunks are now only loaded once in the main process when coverage is actually enabled.

Worker static JS asset reduction:

```
+------------------+----------+----------+---------+
| Chunk            | baseline | cov-lazy | Δ       |
+------------------+----------+----------+---------+
| worker.js chain  | 262KB    | 163KB    | -99KB   |
| 7704.js (cov)    | 52 PIDs  | 1 PID    | -98%    |
| 4411.js (glob)   | 54 PIDs  | 1 PID    | -98%    |
+------------------+----------+----------+---------+
```

### Benchmark

Fixture: 50 test files × 20 tests (1000 tests), 14-core machine, `isolateWorkers: true`, `NODE_COMPILE_CACHE` disabled.

```
hyperfine --warmup 5 --runs 30

Benchmark 1: baseline
  Time (mean ± σ):     571.0 ms ±  15.9 ms    [User: 3478.4 ms, System: 709.6 ms]
  Range (min … max):   546.9 ms … 616.1 ms    30 runs

Benchmark 2: cov-lazy
  Time (mean ± σ):     558.9 ms ±  25.5 ms    [User: 3264.9 ms, System: 716.2 ms]
  Range (min … max):   533.6 ms … 637.5 ms    30 runs

Summary
  cov-lazy ran
    1.02 ± 0.05 times faster than baseline
```

Wall clock: ~2% (limited by 14-core parallelism). User CPU: **-214ms (-6.1%)**, reflecting ~4ms less parse/compile per worker × 52 worker processes.

### User Impact

Marginal wall-clock improvement for typical runs; more visible on lower-core machines or larger test suites.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
