### PR TITLE
ci: add paths filter and concurrency to CI workflows

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,9 +3,19 @@ name: CodSpeed
 on:
   pull_request:
     types: [opened, synchronize]
+    paths:
+      - 'packages/**'
+      - 'benchmarks/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/codspeed.yml'
   push:
     branches:
       - main
+    paths:
+      - 'packages/**'
+      - 'benchmarks/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/codspeed.yml'
   schedule:
     # Run every 6 hours on main to build a continuous baseline for CPU benchmark
     - cron: '0 */6 * * *'
@@ -16,6 +26,10 @@ on:
         description: 'Git ref to benchmark (branch, tag, or SHA). Defaults to the selected branch.'
         required: false
         type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

### Background

CI workflows (CodSpeed benchmarks and tests) run on every PR push regardless of what changed, wasting resources on docs-only PRs. Consecutive pushes also run in parallel, meaning stale runs consume CI minutes unnecessarily.

### Implementation

- Add `paths` filter to CodSpeed workflow so benchmarks only trigger when `packages/**`, `benchmarks/**`, `pnpm-lock.yaml`, or the workflow file itself changes
- Add `concurrency` with `cancel-in-progress` to both `codspeed.yml` and `test.yml` so consecutive pushes to the same PR cancel the previous run (main branch runs are never cancelled)

### User Impact

None — internal CI optimization.