### PR TITLE
fix(core): improve bun compatibility and tty status rendering

### DIFF
--- a/packages/core/licensePlugin.ts
+++ b/packages/core/licensePlugin.ts
@@ -1,4 +1,4 @@
-import WebpackLicensePlugin from 'webpack-license-plugin';
+import type WebpackLicensePlugin from 'webpack-license-plugin';
 
 type PackageLicenseMeta =
   NonNullable<
@@ -9,7 +9,11 @@ type PackageLicenseMeta =
     ? Meta
     : never;
 
-export function licensePlugin() {
+export async function licensePlugin() {
+  const { default: WebpackLicensePlugin } = await import(
+    'webpack-license-plugin'
+  );
+
   const formatLicenseTitle = (packageMeta: PackageLicenseMeta) => {
     const licenseId = packageMeta.license ?? 'undefined';
     const repositoryUrl = packageMeta.repository;

--- a/packages/core/licensePlugin.ts
+++ b/packages/core/licensePlugin.ts
@@ -1,8 +1,9 @@
-import type WebpackLicensePlugin from 'webpack-license-plugin';
+type WebpackLicensePluginCtor =
+  typeof import('webpack-license-plugin')['default'];
 
 type PackageLicenseMeta =
   NonNullable<
-    ConstructorParameters<typeof WebpackLicensePlugin>[0]
+    ConstructorParameters<WebpackLicensePluginCtor>[0]
   > extends Partial<{
     additionalFiles: Record<string, (packages: Array<infer Meta>) => unknown>;
   }>

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -6,6 +6,7 @@ import { licensePlugin } from './licensePlugin';
 import { version } from './package.json';
 
 const isBuildWatch = process.argv.includes('--watch');
+const isLibBuild = process.argv.includes('build');
 
 export default defineConfig({
   lib: [
@@ -102,7 +103,8 @@ export default defineConfig({
                 },
               ],
             }),
-            isBuildWatch ? null : licensePlugin(),
+            // only load & apply licensePlugin in lib build
+            isBuildWatch || !isLibBuild ? null : await licensePlugin(),
             rsdoctorCIPlugin({ reportDir: '.rsdoctor/main' }),
           ].filter(Boolean),
         },

--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -2,7 +2,12 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'pathe';
 import { type Options, Tinypool } from 'tinypool';
 import type { EntryInfo } from '../types';
-import { bgColor, color, getForceColorEnv } from '../utils';
+import {
+  bgColor,
+  color,
+  getForceColorEnv,
+  getWorkerSerialization,
+} from '../utils';
 
 let globalTeardownCallbacks: (() => Promise<void> | void)[] = [];
 
@@ -33,7 +38,7 @@ function createSetupPool() {
     minThreads: 1,
     concurrentTasksPerWorker: 1,
     isolateWorkers: false,
-    serialization: 'advanced',
+    serialization: getWorkerSerialization(),
     env: {
       NODE_ENV: 'test',
       ...getForceColorEnv(),

--- a/packages/core/src/pool/forks.ts
+++ b/packages/core/src/pool/forks.ts
@@ -11,6 +11,7 @@ import type {
   Test,
   TestFileResult,
 } from '../types';
+import { getWorkerSerialization } from '../utils';
 import { createWorkerStderrCapture } from './stderrCapture';
 import { parseWorkerMetaMessage, type WorkerMetaMessage } from './workerMeta';
 
@@ -100,7 +101,7 @@ export const createForksPool = (poolOptions: {
     minThreads,
     concurrentTasksPerWorker: 1,
     isolateWorkers: isolate,
-    serialization: 'advanced',
+    serialization: getWorkerSerialization(),
   };
 
   const pool = new Tinypool(options);

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -64,6 +64,20 @@ export class DefaultReporter implements Reporter {
     this.nonTTYProgressNotifier?.start();
   }
 
+  protected withSuspendedStatusRenderer(fn: () => void): void {
+    if (!this.statusRenderer) {
+      fn();
+      return;
+    }
+
+    this.statusRenderer.suspendWindowOutput();
+    try {
+      fn();
+    } finally {
+      this.statusRenderer.resumeWindowOutput();
+    }
+  }
+
   onTestFileResult(test: TestFileResult): void {
     this.statusRenderer?.onTestFileResult();
     this.nonTTYProgressNotifier?.notifyOutput();
@@ -102,17 +116,7 @@ export class DefaultReporter implements Reporter {
       }
     };
 
-    if (this.statusRenderer) {
-      this.statusRenderer.suspendWindowOutput();
-      try {
-        logResults();
-      } finally {
-        this.statusRenderer.resumeWindowOutput();
-      }
-      return;
-    }
-
-    logResults();
+    this.withSuspendedStatusRenderer(logResults);
   }
 
   onTestCaseResult(): void {
@@ -127,17 +131,9 @@ export class DefaultReporter implements Reporter {
     }
 
     this.nonTTYProgressNotifier?.notifyOutput();
-    if (this.statusRenderer) {
-      this.statusRenderer.suspendWindowOutput();
-      try {
-        logUserConsoleLog(this.rootPath, log);
-      } finally {
-        this.statusRenderer.resumeWindowOutput();
-      }
-      return;
-    }
-
-    logUserConsoleLog(this.rootPath, log);
+    this.withSuspendedStatusRenderer(() => {
+      logUserConsoleLog(this.rootPath, log);
+    });
   }
 
   onExit(): void {

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -103,7 +103,12 @@ export class DefaultReporter implements Reporter {
     };
 
     if (this.statusRenderer) {
-      this.statusRenderer.withWindowHidden(logResults);
+      this.statusRenderer.suspendWindowOutput();
+      try {
+        logResults();
+      } finally {
+        this.statusRenderer.resumeWindowOutput();
+      }
       return;
     }
 
@@ -123,9 +128,12 @@ export class DefaultReporter implements Reporter {
 
     this.nonTTYProgressNotifier?.notifyOutput();
     if (this.statusRenderer) {
-      this.statusRenderer.withWindowHidden(() =>
-        logUserConsoleLog(this.rootPath, log),
-      );
+      this.statusRenderer.suspendWindowOutput();
+      try {
+        logUserConsoleLog(this.rootPath, log);
+      } finally {
+        this.statusRenderer.resumeWindowOutput();
+      }
       return;
     }
 

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -80,25 +80,34 @@ export class DefaultReporter implements Reporter {
     const slowTestThreshold =
       projectConfig?.slowTestThreshold ?? this.config.slowTestThreshold;
 
-    logFileTitle(test, relativePath, false, this.options.showProjectName);
-    // Always display all test cases when running a single test file
-    const showAllCases = this.testState.getTestFiles()?.length === 1;
+    const logResults = () => {
+      logFileTitle(test, relativePath, false, this.options.showProjectName);
+      // Always display all test cases when running a single test file
+      const showAllCases = this.testState.getTestFiles()?.length === 1;
 
-    const hideSkippedTests =
-      projectConfig?.hideSkippedTests ?? this.config.hideSkippedTests;
+      const hideSkippedTests =
+        projectConfig?.hideSkippedTests ?? this.config.hideSkippedTests;
 
-    for (const result of test.results) {
-      const isDisplayed =
-        showAllCases ||
-        result.status === 'fail' ||
-        (result.duration ?? 0) > slowTestThreshold ||
-        (result.retryCount ?? 0) > 0;
-      isDisplayed &&
-        logCase(result, {
-          slowTestThreshold,
-          hideSkippedTests,
-        });
+      for (const result of test.results) {
+        const isDisplayed =
+          showAllCases ||
+          result.status === 'fail' ||
+          (result.duration ?? 0) > slowTestThreshold ||
+          (result.retryCount ?? 0) > 0;
+        isDisplayed &&
+          logCase(result, {
+            slowTestThreshold,
+            hideSkippedTests,
+          });
+      }
+    };
+
+    if (this.statusRenderer) {
+      this.statusRenderer.withWindowHidden(logResults);
+      return;
     }
+
+    logResults();
   }
 
   onTestCaseResult(): void {
@@ -113,6 +122,12 @@ export class DefaultReporter implements Reporter {
     }
 
     this.nonTTYProgressNotifier?.notifyOutput();
+    if (this.statusRenderer) {
+      this.statusRenderer.withWindowHidden(() =>
+        logUserConsoleLog(this.rootPath, log),
+      );
+      return;
+    }
 
     logUserConsoleLog(this.rootPath, log);
   }

--- a/packages/core/src/reporter/statusRenderer.ts
+++ b/packages/core/src/reporter/statusRenderer.ts
@@ -51,6 +51,10 @@ export class StatusRenderer {
     const runningModules = this.testState.getRunningModules();
     const testModules = this.testState.getTestModules();
 
+    if (runningModules.size === 0) {
+      return [];
+    }
+
     // only display running tests if they have been running for more than 2 seconds
     const shouldDisplayRunningTests = (runningTests: TestCaseInfo[]) => {
       return (
@@ -116,5 +120,9 @@ export class StatusRenderer {
   clear(): void {
     this.startTime = undefined;
     this.renderer?.finish();
+  }
+
+  withWindowHidden<T>(action: () => T): T {
+    return this.renderer.withWindowHidden(action);
   }
 }

--- a/packages/core/src/reporter/statusRenderer.ts
+++ b/packages/core/src/reporter/statusRenderer.ts
@@ -106,6 +106,7 @@ export class StatusRenderer {
   }
 
   onTestFileStart(): void {
+    this.renderer.start();
     this.renderer?.schedule();
   }
 

--- a/packages/core/src/reporter/statusRenderer.ts
+++ b/packages/core/src/reporter/statusRenderer.ts
@@ -123,7 +123,11 @@ export class StatusRenderer {
     this.renderer?.finish();
   }
 
-  withWindowHidden<T>(action: () => T): T {
-    return this.renderer.withWindowHidden(action);
+  suspendWindowOutput(): void {
+    this.renderer.suspendWindowOutput();
+  }
+
+  resumeWindowOutput(): void {
+    this.renderer.resumeWindowOutput();
   }
 }

--- a/packages/core/src/reporter/verbose.ts
+++ b/packages/core/src/reporter/verbose.ts
@@ -73,7 +73,12 @@ export class VerboseReporter extends DefaultReporter {
     };
 
     if (this.statusRenderer) {
-      this.statusRenderer.withWindowHidden(logResults);
+      this.statusRenderer.suspendWindowOutput();
+      try {
+        logResults();
+      } finally {
+        this.statusRenderer.resumeWindowOutput();
+      }
       return;
     }
 

--- a/packages/core/src/reporter/verbose.ts
+++ b/packages/core/src/reporter/verbose.ts
@@ -56,13 +56,27 @@ export class VerboseReporter extends DefaultReporter {
     const hideSkippedTests =
       projectConfig?.hideSkippedTests ?? this.config.hideSkippedTests;
 
-    logFileTitle(test, relativePath, true, this.verboseOptions.showProjectName);
+    const logResults = () => {
+      logFileTitle(
+        test,
+        relativePath,
+        true,
+        this.verboseOptions.showProjectName,
+      );
 
-    for (const result of test.results) {
-      logCase(result, {
-        slowTestThreshold,
-        hideSkippedTests,
-      });
+      for (const result of test.results) {
+        logCase(result, {
+          slowTestThreshold,
+          hideSkippedTests,
+        });
+      }
+    };
+
+    if (this.statusRenderer) {
+      this.statusRenderer.withWindowHidden(logResults);
+      return;
     }
+
+    logResults();
   }
 }

--- a/packages/core/src/reporter/verbose.ts
+++ b/packages/core/src/reporter/verbose.ts
@@ -72,16 +72,6 @@ export class VerboseReporter extends DefaultReporter {
       }
     };
 
-    if (this.statusRenderer) {
-      this.statusRenderer.suspendWindowOutput();
-      try {
-        logResults();
-      } finally {
-        this.statusRenderer.resumeWindowOutput();
-      }
-      return;
-    }
-
-    logResults();
+    this.withSuspendedStatusRenderer(logResults);
   }
 }

--- a/packages/core/src/reporter/windowedRenderer.ts
+++ b/packages/core/src/reporter/windowedRenderer.ts
@@ -152,6 +152,14 @@ export class WindowRenderer {
     }
 
     const windowContent = this.options.getWindow();
+    if (windowContent.length === 0) {
+      this.clearWindow();
+      if (message) {
+        this.write(message, type);
+      }
+      return;
+    }
+
     const rowCount = getRenderedRowCount(
       windowContent,
       this.options.logger.getColumns(),

--- a/packages/core/src/reporter/windowedRenderer.ts
+++ b/packages/core/src/reporter/windowedRenderer.ts
@@ -50,6 +50,7 @@ export class WindowRenderer {
   private renderScheduled = false;
 
   private windowHeight = 0;
+  private started = false;
   private finished = false;
   private hiddenForOutputCount = 0;
   private readonly cleanups: (() => void)[] = [];
@@ -75,13 +76,13 @@ export class WindowRenderer {
       this.interceptStream(process.stderr, 'error'),
     );
 
-    this.start();
-
     process.once('exit', this.exitHandler);
   }
 
   start(): void {
+    this.started = true;
     this.finished = false;
+    clearInterval(this.renderInterval);
     this.renderInterval = setInterval(
       () => this.schedule(),
       this.options.interval,
@@ -98,15 +99,13 @@ export class WindowRenderer {
    * All intercepted writes are forwarded to actual write after this.
    */
   finish(): void {
-    if (this.finished) {
+    if (this.finished || !this.started) {
       return;
     }
 
-    this.flushBuffer();
     this.finished = true;
-    this.clearWindow();
-    this.stop();
-    process.removeListener('exit', this.exitHandler);
+    this.flushBuffer();
+    clearInterval(this.renderInterval);
   }
 
   /**
@@ -201,7 +200,7 @@ export class WindowRenderer {
     // @ts-expect-error -- not sure how 2 overloads should be typed
     stream.write = (chunk, _, callback) => {
       if (chunk) {
-        if (this.finished || this.hiddenForOutputCount > 0) {
+        if (this.finished || !this.started || this.hiddenForOutputCount > 0) {
           this.write(chunk.toString(), type);
         } else {
           this.buffer.push({ type, message: chunk.toString() });

--- a/packages/core/src/reporter/windowedRenderer.ts
+++ b/packages/core/src/reporter/windowedRenderer.ts
@@ -19,10 +19,9 @@ import { stripVTControlCharacters } from 'node:util';
 const DEFAULT_RENDER_INTERVAL_MS = 1_000;
 
 const ESC = '\x1B[';
-const CLEAR_LINE = `${ESC}K`;
+const CLEAR_LINE = `${ESC}2K`;
+const CARRIAGE_RETURN = '\r';
 const MOVE_CURSOR_ONE_ROW_UP = `${ESC}1A`;
-const SYNC_START = `${ESC}?2026h`;
-const SYNC_END = `${ESC}?2026l`;
 
 export interface Options {
   logger: {
@@ -52,6 +51,7 @@ export class WindowRenderer {
 
   private windowHeight = 0;
   private finished = false;
+  private hiddenForOutputCount = 0;
   private readonly cleanups: (() => void)[] = [];
   private readonly exitHandler = () => {
     this.finish();
@@ -98,9 +98,14 @@ export class WindowRenderer {
    * All intercepted writes are forwarded to actual write after this.
    */
   finish(): void {
-    this.finished = true;
+    if (this.finished) {
+      return;
+    }
+
     this.flushBuffer();
-    clearInterval(this.renderInterval);
+    this.finished = true;
+    this.clearWindow();
+    this.stop();
     process.removeListener('exit', this.exitHandler);
   }
 
@@ -108,6 +113,10 @@ export class WindowRenderer {
    * Queue new render update
    */
   schedule(): void {
+    if (this.hiddenForOutputCount > 0) {
+      return;
+    }
+
     if (!this.renderScheduled) {
       this.renderScheduled = true;
       this.flushBuffer();
@@ -119,34 +128,25 @@ export class WindowRenderer {
   }
 
   private flushBuffer() {
-    if (this.buffer.length === 0) {
+    const messages = this.drainBuffer();
+
+    if (messages.length === 0) {
       return this.render();
     }
 
-    let current: any;
-
-    // Concatenate same types into a single render
-    for (const next of this.buffer.splice(0)) {
-      if (!current) {
-        current = next;
-        continue;
-      }
-
-      if (current.type !== next.type) {
-        this.render(current.message, current.type);
-        current = next;
-        continue;
-      }
-
-      current.message += next.message;
-    }
-
-    if (current) {
-      this.render(current?.message, current?.type);
+    for (const message of messages) {
+      this.render(message.message, message.type);
     }
   }
 
   private render(message?: string, type: StreamType = 'output') {
+    if (this.hiddenForOutputCount > 0) {
+      if (message) {
+        this.write(message, type);
+      }
+      return;
+    }
+
     if (this.finished) {
       this.clearWindow();
       return this.write(message || '', type);
@@ -166,7 +166,6 @@ export class WindowRenderer {
       );
     }
 
-    this.write(SYNC_START);
     this.clearWindow();
 
     if (message) {
@@ -178,7 +177,6 @@ export class WindowRenderer {
     }
 
     this.write(windowContent.join('\n'));
-    this.write(SYNC_END);
 
     this.windowHeight = rowCount + Math.max(0, padding);
   }
@@ -188,10 +186,10 @@ export class WindowRenderer {
       return;
     }
 
-    this.write(CLEAR_LINE);
+    this.write(`${CARRIAGE_RETURN}${CLEAR_LINE}`);
 
     for (let i = 1; i < this.windowHeight; i++) {
-      this.write(`${MOVE_CURSOR_ONE_ROW_UP}${CLEAR_LINE}`);
+      this.write(`${MOVE_CURSOR_ONE_ROW_UP}${CARRIAGE_RETURN}${CLEAR_LINE}`);
     }
 
     this.windowHeight = 0;
@@ -203,7 +201,7 @@ export class WindowRenderer {
     // @ts-expect-error -- not sure how 2 overloads should be typed
     stream.write = (chunk, _, callback) => {
       if (chunk) {
-        if (this.finished) {
+        if (this.finished || this.hiddenForOutputCount > 0) {
           this.write(chunk.toString(), type);
         } else {
           this.buffer.push({ type, message: chunk.toString() });
@@ -219,6 +217,48 @@ export class WindowRenderer {
 
   private write(message: string, type: 'output' | 'error' = 'output') {
     this.streams[type](message);
+  }
+
+  private drainBuffer(): { type: StreamType; message: string }[] {
+    const messages: { type: StreamType; message: string }[] = [];
+    let current: { type: StreamType; message: string } | undefined;
+
+    for (const next of this.buffer.splice(0)) {
+      if (!current) {
+        current = { ...next };
+        continue;
+      }
+
+      if (current.type !== next.type) {
+        messages.push(current);
+        current = { ...next };
+        continue;
+      }
+
+      current.message += next.message;
+    }
+
+    if (current) {
+      messages.push(current);
+    }
+
+    return messages;
+  }
+
+  withWindowHidden<T>(action: () => T): T {
+    this.flushBuffer();
+    this.clearWindow();
+    this.hiddenForOutputCount += 1;
+
+    try {
+      return action();
+    } finally {
+      this.hiddenForOutputCount -= 1;
+
+      if (!this.finished && this.hiddenForOutputCount === 0) {
+        this.render();
+      }
+    }
   }
 }
 

--- a/packages/core/src/reporter/windowedRenderer.ts
+++ b/packages/core/src/reporter/windowedRenderer.ts
@@ -244,19 +244,21 @@ export class WindowRenderer {
     return messages;
   }
 
-  withWindowHidden<T>(action: () => T): T {
+  suspendWindowOutput(): void {
     this.flushBuffer();
     this.clearWindow();
     this.hiddenForOutputCount += 1;
+  }
 
-    try {
-      return action();
-    } finally {
-      this.hiddenForOutputCount -= 1;
+  resumeWindowOutput(): void {
+    if (this.hiddenForOutputCount === 0) {
+      return;
+    }
 
-      if (!this.finished && this.hiddenForOutputCount === 0) {
-        this.render();
-      }
+    this.hiddenForOutputCount -= 1;
+
+    if (!this.finished && this.hiddenForOutputCount === 0) {
+      this.render();
     }
   }
 }

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -178,3 +178,12 @@ export const isTTY = (type: 'stdin' | 'stdout' = 'stdout'): boolean => {
 
 export const isDeno: boolean =
   typeof process !== 'undefined' && process.versions?.deno !== undefined;
+
+export const isBun: boolean =
+  typeof process !== 'undefined' && process.versions?.bun !== undefined;
+
+export const getWorkerSerialization = (): 'advanced' | 'json' => {
+  return typeof process !== 'undefined' && process.versions?.bun !== undefined
+    ? 'json'
+    : 'advanced';
+};

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -179,9 +179,6 @@ export const isTTY = (type: 'stdin' | 'stdout' = 'stdout'): boolean => {
 export const isDeno: boolean =
   typeof process !== 'undefined' && process.versions?.deno !== undefined;
 
-export const isBun: boolean =
-  typeof process !== 'undefined' && process.versions?.bun !== undefined;
-
 export const getWorkerSerialization = (): 'advanced' | 'json' => {
   return typeof process !== 'undefined' && process.versions?.bun !== undefined
     ? 'json'

--- a/packages/core/tests/utils/helper.test.ts
+++ b/packages/core/tests/utils/helper.test.ts
@@ -1,5 +1,9 @@
 import { sep } from 'node:path';
-import { parsePosix, prettyTime } from '../../src/utils/helper';
+import {
+  getWorkerSerialization,
+  parsePosix,
+  prettyTime,
+} from '../../src/utils/helper';
 
 it('parsePosix correctly', () => {
   const splitPaths = ['packages', 'core', 'tests', 'index.test.ts'];
@@ -20,4 +24,30 @@ it('should prettyTime correctly', () => {
   expect(prettyTime(110000)).toBe('1m 50s');
   expect(prettyTime(111100)).toBe('1m 51s');
   expect(prettyTime(111900)).toBe('1m 52s');
+});
+
+it('should use advanced serialization outside Bun', () => {
+  const originalBunVersion = process.versions.bun;
+
+  Reflect.deleteProperty(process.versions, 'bun');
+
+  expect(getWorkerSerialization()).toBe('advanced');
+
+  if (originalBunVersion !== undefined) {
+    process.versions.bun = originalBunVersion;
+  }
+});
+
+it('should use json serialization in Bun', () => {
+  const originalBunVersion = process.versions.bun;
+
+  process.versions.bun = originalBunVersion ?? '1.0.0';
+
+  expect(getWorkerSerialization()).toBe('json');
+
+  if (originalBunVersion === undefined) {
+    Reflect.deleteProperty(process.versions, 'bun');
+  } else {
+    process.versions.bun = originalBunVersion;
+  }
 });

--- a/packages/core/tests/utils/helper.test.ts
+++ b/packages/core/tests/utils/helper.test.ts
@@ -29,25 +29,27 @@ it('should prettyTime correctly', () => {
 it('should use advanced serialization outside Bun', () => {
   const originalBunVersion = process.versions.bun;
 
-  Reflect.deleteProperty(process.versions, 'bun');
-
-  expect(getWorkerSerialization()).toBe('advanced');
-
-  if (originalBunVersion !== undefined) {
-    process.versions.bun = originalBunVersion;
+  try {
+    Reflect.deleteProperty(process.versions, 'bun');
+    expect(getWorkerSerialization()).toBe('advanced');
+  } finally {
+    if (originalBunVersion !== undefined) {
+      process.versions.bun = originalBunVersion;
+    }
   }
 });
 
 it('should use json serialization in Bun', () => {
   const originalBunVersion = process.versions.bun;
 
-  process.versions.bun = originalBunVersion ?? '1.0.0';
-
-  expect(getWorkerSerialization()).toBe('json');
-
-  if (originalBunVersion === undefined) {
-    Reflect.deleteProperty(process.versions, 'bun');
-  } else {
-    process.versions.bun = originalBunVersion;
+  try {
+    process.versions.bun = originalBunVersion ?? '1.0.0';
+    expect(getWorkerSerialization()).toBe('json');
+  } finally {
+    if (originalBunVersion === undefined) {
+      Reflect.deleteProperty(process.versions, 'bun');
+    } else {
+      process.versions.bun = originalBunVersion;
+    }
   }
 });


### PR DESCRIPTION
## Summary
fix ` TypeError: Unable to deserialize data.` error  when exec `bunx --bun rstest`.


### Background
Bun could not run `rstest` reliably because worker initialization used unsupported child-process serialization, and the default TTY status renderer could leave stale status lines in some terminal flows. The core package also had a local license plugin change intended to reduce webpack warning noise.

### Implementation
- Fall back to JSON worker serialization in Bun for the core worker pool and global setup worker, and add coverage for the serialization selection helper.
- Update the default/verbose reporter status rendering path to suspend the live status window while printing file results or console output, stop rendering empty post-run status windows, and simplify terminal control sequences for better TTY behavior.
- Include the existing `licensePlugin` / `rslib.config` change that adjusts the webpack license plugin integration.

### User Impact
`bunx --bun rstest` now works for more core scenarios and the default TTY reporter behaves better, but some Bun-specific cases still need follow-up work, including inline snapshot-related failures.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

## Validation

- `pnpm --filter @rstest/core build`
- `pnpm exec rstest packages/core/tests/utils/helper.test.ts`
- `TERM=xterm-256color bunx --bun rstest --reporter default` in `examples/node`
- `pnpm format` was attempted, but it did not complete because the repo's current Biome schema/version mismatch and unrelated existing warnings blocked a full successful run.