### PR TITLE
fix(core): guard tinypool send errors on worker shutdown

### DIFF
--- a/packages/core/src/pool/forks.ts
+++ b/packages/core/src/pool/forks.ts
@@ -1,8 +1,9 @@
+import type { ChildProcess } from 'node:child_process';
 import EventEmitter from 'node:events';
 import { fileURLToPath } from 'node:url';
 import { createBirpc } from 'birpc';
 import { dirname, resolve } from 'pathe';
-import { type Options, Tinypool } from 'tinypool';
+import { type Options, Tinypool, type TinypoolWorker } from 'tinypool';
 import type {
   FormattedError,
   RuntimeRPC,
@@ -16,6 +17,7 @@ import { parseWorkerMetaMessage, type WorkerMetaMessage } from './workerMeta';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const patchedWorkerSendSymbol = Symbol('rstestTinypoolProcessSendPatched');
 
 type ForksChannel = {
   onMessage: (callback: (...args: any[]) => void) => void;
@@ -25,6 +27,70 @@ type ForksChannel = {
 type ForksChannelContext = {
   channel: ForksChannel;
   cleanup: () => void;
+};
+
+type TinypoolProcessWorker = TinypoolWorker & {
+  process?: ChildProcess;
+  send: (message: any) => void;
+};
+
+export const isIgnorableTinypoolProcessSendError = (
+  error: unknown,
+  platform: NodeJS.Platform = process.platform,
+): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const errno = error as NodeJS.ErrnoException;
+  if (
+    errno.code === 'ERR_IPC_CHANNEL_CLOSED' ||
+    errno.code === 'EPIPE' ||
+    errno.code === 'ECONNRESET'
+  ) {
+    return true;
+  }
+
+  return platform === 'win32' && error.message.includes('write UNKNOWN');
+};
+
+export const patchTinypoolProcessWorkerSend = (
+  pool: Pick<Tinypool, 'threads'>,
+  platform: NodeJS.Platform = process.platform,
+): void => {
+  const processWorker = pool.threads.find(
+    (worker): worker is TinypoolProcessWorker =>
+      worker.runtime === 'child_process',
+  );
+
+  if (!processWorker) {
+    return;
+  }
+
+  const prototype = Object.getPrototypeOf(
+    processWorker,
+  ) as TinypoolProcessWorker &
+    Partial<Record<typeof patchedWorkerSendSymbol, true>>;
+
+  if (prototype[patchedWorkerSendSymbol]) {
+    return;
+  }
+
+  const originalSend = prototype.send;
+  prototype.send = function patchedSend(
+    this: TinypoolProcessWorker,
+    message: any,
+  ) {
+    try {
+      return originalSend.call(this, message);
+    } catch (error) {
+      if (isIgnorableTinypoolProcessSendError(error, platform)) {
+        return;
+      }
+      throw error;
+    }
+  };
+  prototype[patchedWorkerSendSymbol] = true;
 };
 
 export function createForksChannel(
@@ -104,6 +170,7 @@ export const createForksPool = (poolOptions: {
   };
 
   const pool = new Tinypool(options);
+  patchTinypoolProcessWorkerSend(pool);
   const stderrCapture = createWorkerStderrCapture(pool);
   let nextTaskId = 0;
 

--- a/packages/core/src/pool/forks.ts
+++ b/packages/core/src/pool/forks.ts
@@ -34,24 +34,36 @@ type TinypoolProcessWorker = TinypoolWorker & {
   send: (message: any) => void;
 };
 
+const isWorkerProcessUnavailable = (
+  childProcess?: ChildProcess,
+): childProcess is ChildProcess => {
+  return (
+    !!childProcess &&
+    (childProcess.connected === false ||
+      childProcess.exitCode !== null ||
+      childProcess.killed)
+  );
+};
+
 export const isIgnorableTinypoolProcessSendError = (
   error: unknown,
   platform: NodeJS.Platform = process.platform,
 ): boolean => {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  const errno = error as NodeJS.ErrnoException;
+  const errno = error as NodeJS.ErrnoException | undefined;
+  const message =
+    typeof errno?.message === 'string' ? errno.message : String(error ?? '');
   if (
-    errno.code === 'ERR_IPC_CHANNEL_CLOSED' ||
-    errno.code === 'EPIPE' ||
-    errno.code === 'ECONNRESET'
+    errno?.code === 'ERR_IPC_CHANNEL_CLOSED' ||
+    errno?.code === 'EPIPE' ||
+    errno?.code === 'ECONNRESET'
   ) {
     return true;
   }
 
-  return platform === 'win32' && error.message.includes('write UNKNOWN');
+  return (
+    platform === 'win32' &&
+    (errno?.code === 'UNKNOWN' || message.includes('write UNKNOWN'))
+  );
 };
 
 export const patchTinypoolProcessWorkerSend = (
@@ -81,6 +93,10 @@ export const patchTinypoolProcessWorkerSend = (
     this: TinypoolProcessWorker,
     message: any,
   ) {
+    if (isWorkerProcessUnavailable(this.process)) {
+      return;
+    }
+
     try {
       return originalSend.call(this, message);
     } catch (error) {

--- a/packages/core/tests/pool/forks.test.ts
+++ b/packages/core/tests/pool/forks.test.ts
@@ -1,4 +1,8 @@
-import { createForksChannel } from '../../src/pool/forks';
+import {
+  createForksChannel,
+  isIgnorableTinypoolProcessSendError,
+  patchTinypoolProcessWorkerSend,
+} from '../../src/pool/forks';
 
 describe('createForksChannel', () => {
   it('should disable birpc timeout', () => {
@@ -35,5 +39,72 @@ describe('createForksChannel', () => {
     expect(closeError?.message).toBe(
       '[rstest-pool]: Pending methods while closing rpc',
     );
+  });
+});
+
+describe('isIgnorableTinypoolProcessSendError', () => {
+  it('should ignore Windows write UNKNOWN errors', () => {
+    const error = Object.assign(new Error('write UNKNOWN'), {
+      code: 'UNKNOWN',
+    });
+
+    expect(isIgnorableTinypoolProcessSendError(error, 'win32')).toBe(true);
+  });
+
+  it('should ignore closed IPC channel errors', () => {
+    const error = Object.assign(new Error('Channel closed'), {
+      code: 'ERR_IPC_CHANNEL_CLOSED',
+    });
+
+    expect(isIgnorableTinypoolProcessSendError(error, 'darwin')).toBe(true);
+  });
+
+  it('should not ignore unrelated errors', () => {
+    expect(
+      isIgnorableTinypoolProcessSendError(new Error('boom'), 'win32'),
+    ).toBe(false);
+  });
+});
+
+describe('patchTinypoolProcessWorkerSend', () => {
+  it('should swallow ignorable send errors from child-process workers', () => {
+    const worker = Object.create({
+      send() {
+        throw Object.assign(new Error('write UNKNOWN'), {
+          code: 'UNKNOWN',
+        });
+      },
+    }) as {
+      runtime: string;
+      send: (message: { taskId: number }) => void;
+    };
+    worker.runtime = 'child_process';
+
+    patchTinypoolProcessWorkerSend(
+      {
+        threads: [worker as any],
+      },
+      'win32',
+    );
+
+    expect(() => worker.send({ taskId: 1 })).not.toThrow();
+  });
+
+  it('should preserve non-ignorable send errors', () => {
+    const worker = Object.create({
+      send() {
+        throw new Error('boom');
+      },
+    }) as {
+      runtime: string;
+      send: (message: { taskId: number }) => void;
+    };
+    worker.runtime = 'child_process';
+
+    patchTinypoolProcessWorkerSend({
+      threads: [worker as any],
+    });
+
+    expect(() => worker.send({ taskId: 1 })).toThrow('boom');
   });
 });

--- a/packages/core/tests/pool/forks.test.ts
+++ b/packages/core/tests/pool/forks.test.ts
@@ -59,6 +59,15 @@ describe('isIgnorableTinypoolProcessSendError', () => {
     expect(isIgnorableTinypoolProcessSendError(error, 'darwin')).toBe(true);
   });
 
+  it('should ignore Windows UNKNOWN code errors even without Error instances', () => {
+    const error = {
+      code: 'UNKNOWN',
+      message: 'write UNKNOWN',
+    };
+
+    expect(isIgnorableTinypoolProcessSendError(error, 'win32')).toBe(true);
+  });
+
   it('should not ignore unrelated errors', () => {
     expect(
       isIgnorableTinypoolProcessSendError(new Error('boom'), 'win32'),
@@ -106,5 +115,32 @@ describe('patchTinypoolProcessWorkerSend', () => {
     });
 
     expect(() => worker.send({ taskId: 1 })).toThrow('boom');
+  });
+
+  it('should skip sends for disconnected child-process workers', () => {
+    let called = 0;
+    const worker = Object.create({
+      send() {
+        called += 1;
+      },
+    }) as {
+      process: { connected: boolean; exitCode: null; killed: boolean };
+      runtime: string;
+      send: (message: { taskId: number }) => void;
+    };
+    worker.runtime = 'child_process';
+    worker.process = {
+      connected: false,
+      exitCode: null,
+      killed: false,
+    };
+
+    patchTinypoolProcessWorkerSend({
+      threads: [worker as any],
+    });
+
+    worker.send({ taskId: 1 });
+
+    expect(called).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

### Background
Windows child-process IPC can throw ignorable send errors during worker shutdown, which can surface as flaky tinypool failures instead of normal teardown handling.

### Implementation
- patch tinypool child-process workers in the forks pool to swallow shutdown-time send errors that indicate a closed IPC channel
- limit the guard to known ignorable cases such as `ERR_IPC_CHANNEL_CLOSED`, `EPIPE`, `ECONNRESET`, and Windows `write UNKNOWN`
- add focused unit coverage for the guard and for preserving unrelated send failures

### User Impact
Windows users should stop seeing random test failures caused by ignorable tinypool IPC write errors during worker teardown.

## Related Links

Fixes #1142

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).