### PR TITLE
feat(core): support bundleDependencies patterns

### DIFF
--- a/e2e/externals/bundleDependencies.test.ts
+++ b/e2e/externals/bundleDependencies.test.ts
@@ -1,7 +1,8 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from '@rstest/core';
+import { beforeAll, describe, expect, it } from '@rstest/core';
+import fse from 'fs-extra';
 import { runRstestCli } from '../scripts/';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -44,6 +45,21 @@ async function readTestOutput(testName = 'index'): Promise<string> {
 }
 
 describe('test bundleDependencies', () => {
+  beforeAll(() => {
+    fse.copySync(
+      join(__dirname, './fixtures/test-lodash'),
+      join(__dirname, './fixtures/test-pkg/node_modules/test-lodash'),
+    );
+    fse.copySync(
+      join(__dirname, './fixtures/test-module-field'),
+      join(__dirname, './fixtures/test-pkg/node_modules/test-module-field'),
+    );
+    fse.copySync(
+      join(__dirname, './fixtures/test-interop'),
+      join(__dirname, './fixtures/test-pkg/node_modules/test-interop'),
+    );
+  });
+
   it('should externalize dependencies in jsdom when bundleDependencies is false', async () => {
     const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/e2e/externals/bundleDependencies.test.ts
+++ b/e2e/externals/bundleDependencies.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
@@ -9,12 +9,37 @@ const __dirname = dirname(__filename);
 
 const distDir = join(__dirname, 'dist-deps/.rstest-temp');
 
-function readTestOutput(): string {
+function resolveTestOutputFile(testName = 'index'): string | undefined {
   const ext = process.env.RSTEST_OUTPUT_MODULE !== 'false' ? '.mjs' : '.js';
-  const file = join(distDir, `fixtures_index~test~ts${ext}`);
+  const file = join(distDir, `fixtures_${testName}~test~ts${ext}`);
+
   if (existsSync(file)) {
-    return readFileSync(file, 'utf-8');
+    return file;
   }
+
+  const matchedFile = readdirSync(distDir).find(
+    (entry) =>
+      entry.startsWith(`fixtures_${testName}~test~ts`) && entry.endsWith(ext),
+  );
+
+  if (matchedFile) {
+    return join(distDir, matchedFile);
+  }
+
+  return undefined;
+}
+
+async function readTestOutput(testName = 'index'): Promise<string> {
+  for (let i = 0; i < 10; i++) {
+    const file = resolveTestOutputFile(testName);
+
+    if (file) {
+      return readFileSync(file, 'utf-8');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
   throw new Error('No test output file found');
 }
 
@@ -38,7 +63,7 @@ describe('test bundleDependencies', () => {
 
     await expectExecSuccess();
 
-    const output = readTestOutput();
+    const output = await readTestOutput();
 
     // strip-ansi source code should NOT be inlined when externalized
     expect(output).not.toContain('function stripAnsi');
@@ -63,7 +88,7 @@ describe('test bundleDependencies', () => {
 
     await expectExecSuccess();
 
-    const output = readTestOutput();
+    const output = await readTestOutput();
 
     // jsdom should still bundle dependencies by default
     expect(output).toContain('function stripAnsi');
@@ -87,9 +112,105 @@ describe('test bundleDependencies', () => {
 
     await expectExecSuccess();
 
-    const output = readTestOutput();
+    const output = await readTestOutput();
 
     // strip-ansi source code should be inlined when bundled
     expect(output).toContain('function stripAnsi');
+  });
+
+  it('should bundle only the named dependencies when bundleDependencies is an array', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        './fixtures/namedBundleDependencies.test.ts',
+        '-c',
+        './fixtures/rstest.bundleNamedDeps.config.mts',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const output = await readTestOutput('namedBundleDependencies');
+
+    expect(output).toContain("const VERSION = '4.17.21';");
+    expect(output).not.toContain("throw new Error('dirname is not defined');");
+  });
+
+  it('should bundle relative imports inside named dependencies', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        './fixtures/namedBundleRelative.test.ts',
+        '-c',
+        './fixtures/rstest.bundleRelativeDeps.config.mts',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const output = await readTestOutput('namedBundleRelative');
+
+    expect(output).toContain("exports.a = 'world';");
+    expect(output).not.toContain('__webpack_require__("test-interop")');
+  });
+
+  it('should bundle relative imports when a package subpath is listed', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        './fixtures/namedBundleRelative.test.ts',
+        '-c',
+        './fixtures/rstest.bundleRelativeDepsSubpath.config.mts',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const output = await readTestOutput('namedBundleRelative');
+
+    expect(output).toContain("exports.a = 'world';");
+    expect(output).not.toContain('__webpack_require__("test-interop")');
+  });
+
+  it('should bundle relative imports when a package glob is listed', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        './fixtures/namedBundleRelative.test.ts',
+        '-c',
+        './fixtures/rstest.bundleRelativeDepsGlob.config.mts',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const output = await readTestOutput('namedBundleRelative');
+
+    expect(output).toContain("exports.a = 'world';");
+    expect(output).not.toContain('__webpack_require__("test-interop")');
   });
 });

--- a/e2e/externals/fixtures/namedBundleDependencies.test.ts
+++ b/e2e/externals/fixtures/namedBundleDependencies.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from '@rstest/core';
+import { a, VERSION } from './test-pkg/namedBundleDependencies';
+
+it('should load both package dependencies correctly', () => {
+  expect(VERSION).toBe('4.17.21');
+  expect(a).toBe(1);
+});

--- a/e2e/externals/fixtures/namedBundleRelative.test.ts
+++ b/e2e/externals/fixtures/namedBundleRelative.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from '@rstest/core';
+import greet, { a } from './test-pkg/namedBundleRelative';
+
+it('should bundle relative imports inside named dependencies', () => {
+  expect(a).toBe('world');
+  expect(greet()).toBe('hello world');
+});

--- a/e2e/externals/fixtures/rstest.bundleNamedDeps.config.mts
+++ b/e2e/externals/fixtures/rstest.bundleNamedDeps.config.mts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  dev: {
+    writeToDisk: true,
+  },
+  output: {
+    cleanDistPath: true,
+    bundleDependencies: ['test-lodash'],
+    distPath: 'dist-deps/.rstest-temp',
+  },
+});

--- a/e2e/externals/fixtures/rstest.bundleRelativeDeps.config.mts
+++ b/e2e/externals/fixtures/rstest.bundleRelativeDeps.config.mts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  dev: {
+    writeToDisk: true,
+  },
+  output: {
+    cleanDistPath: true,
+    bundleDependencies: ['test-interop'],
+    distPath: 'dist-deps/.rstest-temp',
+  },
+});

--- a/e2e/externals/fixtures/rstest.bundleRelativeDepsGlob.config.mts
+++ b/e2e/externals/fixtures/rstest.bundleRelativeDepsGlob.config.mts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  dev: {
+    writeToDisk: true,
+  },
+  output: {
+    cleanDistPath: true,
+    bundleDependencies: ['test-interop/*'],
+    distPath: 'dist-deps/.rstest-temp',
+  },
+});

