### PR TITLE
docs(core): fix coverage exclude JSDoc defaults

### DIFF
--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -75,11 +75,14 @@ export type CoverageOptions = {
    * This option accepts an array of wax(https://crates.io/crates/wax)-compatible glob patterns
    *
    * @default ['**\/node_modules/**',
-   *           '**\/dist/**',
    *           '**\/test/**',
    *           '**\/__tests__/**',
-   *           '**\/*.{test,spec}.?(c|m)[jt]s?(x)',
-   *           '**\/__mocks__/**'
+   *           '**\/__mocks__/**',
+   *           '**\/*.d.ts',
+   *           '**\/*.{test,spec}.[jt]s',
+   *           '**\/*.{test,spec}.[cm][jt]s',
+   *           '**\/*.{test,spec}.[jt]sx',
+   *           '**\/*.{test,spec}.[cm][jt]sx'
    * ]
    */
   exclude?: string[];


### PR DESCRIPTION
## Summary

### Background
The default `coverage.exclude` patterns in the core type JSDoc had drifted from the actual runtime defaults after #1022. That made the inline API documentation show `dist/**` as excluded by default even though the current behavior no longer does that.

### Implementation
- Updated the `CoverageOptions.exclude` JSDoc in `packages/core/src/types/coverage.ts` to match the real default patterns.
- Removed the stale `dist/**` entry and listed the current spec and declaration file patterns explicitly.
- Validation: ran `pnpm prettier --check packages/core/src/types/coverage.ts`; skipped broader build and test runs because this is a JSDoc-only change.

### User Impact
Developers reading the core config types now see the correct default `coverage.exclude` behavior.

## Related Links

- fix #1122
- Related to #1022

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).