### PR TITLE
fix: use web condition names by default in browser-like test environment

### DIFF
--- a/examples/svelte-rsbuild/package.json
+++ b/examples/svelte-rsbuild/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@examples/svelte-rsbuild",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild dev",
+    "preview": "rsbuild preview",
+    "test": "rstest",
+    "test:watch": "rstest --watch"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "2.0.0-rc.1",
+    "@rsbuild/plugin-svelte": "^1.1.1",
+    "@rstest/adapter-rsbuild": "workspace:*",
+    "@rstest/core": "workspace:*",
+    "happy-dom": "^20.8.9",
+    "svelte": "^5.55.2",
+    "typescript": "^6.0.2"
+  }
+}

--- a/examples/svelte-rsbuild/rsbuild.config.ts
+++ b/examples/svelte-rsbuild/rsbuild.config.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@rsbuild/core';
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [pluginSvelte()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+    define: {
+      __APP_VERSION__: JSON.stringify('1.0.0'),
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(dirname, 'src'),
+      '@components': path.resolve(dirname, 'src/components'),
+    },
+  },
+});

--- a/examples/svelte-rsbuild/rstest.config.ts
+++ b/examples/svelte-rsbuild/rstest.config.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
+import { defineConfig } from '@rstest/core';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  extends: withRsbuildConfig({ cwd: dirname }),
+  testEnvironment: 'happy-dom',
+});

--- a/examples/svelte-rsbuild/src/components/Counter.svelte
+++ b/examples/svelte-rsbuild/src/components/Counter.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { getDefaultStep } from '@/utils/step';
+
+export let initialValue = 0;
+export let step = getDefaultStep();
+
+let count = initialValue;
+
+function decrement() {
+  count -= step;
+}
+
+function increment() {
+  count += step;
+}
+
+function reset() {
+  count = initialValue;
+}
+</script>
+
+<div data-testid="counter">
+  <button type="button" on:click={decrement} data-testid="decrement-btn">-</button>
+  <span data-testid="counter-value">{count}</span>
+  <button type="button" on:click={increment} data-testid="increment-btn">+</button>
+  <button type="button" on:click={reset} data-testid="reset-btn">Reset</button>
+</div>

--- a/examples/svelte-rsbuild/src/env.d.ts
+++ b/examples/svelte-rsbuild/src/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="@rsbuild/core/types" />
+/// <reference types="svelte" />

--- a/examples/svelte-rsbuild/src/index.ts
+++ b/examples/svelte-rsbuild/src/index.ts
@@ -1,0 +1,15 @@
+import { mount } from 'svelte';
+import Counter from './components/Counter.svelte';
+
+const target =
+  document.getElementById('root') ??
+  document.body.appendChild(document.createElement('div'));
+
+target.id = 'root';
+
+export default mount(Counter, {
+  target,
+  props: {
+    initialValue: 1,
+  },
+});

--- a/examples/svelte-rsbuild/src/utils/step.ts
+++ b/examples/svelte-rsbuild/src/utils/step.ts
@@ -1,0 +1,3 @@
+export function getDefaultStep() {
+  return 1;
+}

--- a/examples/svelte-rsbuild/test/adapter.test.ts
+++ b/examples/svelte-rsbuild/test/adapter.test.ts
@@ -1,0 +1,49 @@
+import Counter from '@components/Counter.svelte';
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
+import { mount, tick, unmount } from 'svelte';
+
+declare const __APP_VERSION__: string;
+
+describe('withRsbuildConfig - pluginSvelte support', () => {
+  let container: HTMLDivElement;
+  let instance: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(async () => {
+    if (instance) {
+      await unmount(instance);
+      instance = undefined;
+    }
+
+    container.remove();
+  });
+
+  it('should resolve @components alias from rsbuild.config.ts', async () => {
+    instance = mount(Counter, {
+      target: container,
+      props: {
+        initialValue: 5,
+      },
+    });
+
+    await tick();
+
+    expect(
+      container.querySelector('[data-testid="counter-value"]')?.textContent,
+    ).toBe('5');
+  });
+
+  it('should resolve @/ alias from rsbuild.config.ts', async () => {
+    const { getDefaultStep } = await import('@/utils/step');
+
+    expect(getDefaultStep()).toBe(1);
+  });
+
+  it('should inherit __APP_VERSION__ from rsbuild.config.ts', () => {
+    expect(__APP_VERSION__).toBe('1.0.0');
+  });
+});

