### PR TITLE
fix(browser): resolve actual port when devServer.listen() returns 0

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -518,6 +518,30 @@ type BrowserLazyCompilationConfig = {
   test?: (module: LazyCompilationModule) => boolean;
 };
 
+/**
+ * Resolve the actual port the dev server is listening on.
+ *
+ * Rsbuild's `devServer.listen()` may return `0` when configured with
+ * `server.port: 0` because its internal `getPort` never reads back the
+ * OS-assigned ephemeral port.  This helper falls back to
+ * `httpServer.address()` to obtain the real bound port.
+ */
+export const resolveListenPort = (
+  listenPort: number,
+  httpServer: {
+    address: () => ReturnType<import('node:net').Server['address']>;
+  } | null,
+): number => {
+  if (listenPort) {
+    return listenPort;
+  }
+  const addr = httpServer?.address();
+  if (addr && typeof addr === 'object') {
+    return addr.port;
+  }
+  return listenPort;
+};
+
 export const createBrowserLazyCompilationConfig = (
   setupFiles: string[],
 ): BrowserLazyCompilationConfig => {
@@ -1549,7 +1573,8 @@ const createBrowserRuntime = async ({
     },
   );
 
-  const { port } = await devServer.listen();
+  const { port: listenPort } = await devServer.listen();
+  const port = resolveListenPort(listenPort, devServer.httpServer);
 
   // Create WebSocket server on an available port
   // Using port: 0 lets the OS assign an available port, avoiding conflicts

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -3,6 +3,7 @@ import type { ProjectContext, Rstest } from '@rstest/core/browser';
 import {
   createBrowserLazyCompilationConfig,
   createBrowserRsbuildDevConfig,
+  resolveListenPort,
 } from '../src/hostController';
 
 /**
@@ -147,5 +148,27 @@ describe('browser config resolution', () => {
         nameForCondition: () => '/project/tests/../tests/rstest.setup.ts',
       }),
     ).toBe(false);
+  });
+});
+
+describe('resolveListenPort', () => {
+  it('should return listenPort when it is non-zero', () => {
+    expect(resolveListenPort(4000, null)).toBe(4000);
+  });
+
+  it('should fall back to httpServer.address() when listenPort is 0', () => {
+    const httpServer = {
+      address: () => ({ address: '127.0.0.1', family: 'IPv4', port: 52341 }),
+    };
+    expect(resolveListenPort(0, httpServer)).toBe(52341);
+  });
+
+  it('should return 0 when both listenPort and httpServer are unavailable', () => {
+    expect(resolveListenPort(0, null)).toBe(0);
+  });
+
+  it('should return 0 when httpServer.address() returns a string', () => {
+    const httpServer = { address: () => '/tmp/sock' as unknown as null };
+    expect(resolveListenPort(0, httpServer as any)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

### Background

When `browser.port` is set to `0`, Rsbuild's `devServer.listen()` returns `0` instead of the real OS-assigned ephemeral port — its internal `getPort` never reads `httpServer.address().port` after binding. This causes Playwright to fail with an "unsafe port" error when navigating to `http://localhost:0/runner.html`.

### Implementation

- Extract `resolveListenPort()` helper that falls back to `httpServer.address()` when the reported listen port is `0`.
- Add unit tests covering normal port, ephemeral port fallback, null httpServer, and Unix socket address cases.

### User Impact

`browser.port: 0` now works correctly — the framework resolves the real bound port instead of passing `0` to Playwright.

## Related Links

Fixes #1096

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
