### PR TITLE
fix(watch): track chunk hashes by file path for dynamic import detection

### DIFF
--- a/e2e/watch/fixtures-dynamic/index.test.ts
+++ b/e2e/watch/fixtures-dynamic/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('index', () => {
+  it('should transform late', async () => {
+    const { getLate } = await import('./src/late');
+    expect(getLate()).toBe('LATE');
+  });
+});

--- a/e2e/watch/fixtures-dynamic/other.test.ts
+++ b/e2e/watch/fixtures-dynamic/other.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('other', () => {
+  it('should transform other', async () => {
+    const { getOther } = await import('./src/other');
+    expect(getOther()).toBe('OTHER');
+  });
+});

--- a/e2e/watch/fixtures-dynamic/rstest.config.mts
+++ b/e2e/watch/fixtures-dynamic/rstest.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      watchOptions: {
+        aggregateTimeout: 10,
+      },
+    },
+  },
+});

--- a/e2e/watch/fixtures-dynamic/src/late.ts
+++ b/e2e/watch/fixtures-dynamic/src/late.ts
@@ -1,0 +1,3 @@
+import { transform } from './shared';
+
+export const getLate = () => transform('late');

--- a/e2e/watch/fixtures-dynamic/src/other.ts
+++ b/e2e/watch/fixtures-dynamic/src/other.ts
@@ -1,0 +1,3 @@
+import { transform } from './shared';
+
+export const getOther = () => transform('other');

--- a/e2e/watch/fixtures-dynamic/src/shared.ts
+++ b/e2e/watch/fixtures-dynamic/src/shared.ts
@@ -1,0 +1,1 @@
+export const transform = (value: string) => value.toUpperCase();