--- a/e2e/externals/fixtures/rstest.bundleRelativeDepsSubpath.config.mts
+++ b/e2e/externals/fixtures/rstest.bundleRelativeDepsSubpath.config.mts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  dev: {
+    writeToDisk: true,
+  },
+  output: {
+    cleanDistPath: true,
+    bundleDependencies: ['test-interop/index.js'],
+    distPath: 'dist-deps/.rstest-temp',
+  },
+});

--- a/e2e/externals/fixtures/test-pkg/namedBundleDependencies.ts
+++ b/e2e/externals/fixtures/test-pkg/namedBundleDependencies.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error: the package is alongside, only for testing purposes
+export { VERSION } from 'test-lodash';
+// @ts-expect-error: the package is alongside, only for testing purposes
+export { a } from 'test-module-field';

--- a/e2e/externals/fixtures/test-pkg/namedBundleRelative.ts
+++ b/e2e/externals/fixtures/test-pkg/namedBundleRelative.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error: the package is alongside, only for testing purposes
+export { a, default } from 'test-interop';

--- a/packages/core/src/core/plugins/external.ts
+++ b/packages/core/src/core/plugins/external.ts
@@ -1,7 +1,11 @@
 import { isBuiltin } from 'node:module';
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import type { RstestContext } from '../../types';
+import type { BundleDependencyPattern } from '../../types/config';
 import { ADDITIONAL_NODE_BUILTINS, castArray } from '../../utils';
