### PR TITLE
docs(website): clarify adapter config pruning

### DIFF
--- a/website/docs/en/guide/integration/rsbuild.mdx
+++ b/website/docs/en/guide/integration/rsbuild.mdx
@@ -24,7 +24,7 @@ To add Rstest to an existing project, follow the [Quick Start](/guide/start/quic
 
 ## Reuse Rsbuild config
 
-[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) is an official adapter that allows Rstest to automatically inherit configuration from your existing Rsbuild config file. This ensures your test environment matches your build configuration without duplication.
+[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) is an official adapter that allows Rstest to automatically inherit test-relevant configuration from your existing Rsbuild config file. This keeps your test environment aligned with your build setup without carrying over options that only matter to dev servers or page output.
 
 ### Install adapter
 
@@ -49,8 +49,10 @@ export default defineConfig({
 This will automatically:
 
 - Load your `rsbuild.config.ts` file
-- Map compatible Rsbuild options to Rstest configuration
+- Extract and map test-relevant Rsbuild options to Rstest configuration
 - Merge with any additional Rstest config you provide
+
+The adapter does not reuse the entire Rsbuild config as-is. It keeps the parts that matter for test execution, such as module resolution, transforms, CSS Modules, and `target`, and automatically drops options like `dev`, `server`, and `html` that are specific to the dev server, page entry, or production output.
 
 By default, the adapter uses `process.cwd()` to resolve the Rsbuild config. If your config lives elsewhere, you can use the `cwd` option. See [API](#api) for more details.
 
@@ -171,6 +173,8 @@ export default defineConfig({
 
 The adapter automatically maps these Rsbuild options to Rstest:
 
+Only the fields listed below are inherited. Rsbuild options that are not listed are ignored by default, which means test-irrelevant sections such as `dev`, `server`, and `html` are automatically pruned during conversion.
+
 | Rsbuild option          | Rstest equivalent     | Notes                                |
 | ----------------------- | --------------------- | ------------------------------------ |
 | `name` from environment | `name`                | Environment identifier               |
@@ -186,6 +190,8 @@ The adapter automatically maps these Rsbuild options to Rstest:
 | `tools.swc`             | `tools.swc`           | SWC configuration                    |
 | `tools.bundlerChain`    | `tools.bundlerChain`  | Bundler chain configuration          |
 | `output.target`         | `testEnvironment`     | 'happy-dom' for web, 'node' for node |
+
+The adapter also removes the `rsbuild:type-check` plugin because type checking is not part of the test runtime pipeline.
 
 ## Debug config
 

--- a/website/docs/en/guide/integration/rslib.mdx
+++ b/website/docs/en/guide/integration/rslib.mdx
@@ -24,7 +24,7 @@ To add Rstest to an existing project, follow the [Quick Start](/guide/start/quic
 
 ## Reuse Rslib config
 
-[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) is an official adapter that allows Rstest to automatically inherit configuration from your existing Rslib config file. This ensures your test environment matches your build configuration without duplication.
+[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) is an official adapter that allows Rstest to automatically inherit test-relevant configuration from your existing Rslib config file. This keeps your test environment aligned with your build setup without carrying over options that only matter to build output.
 
 ### Install adapter
 
@@ -49,8 +49,10 @@ export default defineConfig({
 This will automatically:
 
 - Load your `rslib.config.ts` file
-- Map compatible Rslib options to Rstest configuration
+- Extract and map test-relevant Rslib options to Rstest configuration
 - Merge with any additional Rstest config you provide
+
+The adapter does not reuse the entire Rslib config as-is. It keeps the parts that matter for test execution, such as module resolution, transforms, CSS Modules, decorator-related settings, and `target`, and automatically drops unmapped fields like `dev`, `server`, and `html`, along with other options that only exist for dev server, page entry, or build output.
 
 By default, the adapter uses `process.cwd()` to resolve the Rslib config. If your config lives elsewhere, you can use the `cwd` option. See [API](#api) for more details.
 
@@ -123,6 +125,8 @@ export default defineConfig({
 
 You can then reference specific lib configurations in your Rstest config. Rstest will adapt the Rslib shared configuration and the lib configuration with a matching `libId` to Rstest format.
 
+This still does not copy the whole lib config verbatim. The adapter only takes the lib's `source`, `output`, `tools`, `plugins`, and `resolve` fields that are relevant to test execution, then merges them with the shared config before converting the result to Rstest format.
+
 ```ts
 // For testing the 'core' environment
 export default defineConfig({
@@ -171,6 +175,8 @@ export default defineConfig({
 ## Configuration mapping
 
 The adapter automatically maps these Rslib options to Rstest:
+
+Only the fields listed below are inherited. Rslib options that are not listed are ignored by default, which means test-irrelevant sections such as `dev`, `server`, and `html` are automatically pruned during conversion.
 
 | Rslib option          | Rstest equivalent     | Notes                                                  |
 | --------------------- | --------------------- | ------------------------------------------------------ |

--- a/website/docs/zh/guide/integration/rsbuild.mdx
+++ b/website/docs/zh/guide/integration/rsbuild.mdx
@@ -24,7 +24,7 @@ npm create rsbuild@latest -- --tools rstest
 
 ## 复用 Rsbuild 配置
 
-[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) 是一个官方适配器，它允许 Rstest 自动从你现有的 Rsbuild 配置文件中继承配置。这可以确保你的测试环境与构建配置相匹配，而无需重复配置。
+[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) 是一个官方适配器，它允许 Rstest 自动从你现有的 Rsbuild 配置文件中继承测试相关配置。这可以确保测试环境与构建配置尽量保持一致，同时避免把仅用于开发服务器或页面构建的选项带进测试流程。
 
 ### 安装适配器
 
@@ -49,8 +49,10 @@ export default defineConfig({
 这将自动：
 
 - 加载你的 `rsbuild.config.ts` 文件
-- 将兼容的 Rsbuild 选项映射到 Rstest 配置
+- 提取并映射测试相关的 Rsbuild 选项到 Rstest 配置
 - 与你提供的任何其他 Rstest 配置合并
+
+适配器不会原样复用整份 Rsbuild 配置，而是只保留测试运行需要的部分，例如模块解析、代码转换、CSS Modules 和 `target`。像 `dev`、`server`、`html` 这类面向开发服务器、页面入口或产物输出的配置，会在转换时自动裁剪掉，避免把测试无关配置带入 Rstest。
 
 默认情况下，适配器使用 `process.cwd()` 来解析 Rsbuild 配置。如果你的配置文件在其他地方，你可以使用 `cwd` 选项。更多详情请参阅 [API](#api) 部分。
 
@@ -171,6 +173,8 @@ export default defineConfig({
 
 适配器会自动将这些 Rsbuild 选项映射到 Rstest：
 
+下表中列出的字段会被继承；没有列出的 Rsbuild 选项默认不会进入 Rstest 配置。这意味着 `dev`、`server`、`html` 等与测试运行无关的配置会被自动忽略。
+
 | Rsbuild 选项            | Rstest 等效项         | 说明                                       |
 | ----------------------- | --------------------- | ------------------------------------------ |
 | `name` from environment | `name`                | 环境标识符                                 |
@@ -186,6 +190,8 @@ export default defineConfig({
 | `tools.swc`             | `tools.swc`           | SWC 配置                                   |
 | `tools.bundlerChain`    | `tools.bundlerChain`  | Bundler 链配置                             |
 | `output.target`         | `testEnvironment`     | web 环境为 'happy-dom'，node 环境为 'node' |
+
+另外，适配器还会移除 `rsbuild:type-check` 插件，因为类型检查不属于测试运行时所需的构建链路。
 
 ## 调试配置
 

--- a/website/docs/zh/guide/integration/rslib.mdx
+++ b/website/docs/zh/guide/integration/rslib.mdx
@@ -24,7 +24,7 @@ npx create-rslib --template react-ts --tools rstest --dir my-project
 
 ## 复用 Rslib 配置
 
-[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) 是 Rstest 官方提供的适配器，允许 Rstest 自动继承现有 Rslib 配置文件中的配置。这样可以确保测试环境与构建配置一致，避免重复配置。
+[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) 是 Rstest 官方提供的适配器，允许 Rstest 自动继承现有 Rslib 配置文件中的测试相关配置。这样可以确保测试环境与构建配置尽量保持一致，同时避免把只服务于构建产物的选项带进测试流程。
 
 ### 安装适配器
 
@@ -49,8 +49,10 @@ export default defineConfig({
 这将自动：
 
 - 加载你的 `rslib.config.ts` 文件
-- 将兼容的 Rslib 选项映射到 Rstest 配置
+- 提取并映射测试相关的 Rslib 选项到 Rstest 配置
 - 与你提供的其他 Rstest 配置合并
+
+适配器不会原样复用整份 Rslib 配置，而是只保留测试运行需要的部分，例如模块解析、代码转换、CSS Modules、装饰器相关配置和 `target`。像 `dev`、`server`、`html` 等未映射字段，以及其他仅用于开发服务器、页面入口或构建产物的配置，会在转换时自动裁剪掉。
 
 默认情况下，适配器使用 `process.cwd()` 来解析 Rslib 配置。如果配置文件在其他目录，可以使用 `cwd` 选项。更多详情请参阅 [API](#api)。
 
@@ -123,6 +125,8 @@ export default defineConfig({
 
 你可以在 Rstest 配置中引用特定的 lib 配置。Rstest 会将 Rslib 的共享配置和具有匹配 `libId` 的 lib 配置调整为 Rstest 格式。
 
+这里也不是直接复用整个 lib 配置。适配器只会提取该 lib 中与测试执行相关的 `source`、`output`、`tools`、`plugins` 和 `resolve` 配置，再与共享配置合并后转换为 Rstest 配置。
+
 ```ts
 // 用于测试 'core' 环境
 export default defineConfig({
@@ -171,6 +175,8 @@ export default defineConfig({
 ## 配置映射
 
 适配器会自动将以下 Rslib 选项映射到 Rstest：
+
+下表中列出的字段会被继承；没有列出的 Rslib 选项默认不会进入 Rstest 配置。这意味着 `dev`、`server`、`html` 等与测试运行无关的配置会被自动忽略。
 
 | Rslib 选项            | Rstest 等效项         | 说明                                                 |
 | --------------------- | --------------------- | ---------------------------------------------------- |


### PR DESCRIPTION
## Summary

### Background
The adapter integration docs implied that Rsbuild and Rslib configs were inherited broadly, but they did not explain that Rstest only keeps the subset needed for test execution.

### Implementation
- Clarified in the Rsbuild and Rslib integration guides that adapters extract test-relevant config instead of reusing the full build config.
- Added explicit examples that sections such as `dev`, `server`, and `html` are pruned automatically.
- Documented adapter-specific behavior such as Rsbuild type-check plugin removal and `libId` subset extraction in Rslib.

### User Impact
Users can understand which adapter config is reused in tests and which build-only settings are ignored.

## Related Links

Docs-only validation: `pnpm format`, `pnpm run lint`, and `pnpm --filter rstest-website build`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
