### PR TITLE
feat(core): support output.emitAssets

### DIFF
--- a/packages/adapter-rsbuild/README.md
+++ b/packages/adapter-rsbuild/README.md
@@ -18,7 +18,7 @@ import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
 
 export default defineConfig({
   extends: withRsbuildConfig(),
-  // other rstest config options
+  // other Rstest config options
 });
 ```
 

--- a/packages/adapter-rsbuild/src/toRstestConfig.ts
+++ b/packages/adapter-rsbuild/src/toRstestConfig.ts
@@ -31,7 +31,8 @@ export function toRstestConfig({
     : rsbuildConfig;
 
   const { rspack, swc, bundlerChain } = finalBuildConfig.tools || {};
-  const { cssModules, target, module } = finalBuildConfig.output || {};
+  const { cssModules, emitAssets, target, module } =
+    finalBuildConfig.output || {};
   const {
     assetsInclude,
     decorators,
@@ -66,6 +67,7 @@ export function toRstestConfig({
     resolve: finalBuildConfig.resolve,
     output: {
       cssModules,
+      emitAssets,
       module,
     },
     tools: {

--- a/packages/adapter-rsbuild/tests/toRstestConfig.test.ts
+++ b/packages/adapter-rsbuild/tests/toRstestConfig.test.ts
@@ -26,6 +26,9 @@ describe('toRstestConfig', () => {
     },
     environments: {
       test: {
+        output: {
+          emitAssets: false,
+        },
         source: {
           define: {
             'process.env.NODE_ENV': '"test"',
@@ -59,6 +62,7 @@ describe('toRstestConfig', () => {
     });
     expect(config.resolve?.conditionNames).toEqual(['custom', 'import']);
     expect(config.resolve?.mainFields).toEqual(['module', 'main']);
+    expect(config.output?.emitAssets).toBeUndefined();
     expect(config.testEnvironment).toBe('happy-dom');
   });
 
@@ -78,6 +82,7 @@ describe('toRstestConfig', () => {
     });
     expect(config.resolve?.conditionNames).toEqual(['custom', 'import']);
     expect(config.resolve?.mainFields).toEqual(['module', 'main']);
+    expect(config.output?.emitAssets).toBe(false);
   });
 
   it('should map node target to node test environment', () => {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -29,7 +29,7 @@ export type RstestPoolOptions = {
 
 export type RstestOutputConfig = Pick<
   NonNullable<RsbuildConfig['output']>,
-  'cssModules' | 'externals' | 'cleanDistPath' | 'module'
+  'cssModules' | 'emitAssets' | 'externals' | 'cleanDistPath' | 'module'
 > & {
   distPath?: string | { root?: string };
   /**

--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -33,7 +33,7 @@ When you output JavaScript files in ES module format (`output.module: true`), Rs
 - Dependencies imported via `import` syntax will be treated as ES module type externals.
 - Dependencies imported via `require` syntax will be treated as CommonJS externals.
 
-When you import CommonJS modules using the `import` syntax, Rstest will attempt interop handling, allowing you to import CommonJS module exports normally using `import` syntax. The following code works correctly in rstest:
+When you import CommonJS modules using the `import` syntax, Rstest will attempt interop handling, allowing you to import CommonJS module exports normally using `import` syntax. The following code works correctly in Rstest:
 
 ```ts title="cjs-module"
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -158,7 +158,7 @@ Controls whether third-party dependencies from `node_modules` are bundled or ext
 - `true`: Always bundle all third-party dependencies, regardless of test environment.
 - `false`: Always externalize third-party dependencies, regardless of test environment.
 
-When this option is unset, rstest bundles dependencies in browser-like test environments (jsdom, happy-dom, etc.), and externalizes them in the `node` environment.
+When this option is unset, Rstest bundles dependencies in browser-like test environments (jsdom, happy-dom, etc.), and externalizes them in the `node` environment.
 
 :::warning
 This option only applies to non-browser mode. In [browser mode](/guide/browser-testing), all dependencies are always bundled, so `output.bundleDependencies: false` is not supported.
