### PR TITLE
fix(core): auto-create default export for factory mock of CJS modules

### DIFF
--- a/e2e/mock/src/defaultImportCjs.ts
+++ b/e2e/mock/src/defaultImportCjs.ts
@@ -1,0 +1,10 @@
+// Uses default import from a CJS module (node:path) for testing factory mock default interop
+import path from 'node:path';
+
+export function getBasename(filePath: string): string {
+  return path.basename(filePath);
+}
+
+export function joinPaths(...paths: string[]): string {
+  return path.join(...paths);
+}

--- a/e2e/mock/tests/defaultInterop.test.ts
+++ b/e2e/mock/tests/defaultInterop.test.ts
@@ -1,5 +1,6 @@
 import { expect, rs, test } from '@rstest/core';
 import increment from 'react';
+import { getBasename, joinPaths } from '../src/defaultImportCjs';
 
 rs.mock('react', () => {
   return {
@@ -7,7 +8,22 @@ rs.mock('react', () => {
   };
 });
 
+// Mock node:path with a factory that has no `default` property.
+// The mock system should auto-create a default export so that
+// `import path from 'node:path'` in the source module works correctly.
+rs.mock('node:path', () => {
+  return {
+    basename: (filePath: string) => `mocked-${filePath.split('/').pop()}`,
+    join: (...paths: string[]) => paths.join('/'),
+  };
+});
+
 test('interop default export', async () => {
   // @ts-expect-error
   expect(increment(1)).toBe(43);
+});
+
+test('interop default export for factory without explicit default', () => {
+  expect(getBasename('/foo/bar/baz.txt')).toBe('mocked-baz.txt');
+  expect(joinPaths('a', 'b', 'c')).toBe('a/b/c');
 });

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -39,6 +39,29 @@ const hasOwn = (target, property) => Object.hasOwn(target, property);
 
 const isPromise = (value) => value instanceof Promise;
 
+/**
+ * Define named exports on __webpack_exports__ from a module object, and
+ * auto-create a `default` export for CJS-style modules that lack one.
+ * This preserves `import foo from 'mod'` behavior for mocked CJS modules.
+ */
+const defineExportsWithCjsInterop = (
+  moduleObj,
+  __webpack_exports__,
+  __webpack_require__,
+) => {
+  __webpack_require__.r(__webpack_exports__);
+  for (const key in moduleObj) {
+    __webpack_require__.d(__webpack_exports__, {
+      [key]: () => moduleObj[key],
+    });
+  }
+  if (!moduleObj.__esModule && !('default' in moduleObj)) {
+    __webpack_require__.d(__webpack_exports__, {
+      default: () => moduleObj,
+    });
+  }
+};
+
 //#region rs.unmock
 __webpack_require__.rstest_unmock = (id) => {
   const originalModuleFactory =
@@ -161,18 +184,11 @@ const getMockImplementation = (mockType = 'mock') => {
           return;
         }
 
-        __webpack_require__.r(__webpack_exports__);
-        for (const key in mockedModule) {
-          __webpack_require__.d(__webpack_exports__, {
-            [key]: () => mockedModule[key],
-          });
-        }
-        // For CJS modules, add default export to preserve default-import behavior
-        if (!isEsModule && !('default' in mockedModule)) {
-          __webpack_require__.d(__webpack_exports__, {
-            default: () => mockedModule,
-          });
-        }
+        defineExportsWithCjsInterop(
+          mockedModule,
+          __webpack_exports__,
+          __webpack_require__,
+        );
       };
 
       __webpack_modules__[id] = finalModFactory;
@@ -202,12 +218,11 @@ const getMockImplementation = (mockType = 'mock') => {
           return;
         }
 
-        __webpack_require__.r(__webpack_exports__);
-        for (const key in res) {
-          __webpack_require__.d(__webpack_exports__, {
-            [key]: () => res[key],
-          });
-        }
+        defineExportsWithCjsInterop(
+          res,
+          __webpack_exports__,
+          __webpack_require__,
+        );
       };
 
       __webpack_modules__[id] = finalModFactory;


### PR DESCRIPTION
## Summary

### Background

When using `rs.mock('mod', () => cjsExports)` with a factory that returns an object without a `default` property (e.g. `memfs`), `import foo from 'mod'` in the source module resolves to `undefined`. The spy/mock-options path already handled this via CJS default interop, but the factory function path did not.

### Implementation

- Extract `defineExportsWithCjsInterop` helper in `mockRuntimeCode.js` that defines named exports and auto-creates a `default` export for non-ESM modules lacking one
- Replace the duplicated export-definition logic in both the spy/mock-options path and the factory function path with the shared helper
- Add test case in `e2e/mock/tests/defaultInterop.test.ts` covering factory mock without explicit `default` property

### User Impact

`rs.mock('fs', () => require('memfs'))` and similar CJS factory mocks now work correctly with default imports.

## Related Links

Fixes #1173

## Checklist

- [x] Changes have been tested locally (`pnpm test` + `pnpm e2e`)