### PR TITLE
chore: replace nano-staged + simple-git-hooks with lefthook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ packages/vscode/*.vsix
 packages/vscode/icon.png
 
 .rstest-temp/
+lefthook-local.yml
 
 # Generated memory benchmark fixture
 benchmarks/fixtures/memory/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,14 +2,18 @@ pre-commit:
   parallel: true
   commands:
     prettier:
-      glob: "!(CLAUDE).{md,mdx,css,less,scss,json,jsonc,json5}"
-      run: pnpm prettier --write {staged_files} && git add {staged_files}
+      glob: "**/*.{md,mdx,css,less,scss,json,jsonc,json5}"
+      exclude: "CLAUDE.md"
+      stage_fixed: true
+      run: pnpm prettier --write {staged_files}
     biome:
-      glob: "*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}"
-      run: pnpm biome check --write {staged_files} && git add {staged_files}
+      glob: "**/*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}"
+      stage_fixed: true
+      run: pnpm biome check --write {staged_files}
     check-dependency-version:
-      glob: "package.json"
-      run: pnpm run check-dependency-version && pnpm prettier --write {staged_files} && git add {staged_files}
+      glob: "**/package.json"
+      stage_fixed: true
+      run: pnpm run check-dependency-version && pnpm prettier --write {staged_files}
     pnpm-dedupe:
       glob: "pnpm-lock.yaml"
       run: pnpm dedupe --check

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  commands:
+    prettier:
+      glob: "!(CLAUDE).{md,mdx,css,less,scss,json,jsonc,json5}"
+      run: pnpm prettier --write {staged_files} && git add {staged_files}
+    biome:
+      glob: "*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}"
+      run: pnpm biome check --write {staged_files} && git add {staged_files}
+    check-dependency-version:
+      glob: "package.json"
+      run: pnpm run check-dependency-version && pnpm prettier --write {staged_files} && git add {staged_files}
+    pnpm-dedupe:
+      glob: "pnpm-lock.yaml"
+      run: pnpm dedupe --check

--- a/package.json
+++ b/package.json
@@ -13,25 +13,11 @@
     "format": "biome check --write && prettier --write '**/*.{md,mdx,css,less,scss,json,jsonc,json5}' && heading-case --write",
     "lint": "biome check . --diagnostic-level=warn && pnpm run check-spell && pnpm lint:type",
     "lint:type": "rslint",
-    "prepare": "simple-git-hooks && pnpm run build",
+    "prepare": "lefthook install && pnpm run build",
     "test": "rstest",
     "test:examples": "pnpm --filter \"@examples/*\" test",
     "test:vscode": "pnpm --filter ./packages/vscode test",
     "typecheck": "pnpm --filter \"!@examples/*\" run typecheck"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "npx nano-staged"
-  },
-  "nano-staged": {
-    "!(CLAUDE).{md,mdx,css,less,scss,json,jsonc,json5}": "prettier --write",
-    "*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}": [
-      "biome check --write"
-    ],
-    "package.json": [
-      "pnpm run check-dependency-version",
-      "prettier --write"
-    ],
-    "pnpm-lock.yaml": "pnpm dedupe --check"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
@@ -45,12 +31,11 @@
     "cspell-ban-words": "^0.0.4",
     "heading-case": "^1.1.0",
     "knip": "^6.4.1",
-    "nano-staged": "^0.9.0",
+    "lefthook": "^1.11.13",
     "path-serializer": "0.6.0",
     "playwright": "^1.59.1",
     "prettier": "^3.8.2",
     "prettier-plugin-packagejson": "^3.0.2",
-    "simple-git-hooks": "^2.13.1",
     "typescript": "^6.0.2"
   },
   "packageManager": "pnpm@10.12.4",
