### PR TITLE
docs: improve markdown reporter docs examples

### DIFF
--- a/website/docs/en/guide/basic/reporters.mdx
+++ b/website/docs/en/guide/basic/reporters.mdx
@@ -326,6 +326,16 @@ The default preset is `normal`, which is tuned for agent workflows:
 - Console output is enabled by default, but limited to keep the report size under control.
 - When the number of failures exceeds `failures.max`, the reporter prints a full failure list with minimal fields (repro / type / message / expected / actual), and only expands full details for the first `failures.max` failures.
 
+The available presets mainly differ in how much detail they keep in failure sections:
+
+| Preset    | Best for                                                   | Failure details                      | Console logs                                                       | Code frames                      |
+| --------- | ---------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------ | -------------------------------- |
+| `normal`  | Default agent workflows                                    | `stack: 'top'`, `failures.max: 50`   | Enabled, capped at 10 logs per test path and 500 chars per entry   | Enabled, 2 lines above and below |
+| `compact` | CI logs, repeated agent loops, token-sensitive runs        | `stack: 'top'`, `failures.max: 20`   | Disabled                                                           | Disabled                         |
+| `full`    | Deep debugging when you want maximum context in one report | `stack: 'full'`, `failures.max: 200` | Enabled, capped at 200 logs per test path and 5000 chars per entry | Enabled, 3 lines above and below |
+
+All presets still keep the same markdown structure. The main difference is how much failure context is expanded by default.
+
 <Tabs defaultValue='rstest.config.ts'>
   <Tab label="CLI">
 ```bash
@@ -343,7 +353,85 @@ export default defineConfig({
   </Tab>
 </Tabs>
 
-You can further tune the output via reporter options:
+The default output always starts with a summary section, then shows test lists when needed, and ends with a failures section.
+
+When all tests pass, the output looks like this:
+
+````md
+# Rstest Test Execution Report
+
+## Summary
+
+```json
+{
+  "status": "pass",
+  "counts": {
+    "testFiles": 2,
+    "failedFiles": 0,
+    "tests": 14,
+    "failedTests": 0,
+    "passedTests": 13,
+    "skippedTests": 1,
+    "todoTests": 0
+  }
+}
+```
+
+## Failures
+
+No test failures reported.
+
+Note: all tests passed. Lists omitted for brevity.
+````
+
+When there are failures, the output keeps the same summary format and adds structured failure details:
+
+````md
+# Rstest Test Execution Report
+
+## Summary
+
+```json
+{
+  "status": "fail",
+  "counts": {
+    "testFiles": 1,
+    "failedFiles": 1,
+    "tests": 1,
+    "failedTests": 1,
+    "passedTests": 0,
+    "skippedTests": 0,
+    "todoTests": 0
+  }
+}
+```
+
+## Failures
+
+### [F01] fixtures/agent-md/index.test.ts :: agent-md > fails with diff
+
+details:
+
+```json
+{
+  "testPath": "fixtures/agent-md/index.test.ts",
+  "fullName": "agent-md > fails with diff",
+  "status": "fail"
+}
+```
+
+diff:
+
+```diff
+- Expected
++ Received
+
+- 3
++ 2
+```
+````
+
+If you want a smaller payload for CI logs or multi-step agent loops, switch to the `compact` preset and lower the failure cap:
 
 ```ts title=rstest.config.ts
 import { defineConfig } from '@rstest/core';
