### PR TITLE
release: 0.9.5

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: add `output.distPath.root` configuration by @9aoy in https://github.com/web-infra-dev/rstest/pull/1083
* feat(core): add output.bundleDependencies config option by @9aoy in https://github.com/web-infra-dev/rstest/pull/1072
* feat: add unmockRequire / doUnmockRequire API by @9aoy in https://github.com/web-infra-dev/rstest/pull/1098
* feat(browser): support output browser inspect config files when DEBUG is enabled by @9aoy in https://github.com/web-infra-dev/rstest/pull/1104
### Performance 🚀
* perf(core): cache TraceMap and parsed sourcemaps, use Set for coverage file lookup by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1074
* perf(core): lazy load runtime diff formatting and fake timers by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1079
* perf(core): split monolithic worker bundle into lazy-loaded chunks by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1085
* perf(core): replace jest-diff and pretty-format with @vitest/utils by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1087
* perf: pre-filter test projects to avoid unnecessary builds by @9aoy in https://github.com/web-infra-dev/rstest/pull/1092
* perf(worker): lazy-load coverage provider to reduce worker startup overhead by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1110
### Bug Fixes 🐞
* fix(core): propagate color env to worker processes for correct ANSI output by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1081
* fix: always bundle requests when using inline loader by @9aoy in https://github.com/web-infra-dev/rstest/pull/1089
* fix: enable full knip checks and clean up unused exports and dead code by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1102
* fix(core): scope cli options to relevant commands by @9aoy in https://github.com/web-infra-dev/rstest/pull/1107
* fix(browser): keep lazyCompilation and hmr enabled by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1109
### Document 📖
* docs: add mocking guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/1078
* docs: link `Markdown reporter` to AI guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/1084
* docs: polish rstest features by @9aoy in https://github.com/web-infra-dev/rstest/pull/1093
* docs: clarify single-value include glob behavior by @9aoy in https://github.com/web-infra-dev/rstest/pull/1100
* docs: add `view test temporary outputs` guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/1103
* docs: add ApiMeta for `output.bundleDependencies` configuration by @9aoy in https://github.com/web-infra-dev/rstest/pull/1108
### Other Changes
* chore(deps): update dorny/paths-filter action to v4 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1076
* chore(deps): update dependency bumpp to v11 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1075
* chore(deps): update pnpm/action-setup action to v5 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1077
* test(core): use unique temp file paths in extends config tests by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1080
* ci: add Rsdoctor CI bundle tracking by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1086
* ci: update rsdoctor-action to latest commit by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1094
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1097
* ci: add knip for unused dependencies detection by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1095
* chore(ci): update rsdoctor reportDir by @9aoy in https://github.com/web-infra-dev/rstest/pull/1099
* chore(lint): migrate rslint to flat config by @chenjiahan in https://github.com/web-infra-dev/rstest/pull/1101
* ci: merge lint into test workflow and gate e2e on both lint and ut by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1105
* chore(ci): fix MODULE_TYPELESS_PACKAGE_JSON warnings by @9aoy in https://github.com/web-infra-dev/rstest/pull/1106


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.9.4...v0.9.5