--- a/examples/svelte-rsbuild/test/counter.test.ts
+++ b/examples/svelte-rsbuild/test/counter.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
+import { mount, tick, unmount } from 'svelte';
+import Counter from '../src/components/Counter.svelte';
+
+describe('pluginSvelte - component rendering', () => {
+  let container: HTMLDivElement;
+  let instance: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(async () => {
+    if (instance) {
+      await unmount(instance);
+      instance = undefined;
+    }
+
+    container.remove();
+  });
+
+  it('should render with initial value', async () => {
+    instance = mount(Counter, {
+      target: container,
+      props: {
+        initialValue: 10,
+      },
+    });
+
+    await tick();
+
+    expect(
+      container.querySelector('[data-testid="counter-value"]')?.textContent,
+    ).toBe('10');
+  });
+
+  it('should increment on button click', async () => {
+    instance = mount(Counter, {
+      target: container,
+    });
+
+    await tick();
+
+    const incrementButton = container.querySelector(
+      '[data-testid="increment-btn"]',
+    ) as HTMLButtonElement;
+    incrementButton.click();
+
+    await tick();
+
+    expect(
+      container.querySelector('[data-testid="counter-value"]')?.textContent,
+    ).toBe('1');
+  });
+});

--- a/examples/svelte-rsbuild/tsconfig.json
+++ b/examples/svelte-rsbuild/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "types": ["@rstest/core"],
+    "paths": {
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"]
+    }
+  },
+  "include": ["src", "test", "rstest.config.ts", "rsbuild.config.ts"]
+}

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -68,9 +68,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
           resolve: {
             // override default resolve conditionNames for browser-like environment, use `browser` field instead of `node` field
             conditionNames:
-              testEnvironment.name === 'node'
-                ? undefined
-                : ['webpack', 'development', 'browser', '...'],
+              testEnvironment.name === 'node' ? undefined : ['browser', '...'],
           },
           output: {
             assetPrefix: '',

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -65,6 +65,13 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
               'import.meta.env': 'process.env',
             },
           },
+          resolve: {
+            // override default resolve conditionNames for web-like environment, use `browser` field instead of `node` field
+            conditionNames:
+              testEnvironment.name === 'node'
+                ? undefined
+                : ['webpack', 'development', 'browser', '...'],
+          },
           output: {
             assetPrefix: '',
             // Pass resources to the worker on demand according to entry

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -66,7 +66,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
             },
           },
           resolve: {
-            // override default resolve conditionNames for web-like environment, use `browser` field instead of `node` field
+            // override default resolve conditionNames for browser-like environment, use `browser` field instead of `node` field
             conditionNames:
               testEnvironment.name === 'node'
                 ? undefined

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -66,7 +66,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
             },
           },
           resolve: {
-            // override default resolve conditionNames for browser-like environment, use `browser` field instead of `node` field
+            // Extend the default resolve conditionNames for browser-like environment, use `browser` field instead of `node` field
             conditionNames:
               testEnvironment.name === 'node' ? undefined : ['browser', '...'],
           },

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -1024,8 +1024,6 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
       },
     },
     "conditionNames": [
-      "webpack",
-      "development",
       "browser",
       "...",
     ],
@@ -2827,8 +2825,6 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
       },
     },
     "conditionNames": [
-      "webpack",
-      "development",
       "browser",
       "...",
     ],

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -1023,6 +1023,12 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
         ],
       },
     },
+    "conditionNames": [
+      "webpack",
+      "development",
+      "browser",
+      "...",
+    ],
     "extensionAlias": {
       ".js": [
         ".js",
@@ -2820,6 +2826,12 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
         ],
       },
     },
