### PR TITLE
fix(coverage): strip coverage from browser results and add explanatory comments

### DIFF
--- a/e2e/browser-mode/coverage.test.ts
+++ b/e2e/browser-mode/coverage.test.ts
@@ -17,6 +17,23 @@ describe('browser mode - coverage', () => {
     expect(cli.stdout.replaceAll(' ', '')).toContain('multiply.ts|0|100|0|0');
   });
 
+  it('should collect and merge coverage from browser + node multiproject', async () => {
+    const { expectExecSuccess, cli } = await runBrowserCli('browser-coverage', {
+      args: ['-c', 'rstest.multiproject.config.mts'],
+    });
+
+    await expectExecSuccess();
+
+    expect(cli.stdout).toMatch(/Coverage enabled with istanbul/);
+
+    // sum.ts covered by browser project, multiply.ts covered by node project
+    // Both should appear in the merged coverage report
+    expect(cli.stdout.replaceAll(' ', '')).toContain('sum.ts|100|100|100|100');
+    expect(cli.stdout.replaceAll(' ', '')).toContain(
+      'multiply.ts|100|100|100|100',
+    );
+  });
+
   it('should collect coverage data successfully without include option', async () => {
     const { expectExecSuccess, cli } = await runBrowserCli('browser-coverage', {
       args: ['-c', 'rstest.noInclude.config.mts'],

--- a/e2e/browser-mode/fixtures/browser-coverage/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-coverage/rstest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
     headless: true,
     port: BROWSER_PORTS['browser-coverage'],
   },
-  include: ['tests/**/*.test.ts'],
+  include: ['tests/*.test.ts'],
   coverage: {
     enabled: true,
     include: ['src/**/*.ts'],

--- a/e2e/browser-mode/fixtures/browser-coverage/rstest.multiproject.config.mts
+++ b/e2e/browser-mode/fixtures/browser-coverage/rstest.multiproject.config.mts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS } from '../ports';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    include: ['src/**/*.ts'],
+  },
+  projects: [
+    {
+      name: 'browser',
+      browser: {
+        enabled: true,
+        provider: 'playwright',
+        headless: true,
+        port: BROWSER_PORTS['browser-coverage-multiproject'],
+      },
+      include: ['tests/sum.test.ts'],
+    },
+    {
+      name: 'node',
+      include: ['tests/node/**/*.test.ts'],
+    },
+  ],
+});

--- a/e2e/browser-mode/fixtures/browser-coverage/tests/node/multiply.test.ts
+++ b/e2e/browser-mode/fixtures/browser-coverage/tests/node/multiply.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from '@rstest/core';
+import { multiply } from '../../src/multiply';
+
+describe('multiply', () => {
+  it('should multiply two numbers', () => {
+    expect(multiply(2, 3)).toBe(6);
+  });
+});

--- a/e2e/browser-mode/fixtures/ports.ts
+++ b/e2e/browser-mode/fixtures/ports.ts
@@ -28,6 +28,7 @@ export const BROWSER_PORTS = {
   reporter: 5220,
   'reporter-watch': 5222,
   'github-actions': 5224,
+  'browser-coverage-multiproject': 5228,
 } as const;
 
 const browserPortValues = Object.values(BROWSER_PORTS);

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -497,7 +497,18 @@ export async function runTests(context: Rstest): Promise<void> {
       // so we should not merge stale browser results into node results
       if (shouldUnifyReporter && browserResult?.results) {
         results.push(...browserResult.results);
-        coverageResults.push(...browserResult.results);
+        // Strip coverage from browser results to avoid memory bloat in reporter/state caches,
+        // same as the node-side pool layer does via `delete result.coverage`
+        for (const r of browserResult.results) {
+          if (r.coverage) {
+            coverageResults.push({
+              testPath: r.testPath,
+              project: r.project,
+              coverage: r.coverage,
+            });
+            delete r.coverage;
+          }
+        }
       }
       if (shouldUnifyReporter && browserResult?.testResults) {
         testResults.push(...browserResult.testResults);

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -83,6 +83,10 @@ export async function generateCoverage(
         logger.info('Generating coverage for untested files...');
       }, 1000);
 
+      // Process projects sequentially to limit peak memory — parallel
+      // instrumentation of untested files across many projects can multiply
+      // the resident set. Sequential processing lets each project's
+      // intermediate data be GC'd before the next one starts.
       const allFiles: string[] = [];
       for (const p of projects) {
         const includedFiles = await getIncludedFiles(coverage, p.rootPath);
@@ -149,6 +153,12 @@ async function generateCoverageForUntestedFiles(
     return;
   }
 
+  /**
+   * Process untested files in batches to bound peak memory — each batch is
+   * instrumented, merged into the coverage map, and then released before the
+   * next batch starts. 25 is an empirical sweet-spot that keeps memory
+   * reasonable without adding noticeable per-batch overhead.
+   */
   const batchSize = 25;
 
   for (let index = 0; index < uncoveredFiles.length; index += batchSize) {


### PR DESCRIPTION
## Summary

### Background

PR #1154 reduced coverage memory usage by stripping coverage data from node test results in the pool layer, but browser results were pushed into the unified reporter path without the same treatment. This left coverage data attached to browser `TestFileResult` objects, causing continued memory bloat in reporter/state caches for mixed browser + node projects.

### Implementation

- Strip `coverage` from browser results in the `shouldUnifyReporter` path (`runTests.ts`), extracting it into `coverageResults` before deleting — matching existing node-side pool behavior.
- Add JSDoc explaining the `batchSize = 25` empirical choice in `generateCoverageForUntestedFiles`.
- Add comment explaining why projects are processed sequentially (memory peak reduction) rather than with `Promise.all`.
- Add e2e test for browser + node multiproject coverage merging, reusing the existing `browser-coverage` fixture with an alternate multiproject config.

### User Impact

Reduced memory usage for browser + node multiproject test runs with coverage enabled.

## Checklist

- [x] Changes follow [Contributing Guide](https://github.com/user/rstest/blob/main/CONTRIBUTING.md)
- [x] Changes have been tested locally (`pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `cd e2e && pnpm test`)