### PR TITLE
feat: provide unique testId via testContext

### DIFF
--- a/e2e/runner/test/async.test.ts
+++ b/e2e/runner/test/async.test.ts
@@ -20,42 +20,49 @@ afterAll(() => {
     'run 2-1',
     'run 3-0',
   ]);
-  expect(runIds).toMatchInlineSnapshot(`
+  const fileHashes = new Set(runIds.map(([id]) => id.split('_')[0]));
+  expect(fileHashes.size).toBe(1);
+
+  const fileHash = [...fileHashes][0]!;
+  expect(fileHash).toMatch(/^[0-9a-f]{10}$/);
+  expect(
+    runIds.map(([id, name]) => [id.slice(fileHash.length), name]),
+  ).toMatchInlineSnapshot(`
     [
       [
-        "419cefd87e_0_0_0",
+        "_0_0_0",
         "0-0",
       ],
       [
-        "419cefd87e_0_0_1_0",
+        "_0_0_1_0",
         "0-1-0",
       ],
       [
-        "419cefd87e_0_0_1_1_0",
+        "_0_0_1_1_0",
         "0-1-1-0",
       ],
       [
-        "419cefd87e_0_0_2_0",
+        "_0_0_2_0",
         "0-2-0",
       ],
       [
-        "419cefd87e_0_0_3",
+        "_0_0_3",
         "0-3",
       ],
       [
-        "419cefd87e_0_1",
+        "_0_1",
         "1",
       ],
       [
-        "419cefd87e_0_2_0_0",
+        "_0_2_0_0",
         "2-0-0",
       ],
       [
-        "419cefd87e_0_2_1",
+        "_0_2_1",
         "2-1",
       ],
       [
-        "419cefd87e_0_3",
+        "_0_3",
         "3",
       ],
     ]

--- a/e2e/runner/test/async.test.ts
+++ b/e2e/runner/test/async.test.ts
@@ -1,7 +1,12 @@
-import { afterAll, describe, expect, it } from '@rstest/core';
+import { afterAll, afterEach, describe, expect, it } from '@rstest/core';
 import { sleep } from '../../scripts/utils';
 
 const logs: string[] = [];
+const runIds: [string, string][] = [];
+
+afterEach(({ task }) => {
+  runIds.push([task.id, task.name]);
+});
 
 afterAll(() => {
   expect(logs).toEqual([
@@ -15,6 +20,46 @@ afterAll(() => {
     'run 2-1',
     'run 3-0',
   ]);
+  expect(runIds).toMatchInlineSnapshot(`
+    [
+      [
+        "419cefd87e_0_0_0",
+        "0-0",
+      ],
+      [
+        "419cefd87e_0_0_1_0",
+        "0-1-0",
+      ],
+      [
+        "419cefd87e_0_0_1_1_0",
+        "0-1-1-0",
+      ],
+      [
+        "419cefd87e_0_0_2_0",
+        "0-2-0",
+      ],
+      [
+        "419cefd87e_0_0_3",
+        "0-3",
+      ],
+      [
+        "419cefd87e_0_1",
+        "1",
+      ],
+      [
+        "419cefd87e_0_2_0_0",
+        "2-0-0",
+      ],
+      [
+        "419cefd87e_0_2_1",
+        "2-1",
+      ],
+      [
+        "419cefd87e_0_3",
+        "3",
+      ],
+    ]
+  `);
 });
 
 describe('should run async suite in the correct order', () => {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -530,7 +530,7 @@ export class TestRunner {
 
     const current = this._test;
 
-    context.task = { name: test.name };
+    context.task = { id: test.testId, name: test.name };
 
     Object.defineProperty(context, 'expect', {
       get: () => {

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -26,7 +26,7 @@ import type {
   TestSuite,
 } from '../../types';
 import { ROOT_SUITE_NAME } from '../../utils/constants';
-import { castArray } from '../../utils/helper';
+import { castArray, generateFilePathHash } from '../../utils/helper';
 import {
   formatName,
   isTemplateStringsArray,
@@ -55,7 +55,7 @@ class RunnerRuntime {
   private currentCollectList: (() => MaybePromise<void>)[] = [];
   private readonly runtimeConfig;
   private readonly project: string;
-  private testId = 1;
+  private readonly fileHash: string;
 
   constructor({
     testPath,
@@ -68,6 +68,7 @@ class RunnerRuntime {
   }) {
     this.project = project;
     this.testPath = testPath;
+    this.fileHash = generateFilePathHash(project, testPath);
     this.runtimeConfig = runtimeConfig;
   }
 
@@ -223,9 +224,29 @@ class RunnerRuntime {
   addTest(
     testInfo: Omit<TestSuite, 'testId'> | Omit<TestCase, 'testId'>,
   ): void {
+    // Compute index-based testId: {fileHash}_{idx0}_{idx1}_...
+    // The internal ROOT_SUITE_NAME uses the fileHash directly so it doesn't
+    // add an extra level to child IDs.
+    const parent =
+      this._currentTest.length > 0
+        ? this._currentTest[this._currentTest.length - 1]
+        : undefined;
+
+    let testId: string;
+    if (testInfo.name === ROOT_SUITE_NAME) {
+      testId = this.fileHash;
+    } else {
+      const childIndex =
+        parent && parent.type === 'suite'
+          ? parent.tests.length
+          : this.tests.length;
+      const parentId = parent?.testId ?? this.fileHash;
+      testId = `${parentId}_${childIndex}`;
+    }
+
     const test = {
       ...testInfo,
-      testId: `${this.testId++}`,
+      testId,
     };
     if (this._currentTest.length === 0) {
       this.tests.push(test);

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -15,6 +15,8 @@ export type TestContext = {
    * Metadata of the current test
    */
   task: {
+    /** A stable, unique identifier for the test */
+    id: string;
     /** Test name provided by user */
     name: string;
     /** Result of the current test, undefined if the test is not run yet */

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -3,6 +3,34 @@ import type { RuntimeConfig, TestResult } from '../types';
 import { TEST_DELIMITER } from './constants';
 import { color } from './logger';
 
+/**
+ * Generate a stable hash for a file path.
+ * Uses FNV-1a to produce a 10-char hex string.
+ */
+export function generateFilePathHash(
+  project: string,
+  testPath: string,
+): string {
+  const str = `${project}\0${testPath}`;
+
+  // FNV-1a 32-bit hash, produce 10 hex chars by combining two rounds
+  let h1 = 0x811c9dc5;
+  let h2 = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h1 ^= str.charCodeAt(i);
+    h1 = Math.imul(h1, 0x01000193);
+  }
+  for (let i = str.length - 1; i >= 0; i--) {
+    h2 ^= str.charCodeAt(i);
+    h2 = Math.imul(h2, 0x01000193);
+  }
+
+  // Combine to get 10 hex chars
+  const hex1 = (h1 >>> 0).toString(16).padStart(8, '0');
+  const hex2 = (h2 >>> 0).toString(16).padStart(8, '0');
+  return (hex1 + hex2).slice(0, 10);
+}
+
 export const formatRootStr = (rootStr: string, root: string): string => {
   return rootStr.includes('<rootDir>')
     ? normalize(rootStr.replace('<rootDir>', normalize(root)))

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -1,5 +1,6 @@
 import { createRuntimeAPI } from '../../src/runtime/runner/runtime';
 import type { RuntimeConfig, TestSuite } from '../../src/types';
+import { generateFilePathHash } from '../../src/utils/helper';
 
 describe('RunnerRuntime', () => {
   it('should add test correctly', async () => {
@@ -32,18 +33,29 @@ describe('RunnerRuntime', () => {
       'test - 2',
     ]);
 
-    expect(tests.map((test) => test.testId)).toMatchInlineSnapshot(`
-      [
-        "1",
-        "5",
-        "6",
-      ]
-    `);
+    const fileHash = generateFilePathHash('rstest', __filename);
+    expect(tests.map((test) => test.testId)).toEqual([
+      `${fileHash}_0`,
+      `${fileHash}_1`,
+      `${fileHash}_2`,
+    ]);
 
     expect((tests[0] as TestSuite).tests.map((test) => test.name)).toEqual([
       'test - 0',
       'test - 1',
     ]);
+
+    // Verify nested testId format: fileHash_suiteIdx_childIdx
+    expect((tests[0] as TestSuite).tests.map((test) => test.testId)).toEqual([
+      `${fileHash}_0_0`,
+      `${fileHash}_0_1`,
+    ]);
+
+    expect(
+      ((tests[0] as TestSuite).tests[1] as TestSuite).tests.map(
+        (test) => test.testId,
+      ),
+    ).toEqual([`${fileHash}_0_1_0`]);
 
     expect(
       ((tests[0] as TestSuite).tests[1] as TestSuite).tests.map(

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -294,6 +294,11 @@ export interface TestContext {
    * Metadata of the current test
    */
   task: {
+    /**
+     * A unique identifier for the test.
+     * The format is `{fileHash}_{suiteIndex}_{testIndex}_...`, for example `419cefd87e_0_0`.
+     */
+    id: string;
     /** Test name provided by user */
     name: string;
     /** Result of the current test, undefined if the test is not run yet */

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -283,6 +283,11 @@ export interface TestContext {
    * Metadata of the current test
    */
   task: {
+    /**
+     * A unique identifier for the test.
+     * The format is `{fileHash}_{suiteIndex}_{testIndex}_...`, for example `419cefd87e_0_0`.
+     */
+    id: string;
     /** Test name provided by user */
     name: string;
     /** Result of the current test, undefined if the test is not run yet */


### PR DESCRIPTION
## Summary

provide unique testId via testContext.

```ts
  it('get task info', ({ task }) => {
    console.log('taskId', task.id);
  });
```

```ts
export interface TestContext {
  /**
   * Metadata of the current test
   */
  task: {
    /**
     * A unique identifier for the test.
     * The format is `{fileHash}_{suiteIndex}_{testIndex}_...`, for example `419cefd87e_0_0`.
     */
    id: string;
    ...
  };
  ...
}
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