@@ -62,7 +47,7 @@
     "onlyBuiltDependencies": [
       "@biomejs/biome",
       "core-js",
-      "simple-git-hooks"
+      "lefthook"
     ],
     "packageExtensions": {
       "@vue/test-utils": {
@@ -74,8 +59,7 @@
       }
     },
     "ignoredBuiltDependencies": [
-      "@biomejs/biome",
-      "simple-git-hooks"
+      "@biomejs/biome"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,9 +43,9 @@ importers:
       knip:
         specifier: ^6.4.1
         version: 6.4.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
-      nano-staged:
-        specifier: ^0.9.0
-        version: 0.9.0
+      lefthook:
+        specifier: ^1.11.13
+        version: 1.13.6
       path-serializer:
         specifier: 0.6.0
         version: 0.6.0
@@ -58,9 +58,6 @@ importers:
       prettier-plugin-packagejson:
         specifier: ^3.0.2
         version: 3.0.2(prettier@3.8.2)
-      simple-git-hooks:
-        specifier: ^2.13.1
-        version: 2.13.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -5695,6 +5692,60 @@ packages:
   launch-editor@2.13.2:
     resolution: {integrity: sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==}
 
+  lefthook-darwin-arm64@1.13.6:
+    resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.13.6:
+    resolution: {integrity: sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.13.6:
+    resolution: {integrity: sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.13.6:
+    resolution: {integrity: sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.13.6:
+    resolution: {integrity: sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.13.6:
+    resolution: {integrity: sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.13.6:
+    resolution: {integrity: sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.13.6:
+    resolution: {integrity: sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.13.6:
+    resolution: {integrity: sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.13.6:
+    resolution: {integrity: sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.13.6:
+    resolution: {integrity: sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g==}
+    hasBin: true
+
   less-loader@12.3.2:
     resolution: {integrity: sha512-uLV5c702ff2jBvO7qewpkLRzkh/I9QW07ur2NKkv8TVTrtX2lrKjEbEU/LLXAn7cgpCIBbkfyUm4qYXCQs5/+w==}
     engines: {node: '>= 18.12.0'}
@@ -6212,11 +6263,6 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
-  nano-staged@0.9.0:
-    resolution: {integrity: sha512-0JfyX4i0Vp5HhC9RDtJ1kp7psz8CFuS3Gya3Z6WZv//QCwA9dPzi1S803VdR0c0P6R7sSvweZ5mSJmYQ/N+loQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -7150,10 +7196,6 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  simple-git-hooks@2.13.1:
-    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
-    hasBin: true
 
   simple-invariant@2.0.1:
     resolution: {integrity: sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==}
@@ -12938,6 +12980,49 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
+  lefthook-darwin-arm64@1.13.6:
+    optional: true
+
+  lefthook-darwin-x64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-x64@1.13.6:
+    optional: true
+
+  lefthook-linux-arm64@1.13.6:
+    optional: true
+
+  lefthook-linux-x64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-x64@1.13.6:
+    optional: true
+
+  lefthook-windows-arm64@1.13.6:
+    optional: true
+
+  lefthook-windows-x64@1.13.6:
+    optional: true
+
+  lefthook@1.13.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.13.6
+      lefthook-darwin-x64: 1.13.6
+      lefthook-freebsd-arm64: 1.13.6
+      lefthook-freebsd-x64: 1.13.6
+      lefthook-linux-arm64: 1.13.6
+      lefthook-linux-x64: 1.13.6
+      lefthook-openbsd-arm64: 1.13.6
+      lefthook-openbsd-x64: 1.13.6
+      lefthook-windows-arm64: 1.13.6
+      lefthook-windows-x64: 1.13.6
+
   less-loader@12.3.2(@rspack/core@2.0.0-rc.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.106.1):
     dependencies:
       less: 4.6.4
@@ -13709,10 +13794,6 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@0.0.8: {}
-
-  nano-staged@0.9.0:
-    dependencies:
-      picocolors: 1.1.1
 
   nanoid@3.3.11: {}
 
@@ -14754,8 +14835,6 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
     optional: true
-
-  simple-git-hooks@2.13.1: {}
 
   simple-invariant@2.0.1: {}
 


### PR DESCRIPTION
## Summary

### Background

The project uses two separate packages (`simple-git-hooks` + `nano-staged`) for Git hook management and staged file linting. This can be consolidated into a single tool.

### Implementation

- Replace `simple-git-hooks` and `nano-staged` with `lefthook`, reducing two dependencies to one
- Add `lefthook.yml` with equivalent pre-commit commands (prettier, biome, check-dependency-version, pnpm-dedupe) running in parallel
- Update `prepare` script, `pnpm.onlyBuiltDependencies`, and `.gitignore` accordingly

### User Impact

None — internal DX tooling change only.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).