### PR TITLE
fix(coverage): stream-merge coverage data to reduce memory usage

### DIFF
--- a/e2e/reporter/mergeReports.test.ts
+++ b/e2e/reporter/mergeReports.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
@@ -104,6 +104,12 @@ describe('merge-reports', () => {
       },
     });
     await shard1Success();
+
+    const shard1Blob = JSON.parse(
+      readFileSync(join(blobDir, 'blob-1-2.json'), 'utf-8'),
+    ) as { coverage?: Record<string, unknown>; coverageResults?: unknown[] };
+    expect(shard1Blob.coverage).toBeTruthy();
+    expect(shard1Blob.coverageResults).toBeUndefined();
 
     // Run shard 2/2 with blob reporter + coverage
     const { expectExecSuccess: shard2Success } = await runRstestCli({

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -8,7 +8,9 @@ import type { Rspack } from '@rstest/core';
 import {
   type BrowserTestRunOptions,
   type BrowserTestRunResult,
+  type CoverageMapData,
   color,
+  createCoverageProvider,
   type FormattedError,
   getSetupFiles,
   getTestEntries,
@@ -1781,6 +1783,13 @@ export const runBrowserController = async (
     }
   };
 
+  const coverageConfig = browserProjects.find(
+    (project) => project.normalizedConfig.coverage?.enabled,
+  )?.normalizedConfig.coverage;
+  const coverageProvider = coverageConfig?.enabled
+    ? await createCoverageProvider(coverageConfig, context.rootPath)
+    : null;
+
   const notifyTestRunEnd = async ({
     duration,
     unhandledErrors,
@@ -1798,9 +1807,26 @@ export const runBrowserController = async (
       return;
     }
 
+    // Merge per-file coverage into a single CoverageMapData for reporters
+    let mergedCoverage: CoverageMapData | undefined;
+    if (coverageProvider) {
+      const coverageMap = coverageProvider.createCoverageMap();
+      let hasCoverage = false;
+      for (const result of context.reporterResults.results) {
+        if (result.coverage) {
+          coverageMap.merge(result.coverage);
+          hasCoverage = true;
+        }
+      }
+      if (hasCoverage) {
+        mergedCoverage = coverageMap.toJSON();
+      }
+    }
+
     for (const reporter of context.reporters) {
       await reporter.onTestRunEnd?.({
         results: context.reporterResults.results,
+        coverage: mergedCoverage,
         testResults: context.reporterResults.testResults,
         duration,
         snapshotSummary: context.snapshotManager.summary,

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -11,7 +11,7 @@ import * as rsbuild from '@rsbuild/core';
 // Re-export Rstest type for convenience
 export type { Rstest } from './core/rstest';
 // Coverage support for browser mode
-export { loadCoverageProvider } from './coverage';
+export { createCoverageProvider, loadCoverageProvider } from './coverage';
 // Runtime API
 export { createRstestRuntime } from './runtime/api';
 // Public runtime API (for browser client usage)
@@ -22,6 +22,7 @@ export { setRealTimers } from './runtime/util';
 export type {
   BrowserTestRunOptions,
   BrowserTestRunResult,
+  CoverageMapData,
   DevicePreset,
   FormattedError,
   ListCommandResult,

--- a/packages/core/src/core/mergeReports.ts
+++ b/packages/core/src/core/mergeReports.ts
@@ -3,12 +3,13 @@ import { join, relative } from 'pathe';
 import { createCoverageProvider } from '../coverage';
 import type { BlobData } from '../reporter/blob';
 import type {
+  CoverageMapData,
   Duration,
   SnapshotSummary,
-  TestFileCoverageResult,
   TestFileResult,
   TestResult,
 } from '../types';
+import type { CoverageMap } from '../types/coverage';
 import { color, logger, prettyTime } from '../utils';
 import type { Rstest } from './rstest';
 
@@ -95,6 +96,15 @@ function mergeDurations(durations: Duration[]): Duration {
   return { totalTime, buildTime, testTime };
 }
 
+function mergeBlobCoverage(blob: BlobData, coverageMap: CoverageMap): boolean {
+  if (!blob.coverage) {
+    return false;
+  }
+
+  coverageMap.merge(blob.coverage);
+  return true;
+}
+
 export async function mergeReports(
   context: Rstest,
   options?: {
@@ -108,6 +118,10 @@ export async function mergeReports(
     : join(context.rootPath, DEFAULT_BLOB_DIR);
 
   const blobs = loadBlobFiles(blobDir);
+  const coverageOptions = context.normalizedConfig.coverage;
+  const coverageProvider = coverageOptions.enabled
+    ? await createCoverageProvider(coverageOptions, context.rootPath)
+    : null;
 
   const relativeBlobDir = relative(context.rootPath, blobDir) || '.';
   logger.log(
@@ -115,16 +129,16 @@ export async function mergeReports(
   );
 
   const allResults: TestFileResult[] = [];
-  const allCoverageResults: TestFileCoverageResult[] = [];
   const allTestResults: TestResult[] = [];
   const allDurations: Duration[] = [];
   const shardDurations: { label: string; duration: Duration }[] = [];
   const allSnapshotSummaries: SnapshotSummary[] = [];
   const allUnhandledErrors: Error[] = [];
+  const mergedCoverageMap = coverageProvider?.createCoverageMap();
+  let hasCoverage = false;
 
   for (const blob of blobs) {
     allResults.push(...blob.results);
-    allCoverageResults.push(...(blob.coverageResults || blob.results));
     allTestResults.push(...blob.testResults);
     allDurations.push(blob.duration);
     allSnapshotSummaries.push(blob.snapshotSummary);
@@ -133,6 +147,10 @@ export async function mergeReports(
       ? `Shard ${blob.shard.index}/${blob.shard.count}`
       : 'Shard';
     shardDurations.push({ label: shardLabel, duration: blob.duration });
+
+    if (mergedCoverageMap && mergeBlobCoverage(blob, mergedCoverageMap)) {
+      hasCoverage = true;
+    }
 
     if (blob.unhandledErrors) {
       for (const e of blob.unhandledErrors) {
@@ -154,6 +172,8 @@ export async function mergeReports(
 
   const mergedDuration = mergeDurations(allDurations);
   const mergedSnapshotSummary = mergeSnapshots(allSnapshotSummaries);
+  const mergedCoverage: CoverageMapData | undefined =
+    hasCoverage && mergedCoverageMap ? mergedCoverageMap.toJSON() : undefined;
 
   const hasFailure =
     allResults.some((r) => r.status === 'fail') ||
@@ -188,6 +208,7 @@ export async function mergeReports(
   for (const reporter of context.reporters) {
     await reporter.onTestRunEnd?.({
       results: allResults,
+      coverage: mergedCoverage,
       testResults: allTestResults,
       duration: mergedDuration,
       snapshotSummary: mergedSnapshotSummary,
@@ -198,17 +219,13 @@ export async function mergeReports(
     });
   }
 
-  const { coverage } = context.normalizedConfig;
-  if (coverage.enabled && (!hasFailure || coverage.reportOnFailure)) {
-    const coverageProvider = await createCoverageProvider(
-      coverage,
-      context.rootPath,
-    );
-
-    if (coverageProvider) {
-      const { generateCoverage } = await import('../coverage/generate');
-      await generateCoverage(context, allCoverageResults, coverageProvider);
-    }
+  if (
+    coverageProvider &&
+    mergedCoverageMap &&
+    (!hasFailure || coverageOptions.reportOnFailure)
+  ) {
+    const { generateCoverage } = await import('../coverage/generate');
+    await generateCoverage(context, mergedCoverageMap, coverageProvider);
   }
 
   if (cleanup && existsSync(blobDir)) {

--- a/packages/core/src/core/mergeReports.ts
+++ b/packages/core/src/core/mergeReports.ts
@@ -97,22 +97,12 @@ function mergeDurations(durations: Duration[]): Duration {
 }
 
 function mergeBlobCoverage(blob: BlobData, coverageMap: CoverageMap): boolean {
-  if (blob.coverage) {
-    coverageMap.merge(blob.coverage);
-    return true;
+  if (!blob.coverage) {
+    return false;
   }
 
-  // Fallback: browser-only blobs may not have a top-level `coverage` field
-  // because hostController.ts calls onTestRunEnd without it. Extract coverage
-  // from individual results instead.
-  let found = false;
-  for (const result of blob.results) {
-    if (result.coverage) {
-      coverageMap.merge(result.coverage);
-      found = true;
-    }
-  }
-  return found;
+  coverageMap.merge(blob.coverage);
+  return true;
 }
 
 export async function mergeReports(

--- a/packages/core/src/core/mergeReports.ts
+++ b/packages/core/src/core/mergeReports.ts
@@ -97,12 +97,22 @@ function mergeDurations(durations: Duration[]): Duration {
 }
 
 function mergeBlobCoverage(blob: BlobData, coverageMap: CoverageMap): boolean {
-  if (!blob.coverage) {
-    return false;
+  if (blob.coverage) {
+    coverageMap.merge(blob.coverage);
+    return true;
   }
 
-  coverageMap.merge(blob.coverage);
-  return true;
+  // Fallback: browser-only blobs may not have a top-level `coverage` field
+  // because hostController.ts calls onTestRunEnd without it. Extract coverage
+  // from individual results instead.
+  let found = false;
+  for (const result of blob.results) {
+    if (result.coverage) {
+      coverageMap.merge(result.coverage);
+      found = true;
+    }
+  }
+  return found;
 }
 
 export async function mergeReports(

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -1,12 +1,8 @@
 import { constants as osConstants } from 'node:os';
 import { createCoverageProvider } from '../coverage';
 import { createPool } from '../pool';
-import type {
-  EntryInfo,
-  ProjectEntries,
-  SourceMapInput,
-  TestFileCoverageResult,
-} from '../types';
+import type { EntryInfo, ProjectEntries, SourceMapInput } from '../types';
+import type { CoverageMap } from '../types/coverage';
 import {
   clearScreen,
   color,
@@ -91,12 +87,14 @@ export async function runTests(context: Rstest): Promise<void> {
         context.rootPath,
       );
       if (coverageProvider) {
+        const browserCoverageMap = coverageProvider.createCoverageMap();
+        for (const result of browserResult.results) {
+          if (result.coverage) {
+            browserCoverageMap.merge(result.coverage);
+          }
+        }
         const { generateCoverage } = await import('../coverage/generate');
-        await generateCoverage(
-          context,
-          browserResult.results,
-          coverageProvider,
-        );
+        await generateCoverage(context, browserCoverageMap, coverageProvider);
       }
     }
 
@@ -332,6 +330,10 @@ export async function runTests(context: Rstest): Promise<void> {
     // TODO: this is not the best practice for collecting test files
     context.stateManager.testFiles = isWatchMode ? undefined : entryFiles;
 
+    const mergedCoverageMap: CoverageMap | undefined = coverageProvider
+      ? coverageProvider.createCoverageMap()
+      : undefined;
+
     const returns = await Promise.all(
       projects.map(async (p) => {
         const {
@@ -371,7 +373,6 @@ export async function runTests(context: Rstest): Promise<void> {
           });
           if (!success) {
             return {
-              coverageResults: [],
               results: [],
               testResults: [],
               errors,
@@ -413,17 +414,17 @@ export async function runTests(context: Rstest): Promise<void> {
         }
 
         currentEntries.push(...finalEntries);
-        const { coverageResults, results, testResults } = await pool.runTests({
+        const { results, testResults } = await pool.runTests({
           entries: finalEntries,
           getSourceMaps,
           setupEntries,
           getAssetFiles,
           project: p,
           updateSnapshot: context.snapshotManager.options.updateSnapshot,
+          onCoverageResult: (coverage) => mergedCoverageMap?.merge(coverage),
         });
 
         return {
-          coverageResults,
           results,
           testResults,
           assetNames,
@@ -486,9 +487,6 @@ export async function runTests(context: Rstest): Promise<void> {
             };
 
       const results = returns.flatMap((r) => r.results);
-      const coverageResults: TestFileCoverageResult[] = returns.flatMap(
-        (r) => r.coverageResults || [],
-      );
       const testResults = returns.flatMap((r) => r.testResults);
       const errors = returns.flatMap((r) => r.errors || []);
 
@@ -501,11 +499,7 @@ export async function runTests(context: Rstest): Promise<void> {
         // same as the node-side pool layer does via `delete result.coverage`
         for (const r of browserResult.results) {
           if (r.coverage) {
-            coverageResults.push({
-              testPath: r.testPath,
-              project: r.project,
-              coverage: r.coverage,
-            });
+            mergedCoverageMap?.merge(r.coverage);
             delete r.coverage;
           }
         }
@@ -584,7 +578,7 @@ export async function runTests(context: Rstest): Promise<void> {
       for (const reporter of reporters) {
         await reporter.onTestRunEnd?.({
           results: context.reporterResults.results,
-          coverageResults,
+          coverage: mergedCoverageMap?.toJSON(),
           testResults: context.reporterResults.testResults,
           unhandledErrors: errors,
           snapshotSummary: snapshotManager.summary,
@@ -600,7 +594,7 @@ export async function runTests(context: Rstest): Promise<void> {
       if (coverageProvider && (!isFailure || coverage.reportOnFailure)) {
         const { generateCoverage } = await import('../coverage/generate');
 
-        await generateCoverage(context, coverageResults, coverageProvider);
+        await generateCoverage(context, mergedCoverageMap!, coverageProvider);
       }
 
       if (isFailure) {

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -1,7 +1,7 @@
 import type FS from 'node:fs';
 import { normalize } from 'pathe';
 import { glob, isDynamicPattern } from 'tinyglobby';
-import type { RstestContext, TestFileCoverageResult } from '../types';
+import type { RstestContext } from '../types';
 import type {
   CoverageMap,
   CoverageOptions,
@@ -48,7 +48,7 @@ export const getIncludedFiles = async (
 
 export async function generateCoverage(
   context: RstestContext,
-  results: TestFileCoverageResult[],
+  coverageMap: CoverageMap,
   coverageProvider: CoverageProvider,
 ): Promise<void> {
   const {
@@ -57,14 +57,7 @@ export async function generateCoverage(
     projects,
   } = context;
   try {
-    const finalCoverageMap = coverageProvider.createCoverageMap();
-
-    // Merge coverage data from all test files
-    for (const result of results) {
-      if (result.coverage) {
-        finalCoverageMap.merge(result.coverage);
-      }
-    }
+    const finalCoverageMap = coverageMap;
 
     if (!coverage.allowExternal) {
       finalCoverageMap.filter((filePath) => {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -10,7 +10,6 @@ import type {
   RuntimeConfig,
   RuntimeRPC,
   TestCaseInfo,
-  TestFileCoverageResult,
   TestFileInfo,
   TestFileResult,
   TestInfo,
@@ -148,8 +147,14 @@ export const createPool = async ({
     setupEntries: EntryInfo[];
     updateSnapshot: SnapshotUpdateState;
     project: ProjectContext;
+    /** When provided, coverage data is passed to this callback immediately for caller-owned merging. */
+    onCoverageResult?: (
+      coverage: Record<
+        string,
+        import('istanbul-lib-coverage').FileCoverageData
+      >,
+    ) => void;
   }) => Promise<{
-    coverageResults: TestFileCoverageResult[];
     results: TestFileResult[];
     testResults: TestResult[];
   }>;
@@ -303,11 +308,11 @@ export const createPool = async ({
       setupEntries,
       project,
       updateSnapshot,
+      onCoverageResult,
     }) => {
       const projectName = project.name;
       const runtimeConfig = getRuntimeConfig(project);
       const setupAssets = setupEntries.flatMap((entry) => entry.files || []);
-      const coverageResults: TestFileCoverageResult[] = [];
 
       const results = await Promise.all(
         entries.map(async (entryInfo, index) => {
@@ -389,11 +394,7 @@ export const createPool = async ({
               } as TestFileResult;
             });
           if (result.coverage) {
-            coverageResults.push({
-              testPath: result.testPath,
-              project: result.project,
-              coverage: result.coverage,
-            });
+            onCoverageResult?.(result.coverage);
             delete result.coverage;
           }
           context.stateManager.onTestFileResult(result);
@@ -410,7 +411,7 @@ export const createPool = async ({
 
       const testResults = results.flatMap((r) => r.results);
 
-      return { coverageResults, results, testResults, project };
+      return { results, testResults, project };
     },
     collectTests: async ({
       entries,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import type { SnapshotUpdateState } from '@vitest/snapshot';
 import { basename, dirname, join } from 'pathe';
 import type {
+  CoverageMapData,
   EntryInfo,
   FormattedError,
   ProjectContext,
@@ -148,12 +149,7 @@ export const createPool = async ({
     updateSnapshot: SnapshotUpdateState;
     project: ProjectContext;
     /** When provided, coverage data is passed to this callback immediately for caller-owned merging. */
-    onCoverageResult?: (
-      coverage: Record<
-        string,
-        import('istanbul-lib-coverage').FileCoverageData
-      >,
-    ) => void;
+    onCoverageResult?: (coverage: CoverageMapData) => void;
   }) => Promise<{
     results: TestFileResult[];
     testResults: TestResult[];

--- a/packages/core/src/reporter/blob.ts
+++ b/packages/core/src/reporter/blob.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'pathe';
 import type {
+  CoverageMapData,
   Duration,
   NormalizedConfig,
   Reporter,
   SnapshotSummary,
-  TestFileCoverageResult,
   TestFileResult,
   TestResult,
   UserConsoleLog,
@@ -16,7 +16,7 @@ export type BlobData = {
   version: string;
   shard?: { index: number; count: number };
   results: TestFileResult[];
-  coverageResults?: TestFileCoverageResult[];
+  coverage?: CoverageMapData;
   testResults: TestResult[];
   duration: Duration;
   snapshotSummary: SnapshotSummary;
@@ -52,14 +52,14 @@ export class BlobReporter implements Reporter {
 
   async onTestRunEnd({
     results,
-    coverageResults,
+    coverage,
     testResults,
     duration,
     snapshotSummary,
     unhandledErrors,
   }: {
     results: TestFileResult[];
-    coverageResults?: TestFileCoverageResult[];
+    coverage?: CoverageMapData;
     testResults: TestResult[];
     duration: Duration;
     snapshotSummary: SnapshotSummary;
@@ -74,7 +74,7 @@ export class BlobReporter implements Reporter {
       version: RSTEST_VERSION,
       shard: shard ? { index: shard.index, count: shard.count } : undefined,
       results,
-      coverageResults,
+      coverage,
       testResults,
       duration,
       snapshotSummary,

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -1,9 +1,9 @@
 import type { SourceMapInput } from '@jridgewell/trace-mapping';
 import type { SnapshotSummary } from '@vitest/snapshot';
 import type { Options as WindowRendererOptionsOptions } from '../reporter/windowedRenderer';
+import type { CoverageMapData } from './coverage';
 import type {
   TestCaseInfo,
-  TestFileCoverageResult,
   TestFileInfo,
   TestFileResult,
   TestResult,
@@ -216,7 +216,7 @@ export interface Reporter {
    */
   onTestRunEnd?: ({
     results,
-    coverageResults,
+    coverage,
     testResults,
     duration,
     getSourcemap,
@@ -224,7 +224,7 @@ export interface Reporter {
     unhandledErrors,
   }: {
     results: TestFileResult[];
-    coverageResults?: TestFileCoverageResult[];
+    coverage?: CoverageMapData;
     testResults: TestResult[];
     duration: Duration;
     getSourcemap: GetSourcemap;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -162,11 +162,6 @@ export type TestFileResult = TestResult & {
   coverage?: Record<string, FileCoverageData>;
 };
 
-export type TestFileCoverageResult = Pick<
-  TestFileResult,
-  'testPath' | 'project' | 'coverage'
->;
-
 export interface UserConsoleLog {
   content: string;
   name: string;

--- a/packages/core/tests/coverage/generate.test.ts
+++ b/packages/core/tests/coverage/generate.test.ts
@@ -86,7 +86,7 @@ describe('generateCoverage', () => {
     } as RstestContext;
 
     try {
-      await generateCoverage(context, [], provider);
+      await generateCoverage(context, createCoverageMap(), provider);
       expect(batches).toEqual([25, 25, 5]);
     } finally {
       rmSync(rootPath, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

### Background

When running coverage with large test suites (~1100 files), the main process accumulates all per-file raw coverage data in a `coverageResults[]` array until the run finishes, then merges everything at once. With significant overlap (many tests covering the same source files), this causes O(N) memory growth that leads to OOM crashes. Reported in #1148.

### Implementation

- Add an `onCoverageResult` callback to the pool layer so each worker's coverage is merged into a shared `CoverageMap` immediately and the raw data is discarded via `delete result.coverage`.
- Remove the `coverageResults[]` accumulation from `pool/index.ts` and `runTests.ts`.
- Update `generateCoverage` to accept a pre-merged `CoverageMap` instead of `TestFileCoverageResult[]`.
- Update `mergeReports.ts` (shard/blob path) to incrementally merge `blob.coverage` into a `CoverageMap` instead of collecting raw arrays.
- Update `blob.ts` to serialize/deserialize `coverage: CoverageMapData` instead of `coverageResults: TestFileCoverageResult[]`.
- Add e2e assertion verifying blob files use the new `coverage` field.

### Memory gain

Measured with a synthetic fixture: 200 test files × 50 shared source files (40× overlap per source).

| Metric | Before | After |
|--------|--------|-------|
| Heap after merge | 1896.7 MB | 82–100 MB |
| Reduction | — | ~95% |

The gain scales with overlap — projects where many tests cover the same source files see the largest reduction.

### Real-world scenario benefits

https://github.com/web-infra-dev/rstest/issues/1148#issuecomment-4243594962

<img width="940" height="177" alt="Google Chrome 2026-04-15 15 13 44" src="https://github.com/user-attachments/assets/786c7241-c171-4360-ae48-6a8c1e204efc" />

### User Impact

**Slightly breaking change to the Reporter API contract:**
- `onTestRunEnd` parameter `coverageResults` (`TestFileCoverageResult[]`) → `coverage` (`CoverageMapData`).
- The `TestFileCoverageResult` type is removed.
- Custom reporters that read `coverageResults` need to migrate to `coverage` (a merged Istanbul coverage map in JSON form). Built-in reporters are already updated.

## Related Links

- Fixes #1148

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).