@@ -353,10 +441,9 @@ export default defineConfig({
     [
       'md',
       {
-        preset: 'normal',
-        failures: { max: 50 },
-        stack: 'top',
-        console: { maxLogsPerTestPath: 10, maxCharsPerEntry: 500 },
+        preset: 'compact',
+        failures: { max: 20 },
+        reproduction: 'file+name',
       },
     ],
   ],

--- a/website/docs/en/guide/basic/reporters.mdx
+++ b/website/docs/en/guide/basic/reporters.mdx
@@ -353,13 +353,11 @@ export default defineConfig({
   </Tab>
 </Tabs>
 
-The default output always starts with a summary section, then shows test lists when needed, and ends with a failures section.
+The default output always starts with a report title, then shows a summary section, test lists when needed, and a failures section.
 
-When all tests pass, the output looks like this:
+When all tests pass, an excerpt looks like this:
 
 ````md
-# Rstest Test Execution Report
-
 ## Summary
 
 ```json
@@ -384,11 +382,9 @@ No test failures reported.
 Note: all tests passed. Lists omitted for brevity.
 ````
 
-When there are failures, the output keeps the same summary format and adds structured failure details:
+When there are failures, an excerpt looks like this:
 
 ````md
-# Rstest Test Execution Report
-
 ## Summary
 
 ```json

--- a/website/docs/zh/guide/basic/reporters.mdx
+++ b/website/docs/zh/guide/basic/reporters.mdx
@@ -351,13 +351,11 @@ export default defineConfig({
   </Tab>
 </Tabs>
 
-默认输出总是先给出摘要，然后在需要时列出测试项，最后给出失败信息。
+默认输出总是先给出报告标题，然后是摘要；在需要时列出测试项，最后给出失败信息。
 
-当所有测试都通过时，输出大致如下：
+当所有测试都通过时，输出摘录大致如下：
 
 ````md
-# Rstest Test Execution Report
-
 ## Summary
 
 ```json
@@ -382,11 +380,9 @@ No test failures reported.
 Note: all tests passed. Lists omitted for brevity.
 ````
 
-当存在失败时，输出会保留同样的摘要结构，并附带结构化失败详情：
+当存在失败时，输出摘录大致如下：
 
 ````md
-# Rstest Test Execution Report
-
 ## Summary
 
 ```json

--- a/website/docs/zh/guide/basic/reporters.mdx
+++ b/website/docs/zh/guide/basic/reporters.mdx
@@ -324,6 +324,16 @@ Markdown 报告器会将结果以一份完整的 markdown 文档输出到 stdout
 - console 默认开启，但带有严格的输出上限，避免报告体积失控。
 - 当失败数量超过 `failures.max` 时，会先输出包含最小字段的完整失败列表（repro / type / message / expected / actual），并且只展开前 `failures.max` 个失败的完整详情。
 
+几个 preset 的主要区别，在于失败信息默认会保留多少上下文：
+
+| Preset    | 适用场景                                         | 失败详情                             | Console logs                                         | Code frames           |
+| --------- | ------------------------------------------------ | ------------------------------------ | ---------------------------------------------------- | --------------------- |
+| `normal`  | 默认的 agent 工作流                              | `stack: 'top'`、`failures.max: 50`   | 开启，每个 test path 最多 10 条、每条最多 500 字符   | 开启，默认上下各 2 行 |
+| `compact` | CI 日志、多轮 agent 调用、对 token 更敏感的场景  | `stack: 'top'`、`failures.max: 20`   | 关闭                                                 | 关闭                  |
+| `full`    | 希望一份报告里保留尽可能多调试信息的深度排查场景 | `stack: 'full'`、`failures.max: 200` | 开启，每个 test path 最多 200 条、每条最多 5000 字符 | 开启，默认上下各 3 行 |
+
+这些 preset 不会改变 markdown 的整体结构，主要影响的是失败部分默认展开的上下文多少。
+
 <Tabs defaultValue='rstest.config.ts'>
   <Tab label="CLI">
 ```bash
@@ -341,7 +351,85 @@ export default defineConfig({
   </Tab>
 </Tabs>
 
-你也可以通过 reporter options 进一步调整输出：
+默认输出总是先给出摘要，然后在需要时列出测试项，最后给出失败信息。
+
+当所有测试都通过时，输出大致如下：
+
+````md
+# Rstest Test Execution Report
+
+## Summary
+
+```json
+{
+  "status": "pass",
+  "counts": {
+    "testFiles": 2,
+    "failedFiles": 0,
+    "tests": 14,
+    "failedTests": 0,
+    "passedTests": 13,
+    "skippedTests": 1,
+    "todoTests": 0
+  }
+}
+```
+
+## Failures
+
+No test failures reported.
+
+Note: all tests passed. Lists omitted for brevity.
+````
+
+当存在失败时，输出会保留同样的摘要结构，并附带结构化失败详情：
+
+````md
+# Rstest Test Execution Report
+
+## Summary
+
+```json
+{
+  "status": "fail",
+  "counts": {
+    "testFiles": 1,
+    "failedFiles": 1,
+    "tests": 1,
+    "failedTests": 1,
+    "passedTests": 0,
+    "skippedTests": 0,
+    "todoTests": 0
+  }
+}
+```
+
+## Failures
+
+### [F01] fixtures/agent-md/index.test.ts :: agent-md > fails with diff
+
+details:
+
+```json
+{
+  "testPath": "fixtures/agent-md/index.test.ts",
+  "fullName": "agent-md > fails with diff",
+  "status": "fail"
+}
+```
+
+diff:
+
+```diff
+- Expected
++ Received
+
+- 3
++ 2
+```
+````
+
+如果你希望在 CI 日志或多轮 agent 工作流里进一步压缩输出，可以切到 `compact` preset，并收紧失败详情数量：
 
 ```ts title=rstest.config.ts
 import { defineConfig } from '@rstest/core';
@@ -351,10 +439,9 @@ export default defineConfig({
     [
       'md',
       {
-        preset: 'normal',
-        failures: { max: 50 },
-        stack: 'top',
-        console: { maxLogsPerTestPath: 10, maxCharsPerEntry: 500 },
+        preset: 'compact',
+        failures: { max: 20 },
+        reproduction: 'file+name',
       },
     ],
   ],


### PR DESCRIPTION
## Summary

Improve the `md` reporter documentation examples in both English and Chinese.

## What changed

- add a preset comparison table for `normal`, `compact`, and `full`
- add default output examples for both passing and failing runs
- keep the AI guide unchanged and limit the update to the reporter guide

## Why

The previous section only showed a minimal config snippet and repeated default options. This change makes the reporter output easier to understand by showing what users will actually see and how the presets differ.

## Validation

- `pnpm --dir website build`
