### PR TITLE
fix(coverage): reduce coverage memory usage

### DIFF
--- a/packages/core/src/core/mergeReports.ts
+++ b/packages/core/src/core/mergeReports.ts
@@ -5,6 +5,7 @@ import type { BlobData } from '../reporter/blob';
 import type {
   Duration,
   SnapshotSummary,
+  TestFileCoverageResult,
   TestFileResult,
   TestResult,
 } from '../types';
@@ -114,6 +115,7 @@ export async function mergeReports(
   );
 
   const allResults: TestFileResult[] = [];
+  const allCoverageResults: TestFileCoverageResult[] = [];
   const allTestResults: TestResult[] = [];
   const allDurations: Duration[] = [];
   const shardDurations: { label: string; duration: Duration }[] = [];
@@ -122,6 +124,7 @@ export async function mergeReports(
 
   for (const blob of blobs) {
     allResults.push(...blob.results);
+    allCoverageResults.push(...(blob.coverageResults || blob.results));
     allTestResults.push(...blob.testResults);
     allDurations.push(blob.duration);
     allSnapshotSummaries.push(blob.snapshotSummary);
@@ -204,7 +207,7 @@ export async function mergeReports(
 
     if (coverageProvider) {
       const { generateCoverage } = await import('../coverage/generate');
-      await generateCoverage(context, allResults, coverageProvider);
+      await generateCoverage(context, allCoverageResults, coverageProvider);
     }
   }
 

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -1,7 +1,12 @@
 import { constants as osConstants } from 'node:os';
 import { createCoverageProvider } from '../coverage';
 import { createPool } from '../pool';
-import type { EntryInfo, ProjectEntries, SourceMapInput } from '../types';
+import type {
+  EntryInfo,
+  ProjectEntries,
+  SourceMapInput,
+  TestFileCoverageResult,
+} from '../types';
 import {
   clearScreen,
   color,
@@ -366,6 +371,7 @@ export async function runTests(context: Rstest): Promise<void> {
           });
           if (!success) {
             return {
+              coverageResults: [],
               results: [],
               testResults: [],
               errors,
@@ -407,7 +413,7 @@ export async function runTests(context: Rstest): Promise<void> {
         }
 
         currentEntries.push(...finalEntries);
-        const { results, testResults } = await pool.runTests({
+        const { coverageResults, results, testResults } = await pool.runTests({
           entries: finalEntries,
           getSourceMaps,
           setupEntries,
@@ -417,6 +423,7 @@ export async function runTests(context: Rstest): Promise<void> {
         });
 
         return {
+          coverageResults,
           results,
           testResults,
           assetNames,
@@ -479,6 +486,9 @@ export async function runTests(context: Rstest): Promise<void> {
             };
 
       const results = returns.flatMap((r) => r.results);
+      const coverageResults: TestFileCoverageResult[] = returns.flatMap(
+        (r) => r.coverageResults || [],
+      );
       const testResults = returns.flatMap((r) => r.testResults);
       const errors = returns.flatMap((r) => r.errors || []);
 
@@ -487,6 +497,7 @@ export async function runTests(context: Rstest): Promise<void> {
       // so we should not merge stale browser results into node results
       if (shouldUnifyReporter && browserResult?.results) {
         results.push(...browserResult.results);
+        coverageResults.push(...browserResult.results);
       }
       if (shouldUnifyReporter && browserResult?.testResults) {
         testResults.push(...browserResult.testResults);
@@ -562,6 +573,7 @@ export async function runTests(context: Rstest): Promise<void> {
       for (const reporter of reporters) {
         await reporter.onTestRunEnd?.({
           results: context.reporterResults.results,
+          coverageResults,
           testResults: context.reporterResults.testResults,
           unhandledErrors: errors,
           snapshotSummary: snapshotManager.summary,
@@ -577,7 +589,7 @@ export async function runTests(context: Rstest): Promise<void> {
       if (coverageProvider && (!isFailure || coverage.reportOnFailure)) {
         const { generateCoverage } = await import('../coverage/generate');
 
-        await generateCoverage(context, results, coverageProvider);
+        await generateCoverage(context, coverageResults, coverageProvider);
       }
 
       if (isFailure) {

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -1,7 +1,7 @@
 import type FS from 'node:fs';
 import { normalize } from 'pathe';
 import { glob, isDynamicPattern } from 'tinyglobby';
-import type { RstestContext, TestFileResult } from '../types';
+import type { RstestContext, TestFileCoverageResult } from '../types';
 import type {
   CoverageMap,
   CoverageOptions,
@@ -48,7 +48,7 @@ export const getIncludedFiles = async (
 
 export async function generateCoverage(
   context: RstestContext,
-  results: TestFileResult[],
+  results: TestFileCoverageResult[],
   coverageProvider: CoverageProvider,
 ): Promise<void> {
   const {
@@ -83,28 +83,24 @@ export async function generateCoverage(
         logger.info('Generating coverage for untested files...');
       }, 1000);
 
-      const allFiles = (
-        await Promise.all(
-          projects.map(async (p) => {
-            const includedFiles = await getIncludedFiles(coverage, p.rootPath);
+      const allFiles: string[] = [];
+      for (const p of projects) {
+        const includedFiles = await getIncludedFiles(coverage, p.rootPath);
+        allFiles.push(...includedFiles);
 
-            const uncoveredFiles = includedFiles.filter(
-              (file) => !coveredFilesSet.has(normalize(file)),
-            );
+        const uncoveredFiles = includedFiles.filter(
+          (file) => !coveredFilesSet.has(normalize(file)),
+        );
 
-            if (uncoveredFiles.length) {
-              await generateCoverageForUntestedFiles(
-                p.environmentName,
-                uncoveredFiles,
-                finalCoverageMap,
-                coverageProvider,
-              );
-            }
-
-            return includedFiles;
-          }),
-        )
-      ).flat();
+        if (uncoveredFiles.length) {
+          await generateCoverageForUntestedFiles(
+            p.environmentName,
+            uncoveredFiles,
+            finalCoverageMap,
+            coverageProvider,
+          );
+        }
+      }
 
       clearTimeout(timeoutId);
 
@@ -153,12 +149,16 @@ async function generateCoverageForUntestedFiles(
     return;
   }
 
-  const coverages = await coverageProvider.generateCoverageForUntestedFiles({
-    environmentName,
-    files: uncoveredFiles,
-  });
+  const batchSize = 25;
 
-  coverages.forEach((coverageData) => {
-    coverageMap.addFileCoverage(coverageData);
-  });
+  for (let index = 0; index < uncoveredFiles.length; index += batchSize) {
+    const coverages = await coverageProvider.generateCoverageForUntestedFiles({
+      environmentName,
+      files: uncoveredFiles.slice(index, index + batchSize),
+    });
+
+    coverages.forEach((coverageData) => {
+      coverageMap.addFileCoverage(coverageData);
+    });
+  }
 }

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -10,6 +10,7 @@ import type {
   RuntimeConfig,
   RuntimeRPC,
   TestCaseInfo,
+  TestFileCoverageResult,
   TestFileInfo,
   TestFileResult,
   TestInfo,
@@ -148,6 +149,7 @@ export const createPool = async ({
     updateSnapshot: SnapshotUpdateState;
     project: ProjectContext;
   }) => Promise<{
+    coverageResults: TestFileCoverageResult[];
     results: TestFileResult[];
     testResults: TestResult[];
   }>;
@@ -305,6 +307,7 @@ export const createPool = async ({
       const projectName = project.name;
       const runtimeConfig = getRuntimeConfig(project);
       const setupAssets = setupEntries.flatMap((entry) => entry.files || []);
+      const coverageResults: TestFileCoverageResult[] = [];
 
       const results = await Promise.all(
         entries.map(async (entryInfo, index) => {
@@ -385,6 +388,14 @@ export const createPool = async ({
                 errors: [err],
               } as TestFileResult;
             });
+          if (result.coverage) {
+            coverageResults.push({
+              testPath: result.testPath,
+              project: result.project,
+              coverage: result.coverage,
+            });
+            delete result.coverage;
+          }
           context.stateManager.onTestFileResult(result);
           reporters.map((reporter) => reporter.onTestFileResult?.(result));
           return result;
@@ -399,7 +410,7 @@ export const createPool = async ({
 
       const testResults = results.flatMap((r) => r.results);
 
-      return { results, testResults, project };
+      return { coverageResults, results, testResults, project };
     },
     collectTests: async ({
       entries,

--- a/packages/core/src/reporter/blob.ts
+++ b/packages/core/src/reporter/blob.ts
@@ -5,6 +5,7 @@ import type {
   NormalizedConfig,
   Reporter,
   SnapshotSummary,
+  TestFileCoverageResult,
   TestFileResult,
   TestResult,
   UserConsoleLog,
@@ -15,6 +16,7 @@ export type BlobData = {
   version: string;
   shard?: { index: number; count: number };
   results: TestFileResult[];
+  coverageResults?: TestFileCoverageResult[];
   testResults: TestResult[];
   duration: Duration;
   snapshotSummary: SnapshotSummary;
@@ -50,12 +52,14 @@ export class BlobReporter implements Reporter {
 
   async onTestRunEnd({
     results,
+    coverageResults,
     testResults,
     duration,
     snapshotSummary,
     unhandledErrors,
   }: {
     results: TestFileResult[];
+    coverageResults?: TestFileCoverageResult[];
     testResults: TestResult[];
     duration: Duration;
     snapshotSummary: SnapshotSummary;
@@ -70,6 +74,7 @@ export class BlobReporter implements Reporter {
       version: RSTEST_VERSION,
       shard: shard ? { index: shard.index, count: shard.count } : undefined,
       results,
+      coverageResults,
       testResults,
       duration,
       snapshotSummary,

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -3,6 +3,7 @@ import type { SnapshotSummary } from '@vitest/snapshot';
 import type { Options as WindowRendererOptionsOptions } from '../reporter/windowedRenderer';
 import type {
   TestCaseInfo,
+  TestFileCoverageResult,
   TestFileInfo,
   TestFileResult,
   TestResult,
@@ -215,6 +216,7 @@ export interface Reporter {
    */
   onTestRunEnd?: ({
     results,
+    coverageResults,
     testResults,
     duration,
     getSourcemap,
@@ -222,6 +224,7 @@ export interface Reporter {
     unhandledErrors,
   }: {
     results: TestFileResult[];
+    coverageResults?: TestFileCoverageResult[];
     testResults: TestResult[];
     duration: Duration;
     getSourcemap: GetSourcemap;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -162,6 +162,11 @@ export type TestFileResult = TestResult & {
   coverage?: Record<string, FileCoverageData>;
 };
 
+export type TestFileCoverageResult = Pick<
+  TestFileResult,
+  'testPath' | 'project' | 'coverage'
+>;
+
 export interface UserConsoleLog {
   content: string;
   name: string;

--- a/packages/core/tests/coverage/generate.test.ts
+++ b/packages/core/tests/coverage/generate.test.ts
@@ -1,0 +1,95 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { FileCoverageData } from 'istanbul-lib-coverage';
+import { withDefaultConfig } from '../../src/config';
+import { generateCoverage } from '../../src/coverage/generate';
+import type { RstestContext } from '../../src/types';
+import type { CoverageMap, CoverageProvider } from '../../src/types/coverage';
+
+describe('generateCoverage', () => {
+  it('batches untested files before asking the provider to instrument them', async () => {
+    const rootPath = mkdtempSync(path.join(tmpdir(), 'rstest-coverage-'));
+    const srcDir = path.join(rootPath, 'src');
+    mkdirSync(srcDir, { recursive: true });
+
+    for (let index = 0; index < 55; index++) {
+      writeFileSync(
+        path.join(srcDir, `file-${index}.ts`),
+        `export const value${index} = ${index};\n`,
+      );
+    }
+
+    const defaultCoverage = withDefaultConfig({}).coverage;
+    const batches: number[] = [];
+    const coveredFiles = new Map<string, FileCoverageData>();
+
+    const createCoverageMap = (): CoverageMap =>
+      ({
+        addFileCoverage(coverage: { path: string }) {
+          coveredFiles.set(coverage.path, coverage);
+        },
+        files() {
+          return Array.from(coveredFiles.keys());
+        },
+        filter(predicate: (filePath: string) => boolean) {
+          for (const filePath of Array.from(coveredFiles.keys())) {
+            if (!predicate(filePath)) {
+              coveredFiles.delete(filePath);
+            }
+          }
+        },
+        merge(coverage: Record<string, FileCoverageData>) {
+          Object.entries(coverage).forEach(([filePath, fileCoverage]) => {
+            coveredFiles.set(filePath, fileCoverage);
+          });
+        },
+      }) as CoverageMap;
+
+    const provider = {
+      init: () => {},
+      collect: () => null,
+      cleanup: () => {},
+      createCoverageMap: () => createCoverageMap(),
+      async generateCoverageForUntestedFiles({ files }) {
+        batches.push(files.length);
+        return files.map((file) => ({
+          path: file,
+          statementMap: {},
+          fnMap: {},
+          branchMap: {},
+          s: {},
+          f: {},
+          b: {},
+          all: false,
+          _coverageSchema: 'test',
+          hash: file,
+        }));
+      },
+      async generateReports() {},
+    } satisfies CoverageProvider;
+
+    const context = {
+      rootPath,
+      normalizedConfig: {
+        coverage: {
+          ...defaultCoverage,
+          include: ['src/**/*.ts'],
+        },
+      },
+      projects: [
+        {
+          rootPath,
+          environmentName: 'node',
+        },
+      ],
+    } as RstestContext;
+
+    try {
+      await generateCoverage(context, [], provider);
+      expect(batches).toEqual([25, 25, 5]);
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -7,12 +7,14 @@ import istanbulLibCoverage from 'istanbul-lib-coverage';
 import { createContext } from 'istanbul-lib-report';
 import reports from 'istanbul-reports';
 import {
+  mapWithConcurrency,
   readInitialCoverage,
   registerSourceMapURL,
   transformCoverage,
 } from './utils';
 
 const { createCoverageMap } = istanbulLibCoverage;
+const UNTESTED_FILES_CONCURRENCY = 4;
 
 // Global type declaration for coverage
 declare global {
@@ -44,8 +46,10 @@ export class CoverageProvider implements RstestCoverageProvider {
 
     const { readFile } = await import('node:fs/promises');
 
-    return await Promise.all(
-      files.map(async (file) => {
+    return mapWithConcurrency(
+      files,
+      UNTESTED_FILES_CONCURRENCY,
+      async (file) => {
         try {
           const content = await readFile(file, 'utf-8');
           const { code } = await transformCoverage(
@@ -62,7 +66,7 @@ export class CoverageProvider implements RstestCoverageProvider {
           process.exitCode = 1;
           return undefined;
         }
-      }),
+      },
     ).then((results) => results.filter((r): r is FileCoverageData => !!r));
   }
 

--- a/packages/coverage-istanbul/src/utils.ts
+++ b/packages/coverage-istanbul/src/utils.ts
@@ -2,6 +2,8 @@ import { runInNewContext } from 'node:vm';
 import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage';
 import type { MapStore } from 'istanbul-lib-source-maps';
 
+const SOURCE_MAP_SCAN_CONCURRENCY = 8;
+
 // ATTENTION: when swc-plugin-coverage-instrument version changed, magic value should be updated too
 // https://github.com/kwonoj/swc-plugin-coverage-instrument/blob/63e9d5e16dbe61073c62af4b7dfed3c1779cbafa/spec/util/constants.ts#L1-L2
 const COVERAGE_MAGIC_KEY = '_coverageSchema';
@@ -108,26 +110,48 @@ export function registerSourceMapURL(
   sourcemapUrlCache.set(filename, url);
 }
 
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await mapper(items[currentIndex]!, currentIndex);
+    }
+  };
+
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return results;
+}
+
 export async function transformCoverage(
   coverageMap: CoverageMap,
   sourcemapUrlCache: Map<string, string | undefined>,
 ): Promise<CoverageMap> {
-  await Promise.all(
+  await mapWithConcurrency(
     coverageMap
       .files()
       // process js/cjs/mjs file only
-      .filter((filename) => filename.endsWith('js'))
-      .map(async (filename) => {
-        let url = sourcemapUrlCache.get(filename);
-        if (!url) {
-          const { readFile } = await import('node:fs/promises');
-          url = await readFile(filename, 'utf8').then(
-            (content) => getSourceMappingURL(content),
-            () => undefined,
-          );
-        }
-        sourcemapUrlCache.set(filename, url);
-      }),
+      .filter((filename) => filename.endsWith('js')),
+    SOURCE_MAP_SCAN_CONCURRENCY,
+    async (filename) => {
+      let url = sourcemapUrlCache.get(filename);
+      if (!url) {
+        const { readFile } = await import('node:fs/promises');
+        url = await readFile(filename, 'utf8').then(
+          (content) => getSourceMappingURL(content),
+          () => undefined,
+        );
+      }
+      sourcemapUrlCache.set(filename, url);
+    },
   );
 
   // Call createSourceMapStore as needed


### PR DESCRIPTION
## Summary

### Background

Coverage generation for untested files could spike memory usage by holding too many transformed files and duplicated coverage payloads in memory at once.

### Implementation

- Batch untested-file instrumentation and process project include lists sequentially to avoid full fan-out.
- Cap concurrency for untested-file transforms and source map scans, and split node coverage payloads out of `TestFileResult` before they reach reporters and state caches.
- Thread the separate coverage payloads through blob reports and merge-reports, and add a regression test for batched untested-file coverage generation.

### User Impact

Large coverage runs are less likely to OOM, with no intended behavior change for browser mode or watch mode.

## Related Links

- Fixes #1148

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `pnpm format`
- `pnpm run lint`
- `pnpm run test`
- `cd e2e && pnpm test`
- `pnpm run typecheck` currently fails in `@rstest/browser-ui` because `@rstest/core/browser-runtime` declarations are not resolved.
- `pnpm run build` currently fails in `@rstest/browser-ui` on Node 24 with `process_argv is not defined` inside Rsbuild CLI startup.