+    "conditionNames": [
+      "webpack",
+      "development",
+      "browser",
+      "...",
+    ],
     "extensionAlias": {
       ".js": [
         ".js",

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -458,6 +458,65 @@ describe('prepareRsbuild', () => {
     expect(bundlerConfigs[0]?.resolve?.mainFields).toEqual(['source', 'main']);
   });
 
+  it('should use web conditionNames by default for jsdom environment', async () => {
+    const rsbuildInstance = await prepareRsbuild(
+      {
+        rootPath,
+        normalizedConfig: {
+          root: rootPath,
+          name: 'test',
+          plugins: [],
+          resolve: {},
+          source: {},
+          output: {
+            distPath: {
+              root: TEMP_RSTEST_OUTPUT_DIR,
+            },
+          },
+          tools: {},
+          testEnvironment: {
+            name: 'jsdom',
+          },
+          isolate: true,
+          pool: { type: 'forks' },
+        },
+        projects: [
+          {
+            name: 'test',
+            rootPath,
+            environmentName: 'test',
+            normalizedConfig: {
+              plugins: [],
+              resolve: {},
+              source: {},
+              output: {},
+              tools: {},
+              testEnvironment: {
+                name: 'jsdom',
+              },
+              isolate: true,
+              browser: { enabled: false },
+            },
+          },
+        ],
+      } as unknown as RstestContext,
+      async () => ({}),
+      {},
+      {},
+    );
+
+    const {
+      origin: { bundlerConfigs },
+    } = await rsbuildInstance.inspectConfig();
+
+    expect(bundlerConfigs[0]?.resolve?.conditionNames).toEqual([
+      'webpack',
+      'development',
+      'browser',
+      '...',
+    ]);
+  });
+
   it('should generate rspack config correctly in watch mode', async () => {
     const rsbuildInstance = await prepareRsbuild(
       {

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -510,8 +510,6 @@ describe('prepareRsbuild', () => {
     } = await rsbuildInstance.inspectConfig();
 
     expect(bundlerConfigs[0]?.resolve?.conditionNames).toEqual([
-      'webpack',
-      'development',
       'browser',
       '...',
     ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,6 +806,30 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
+  examples/svelte-rsbuild:
+    devDependencies:
+      '@rsbuild/core':
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@rsbuild/plugin-svelte':
+        specifier: ^1.1.1
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(less@4.6.4)(postcss@8.5.8)(sass@1.97.3)(svelte@5.55.2)(typescript@6.0.2)
+      '@rstest/adapter-rsbuild':
+        specifier: workspace:*
+        version: link:../../packages/adapter-rsbuild
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.8.9
+      svelte:
+        specifier: ^5.55.2
+        version: 5.55.2
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+
   examples/vue:
     dependencies:
       vue:
@@ -2812,6 +2836,14 @@ packages:
       '@rsbuild/core':
         optional: true
 
+  '@rsbuild/plugin-svelte@1.1.1':
+    resolution: {integrity: sha512-maRgnSH/8nAJKl8yhQyf8W07kzz/tOCK8zZLpOIL7dP1j3Pxir7Uiy98ikPq3fWhPIBBtIzpmY8FUaR44t2CJA==}
+    peerDependencies:
+      '@rsbuild/core': ^1.4.0 || ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
   '@rsbuild/plugin-svgr@1.3.1':
     resolution: {integrity: sha512-HQupp4ubDgoPg0VHva68BZKNEb2GM/bZfQP/Pit2tV7vu/SnOO8MZFdiFbjyK/VXCdQktIMbkNREG7xDgpo/ww==}
     peerDependencies:
@@ -3294,6 +3326,11 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -3748,6 +3785,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -3768,6 +3808,10 @@ packages:
 
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  '@typescript-eslint/types@8.58.1':
+    resolution: {integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260408.1':
     resolution: {integrity: sha512-YcPczNLfPDB13eUBYHkTOkL7HyWqqqEhho4eSxhAvigZuxvtHQ1uyILIvLVAwipEVzhJ8QciKmLdLucpfi4XyA==}
@@ -4109,6 +4153,10 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
 
@@ -4136,6 +4184,10 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
@@ -4664,6 +4716,9 @@ packages:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  devalue@5.7.1:
+    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -4846,10 +4901,16 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esrap@2.2.4:
+    resolution: {integrity: sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -5418,6 +5479,9 @@ packages:
     resolution: {integrity: sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==}
     engines: {node: '>=0.10.0'}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -5745,6 +5809,9 @@ packages:
   loader-utils@3.3.1:
     resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
     engines: {node: '>= 12.13.0'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -7297,6 +7364,61 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte-dev-helper@1.1.9:
+    resolution: {integrity: sha512-oU+Xv7Dl4kRU2kdFjsoPLfJfnt5hUhsFUZtuzI3Ku/f2iAFZqBoEuXOqK3N9ngD4dxQOmN4OKWPHVi3NeAeAfQ==}
+
+  svelte-hmr@0.14.12:
+    resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
+    engines: {node: ^12.20 || ^14.13.1 || >= 16}
+    peerDependencies:
+      svelte: '>=3.19.0'
+
+  svelte-loader@3.2.4:
+    resolution: {integrity: sha512-e0HdDnkYH/MDx4/IfTSka5AOFg9yYJcPuoZJB5x0l60fkHjVjNvrrxr+rJegDG9J7ZymmdHt00/hdLw+QF299w==}
+    peerDependencies:
+      svelte: ^3.0.0 || ^4.0.0-next.0 || ^5.0.0-next.1
+
+  svelte-preprocess@6.0.3:
+    resolution: {integrity: sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==}
+    engines: {node: '>= 18.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      postcss: ^7 || ^8
+      postcss-load-config: '>=3'
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: '>=0.55'
+      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.100 || ^5.0.0
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+
+  svelte@5.55.2:
+    resolution: {integrity: sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==}
+    engines: {node: '>=18'}
+
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
@@ -7865,6 +7987,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -9455,6 +9580,25 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
 
+  '@rsbuild/plugin-svelte@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(less@4.6.4)(postcss@8.5.8)(sass@1.97.3)(svelte@5.55.2)(typescript@6.0.2)':
+    dependencies:
+      svelte-loader: 3.2.4(svelte@5.55.2)
+      svelte-preprocess: 6.0.3(@babel/core@7.29.0)(less@4.6.4)(postcss@8.5.8)(sass@1.97.3)(svelte@5.55.2)(typescript@6.0.2)
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+      - svelte
+      - typescript
+
   '@rsbuild/plugin-svgr@1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(typescript@6.0.2)':
     dependencies:
       '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))
@@ -10080,6 +10224,10 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -10307,7 +10455,7 @@ snapshots:
   '@testing-library/jest-dom@6.9.1':
     dependencies:
       '@adobe/css-tools': 4.4.4
-      aria-query: 5.3.0
+      aria-query: 5.3.1
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
@@ -10545,6 +10693,8 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/trusted-types@2.0.7': {}
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -10562,6 +10712,8 @@ snapshots:
   '@types/yargs@17.0.33':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript-eslint/types@8.58.1': {}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260408.1':
     optional: true
@@ -11052,6 +11204,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  aria-query@5.3.1: {}
+
   asn1.js@4.10.1:
     dependencies:
       bn.js: 4.12.2
@@ -11085,6 +11239,8 @@ snapshots:
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   azure-devops-node-api@12.5.0:
     dependencies:
@@ -11646,6 +11802,8 @@ snapshots:
 
   detect-newline@4.0.1: {}
 
+  devalue@5.7.1: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -11844,7 +12002,14 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  esm-env@1.2.2: {}
+
   esprima@4.0.1: {}
+
+  esrap@2.2.4:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@typescript-eslint/types': 8.58.1
 
   esrecurse@4.3.0:
     dependencies:
@@ -12490,6 +12655,10 @@ snapshots:
 
   is-primitive@3.0.1: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -12857,6 +13026,8 @@ snapshots:
       json5: 2.2.3
 
   loader-utils@3.3.1: {}
+
+  locate-character@3.0.0: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -14806,6 +14977,48 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svelte-dev-helper@1.1.9: {}
+
+  svelte-hmr@0.14.12(svelte@5.55.2):
+    dependencies:
+      svelte: 5.55.2
+
+  svelte-loader@3.2.4(svelte@5.55.2):
+    dependencies:
+      loader-utils: 2.0.4
+      svelte: 5.55.2
+      svelte-dev-helper: 1.1.9
+      svelte-hmr: 0.14.12(svelte@5.55.2)
+
+  svelte-preprocess@6.0.3(@babel/core@7.29.0)(less@4.6.4)(postcss@8.5.8)(sass@1.97.3)(svelte@5.55.2)(typescript@6.0.2):
+    dependencies:
+      svelte: 5.55.2
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      less: 4.6.4
+      postcss: 8.5.8
+      sass: 1.97.3
+      typescript: 6.0.2
+
+  svelte@5.55.2:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.7.1
+      esm-env: 1.2.2
+      esrap: 2.2.4
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+
   svg-parser@2.0.4: {}
 
   svgo@3.3.2:
@@ -15346,6 +15559,8 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
+
+  zimmerframe@1.1.4: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Summary

### Background
browser-like test environments were still resolving with node-oriented defaults, which makes browser-field reproduction harder and left this regression without a framework example outside the existing React and Vue samples.

### Implementation
- Update the core Rsbuild plugin to default web-like environments to `['browser', '...']` condition names. (follow https://github.com/web-infra-dev/rspack/blob/7165b2395e37c73732c5ede3664ca382faae13d0/packages/rspack/src/config/defaults.ts#L1104)
- Add an explicit core test for the default jsdom `conditionNames` behavior and refresh the affected snapshots.
- Add a new `examples/svelte-rsbuild` workspace with adapter-based config, minimal Svelte component tests, and lockfile updates.

### User Impact
Web-like projects now resolve browser-targeted exports by default, and the repo includes a Svelte Rsbuild example that reproduces and validates this path.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1151


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).