### PR TITLE
fix(core): preserve esm sourcemaps in bun vm modules

### DIFF
--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -12,10 +12,34 @@ export enum EsmMode {
   Unlinked = 2,
 }
 
+const sourceUrlCommentRE = /\/\/[#@]\s*sourceURL=/;
+
+export const shouldInjectSourceURL = (): boolean => {
+  return typeof process !== 'undefined' && process.versions?.bun !== undefined;
+};
+
 const isRelativePath = (p: string) => /^\.\.?\//.test(p);
 
 const isBuiltinSpecifier = (specifier: string) =>
   specifier.startsWith('node:') || builtinModules.includes(specifier);
+
+export const appendSourceURL = (
+  codeContent: string,
+  sourceUrl: string,
+): string => {
+  if (sourceUrlCommentRE.test(codeContent)) {
+    return codeContent;
+  }
+
+  // Bun's vm.SourceTextModule reports stack frames and source-map-support
+  // lookups as synthetic "[source:n]" ids instead of the module identifier.
+  // Appending sourceURL keeps the emitted source name stable so sourcemaps
+  // still resolve back to the built asset path.
+  const suffix = `//# sourceURL=${sourceUrl}`;
+  return codeContent.endsWith('\n')
+    ? `${codeContent}${suffix}`
+    : `${codeContent}\n${suffix}`;
+};
 
 const defineRstestDynamicImport =
   ({
@@ -203,7 +227,9 @@ export const loadModule = async ({
   rstestContext: Record<string, any>;
   assetFiles: Record<string, string>;
 }): Promise<any> => {
-  const code = codeContent;
+  const code = shouldInjectSourceURL()
+    ? appendSourceURL(codeContent, distPath)
+    : codeContent;
   let esm = esmCache.get(distPath);
   if (!esm) {
     esm = new vm.SourceTextModule(code, {

--- a/packages/core/tests/runner/loadEsModule.test.ts
+++ b/packages/core/tests/runner/loadEsModule.test.ts
@@ -1,7 +1,9 @@
 import { sep } from 'node:path';
 import {
+  appendSourceURL,
   clearModuleCache,
   loadModule,
+  shouldInjectSourceURL,
 } from '../../src/runtime/worker/loadEsModule';
 
 describe('loadEsModule', () => {
@@ -40,5 +42,41 @@ describe('loadEsModule', () => {
       hasReadFile: true,
       separator: sep,
     });
+  });
+
+  it('should append sourceURL for esm vm execution', () => {
+    expect(
+      appendSourceURL("throw new Error('x')", '/virtual/dist/entry.mjs'),
+    ).toMatchInlineSnapshot(`
+      "throw new Error('x')
+      //# sourceURL=/virtual/dist/entry.mjs"
+    `);
+  });
+
+  it('should not duplicate an existing sourceURL comment', () => {
+    const code = [
+      "throw new Error('x')",
+      '//# sourceURL=/virtual/dist/original.mjs',
+    ].join('\n');
+
+    expect(appendSourceURL(code, '/virtual/dist/entry.mjs')).toBe(code);
+  });
+
+  it('should only inject sourceURL in Bun runtime', async () => {
+    const originalBunVersion = process.versions.bun;
+
+    try {
+      Reflect.deleteProperty(process.versions, 'bun');
+      expect(shouldInjectSourceURL()).toBe(false);
+
+      process.versions.bun = originalBunVersion ?? '1.0.0';
+      expect(shouldInjectSourceURL()).toBe(true);
+    } finally {
+      if (originalBunVersion === undefined) {
+        Reflect.deleteProperty(process.versions, 'bun');
+      } else {
+        process.versions.bun = originalBunVersion;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
### Background
Bun reports `vm.SourceTextModule` stack frames as synthetic `[source:n]` ids, which prevents rstest from matching ESM sourcemaps back to the built asset path.

before:
<img width="641" height="200" alt="image" src="https://github.com/user-attachments/assets/bf9b218b-e862-4c9d-8660-143c071c182b" />


after:
<img width="599" height="274" alt="image" src="https://github.com/user-attachments/assets/452bf74f-8d85-476e-8d24-25e426e44a93" />

### Implementation
- detect Bun runtime in the ESM worker loader before rewriting module source
- append a `sourceURL` comment for Bun-only `SourceTextModule` execution so stack traces and source-map lookups use the emitted asset path
- add regression tests for sourceURL injection, duplicate comment handling, and Bun runtime detection

### User Impact
Bun-driven ESM test failures now point back to the original test file instead of `[source:n]` placeholders.

## Related Links
None

## Checklist
- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
