### PR TITLE
release: 0.9.8

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(core): support bundleDependencies patterns by @9aoy in https://github.com/web-infra-dev/rstest/pull/1118
* feat(reporter): add GitHub step summary for github-actions reporter by @9aoy in https://github.com/web-infra-dev/rstest/pull/1170
* feat: provide unique testId via testContext by @9aoy in https://github.com/web-infra-dev/rstest/pull/1178
### Bug Fixes 🐞
* fix(coverage): reduce coverage memory usage by @9aoy in https://github.com/web-infra-dev/rstest/pull/1154
* fix(coverage): strip coverage from browser results and add explanatory comments by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1158
* fix(watch): track chunk hashes by file path for dynamic import detection by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1162
* fix(coverage): stream-merge coverage data to reduce memory usage by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1169
* fix(core): auto-create default export for factory mock of CJS modules by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1174
* fix(core): improve bun compatibility and tty status rendering by @9aoy in https://github.com/web-infra-dev/rstest/pull/1179
* fix(core): preserve esm sourcemaps in bun vm modules by @9aoy in https://github.com/web-infra-dev/rstest/pull/1184
### Document 📖
* docs(framework): add more framework guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/1151
* docs: add more introduction for test.extend API by @9aoy in https://github.com/web-infra-dev/rstest/pull/1177
### Other Changes
* ci(codspeed): enable memory benchmark on PRs by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1161
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1163
* chore(deps): update dependency @rsbuild/plugin-vue-jsx to v2 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1164
* chore(deps): update dependency @rspack/plugin-react-refresh to v2 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1165
* chore(deps): update dependency lucide-react to v1 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1167
* ci: add paths filter and concurrency to CI workflows by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1175
* chore: replace nano-staged + simple-git-hooks with lefthook by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1176


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.9.7...v0.9.8