@@ -200,6 +200,23 @@ export default defineConfig({
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 
 For custom CSS Modules configuration.
+
+## output.emitAssets <RsbuildDocBadge path="/config/output/emit-assets" text="output.emitAssets" />
+
+<ApiMeta addedVersion="0.9.7" />
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Controls whether imported static assets such as images, fonts, audio, and video are emitted as build assets during test builds.
+
+Rstest forwards this option to the underlying Rsbuild pipeline and follows the same behavior as Rsbuild. When `output.emitAssets` is `true`, imported asset modules are emitted into the build output file system. When it is `false`, those asset files are not emitted.
+
+In Rstest, emitted assets are written to disk only when [dev.writeToDisk](/config/build/dev#devwritetodisk) is enabled or when you run with DEBUG output enabled. Otherwise, they stay in the temporary in-memory output used by the test build.
+
+This option is mainly useful when you want Rstest to match an existing Rsbuild setup, or when your tests do not need to validate emitted static assets.
+
+If you are already reusing your Rsbuild config through [@rstest/adapter-rsbuild](/guide/integration/rsbuild), `output.emitAssets` is inherited automatically.
 
 ## output.distPath <RsbuildDocBadge path="/config/output/dist-path" text="output.distPath" />
 

--- a/website/docs/en/guide/integration/rsbuild.mdx
+++ b/website/docs/en/guide/integration/rsbuild.mdx
@@ -42,7 +42,7 @@ import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
 
 export default defineConfig({
   extends: withRsbuildConfig(),
-  // Additional rstest-specific configuration
+  // Additional Rstest-specific configuration
 });
 ```
 
@@ -189,6 +189,7 @@ Only the fields listed below are inherited. Rsbuild options that are not listed 
 | `source.tsconfigPath`    | `source.tsconfigPath`    | TypeScript config path               |
 | `resolve`                | `resolve`                | Module resolution                    |
 | `output.cssModules`      | `output.cssModules`      | CSS modules configuration            |
+| `output.emitAssets`      | `output.emitAssets`      | Emit imported static assets to disk  |
 | `output.module`          | `output.module`          | Output module type                   |
 | `tools.rspack`           | `tools.rspack`           | Rspack configuration                 |
 | `tools.swc`              | `tools.swc`              | SWC configuration                    |

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -156,7 +156,7 @@ export default defineConfig({
 - `true`：无论测试环境如何，始终打包所有第三方依赖。
 - `false`：无论测试环境如何，始终外部化第三方依赖。
 
-当未设置该选项时，rstest 会在类浏览器测试环境（jsdom、happy-dom 等）中打包依赖，在 `node` 环境中将其外部化。
+当未设置该选项时，Rstest 会在类浏览器测试环境（jsdom、happy-dom 等）中打包依赖，在 `node` 环境中将其外部化。
 
 :::warning
 此选项仅适用于非浏览器模式。在[浏览器模式](/guide/browser-testing)下，所有依赖始终会被打包，因此不支持 `output.bundleDependencies: false`。
@@ -198,6 +198,23 @@ export default defineConfig({
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 
 用于自定义 CSS Modules 的配置。
+
+## output.emitAssets <RsbuildDocBadge path="/config/output/emit-assets" text="output.emitAssets" />
+
+<ApiMeta addedVersion="0.9.7" />
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+控制在测试构建期间，是否将图片、字体、音频、视频等导入的静态资源作为构建产物输出。
+
+Rstest 会将该选项透传给底层的 Rsbuild 构建流程，因此它的行为与 Rsbuild 保持一致。当 `output.emitAssets` 为 `true` 时，导入的 asset module 会被输出到构建产物文件系统中；当它为 `false` 时，这些静态资源文件不会被输出。
+
+在 Rstest 中，只有当你开启 [dev.writeToDisk](/config/build/dev#devwritetodisk) 或启用 DEBUG 产物输出时，这些资源才会真正写入磁盘。否则它们会保留在测试构建使用的临时内存文件系统里。
+
+当你希望 Rstest 与现有的 Rsbuild 配置保持一致，或者在测试中不需要对静态资源进行验证时，这个选项会比较有用。
+
+如果你已经通过 [@rstest/adapter-rsbuild](/guide/integration/rsbuild) 复用 Rsbuild 配置，`output.emitAssets` 也会被自动继承。
 
 ## output.cleanDistPath <RsbuildDocBadge path="/config/output/clean-dist-path" text="output.cleanDistPath" />
 

--- a/website/docs/zh/guide/integration/rsbuild.mdx
+++ b/website/docs/zh/guide/integration/rsbuild.mdx
@@ -42,7 +42,7 @@ import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
 
 export default defineConfig({
   extends: withRsbuildConfig(),
-  // 额外的 rstest 特定配置
+  // 额外的 Rstest 特定配置
 });
 ```
 
@@ -189,6 +189,7 @@ export default defineConfig({
 | `source.tsconfigPath`    | `source.tsconfigPath`    | TypeScript 配置文件路径                    |
 | `resolve`                | `resolve`                | 模块解析                                   |
 | `output.cssModules`      | `output.cssModules`      | CSS 模块配置                               |
+| `output.emitAssets`      | `output.emitAssets`      | 是否将导入的静态资源输出到磁盘             |
 | `output.module`          | `output.module`          | 输出模块类型                               |
 | `tools.rspack`           | `tools.rspack`           | Rspack 配置                                |
 | `tools.swc`              | `tools.swc`              | SWC 配置                                   |

--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -139,6 +139,7 @@ const BUILD_OVERVIEW_GROUPS: BasicGroup[] = [
       'output.externals',
       'output.bundleDependencies',
       'output.cssModules',
+      'output.emitAssets',
       'output.cleanDistPath',
       'output.distPath',
     ],


### PR DESCRIPTION
## Summary

- support`output.emitAssets` configuration

- support inheriting `output.emitAssets` from Rsbuild into Rstest config


## Related Links

https://rsbuild.rs/config/output/emit-assets


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).