### PR TITLE
docs(framework): add more framework guide

### DIFF
--- a/website/docs/en/guide/framework/_meta.json
+++ b/website/docs/en/guide/framework/_meta.json
@@ -1,1 +1,1 @@
-["react", "vue"]
+["react", "vue", "more"]

--- a/website/docs/en/guide/framework/more.mdx
+++ b/website/docs/en/guide/framework/more.mdx
@@ -1,0 +1,46 @@
+---
+description: Rstest is not limited to React and Vue. You can register Rsbuild plugins to enable compilation and testing support for more frameworks.
+---
+
+# More frameworks
+
+This section currently provides full guides for React and Vue, but Rstest's framework support is not limited to those two.
+
+Rstest shares the same plugin system as Rsbuild, so if your framework has an available Rsbuild plugin, you can usually register that plugin in `rstest.config.ts` to enable the framework's compilation support for tests. See [plugins](/config/build/plugins) for how plugin registration works, and browse the [Rsbuild plugin list](https://rsbuild.rs/plugins/list/) for available plugins.
+
+For example, Rsbuild's official plugin list already includes plugins for frameworks such as Preact, Svelte, and Solid, and the community ecosystem also provides plugins for frameworks such as Angular.
+
+## Basic setup
+
+You can usually integrate another framework with this flow:
+
+1. Install the framework's Rsbuild plugin and the framework's own testing utilities.
+2. Register the plugin in `plugins` inside `rstest.config.ts`.
+3. Choose an appropriate `testEnvironment` for the type of test you are running.
+
+- Use `happy-dom` or `jsdom` for component tests that need DOM APIs
+- Use `node` for SSR, utilities, or tests that do not touch the DOM
+
+Here is a minimal configuration example:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { pluginFramework } from 'your-rsbuild-plugin';
+
+export default defineConfig({
+  plugins: [pluginFramework()],
+  testEnvironment: 'happy-dom',
+});
+```
+
+## What else you need
+
+An Rsbuild plugin solves compilation and build integration. The full testing experience usually still depends on the framework's own testing toolchain. In most cases, you should also prepare:
+
+- The framework's recommended component testing utilities
+- Any required setup files
+- Assertion or query tools that fit the framework ecosystem
+
+If your project already uses Rsbuild, Rslib, or one of their adapters, prefer reusing that existing configuration first. That usually lets you inherit plugins, aliases, and other build settings automatically.
+
+If you run into issues while integrating more frameworks, please contact us through [GitHub Issues](https://github.com/web-infra-dev/rstest/issues).

--- a/website/docs/en/guide/framework/more.mdx
+++ b/website/docs/en/guide/framework/more.mdx
@@ -1,10 +1,8 @@
 ---
-description: Rstest is not limited to React and Vue. You can register Rsbuild plugins to enable compilation and testing support for more frameworks.
+description: You can register Rsbuild plugins to enable compilation and testing support for more frameworks.
 ---
 
 # More frameworks
-
-This section currently provides full guides for React and Vue, but Rstest's framework support is not limited to those two.
 
 Rstest shares the same plugin system as Rsbuild, so if your framework has an available Rsbuild plugin, you can usually register that plugin in `rstest.config.ts` to enable the framework's compilation support for tests. See [plugins](/config/build/plugins) for how plugin registration works, and browse the [Rsbuild plugin list](https://rsbuild.rs/plugins/list/) for available plugins.
 

--- a/website/docs/zh/api/runtime-api/rstest/mock-functions.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-functions.mdx
@@ -241,5 +241,5 @@ mockedModule.method.mockReturnValue('mocked');
 
 ## 更多
 
-- [Mock 匹配器](../test-api/expect#mock-matchers)
+- [Mock 匹配器](../test-api/expect#mock-匹配器)
 - [MockInstance API](./mock-instance)

--- a/website/docs/zh/guide/framework/_meta.json
+++ b/website/docs/zh/guide/framework/_meta.json
@@ -1,1 +1,1 @@
-["react", "vue"]
+["react", "vue", "more"]

--- a/website/docs/zh/guide/framework/more.mdx
+++ b/website/docs/zh/guide/framework/more.mdx
@@ -1,0 +1,46 @@
+---
+description: Rstest 不只支持 React 和 Vue。你可以通过注册 Rsbuild 插件，为更多框架启用编译与测试支持。
+---
+
+# 更多框架
+
+本目录当前提供的是 React 和 Vue 的完整示例指南，但 Rstest 的框架支持并不局限于这两者。
+
+Rstest 与 Rsbuild 共享同一套插件系统，因此只要对应框架有可用的 Rsbuild 插件，你通常就可以直接在 `rstest.config.ts` 中注册该插件，为测试启用对应的编译能力。关于插件注册方式，请参阅 [plugins](/config/build/plugins)；可用插件可在 [Rsbuild 插件列表](https://rsbuild.rs/zh/plugins/list/) 中查看。
+
+例如，Rsbuild 官方插件列表中已经包含 Preact、Svelte、Solid 等框架插件，社区生态中也有 Angular 等插件可供使用。
+
+## 基本配置方式
+
+可以按下面的顺序完成接入：
+
+1. 安装目标框架对应的 Rsbuild 插件，以及该框架自己的测试工具。
+2. 在 `rstest.config.ts` 的 `plugins` 中注册该插件。
+3. 根据测试类型选择合适的 `testEnvironment`。
+
+- 组件测试通常使用 `happy-dom` 或 `jsdom`
+- SSR、工具函数或不依赖 DOM 的测试通常使用 `node`
+
+下面是一个最小配置示意：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { pluginFramework } from 'your-rsbuild-plugin';
+
+export default defineConfig({
+  plugins: [pluginFramework()],
+  testEnvironment: 'happy-dom',
+});
+```
+
+## 需要额外准备什么
+
+Rsbuild 插件解决的是框架文件的编译与构建接入，测试体验通常还取决于框架自身的测试工具链。你通常还需要准备：
+
+- 框架推荐的组件测试工具
+- 必要的 setup 文件
+- 与框架生态匹配的断言或查询工具
+
+如果你的项目本身已经在使用 Rsbuild、Rslib 或它们的适配器，也可以优先复用现有配置，这样通常能自动继承插件、别名和其他构建设置。
+
+如果你在接入更多框架时遇到问题，欢迎通过 [GitHub Issues](https://github.com/web-infra-dev/rstest/issues) 与我们联系。

--- a/website/docs/zh/guide/framework/more.mdx
+++ b/website/docs/zh/guide/framework/more.mdx
@@ -1,10 +1,8 @@
 ---
-description: Rstest 不只支持 React 和 Vue。你可以通过注册 Rsbuild 插件，为更多框架启用编译与测试支持。
+description: 你可以通过注册 Rsbuild 插件，为更多框架启用编译与测试支持。
 ---
 
 # 更多框架
-
-本目录当前提供的是 React 和 Vue 的完整示例指南，但 Rstest 的框架支持并不局限于这两者。
 
 Rstest 与 Rsbuild 共享同一套插件系统，因此只要对应框架有可用的 Rsbuild 插件，你通常就可以直接在 `rstest.config.ts` 中注册该插件，为测试启用对应的编译能力。关于插件注册方式，请参阅 [plugins](/config/build/plugins)；可用插件可在 [Rsbuild 插件列表](https://rsbuild.rs/zh/plugins/list/) 中查看。
 


### PR DESCRIPTION
## Summary

### Background

The framework guide only covered React and Vue, which made Rstest's framework support look narrower than it is.

### Implementation

- Added a new "More frameworks" guide in Chinese and English explaining that Rstest can register Rsbuild plugins for additional frameworks.
- Linked readers to the Rsbuild plugin list, added a contact path for integration issues, and exposed the new page in the framework navigation.
- Fixed a Chinese mock-functions doc anchor so the related link resolves correctly.

### User Impact

Users can now discover how to use Rstest with more frameworks and know where to reach out if integration problems appear.

## Validation

- Docs-only change.
- Ran `pnpm --dir website build`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).