--- a/e2e/watch/fixtures/index.test.ts
+++ b/e2e/watch/fixtures/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@rstest/core';
 import { sayHi } from './src/index';
 
 describe('index', () => {
-  it('should test source code correctly', () => {
-    expect(sayHi()).toBe('hi');
+  it('should greet index', () => {
+    expect(sayHi()).toBe('Hello, index!');
   });
 });

--- a/e2e/watch/fixtures/other.test.ts
+++ b/e2e/watch/fixtures/other.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from '@rstest/core';
+import { sayBye } from './src/other';
+
+describe('other', () => {
+  it('should greet other', () => {
+    expect(sayBye()).toBe('Hello, other!');
+  });
+});

--- a/e2e/watch/fixtures/src/index.ts
+++ b/e2e/watch/fixtures/src/index.ts
@@ -1,1 +1,3 @@
-export const sayHi = () => 'hi';
+import { greet } from './shared';
+
+export const sayHi = () => greet('index');

--- a/e2e/watch/fixtures/src/other.ts
+++ b/e2e/watch/fixtures/src/other.ts
@@ -1,0 +1,3 @@
+import { greet } from './shared';
+
+export const sayBye = () => greet('other');

--- a/e2e/watch/fixtures/src/shared.ts
+++ b/e2e/watch/fixtures/src/shared.ts
@@ -1,0 +1,1 @@
+export const greet = (name: string) => `Hello, ${name}!`;

--- a/e2e/watch/index.test.ts
+++ b/e2e/watch/index.test.ts
@@ -12,16 +12,27 @@ rs.setConfig({
 
 const allTestFiles = ['index.test.ts', 'other.test.ts'];
 
+/**
+ * Extract the "Test files to re-run" section from stdout.
+ * Only check this section to avoid false positives from delayed error output
+ * (e.g., GitHub Actions reporter output that arrives after resetStd).
+ */
+const getRerunSection = (stdout: string): string => {
+  const match = stdout.match(/Test files to re-run.*?:\n([\s\S]*?)\n\n/);
+  return match?.[1] ?? '';
+};
+
 const expectRerun = (
   stdout: string,
   expected: string[],
   all = allTestFiles,
 ) => {
+  const rerunSection = getRerunSection(stdout);
   for (const file of expected) {
-    expect(stdout).toMatch(file);
+    expect(rerunSection).toMatch(file);
   }
   for (const file of all.filter((f) => !expected.includes(f))) {
-    expect(stdout).not.toMatch(file);
+    expect(rerunSection).not.toMatch(file);
   }
 };
 

--- a/e2e/watch/index.test.ts
+++ b/e2e/watch/index.test.ts
@@ -10,10 +10,25 @@ rs.setConfig({
   retry: 3,
 });
 
+const allTestFiles = ['index.test.ts', 'other.test.ts'];
+
+const expectRerun = (
+  stdout: string,
+  expected: string[],
+  all = allTestFiles,
+) => {
+  for (const file of expected) {
+    expect(stdout).toMatch(file);
+  }
+  for (const file of all.filter((f) => !expected.includes(f))) {
+    expect(stdout).not.toMatch(file);
+  }
+};
+
 // TODO: The following error occurs only on Windows CI. It should appear in the Rspack version range from 1.5.0 to 1.6.0-beta.0.
 // Error: EBUSY: resource busy or locked, rmdir 'D:\a\rstest\rstest\e2e\watch\fixtures-test-0'
 describe.skipIf(process.platform === 'win32')('watch', () => {
-  it('test files should be ran when create / update / delete', async () => {
+  it('should rerun only affected test files when source changes', async () => {
     const fixturesTargetPath = `${__dirname}/fixtures-test-0${process.env.RSTEST_OUTPUT_MODULE !== 'false' ? '-module' : ''}`;
 
     const { fs } = await prepareFixtures({
@@ -32,47 +47,91 @@ describe.skipIf(process.platform === 'win32')('watch', () => {
       },
     });
 
-    // initial
-    await cli.waitForStdout('Duration');
-    expect(cli.stdout).toMatch('Tests 1 passed');
-    expect(cli.stdout).not.toMatch('Test files to re-run:');
-    expect(cli.stdout).toMatch('Run all tests in project');
-
-    const testFilePath = path.join(fixturesTargetPath, 'bar.test.ts');
-
-    // create
-    cli.resetStd();
-    fs.create(
-      testFilePath,
-      `import { describe, expect, it } from '@rstest/core';
-       describe('bar', () => {
-         it('bar should be to bar', () => {
-           expect('bar').toBe('bar');
-         });
-       });`,
-    );
-
+    // Initial run
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 2 passed');
-    expect(cli.stdout).toMatch(/Test files to re-run.*:\n.*bar\.test\.ts\n\n/);
+    expect(cli.stdout).toMatch('Run all tests in project');
 
-    // update
+    // Modify src/index.ts (leaf): only index.test.ts reruns
     cli.resetStd();
-    fs.update(testFilePath, (content) => {
-      return content.replace("toBe('bar')", "toBe('BAR')");
+    fs.update(path.join(fixturesTargetPath, 'src/index.ts'), (content) => {
+      return content.replace("greet('index')", "greet('INDEX')");
     });
 
     await cli.waitForStdout('Duration');
-    expect(cli.stdout).toMatch('Test Files 1 failed');
-    expect(cli.stdout).toMatch('✗ bar > bar should be to bar');
-    expect(cli.stdout).toMatch(/Test files to re-run.*:\n.*bar\.test\.ts\n\n/);
+    expectRerun(cli.stdout, ['index.test.ts']);
 
-    // delete
+    // Modify src/other.ts (leaf): only other.test.ts reruns
     cli.resetStd();
-    fs.delete(testFilePath);
+    fs.update(path.join(fixturesTargetPath, 'src/other.ts'), (content) => {
+      return content.replace("greet('other')", "greet('OTHER')");
+    });
+
     await cli.waitForStdout('Duration');
-    expect(cli.stdout).toMatch('No test files need re-run.');
-    expect(cli.stdout).toMatch('Test Files 1 passed');
+    expectRerun(cli.stdout, ['other.test.ts']);
+
+    // Modify src/shared.ts (shared): both test files rerun
+    cli.resetStd();
+    fs.update(path.join(fixturesTargetPath, 'src/shared.ts'), () => {
+      return 'export const greet = (name: string) => `Hi, ${name}!`;';
+    });
+
+    await cli.waitForStdout('Duration');
+    expectRerun(cli.stdout, ['index.test.ts', 'other.test.ts']);
+
+    cli.exec.kill();
+  });
+
+  it('should rerun only affected test files with dynamic imports', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures-test-dynamic${process.env.RSTEST_OUTPUT_MODULE !== 'false' ? '-module' : ''}`;
+
+    const { fs } = await prepareFixtures({
+      fixturesPath: `${__dirname}/fixtures-dynamic`,
+      fixturesTargetPath,
+    });
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['watch', '--disableConsoleIntercept'],
+      options: {
+        nodeOptions: {
+          env: { DEBUG: 'rstest' },
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    // Initial run
+    await cli.waitForStdout('Duration');
+    expect(cli.stdout).toMatch('Tests 2 passed');
+    expect(cli.stdout).toMatch('Run all tests in project');
+
+    // Modify src/late.ts (leaf): only index.test.ts reruns
+    cli.resetStd();
+    fs.update(path.join(fixturesTargetPath, 'src/late.ts'), (content) => {
+      return content.replace("transform('late')", "transform('LATE')");
+    });
+
+    await cli.waitForStdout('Duration');
+    expectRerun(cli.stdout, ['index.test.ts']);
+
+    // Modify src/other.ts (leaf): only other.test.ts reruns
+    cli.resetStd();
+    fs.update(path.join(fixturesTargetPath, 'src/other.ts'), (content) => {
+      return content.replace("transform('other')", "transform('OTHER')");
+    });
+
+    await cli.waitForStdout('Duration');
+    expectRerun(cli.stdout, ['other.test.ts']);
+
+    // Modify src/shared.ts (shared): both test files rerun
+    cli.resetStd();
+    fs.update(path.join(fixturesTargetPath, 'src/shared.ts'), () => {
+      return 'export const transform = (value: string) => value.toLowerCase();';
+    });
+
+    await cli.waitForStdout('Duration');
+    expectRerun(cli.stdout, ['index.test.ts', 'other.test.ts']);
 
     cli.exec.kill();
   });

--- a/e2e/watch/restart.test.ts
+++ b/e2e/watch/restart.test.ts
@@ -38,7 +38,7 @@ export default defineConfig({});
 
     // initial run
     await cli.waitForStdout('Duration');
-    expect(cli.stdout).toMatch('Tests 1 passed');
+    expect(cli.stdout).toMatch('Tests 2 passed');
 
     // trigger restart by updating config file
     cli.resetStd();
@@ -46,7 +46,7 @@ export default defineConfig({});
 
     await cli.waitForStdout('restart');
     await cli.waitForStdout('Duration');
-    expect(cli.stdout).toMatch('Tests 1 passed');
+    expect(cli.stdout).toMatch('Tests 2 passed');
 
     // Ensure we kill the entire process tree (important on Windows where child
     // processes may survive and keep the test worker alive).

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -29,7 +29,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 type TestEntryToChunkHashes = {
   name: string;
-  /** key is chunk name, value is chunk hash */
+  /** key is chunk asset file path, value is chunk hash */
   chunks: Record<string, string>;
 }[];
 
@@ -39,7 +39,7 @@ function parseInlineSourceMapStr(code: string) {
     /\/\/# sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,(.+)\s*$/m;
   const match = inlineSourceMapRegex.exec(code);
 
-  if (!match || !match[1]) {
+  if (!match?.[1]) {
     return null;
   }
 
@@ -172,35 +172,52 @@ const calcEntriesToRerun = (
   buildData: {
     entryToChunkHashes?: TestEntryToChunkHashes;
     setupEntryToChunkHashes?: TestEntryToChunkHashes;
+    chunkHashesByFile?: Record<string, string>;
+    runtimeChunkFiles?: string[];
   },
+  outputPath: string,
   runtimeChunkName: string,
   setupEntries: EntryInfo[],
 ): {
   affectedEntries: EntryInfo[];
   deletedEntries: string[];
 } => {
+  const entryByTestPath = new Map(
+    entries.map((entry) => [entry.testPath, entry] as const),
+  );
+  const chunkHashesByFile = new Map(
+    Object.entries(buildData.chunkHashesByFile || {}),
+  );
+  const runtimeChunkFiles = new Set(buildData.runtimeChunkFiles || []);
+
+  for (const chunk of chunks || []) {
+    const isRuntimeChunk =
+      chunk.id === runtimeChunkName || chunk.names?.includes(runtimeChunkName);
+
+    for (const file of chunk.files || []) {
+      const filePath = path.join(outputPath, String(file));
+      chunkHashesByFile.set(filePath, chunk.hash ?? '');
+
+      if (isRuntimeChunk) {
+        runtimeChunkFiles.add(filePath);
+      }
+    }
+  }
+
   const buildChunkHashes = (
     entry: EntryInfo,
     map: Map<string, Record<string, string>>,
   ) => {
-    const validChunks = (entry.chunks || []).filter(
-      (chunk) => chunk !== runtimeChunkName,
+    const chunkHashes = Object.fromEntries(
+      (entry.files || [])
+        .filter((file) => !runtimeChunkFiles.has(file))
+        .map((file) => [file, chunkHashesByFile.get(file) ?? '']),
     );
 
-    validChunks.forEach((chunkName) => {
-      const chunkInfo = chunks?.find((c) =>
-        c.names?.includes(chunkName as string),
-      );
-      if (chunkInfo) {
-        const existing = map.get(entry.testPath) || {};
-        existing[chunkName] = chunkInfo.hash ?? '';
-        map.set(entry.testPath, existing);
-      }
-    });
+    map.set(entry.testPath, chunkHashes);
   };
 
   const processEntryChanges = (
-    _entries: EntryInfo[],
     prevHashes: TestEntryToChunkHashes | undefined,
     currentHashesMap: Map<string, Record<string, string>>,
   ): {
@@ -218,28 +235,28 @@ const calcEntriesToRerun = (
         ...Array.from(prevMap.keys()).filter((name) => !currentNames.has(name)),
       );
 
-      const findAffectedEntry = (testPath: string) => {
-        const currentChunks = currentHashesMap.get(testPath);
+      currentHashesMap.forEach((currentChunks, testPath) => {
         const prevChunks = prevMap.get(testPath);
-
-        if (!currentChunks) return;
 
         if (!prevChunks) {
           affectedPaths.add(testPath);
           return;
         }
 
-        const hasChanges = Object.entries(currentChunks).some(
-          ([chunkName, hash]) => prevChunks[chunkName] !== hash,
+        const currentChunkNames = Object.keys(currentChunks);
+        const prevChunkNames = Object.keys(prevChunks);
+        if (currentChunkNames.length !== prevChunkNames.length) {
+          affectedPaths.add(testPath);
+          return;
+        }
+
+        const hasChanges = currentChunkNames.some(
+          (chunkName) => prevChunks[chunkName] !== currentChunks[chunkName],
         );
 
         if (hasChanges) {
           affectedPaths.add(testPath);
         }
-      };
-
-      currentHashesMap.forEach((_, testPath) => {
-        findAffectedEntry(testPath);
       });
     }
 
@@ -258,11 +275,10 @@ const calcEntriesToRerun = (
     setupEntryToChunkHashesMap.entries(),
   ).map(([name, chunks]) => ({ name, chunks }));
 
-  // apply latest setup entry chunk hashes
   buildData.setupEntryToChunkHashes = setupEntryToChunkHashes;
 
   const entryToChunkHashesMap = new Map<string, Record<string, string>>();
-  (entries || []).forEach((entry) => {
+  entries.forEach((entry) => {
     buildChunkHashes(entry, entryToChunkHashesMap);
   });
 
@@ -270,34 +286,35 @@ const calcEntriesToRerun = (
     entryToChunkHashesMap.entries(),
   ).map(([name, chunks]) => ({ name, chunks }));
 
-  // apply latest entry chunk hashes
   buildData.entryToChunkHashes = entryToChunkHashes;
 
-  const isSetupChanged = () => {
-    const { affectedPaths: affectedSetupPaths, deletedPaths: deletedSetups } =
-      processEntryChanges(
-        setupEntries,
-        previousSetupHashes,
-        setupEntryToChunkHashesMap,
-      );
+  const referencedChunkFiles = new Set<string>();
+  for (const entry of [...setupEntries, ...entries]) {
+    for (const file of entry.files || []) {
+      referencedChunkFiles.add(file);
+    }
+  }
+  buildData.chunkHashesByFile = Object.fromEntries(
+    Array.from(chunkHashesByFile.entries()).filter(([file]) =>
+      referencedChunkFiles.has(file),
+    ),
+  );
+  buildData.runtimeChunkFiles = Array.from(runtimeChunkFiles).filter((file) =>
+    referencedChunkFiles.has(file),
+  );
 
-    const affectedSetups = Array.from(affectedSetupPaths)
-      .map((testPath) => setupEntries.find((e) => e.testPath === testPath))
-      .filter((entry): entry is EntryInfo => entry !== undefined);
+  const { affectedPaths: affectedSetupPaths, deletedPaths: deletedSetups } =
+    processEntryChanges(previousSetupHashes, setupEntryToChunkHashesMap);
 
-    return affectedSetups.length > 0 || deletedSetups.length > 0;
-  };
-
-  if (isSetupChanged()) {
-    // if setup files changed, all test entries are affected
+  if (affectedSetupPaths.size > 0 || deletedSetups.length > 0) {
     return { affectedEntries: entries, deletedEntries: [] };
   }
 
   const { affectedPaths: affectedTestPaths, deletedPaths } =
-    processEntryChanges(entries, previousEntryHashes, entryToChunkHashesMap);
+    processEntryChanges(previousEntryHashes, entryToChunkHashesMap);
 
   const affectedEntries = Array.from(affectedTestPaths)
-    .map((testPath) => entries.find((e) => e.testPath === testPath))
+    .map((testPath) => entryByTestPath.get(testPath))
     .filter((entry): entry is EntryInfo => entry !== undefined);
 
   return { affectedEntries, deletedEntries: deletedPaths };
@@ -437,6 +454,8 @@ export const createRsbuildServer = async ({
     {
       entryToChunkHashes?: TestEntryToChunkHashes;
       setupEntryToChunkHashes?: TestEntryToChunkHashes;
+      chunkHashesByFile?: Record<string, string>;
+      runtimeChunkFiles?: string[];
     }
   > = {};
 
@@ -482,7 +501,6 @@ export const createRsbuildServer = async ({
       assets: true,
       relatedAssets: true,
       cachedAssets: true,
-      // get the compilation time
       chunks: true,
       timings: true,
     });
@@ -563,6 +581,7 @@ export const createRsbuildServer = async ({
           entries,
           chunks,
           buildData[environmentName],
+          outputPath!,
           `${environmentName}-${RUNTIME_CHUNK_NAME}`,
           setupEntries,
         )


### PR DESCRIPTION
## Summary

### Background

In watch mode, changes to files loaded via dynamic import (`await import()`) were not correctly triggering test reruns. The previous implementation tracked chunk hashes by chunk name, but dynamic import chunks may not have stable names.

### Implementation

- Switch from chunk name-based tracking to file path-based tracking in `calcEntriesToRerun`
- Use `entry.files` (from Rsbuild manifest) instead of `entry.chunks` for hash comparison
- Persist `chunkHashesByFile` and `runtimeChunkFiles` in build data for incremental comparison
- Add comprehensive e2e tests with shared dependencies to verify only affected test files rerun

### User Impact

Watch mode now correctly detects changes in dynamic import dependencies and reruns only the affected test files.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).