+
+const NODE_MODULES_PATH_SEGMENT = '/node_modules/';
+const SCRIPT_EXTENSION_RE = /\.(?:[cm]?[jt]sx?)$/;
 
 function hasInlineLoader(request: string): boolean {
   // has inline loader in request
@@ -9,8 +13,133 @@ function hasInlineLoader(request: string): boolean {
   return request.split('!').length > 1;
 }
 
+function normalizePath(value: string): string {
+  return value.replaceAll('\\', '/');
+}
+
+function stripScriptExtension(specifier: string): string {
+  return specifier.replace(SCRIPT_EXTENSION_RE, '');
+}
+
+function isRelativeRequest(request: string): boolean {
+  return request.startsWith('.') || request.startsWith('/');
+}
+
+function getPackageName(specifier: string): string | undefined {
+  const normalizedSpecifier = normalizePath(specifier);
+
+  if (
+    !normalizedSpecifier ||
+    normalizedSpecifier.startsWith('.') ||
+    normalizedSpecifier.startsWith('/') ||
+    normalizedSpecifier.startsWith('node:')
+  ) {
+    return;
+  }
+
+  const segments = normalizedSpecifier.split('/');
+
+  if (normalizedSpecifier.startsWith('@')) {
+    return segments.length >= 2 ? `${segments[0]}/${segments[1]}` : undefined;
+  }
+
+  return segments[0];
+}
+
+function getNodeModulesSpecifierFromResolvedPath(
+  resolvedPath: string,
+): string | undefined {
+  const normalizedResolvedPath = normalizePath(resolvedPath);
+  const nodeModulesIndex = normalizedResolvedPath.lastIndexOf(
+    NODE_MODULES_PATH_SEGMENT,
+  );
+
+  if (nodeModulesIndex === -1) {
+    return;
+  }
+
+  return normalizedResolvedPath.slice(
+    nodeModulesIndex + NODE_MODULES_PATH_SEGMENT.length,
+  );
+}
+
+function patternMatchesSpecifier(
+  pattern: BundleDependencyPattern,
+  specifier: string,
+): boolean {
+  if (pattern instanceof RegExp) {
+    return (
+      pattern.test(specifier) || pattern.test(stripScriptExtension(specifier))
+    );
+  }
+
+  if (pattern.includes('*')) {
+    const escapedPattern = pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`^${escapedPattern.replaceAll('\\*', '.*')}$`);
+
+    return regex.test(specifier) || regex.test(stripScriptExtension(specifier));
+  }
+
+  const patternPackageName = getPackageName(pattern);
+
+  if (patternPackageName === pattern) {
+    return specifier === pattern || specifier.startsWith(`${pattern}/`);
+  }
+
+  return (
+    specifier === pattern ||
+    stripScriptExtension(specifier) === stripScriptExtension(pattern)
+  );
+}
+
+function matchesBundledDependency(
+  request: string,
+  resolvedSpecifier: string | undefined,
+  bundledDependencies: BundleDependencyPattern[] | undefined,
+): boolean {
+  if (!bundledDependencies?.length) {
+    return false;
+  }
+
+  if (
+    bundledDependencies.some((pattern) =>
+      patternMatchesSpecifier(pattern, request),
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    resolvedSpecifier &&
+    bundledDependencies.some((pattern) =>
+      patternMatchesSpecifier(pattern, resolvedSpecifier),
+    )
+  ) {
+    return true;
+  }
+
+  if (!resolvedSpecifier || !isRelativeRequest(request)) {
+    return false;
+  }
+
+  const resolvedPackageName = getPackageName(resolvedSpecifier);
+
+  if (resolvedPackageName === undefined) {
+    return false;
+  }
+
+  return bundledDependencies.some((pattern) => {
+    if (pattern instanceof RegExp) {
+      return false;
+    }
+
+    return getPackageName(pattern) === resolvedPackageName;
+  });
+}
+
 const autoExternalNodeModules: (
   outputModule: boolean,
+  bundledDependencies?: BundleDependencyPattern[],
 ) => (
   data: Rspack.ExternalItemFunctionData,
   callback: (
@@ -19,7 +148,7 @@ const autoExternalNodeModules: (
     type?: Rspack.ExternalsType,
   ) => void,
 ) => void =
-  (outputModule) =>
+  (outputModule, bundledDependencies) =>
   ({ context, request, dependencyType, getResolve }, callback) => {
     if (!request) {
       return callback();
@@ -47,6 +176,9 @@ const autoExternalNodeModules: (
     };
 
     const resolver = getResolve?.();
+    if (matchesBundledDependency(request, undefined, bundledDependencies)) {
+      return callback();
+    }
 
     if (!resolver) {
       return callback();
@@ -59,10 +191,21 @@ const autoExternalNodeModules: (
         return callback(undefined, request, 'node-commonjs');
       }
 
+      const resolvedSpecifier =
+        typeof resolvePath === 'string'
+          ? getNodeModulesSpecifierFromResolvedPath(resolvePath)
+          : undefined;
+      const shouldBundleByResolvedPath = matchesBundledDependency(
+        request,
+        resolvedSpecifier,
+        bundledDependencies,
+      );
+
       if (
         // biome-ignore lint/complexity/useOptionalChain: type error
         resolvePath &&
-        resolvePath.includes('node_modules') &&
+        resolvePath.includes(NODE_MODULES_PATH_SEGMENT) &&
+        !shouldBundleByResolvedPath &&
         !/\.(?:ts|tsx|jsx|mts|cts)$/.test(resolvePath)
       ) {
         return doExternal(resolvePath);
@@ -122,12 +265,21 @@ export const pluginExternal: (context: RstestContext) => RsbuildPlugin = (
       const shouldExternalize =
         bundleDependencies === undefined
           ? testEnvironment.name === 'node'
-          : !bundleDependencies;
+          : Array.isArray(bundleDependencies)
+            ? true
+            : !bundleDependencies;
 
       return mergeEnvironmentConfig(config, {
         output: {
           externals: shouldExternalize
-            ? [autoExternalNodeModules(outputModule)]
+            ? [
+                autoExternalNodeModules(
+                  outputModule,
+                  Array.isArray(bundleDependencies)
+                    ? bundleDependencies
+                    : undefined,
+                ),
+              ]
             : undefined,
         },
         tools: {

--- a/packages/core/src/core/plugins/external.ts
+++ b/packages/core/src/core/plugins/external.ts
@@ -191,9 +191,13 @@ const autoExternalNodeModules: (
         return callback(undefined, request, 'node-commonjs');
       }
 
-      const resolvedSpecifier =
+      const normalizedResolvePath =
         typeof resolvePath === 'string'
-          ? getNodeModulesSpecifierFromResolvedPath(resolvePath)
+          ? normalizePath(resolvePath)
+          : resolvePath;
+      const resolvedSpecifier =
+        typeof normalizedResolvePath === 'string'
+          ? getNodeModulesSpecifierFromResolvedPath(normalizedResolvePath)
           : undefined;
       const shouldBundleByResolvedPath = matchesBundledDependency(
         request,
@@ -203,12 +207,12 @@ const autoExternalNodeModules: (
 
       if (
         // biome-ignore lint/complexity/useOptionalChain: type error
-        resolvePath &&
-        resolvePath.includes(NODE_MODULES_PATH_SEGMENT) &&
+        normalizedResolvePath &&
+        normalizedResolvePath.includes(NODE_MODULES_PATH_SEGMENT) &&
         !shouldBundleByResolvedPath &&
-        !/\.(?:ts|tsx|jsx|mts|cts)$/.test(resolvePath)
+        !/\.(?:ts|tsx|jsx|mts|cts)$/.test(normalizedResolvePath)
       ) {
-        return doExternal(resolvePath);
+        return doExternal(normalizedResolvePath);
       }
       return callback();
     });

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -27,6 +27,8 @@ export type RstestPoolOptions = {
   execArgv?: string[];
 };
 
+export type BundleDependencyPattern = string | RegExp;
+
 export type RstestOutputConfig = Pick<
   NonNullable<RsbuildConfig['output']>,
   'cssModules' | 'externals' | 'cleanDistPath' | 'module'
@@ -36,12 +38,17 @@ export type RstestOutputConfig = Pick<
    * Whether to bundle third-party dependencies from node_modules.
    * - `true`: Always bundle all third-party dependencies.
    * - `false`: Always externalize third-party dependencies.
+   * - `['pkg']`: Bundle the package and all of its subpaths.
+   * - `['pkg/subpath']`: Bundle a specific package subpath.
+   * - `['pkg/*']`: Bundle package subpaths that match the pattern.
+   * - `[/^pkg\\/subpath/]`: Bundle package requests matched by a regular
+   *   expression.
    *
    * When unset, rstest bundles dependencies in browser-like test
    * environments (jsdom, happy-dom, etc.) and externalizes them in the node
    * environment. This option is not supported in browser mode.
    */
-  bundleDependencies?: boolean;
+  bundleDependencies?: boolean | BundleDependencyPattern[];
 };
 
 export type NormalizedOutputConfig = Partial<

--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -227,6 +227,11 @@ Patterns only affect dependency requests that rstest can still process in the cu
 - `bundleDependencies: true` + `externals: ['lodash']`: Bundle all dependencies, but externalize `lodash`.
 - `bundleDependencies: false` + `externals` is not needed, since all dependencies are already externalized.
 
+In practice, the two options are most useful in opposite situations:
+
+- Use `bundleDependencies` patterns when most dependencies should stay external, and you only want to bundle a small set of packages or subpaths.
+- Use `output.externals` when most dependencies should stay bundled, and you only want to externalize a small set of packages.
+
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 
 For custom CSS Modules configuration.

--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -150,13 +150,17 @@ export default defineConfig({
 
 <ApiMeta addedVersion="0.9.5" />
 
-- **Type:** `boolean`
+- **Type:** `boolean | (string | RegExp)[]`
 - **Default:** Depends on `testEnvironment`
 
 Controls whether third-party dependencies from `node_modules` are bundled or externalized.
 
 - `true`: Always bundle all third-party dependencies, regardless of test environment.
 - `false`: Always externalize third-party dependencies, regardless of test environment.
+- `['pkg-name']`: Bundle only the listed packages and externalize the rest.
+- `['pkg-name/subpath']`: Bundle a specific package subpath.
+- `['pkg-name/*']`: Bundle package requests that match the glob-like pattern.
+- `[/^pkg-name\\/subpath/]`: Bundle package requests that match the regular expression.
 
 When this option is unset, rstest bundles dependencies in browser-like test environments (jsdom, happy-dom, etc.), and externalizes them in the `node` environment.
 
@@ -186,6 +190,30 @@ export default defineConfig({
   testEnvironment: 'node',
   output: {
     bundleDependencies: true,
+  },
+});
+```
+
+If you only want to bundle a few packages while keeping the rest externalized, pass their package names:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    bundleDependencies: ['strip-ansi'],
+  },
+});
+```
+
+You can also target subpaths or patterns:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    bundleDependencies: ['strip-ansi/lib/index.js', 'strip-ansi/*'],
   },
 });
 ```

--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -218,6 +218,8 @@ export default defineConfig({
 });
 ```
 
+Patterns only affect dependency requests that rstest can still process in the current bundle graph. If a package has already been externalized, its internal dependencies stay external as well. In other words, `bundleDependencies` does not re-bundle transitive dependencies that are reachable only through an externalized parent package.
+
 ### Relationship with output.externals
 
 `output.bundleDependencies` controls the overall bundling strategy for all `node_modules` dependencies, while [`output.externals`](#outputexternals) allows fine-grained control over individual packages. When both are configured, `output.externals` takes higher priority:

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -225,6 +225,11 @@ export default defineConfig({
 - `bundleDependencies: true` + `externals: ['lodash']`：打包所有依赖，但外部化 `lodash`。
 - `bundleDependencies: false` + `externals` 无需配置，因为所有依赖已被外部化。
 
+实际使用时，这两个配置更适合相反的场景：
+
+- 当大部分依赖都应该保持 external，只有少量包或子路径需要被打包时，更适合使用 `bundleDependencies` pattern。
+- 当大部分依赖都应该保持打包，只有少量包需要被 externalize 时，更适合使用 `output.externals`。
+
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 
 用于自定义 CSS Modules 的配置。

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -148,13 +148,17 @@ export default defineConfig({
 
 <ApiMeta addedVersion="0.9.5" />
 
-- **类型：** `boolean`
+- **类型：** `boolean | (string | RegExp)[]`
 - **默认值：** 取决于 `testEnvironment`
 
 控制是否打包 `node_modules` 中的第三方依赖。
 
 - `true`：无论测试环境如何，始终打包所有第三方依赖。
 - `false`：无论测试环境如何，始终外部化第三方依赖。
+- `['pkg-name']`：仅打包列出的包，其余依赖保持外部化。
+- `['pkg-name/subpath']`：仅打包指定的包子路径。
+- `['pkg-name/*']`：按类似 glob 的模式匹配并打包包请求。
+- `[/^pkg-name\\/subpath/]`：按正则表达式匹配并打包包请求。
 
 当未设置该选项时，rstest 会在类浏览器测试环境（jsdom、happy-dom 等）中打包依赖，在 `node` 环境中将其外部化。
 
@@ -184,6 +188,30 @@ export default defineConfig({
   testEnvironment: 'node',
   output: {
     bundleDependencies: true,
+  },
+});
+```
+
+如果你只想打包少量依赖包，而把其他依赖继续外部化，可以直接传入包名列表：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    bundleDependencies: ['strip-ansi'],
+  },
+});
+```
+
+你也可以直接匹配子路径或模式：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    bundleDependencies: ['strip-ansi/lib/index.js', 'strip-ansi/*'],
   },
 });
 ```

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -216,6 +216,8 @@ export default defineConfig({
 });
 ```
 
+这些模式只会影响 rstest 在当前构建图里仍然能够处理到的依赖请求。如果某个包本身已经被 externalize 了，那么它内部继续引用的子依赖也会保持 external。也就是说，`bundleDependencies` 不会把仅通过某个已 externalize 父包间接到达的传递依赖重新打包回来。
+
 ### 与 output.externals 的关系
 
 `output.bundleDependencies` 控制所有 `node_modules` 依赖的整体打包策略，而 [`output.externals`](#outputexternals) 允许对单个包进行细粒度控制。当两者同时配置时，`output.externals` 的优先级更高：


### PR DESCRIPTION
## Summary

### Background
`output.bundleDependencies` only supported a boolean toggle, so users could not inline a specific dependency or target package subpaths the way Vitest's inline dependency config does.

### Implementation
- Extend `output.bundleDependencies` to accept string and `RegExp` patterns for package names, subpaths, and glob-like `*` matches.
- Update the externalization plugin to match both direct requests and resolved `node_modules` specifiers, while keeping relative imports inside matched dependencies bundled.
- Add e2e coverage for package-name, subpath, glob, and relative-import cases, and document the new config forms in English and Chinese docs.

### User Impact
Users can now selectively bundle dependencies with entries like `['strip-ansi']`, `['strip-ansi/lib/index.js']`, `['strip-ansi/*']`, or `[/^strip-ansi\\/lib\\//]`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).