### PR TITLE
docs(agent-install): route to migration when Jest/Vitest is detected

### DIFF
--- a/website/docs/en/guide/start/agent-migrate.mdx
+++ b/website/docs/en/guide/start/agent-migrate.mdx
@@ -1,0 +1,7 @@
+---
+pageType: 'blank'
+---
+
+import Content from '../../shared/agent-migrate.md';
+
+<Content />

--- a/website/docs/en/guide/start/ai.mdx
+++ b/website/docs/en/guide/start/ai.mdx
@@ -18,11 +18,19 @@ To help AI better understand Rstest's features, configuration, and best practice
 
 ## Agent prompt
 
-If you are using a coding agent (such as Claude Code, Cursor, Copilot, etc.), you can copy the following prompt to set up Rstest in your project:
+If you are using a coding agent (such as Claude Code, Cursor, Copilot, etc.), copy the prompt that matches your project. The agent will read the linked instructions and install dependencies, create configuration, and write tests based on your project type.
 
-<AgentPrompt />
+### Set up Rstest
 
-The agent will read the linked instructions and automatically install dependencies, create configuration, and write tests based on your project type.
+Use this prompt to add Rstest to a project that doesn't have a test runner configured yet:
+
+<AgentPrompt variant="install" />
+
+### Migrate from Jest or Vitest
+
+Use this prompt to migrate an existing Jest or Vitest project to Rstest. For convenience, the linked instructions inline the full [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) skill so nothing needs to be installed; alternatively, you can [install the skill](#agent-skills) and use it directly:
+
+<AgentPrompt variant="migrate" />
 
 ## Agent Skills
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -48,7 +48,11 @@ import { AgentPrompt } from '@components/AgentPrompt';
 
 If you are using a coding agent, you can copy the following prompt to set up Rstest automatically:
 
-<AgentPrompt />
+<AgentPrompt variant="install" />
+
+If you are migrating from an existing Jest or Vitest project, use this prompt:
+
+<AgentPrompt variant="migrate" />
 
 ### Manual installation
 

--- a/website/docs/en/shared/agent-install.md
+++ b/website/docs/en/shared/agent-install.md
@@ -1,77 +1,57 @@
 # Rstest setup — agent execution prompt
 
-Follow these steps **in order** to add Rstest to the current project.
-Read the repository first. Make the smallest correct change.
+Set up Rstest in a project that doesn't have a test runner configured yet. Pick the target, detect what it needs, install, verify.
 
-Fetch a linked doc page **only after** choosing that branch. Do **not** fetch docs for branches you did not select.
+## Prerequisite check
 
-## Guardrails
+If the target already has Jest or Vitest configured (any of the signals below), **STOP this prompt and fetch https://rstest.rs/guide/start/agent-migrate.md instead** — migration has its own flow:
 
-- Always install `@rstest/core`. Config file is always `rstest.config.ts` (even in JS projects).
-- Only add framework plugins, DOM environments, or browser support when the code under test actually needs the transform — not just because `react` or `vue` appears in `dependencies`.
-- Do **not** replace existing Jest/Vitest `test` scripts unless migration is clearly intended — add `"test:unit": "rstest"` or similar instead.
-- If the package already has Jest/Vitest tests and migration is **not** intended, use `include` (https://rstest.rs/config/test/include.md) to target only Rstest's own tests so it does not discover tests written for another runner.
-- If migration **is** intended, follow the migration guide instead of this prompt: Jest → https://rstest.rs/guide/migration/jest.md / Vitest → https://rstest.rs/guide/migration/vitest.md
-- Do **not** reuse Jest/Vitest setup files blindly — only add a setup file (https://rstest.rs/config/test/setup-files.md) if the selected Rstest docs require it and the contents are compatible.
-- If `@rstest/core` or `rstest.config.ts` already exists, extend the existing setup minimally instead of recreating it.
-- Do **not** generate placeholder tests (e.g., `test('placeholder', () => {})`). A real verification test is fine when no tests exist — see Step 8.
-- When signals conflict, the project's existing test/build setup takes precedence.
+- A `jest.config.{js,ts,cjs,mjs,cts,mts,json}` or `vitest.config.{js,ts,cjs,mjs,cts,mts,json}`.
+- A `jest` / `@jest/globals` / `ts-jest` / `vitest` dep, or an inline `"jest"` / `"vitest"` field in `package.json`.
+- A `test` script invoking `jest` / `vitest`.
+- A workspace root with hoisted Jest/Vitest deps or config that affect this target.
+- The user asked to migrate from Jest/Vitest, or to keep Jest/Vitest and add Rstest side-by-side.
 
-## Step 0 — Repo-wide inventory (no changes yet)
+Otherwise, continue below.
 
-Before editing anything, determine:
+## Section 1 — pick the target
 
-- Package manager (from lockfile, or `packageManager` field in root `package.json`)
-- Whether this is a monorepo (`pnpm-workspace.yaml`, `workspaces` in `package.json`, `turbo.json`, `nx.json`)
-- Whether Rstest is already present anywhere (`@rstest/core`, `rstest.config.ts`, scripts)
-- Whether an existing test runner (Jest/Vitest) is in use — if migration is intended, stop here and follow the migration guide (see Guardrails)
+All work in this prompt happens inside a single **target package**.
 
-## Step 1 — find the owning package
+**Single-package repo** → the target is the repo root.
 
-Choose in this order:
+**Monorepo** (signals: `pnpm-workspace.yaml`, `workspaces` in root `package.json`, `turbo.json`, `nx.json`):
 
-1. Package containing the source files being tested
-2. Package containing existing tests for that source
-3. Package containing the relevant build config
-4. If single-package repo, the root
+- If the user named a specific package (by path, package name, or source file), that package is the target.
+- If the user expressed repo-wide scope ("this monorepo", "the whole repo", "every package", "all packages") **and** at least one package has Jest/Vitest signals, **STOP this prompt and fetch https://rstest.rs/guide/start/agent-migrate.md instead** — that flow iterates per package and handles heterogeneity.
+- Otherwise, **STOP this prompt and ask**:
 
-Note: deps, config, and scripts may live in different places. Determine separately:
+  > This is a monorepo. Rstest setup is applied to one package at a time. Which package should Rstest go in — the workspace root, or a specific package (e.g. `packages/foo`)?
 
-- **Config and test files** → always in the owning package.
-- **devDependencies and scripts** → in the owning package, unless the repo centralizes them at the workspace root — follow that convention.
-- **Validate from** → wherever the test script lives.
+## Section 2 — detect
 
-## Step 2 — Package-scoped inventory
+All detection below runs inside the target.
 
-Now inspect the owning package:
+### 2.1 Language
 
-- Source/test file extensions (`.ts`/`.tsx`/`.mts` vs `.js`/`.jsx`/`.mjs`)
-- Build tool in scope (`rsbuild.config.*`, `rslib.config.*`, or neither)
-- Existing test file naming and location
-- Whether tests need Node only, simulated DOM, or real browser APIs
-
-## Step 3 — detect language
-
-Determine from the owning package's **actual source/test file extensions** first. Use `tsconfig.json` or `typescript` dep only as a tiebreaker.
+Determine from the target's **actual source/test file extensions** first. Only fall back to `tsconfig.json` presence or `typescript` in deps when extensions are mixed or absent.
 
 - TypeScript → `.ts` / `.tsx` test files.
 - JavaScript → `.js` / `.jsx` test files.
 
-## Step 4 — detect build tooling → pick adapter
+### 2.2 Build tool (→ pick adapter)
 
-An adapter auto-inherits plugins, aliases, and build config. If using an adapter, follow that guide first — only fetch a framework guide if the adapter guide does not already cover the required setup.
+- **Rsbuild project** (`rsbuild.config.*` or `@rsbuild/core` dep) → follow https://rstest.rs/guide/integration/rsbuild.md
+- **Rslib project** (`rslib.config.*` or `@rslib/core` dep) → follow https://rstest.rs/guide/integration/rslib.md
+- **Neither** → configure Rstest standalone.
 
-- **Rsbuild project** (has `rsbuild.config.*` or `@rsbuild/core` dep) → follow https://rstest.rs/guide/integration/rsbuild.md
-- **Rslib project** (has `rslib.config.*` or `@rslib/core` dep) → follow https://rstest.rs/guide/integration/rslib.md
-- **Neither** → no adapter; configure Rstest standalone (continue below).
+An adapter auto-inherits plugins, aliases, and build config. Even with an adapter you still need to decide `testEnvironment` or browser mode from 2.3 — adapters do not decide those. If 2.3 picks Browser Mode, that takes precedence over adapters.
 
-When using an adapter you may still need to set `testEnvironment` or `browser` — the adapter does not decide those.
+### 2.3 Test environment
 
-## Step 5 — choose test environment
+Decide based on what the target's tests actually need, not solely from framework deps in `package.json`. See https://rstest.rs/config/test/test-environment.md for all options.
 
-Decide based on what the tests actually need, not solely from framework deps in `package.json`. See https://rstest.rs/config/test/test-environment.md for all options.
-
-### A. No DOM APIs needed → node (default)
+#### A. No DOM APIs needed → node (default)
 
 Omit `testEnvironment`. No extra deps. If not using an adapter and no other options are needed:
 
@@ -80,52 +60,39 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({});
 ```
 
-### B. DOM APIs needed, simulated DOM is sufficient → `happy-dom` / `jsdom`
+#### B. DOM APIs needed, simulated DOM is sufficient → `happy-dom` / `jsdom`
 
-Use for tests that render components or rely on DOM APIs.
+Pick B only if any of these hold for the target's source/test code:
 
-- If the project already depends on `jsdom` or `happy-dom`, follow that choice.
-- Otherwise default to `happy-dom` (lighter).
+- Imports JSX or a UI framework (`react`, `react-dom`, `vue`, `@vue/*`, `svelte`, `solid-js`, `preact`, `lit`).
+- Directly references `document`, `window`, `navigator`, `localStorage`, or other DOM globals.
+- The user's request explicitly mentions component/UI testing.
+
+If none of the above hold, stay on A. Seeing `react` in `dependencies` alone is not sufficient.
+
+- If the target already depends on `jsdom` or `happy-dom`, follow that choice. Otherwise default to `happy-dom` (lighter).
 - **React** → follow https://rstest.rs/guide/framework/react.md
 - **Vue** → follow https://rstest.rs/guide/framework/vue.md
+- Other frameworks (Svelte, Solid, Preact, Lit, etc.) → apply the same DOM-environment reasoning and install the framework's standard compiler/plugin if the adapter doesn't already cover it. Keep config minimal.
 
-### C. Real browser behavior needed → browser mode (experimental)
+#### C. Real browser behavior needed → browser mode (experimental)
 
-Choose **only** when tests explicitly require Canvas, WebGL, CSS computed styles, Web Workers, or cross-browser testing. This is opt-in, not a default escalation. Vue Browser Mode is **not yet supported**. See https://rstest.rs/config/test/browser.md for all options.
+Choose **only** when tests explicitly require Canvas, WebGL, CSS computed styles, Web Workers, or cross-browser testing. This is opt-in, not a default escalation. Vue Browser Mode is **not yet supported**. See https://rstest.rs/config/test/browser.md.
 
-→ Follow https://rstest.rs/guide/browser-testing/getting-started.md
-→ For React component testing in browser, also follow https://rstest.rs/guide/browser-testing/framework-guides.md
+→ **STOP this prompt.** Fetch https://rstest.rs/guide/browser-testing/getting-started.md and follow it end-to-end — Browser Mode has its own setup flow that replaces Sections 3–4. For React component testing in browser, also fetch https://rstest.rs/guide/browser-testing/framework-guides.md.
 
-## Step 6 — install dependencies
+## Section 3 — install and configure
 
-Use the repo's existing package manager (`pnpm add -D`, `npm i -D`, `yarn add -D`, `bun add -d`) based on the lockfile. Fall back to the `packageManager` field in root `package.json` if no lockfile exists. Install only packages justified in previous steps.
+All edits are scoped to the target package. If the target already has `@rstest/core`, `rstest.config.ts`, or an `rstest` script, extend it minimally instead of recreating it.
 
-## Step 7 — create config
+- Always install `@rstest/core`. Add any framework plugin / DOM environment justified in Section 2. Use the repo's package manager (pnpm: `pnpm --filter <target> add -D <pkg>`; npm: `npm i -D <pkg> -w <target>`; yarn: `yarn workspace <target> add -D <pkg>`; bun: `bun add -d <pkg> --filter <target>`). For a single-package repo, drop the workspace flag.
+- Config file is always `rstest.config.ts` (even in JS projects), placed in the target directory. Keep it minimal — include only options justified by Section 2. Do not copy examples blindly; see https://rstest.rs/guide/basic/configure-rstest.md only if the guides linked from Section 2 don't fully specify the config.
+- Add `"test": "rstest"` to the target's `package.json`. Preserve existing naming conventions.
 
-Keep it minimal — include **only** options justified by detection.
-→ See https://rstest.rs/guide/basic/configure-rstest.md only if the selected guide above does not fully specify the config.
+## Section 4 — verify
 
-Config examples are in the guide pages linked in Steps 4–5. Do not copy examples blindly.
-
-## Step 8 — update scripts
-
-If migration is intended, you should already be following the migration guide — skip this step.
-
-- Do not overwrite any existing test-related script. Add a new non-conflicting name.
-- **No test script** → add `"test": "rstest"`.
-- **`test` exists (Jest/Vitest)** → add `"test:unit": "rstest"` or similar.
-- **Browser Mode** → consider a dedicated `"test:browser"` script.
-- Preserve the repo's naming conventions.
-
-## Step 9 — verification test (only if needed)
-
-Only if no tests exist and verification is needed:
-
-- Add **one** small test for a real exported function or module. Prefer a function/module over a UI component to avoid introducing extra test utilities.
-- Match existing naming (`*.test.*` vs `*.spec.*`), placement, and language.
-- If no convention, colocate next to the source file.
-- If there is no small, deterministic real export to test, skip this step.
-
-## Step 10 — validate
-
-Run the test command from wherever the test script lives. If it fails, read the error and fix — do not leave a broken setup. If no tests exist and you skipped Step 9, confirm the setup is valid (config loads, `rstest --passWithNoTests` or equivalent succeeds).
+- Run the target's test command from wherever the target's test script lives. If it fails, read the error and fix — do not leave a broken setup.
+- If the target has **zero** test files, add one small real test before running:
+  - Prefer a real exported function/module over a UI component (to avoid extra test utilities).
+  - Match existing naming (`*.test.*` vs `*.spec.*`), placement, and language. If no convention exists, colocate next to the source file.
+  - Do not write placeholder tests (e.g. `test('placeholder', () => {})`). If no small deterministic export exists, skip the test and rely on `rstest --passWithNoTests`.

--- a/website/docs/en/shared/agent-migrate.md
+++ b/website/docs/en/shared/agent-migrate.md
@@ -1,0 +1,90 @@
+# Migrate to Rstest
+
+## Goal
+
+Migrate Jest- or Vitest-based tests and configuration to Rstest with minimal behavior changes.
+
+## Migration principles (must follow)
+
+1. **Smallest-change-first**: prefer the smallest viable change that restores test pass.
+2. **Config before code**: prefer fixing in config/tooling/mocks before touching test logic.
+3. **Do not change user source behavior**: avoid modifying production/business source files unless user explicitly requests it.
+4. **Avoid bulk test rewrites**: do not refactor entire test suites when a local compatibility patch can solve it.
+5. **Preserve test intent**: keep assertions and scenario coverage unchanged unless clearly broken by framework differences.
+6. **Defer legacy runner removal**: keep Jest/Vitest dependency and legacy config during migration; remove only after Rstest tests pass.
+
+## Workflow
+
+1. Detect current test framework (`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md`)
+2. Open the official migration guide(s):
+   - Jest: https://rstest.rs/guide/migration/jest.md
+   - Vitest: https://rstest.rs/guide/migration/vitest.md
+   - Prefer the `.md` URL form when available; Rstest pages provide Markdown variants that are more AI-friendly.
+3. Dependency install gate (blocker check, see `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`)
+4. Apply framework-specific migration deltas:
+   - Jest: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/jest-migration-deltas.md`
+   - Vitest: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/vitest-migration-deltas.md`
+   - Global API replacement rules: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`
+   - Known compatibility pitfalls: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/rstest-compat-pitfalls.md`
+5. Check type errors
+6. Run tests and fix deltas
+7. Remove legacy test runner dependency/config only after Rstest is green
+8. Summarize changes
+
+## 1. Detect current test framework
+
+Use `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md`.
+If both Jest and Vitest are present, migrate one scope at a time (package/suite), keeping mixed mode until each scope is green on Rstest.
+
+## 3. Dependency install gate (blocker check)
+
+Before large-scale edits, verify dependencies can be installed and test runner binaries are available.
+Detailed checks, blocked-mode output format, and `ni` policy are in:
+`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`
+
+## Patch scope policy (strict)
+
+### Preferred change order
+
+1. CLI/script/config migration (`package.json`, `rstest.config.ts`, include/exclude, test environment).
+2. Test setup adapter migration (for example `@testing-library/jest-dom/vitest` to matcher-based setup in Rstest).
+3. Mock compatibility adjustments (target module path, `{ mock: true }`, `importActual`).
+4. Narrow per-test setup fixes (single-file, single-suite level).
+5. Path resolution compatibility fixes (`import.meta.url` vs `__dirname`) in test/setup helpers.
+6. As a last resort, test body changes.
+7. Never modify runtime source logic by default.
+
+### Red lines
+
+- Do not rewrite many tests in one sweep without first proving config-level fixes are insufficient.
+- Do not alter business/runtime behavior to satisfy tests.
+- Do not change assertion semantics just to make tests pass.
+- Do not broaden migration to unrelated packages in monorepo.
+- Do not delete legacy runner dependency/config before confirming Rstest tests pass.
+
+### Escalation rule for large edits
+
+If a fix would require either:
+
+- editing many test files, or
+- changing user source files,
+
+stop and provide:
+
+1. why minimal fixes failed,
+2. proposed large-change options,
+3. expected impact/risk per option,
+4. recommended option.
+
+## 6. Run tests and fix deltas
+
+- Run the test suite and fix failures iteratively.
+- Fix configuration and resolver errors first, then address mocks/timers/snapshots, and touch test logic last.
+- If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3`.
+- Before broad test rewrites, check known pitfalls in:
+  `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/rstest-compat-pitfalls.md`
+
+## 8. Summarize changes
+
+- Provide a concise change summary and list files touched.
+- Call out any remaining manual steps or TODOs.

--- a/website/docs/en/shared/agent-migrate.template.md
+++ b/website/docs/en/shared/agent-migrate.template.md
@@ -1,0 +1,1 @@
+<!-- @inline-skill: migrate-to-rstest -->

--- a/website/docs/zh/guide/start/agent-migrate.mdx
+++ b/website/docs/zh/guide/start/agent-migrate.mdx
@@ -1,0 +1,7 @@
+---
+pageType: 'blank'
+---
+
+import Content from '../../../en/shared/agent-migrate.md';
+
+<Content />

--- a/website/docs/zh/guide/start/ai.mdx
+++ b/website/docs/zh/guide/start/ai.mdx
@@ -18,11 +18,19 @@ import { AgentPrompt } from '@components/AgentPrompt';
 
 ## Agent prompt
 
-如果你正在使用 Coding Agent（如 Claude Code、Cursor、Copilot 等），可以复制以下 prompt 来在项目中设置 Rstest：
+如果你正在使用 Coding Agent（如 Claude Code、Cursor、Copilot 等），请复制下面与你项目匹配的 prompt。Agent 会读取链接中的指令，并根据你的项目类型安装依赖、创建配置并编写测试。
 
-<AgentPrompt />
+### 设置 Rstest
 
-Agent 会读取链接中的指令，根据你的项目类型自动安装依赖、创建配置并编写测试。
+如果当前项目还没有配置测试框架，使用这个 prompt：
+
+<AgentPrompt variant="install" />
+
+### 从 Jest 或 Vitest 迁移
+
+如果要将现有的 Jest 或 Vitest 项目迁移到 Rstest，使用这个 prompt。为方便使用，链接中的指令内联了完整的 [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) skill，无需额外安装；你也可以[安装该 skill](#agent-skills) 后直接使用：
+
+<AgentPrompt variant="migrate" />
 
 ## Agent Skills
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -46,9 +46,13 @@ import { AgentPrompt } from '@components/AgentPrompt';
 
 ### Agent prompt
 
-如果你正在使用 Coding Agent，可以复制以下 prompt 来自动设置 Rstest：
+如果你正在使用 Coding Agent，可以复制下面的 prompt 来自动设置 Rstest：
 
-<AgentPrompt />
+<AgentPrompt variant="install" />
+
+如果要从已有的 Jest 或 Vitest 项目迁移，请使用这个 prompt：
+
+<AgentPrompt variant="migrate" />
 
 ### 手动安装
 

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "prebuild": "pnpm build:agent-install",
     "build": "rspress build",
+    "build:agent-install": "node scripts/buildAgentInstall.mjs",
     "dev": "rspress dev",
     "preview": "rspress preview"
   },

--- a/website/scripts/buildAgentInstall.mjs
+++ b/website/scripts/buildAgentInstall.mjs
@@ -1,0 +1,57 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REF = process.env.AGENT_SKILL_REF || 'main';
+const SKILL_PATH = 'skills/migrate-to-rstest/SKILL.md';
+const SKILL_URL = `https://raw.githubusercontent.com/rstackjs/agent-skills/${REF}/${SKILL_PATH}`;
+const REFERENCES_BASE = `https://raw.githubusercontent.com/rstackjs/agent-skills/${REF}/skills/migrate-to-rstest/`;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SHARED_DIR = resolve(__dirname, '../docs/en/shared');
+const TEMPLATE = resolve(SHARED_DIR, 'agent-migrate.template.md');
+const OUTPUT = resolve(SHARED_DIR, 'agent-migrate.md');
+const PLACEHOLDER = '<!-- @inline-skill: migrate-to-rstest -->';
+
+async function fetchSkill(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+  return res.text();
+}
+
+function processSkill(skill) {
+  let body = skill;
+
+  // Strip YAML frontmatter — Rspress would otherwise parse it as page metadata.
+  body = body.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n+/, '');
+
+  // Rewrite relative references/*.md paths to absolute remote URLs so the
+  // inlined skill can still follow its sub-references without being bundled.
+  body = body.replace(
+    /\breferences\/([\w-]+\.md)\b/g,
+    (_, rest) => `${REFERENCES_BASE}references/${rest}`,
+  );
+
+  return body.trimEnd();
+}
+
+async function main() {
+  const template = await readFile(TEMPLATE, 'utf8');
+  if (!template.includes(PLACEHOLDER)) {
+    throw new Error(`Placeholder ${PLACEHOLDER} not found in ${TEMPLATE}`);
+  }
+
+  const skill = await fetchSkill(SKILL_URL);
+  const processed = processSkill(skill);
+  const rendered = template.replace(PLACEHOLDER, processed);
+
+  await writeFile(OUTPUT, rendered);
+  console.log(`[build-agent-install] Wrote ${OUTPUT} (ref: ${REF})`);
+}
+
+main().catch((err) => {
+  console.error('[build-agent-install]', err.message);
+  process.exit(1);
+});

--- a/website/theme/components/AgentPrompt.tsx
+++ b/website/theme/components/AgentPrompt.tsx
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 import styles from './AgentPrompt.module.scss';
 
-const PROMPT_TEXT =
-  'Set up Rstest in this project by following the instructions here:\nhttps://rstest.rs/guide/start/agent-install.md';
+type Variant = 'install' | 'migrate';
+
+const PROMPTS: Record<Variant, string> = {
+  install:
+    'Set up Rstest in this project by following the instructions here:\nhttps://rstest.rs/guide/start/agent-install.md',
+  migrate:
+    'Migrate this project to Rstest by following the instructions here:\nhttps://rstest.rs/guide/start/agent-migrate.md',
+};
 
 /**
  * SVG icons sourced from @lobehub/icons (MIT license).
@@ -119,9 +125,11 @@ function RotatingIcon({ index, fading }: { index: number; fading: boolean }) {
   );
 }
 
-export function AgentPrompt() {
+export function AgentPrompt({ variant = 'install' }: { variant?: Variant }) {
+  const promptText = PROMPTS[variant];
+
   if (import.meta.env.SSG_MD) {
-    return <>{`\`\`\`\n${PROMPT_TEXT}\n\`\`\`\n`}</>;
+    return <>{`\`\`\`\n${promptText}\n\`\`\`\n`}</>;
   }
 
   const [index, setIndex] = useState(0);
@@ -140,11 +148,11 @@ export function AgentPrompt() {
   }, []);
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(PROMPT_TEXT).then(() => {
+    navigator.clipboard.writeText(promptText).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
-  }, []);
+  }, [promptText]);
 
   const headerBg = `${ICONS[index].color}12`;
 
@@ -165,7 +173,7 @@ export function AgentPrompt() {
           {copied ? '✓ Copied' : 'Copy'}
         </button>
       </div>
-      <div className={styles.body}>{PROMPT_TEXT}</div>
+      <div className={styles.body}>{promptText}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

human input:

make https://github.com/rstackjs/agent-skills/blob/main/skills/migrate-to-rstest/SKILL.md single source of truth, since invoke a skill from a URL is not a standard approach (although leading agents support do so), so we directly inline the skill in the prompt (skill is a prompt somehow) in building phase, while still keeping the SSOT principle.

---

On projects with an existing `jest.config.*` / `vitest.config.*`, agents fetching the install prompt produced a bare `defineConfig({})` and silently ignored the existing setup. The single router prompt gated migration on subjective intent ("if migration is intended"), which agents read as "user said 'install' so not a migration".

## Changes

- **Split prompts by task.** `agent-install.md` (fresh setup where no test runner exists) and `agent-migrate.md` (Jest/Vitest → Rstest). Install prompt detects Jest/Vitest via config files + `package.json` signals and redirects to the migration prompt; coexistence is explicit opt-in. Monorepos pick one target per run (named target / repo-wide migration / otherwise ask).
- **Inline the migration SKILL at build time.** `agent-migrate.md` is generated from the upstream [`migrate-to-rstest`](https://github.com/rstackjs/agent-skills) SKILL so SSOT stays in the skills repo. `website/scripts/buildAgentInstall.mjs` fetches `SKILL.md`, strips frontmatter, rewrites relative `references/*.md` to absolute GitHub raw URLs (lazy-fetched by agents), writes `website/docs/en/shared/agent-migrate.md`. Runs via `prebuild`; pin with `AGENT_SKILL_REF`.
- **Docs surface.** `<AgentPrompt variant="install" | "migrate" />` on quick-start and `/guide/start/ai` (EN/ZH). New `agent-migrate.mdx` pages import the shared generated file.

## Validation

Docs-only. `pnpm format` + `pnpm lint` clean. `prebuild` refreshes the committed `agent-migrate.md` on every docs build.

## Checklist

- [x] Tests updated (or not required). Docs-only.
- [x] Documentation updated.