### PR TITLE
fix(core): preserve runtime meta url for named projects

### DIFF
--- a/e2e/rstest.config.mts
+++ b/e2e/rstest.config.mts
@@ -10,6 +10,7 @@ import { defineConfig } from '@rstest/core';
 const NO_ISOLATE_EXCLUDES = ['watch/**', 'mock/**', 'browser-mode/**'];
 
 export default defineConfig({
+  name: 'rstest:e2e',
   setupFiles: ['../scripts/rstest.setup.ts'],
   // Increased timeout for CI to handle slower environments (e.g., Node.js 22 on Windows)
   // and reduce flaky timeouts caused by resource contention under high parallelism.

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -67,7 +67,9 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
           resolve: {
             // Extend the default resolve conditionNames for browser-like environment, use `browser` field instead of `node` field
             conditionNames:
-              testEnvironment.name === 'node' ? undefined : ['browser', '...'],
+              testEnvironment.name === 'node' || resolve?.conditionNames
+                ? undefined
+                : ['browser', '...'],
           },
           output: {
             assetPrefix: '',

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -3,8 +3,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 import pathe from 'pathe';
 import type { RstestContext } from '../../types';
 import { getTempRstestOutputDir } from '../../utils';
-
-export const RUNTIME_CHUNK_NAME = 'runtime';
+import { getRuntimeChunkName } from '../../utils/runtimeChunk';
 
 const requireShim = `// Rstest ESM shims
 import __rstest_shim_module__ from 'node:module';
@@ -68,9 +67,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
           resolve: {
             // Extend the default resolve conditionNames for browser-like environment, use `browser` field instead of `node` field
             conditionNames:
-              testEnvironment.name === 'node' || resolve?.conditionNames
-                ? undefined
-                : ['browser', '...'],
+              testEnvironment.name === 'node' ? undefined : ['browser', '...'],
           },
           output: {
             assetPrefix: '',
@@ -104,7 +101,10 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
               config.output.devtoolModuleFilenameTemplate =
                 '[absolute-resource-path]';
 
-              if (!config.devtool || !config.devtool.includes('inline')) {
+              if (
+                typeof config.devtool !== 'string' ||
+                !config.devtool.includes('inline')
+              ) {
                 config.devtool = 'nosources-source-map';
               }
 
@@ -182,7 +182,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 ...(config.optimization || {}),
                 // make sure setup file and test file share the runtime
                 runtimeChunk: {
-                  name: `${name}-${RUNTIME_CHUNK_NAME}`,
+                  name: getRuntimeChunkName(name),
                 },
               };
             },

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -3,7 +3,8 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 import pathe from 'pathe';
 import type { RstestContext } from '../../types';
 import { getTempRstestOutputDir } from '../../utils';
-import { getRuntimeChunkName } from '../../utils/runtimeChunk';
+
+export const RUNTIME_CHUNK_NAME = 'runtime';
 
 const requireShim = `// Rstest ESM shims
 import __rstest_shim_module__ from 'node:module';
@@ -184,7 +185,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 ...(config.optimization || {}),
                 // make sure setup file and test file share the runtime
                 runtimeChunk: {
-                  name: getRuntimeChunkName(name),
+                  name: `${name}-${RUNTIME_CHUNK_NAME}`,
                 },
               };
             },

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -16,8 +16,7 @@ import type {
 } from '../types';
 import { isDebug } from '../utils';
 import { isMemorySufficient } from '../utils/memory';
-import { getRuntimeChunkName } from '../utils/runtimeChunk';
-import { pluginBasic } from './plugins/basic';
+import { pluginBasic, RUNTIME_CHUNK_NAME } from './plugins/basic';
 import { pluginCSSFilter } from './plugins/css-filter';
 import { pluginEntryWatch } from './plugins/entry';
 import { pluginExternal } from './plugins/external';
@@ -537,7 +536,7 @@ export const createRsbuildServer = async ({
     const runtimeChunkFiles = getRuntimeChunkFiles({
       chunks,
       outputPath: outputPath!,
-      runtimeChunkName: getRuntimeChunkName(environmentName),
+      runtimeChunkName: `${environmentName}-${RUNTIME_CHUNK_NAME}`,
     });
     const entries: EntryInfo[] = [];
     const setupEntries: EntryInfo[] = [];
@@ -621,7 +620,7 @@ export const createRsbuildServer = async ({
           chunks,
           buildData[environmentName],
           outputPath!,
-          getRuntimeChunkName(environmentName),
+          `${environmentName}-${RUNTIME_CHUNK_NAME}`,
           setupEntries,
         )
       : { affectedEntries: [], deletedEntries: [] };

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -16,7 +16,8 @@ import type {
 } from '../types';
 import { isDebug } from '../utils';
 import { isMemorySufficient } from '../utils/memory';
-import { pluginBasic, RUNTIME_CHUNK_NAME } from './plugins/basic';
+import { getRuntimeChunkName } from '../utils/runtimeChunk';
+import { pluginBasic } from './plugins/basic';
 import { pluginCSSFilter } from './plugins/css-filter';
 import { pluginEntryWatch } from './plugins/entry';
 import { pluginExternal } from './plugins/external';
@@ -32,6 +33,33 @@ type TestEntryToChunkHashes = {
   /** key is chunk asset file path, value is chunk hash */
   chunks: Record<string, string>;
 }[];
+
+const getRuntimeChunkFiles = ({
+  chunks,
+  outputPath,
+  runtimeChunkName,
+}: {
+  chunks: Rspack.StatsChunk[] | undefined;
+  outputPath: string;
+  runtimeChunkName: string;
+}): Set<string> => {
+  const runtimeChunkFiles = new Set<string>();
+
+  for (const chunk of chunks || []) {
+    const isRuntimeChunk =
+      chunk.id === runtimeChunkName || chunk.names?.includes(runtimeChunkName);
+
+    if (!isRuntimeChunk) {
+      continue;
+    }
+
+    for (const file of chunk.files || []) {
+      runtimeChunkFiles.add(path.join(outputPath, String(file)));
+    }
+  }
+
+  return runtimeChunkFiles;
+};
 
 function parseInlineSourceMapStr(code: string) {
   // match the inline source map comment (format may be `//# sourceMappingURL=data:...`)
@@ -506,6 +534,11 @@ export const createRsbuildServer = async ({
     });
 
     const entryFiles = getEntryFiles(manifest, outputPath!);
+    const runtimeChunkFiles = getRuntimeChunkFiles({
+      chunks,
+      outputPath: outputPath!,
+      runtimeChunkName: getRuntimeChunkName(environmentName),
+    });
     const entries: EntryInfo[] = [];
     const setupEntries: EntryInfo[] = [];
     const globalSetupEntries: EntryInfo[] = [];
@@ -521,10 +554,14 @@ export const createRsbuildServer = async ({
         outputPath!,
         filteredAssets[filteredAssets.length - 1]!.name,
       );
+      const runtimeDistPath = entryFiles[entry]?.find((file) =>
+        runtimeChunkFiles.has(file),
+      );
 
       if (setupFiles[environmentName]?.[entry]) {
         setupEntries.push({
           distPath,
+          runtimeDistPath,
           testPath: setupFiles[environmentName][entry],
           files: entryFiles[entry],
           chunks: e.chunks || [],
@@ -538,6 +575,7 @@ export const createRsbuildServer = async ({
         }
         entries.push({
           distPath,
+          runtimeDistPath,
           testPath: sourceEntries[entry],
           files: entryFiles[entry],
           chunks: e.chunks || [],
@@ -545,6 +583,7 @@ export const createRsbuildServer = async ({
       } else if (globalSetupFiles?.[environmentName]?.[entry]) {
         globalSetupEntries.push({
           distPath,
+          runtimeDistPath,
           testPath: globalSetupFiles[environmentName][entry],
           files: entryFiles[entry],
           chunks: e.chunks || [],
@@ -582,7 +621,7 @@ export const createRsbuildServer = async ({
           chunks,
           buildData[environmentName],
           outputPath!,
-          `${environmentName}-${RUNTIME_CHUNK_NAME}`,
+          getRuntimeChunkName(environmentName),
           setupEntries,
         )
       : { affectedEntries: [], deletedEntries: [] };

--- a/packages/core/src/runtime/worker/globalSetupWorker.ts
+++ b/packages/core/src/runtime/worker/globalSetupWorker.ts
@@ -37,6 +37,7 @@ function captureEnvChanges(): Record<string, string | undefined> {
 const runGlobalSetup = async (data: {
   entries: {
     distPath: string;
+    runtimeDistPath?: string;
     testPath: string;
   }[];
   assetFiles: Record<string, string>;
@@ -73,7 +74,7 @@ const runGlobalSetup = async (data: {
     trackEnvChanges();
 
     for (const entry of data.entries) {
-      const { distPath, testPath } = entry;
+      const { distPath, runtimeDistPath, testPath } = entry;
       const setupCodeContent = data.assetFiles[distPath]!;
       const { loadModule } = data.outputModule
         ? await import('./loadEsModule')
@@ -82,6 +83,7 @@ const runGlobalSetup = async (data: {
       const module = await loadModule({
         codeContent: setupCodeContent,
         distPath,
+        runtimeDistPath,
         testPath,
         rstestContext: {
           global,

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -239,6 +239,7 @@ const loadFiles = async ({
   assetFiles,
   rstestContext,
   distPath,
+  runtimeDistPath,
   testPath,
   interopDefault,
   isolate,
@@ -248,6 +249,7 @@ const loadFiles = async ({
   assetFiles: Record<string, string>;
   rstestContext: Record<string, any>;
   distPath: string;
+  runtimeDistPath?: string;
   testPath: string;
   interopDefault: boolean;
   isolate: boolean;
@@ -278,6 +280,7 @@ const loadFiles = async ({
     await loadModule({
       codeContent: setupCodeContent,
       distPath,
+      runtimeDistPath,
       testPath,
       rstestContext,
       assetFiles,
@@ -288,6 +291,7 @@ const loadFiles = async ({
   await loadModule({
     codeContent: assetFiles[distPath]!,
     distPath,
+    runtimeDistPath,
     testPath,
     rstestContext,
     assetFiles,
@@ -310,7 +314,7 @@ const runInPool = async (
 
   isTeardown = false;
   const {
-    entryInfo: { distPath, testPath },
+    entryInfo: { distPath, runtimeDistPath, testPath },
     setupEntries,
     assets,
     type,
@@ -377,6 +381,7 @@ const runInPool = async (
       await loadFiles({
         rstestContext,
         distPath,
+        runtimeDistPath,
         testPath,
         assetFiles,
         setupEntries,
@@ -450,6 +455,7 @@ const runInPool = async (
     await loadFiles({
       rstestContext,
       distPath,
+      runtimeDistPath,
       testPath,
       assetFiles,
       setupEntries,

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -13,7 +13,6 @@ export enum EsmMode {
 }
 
 const sourceUrlCommentRE = /\/\/[#@]\s*sourceURL=/;
-
 export const shouldInjectSourceURL = (): boolean => {
   return typeof process !== 'undefined' && process.versions?.bun !== undefined;
 };
@@ -49,11 +48,13 @@ const defineRstestDynamicImport =
     interopDefault,
     returnModule,
     esmMode,
+    runtimeDistPath,
   }: {
     esmMode: EsmMode;
     assetFiles: Record<string, string>;
     returnModule?: boolean;
     distPath: string;
+    runtimeDistPath?: string;
     testPath: string;
     interopDefault: boolean;
   }) =>
@@ -82,6 +83,7 @@ const defineRstestDynamicImport =
           codeContent: content,
           testPath,
           distPath: joinedPath,
+          runtimeDistPath,
           rstestContext: {},
           assetFiles,
           interopDefault,
@@ -218,11 +220,13 @@ export const loadModule = async ({
   assetFiles,
   interopDefault,
   esmMode = EsmMode.Unknown,
+  runtimeDistPath,
 }: {
   esmMode?: EsmMode;
   interopDefault: boolean;
   codeContent: string;
   distPath: string;
+  runtimeDistPath?: string;
   testPath: string;
   rstestContext: Record<string, any>;
   assetFiles: Record<string, string>;
@@ -238,13 +242,14 @@ export const loadModule = async ({
       columnOffset: 0,
       initializeImportMeta: (meta) => {
         meta.url = pathToFileURL(
-          distPath.endsWith('rstest-runtime.mjs') ? distPath : testPath,
+          distPath === runtimeDistPath ? distPath : testPath,
         ).toString();
         // @ts-expect-error
         meta.__rstest_dynamic_import__ = defineRstestDynamicImport({
           assetFiles,
           testPath,
           distPath: distPath || testPath,
+          runtimeDistPath,
           interopDefault,
           returnModule: false,
           esmMode: EsmMode.Unknown,
@@ -274,6 +279,7 @@ export const loadModule = async ({
           assetFiles,
           testPath,
           distPath: distPath || testPath,
+          runtimeDistPath,
           interopDefault,
           returnModule: true,
           esmMode: EsmMode.Unlinked,
@@ -291,6 +297,7 @@ export const loadModule = async ({
         assetFiles,
         testPath,
         distPath: distPath || testPath,
+        runtimeDistPath,
         interopDefault,
         returnModule: true,
         esmMode: EsmMode.Unlinked,

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -12,6 +12,7 @@ import type { DistPath, TestPath } from './utils';
 
 export type EntryInfo = {
   distPath: DistPath;
+  runtimeDistPath?: DistPath;
   chunks: (string | number)[];
   testPath: TestPath;
   files?: string[];

--- a/packages/core/src/utils/runtimeChunk.ts
+++ b/packages/core/src/utils/runtimeChunk.ts
@@ -1,4 +1,0 @@
-export const RSTEST_RUNTIME_CHUNK_PREFIX = '__rstest_runtime__';
-
-export const getRuntimeChunkName = (environmentName: string): string =>
-  `${RSTEST_RUNTIME_CHUNK_PREFIX}${environmentName}`;

--- a/packages/core/src/utils/runtimeChunk.ts
+++ b/packages/core/src/utils/runtimeChunk.ts
@@ -2,17 +2,3 @@ export const RSTEST_RUNTIME_CHUNK_PREFIX = '__rstest_runtime__';
 
 export const getRuntimeChunkName = (environmentName: string): string =>
   `${RSTEST_RUNTIME_CHUNK_PREFIX}${environmentName}`;
-
-export const isRuntimeChunkFilePath = (distPath: string): boolean => {
-  const normalizedPath = distPath.replace(/\\/g, '/');
-  const lastSlashIndex = normalizedPath.lastIndexOf('/');
-  const basename =
-    lastSlashIndex === -1
-      ? normalizedPath
-      : normalizedPath.slice(lastSlashIndex + 1);
-
-  return (
-    basename.startsWith(RSTEST_RUNTIME_CHUNK_PREFIX) &&
-    basename.endsWith('.mjs')
-  );
-};

--- a/packages/core/src/utils/runtimeChunk.ts
+++ b/packages/core/src/utils/runtimeChunk.ts
@@ -1,0 +1,18 @@
+export const RSTEST_RUNTIME_CHUNK_PREFIX = '__rstest_runtime__';
+
+export const getRuntimeChunkName = (environmentName: string): string =>
+  `${RSTEST_RUNTIME_CHUNK_PREFIX}${environmentName}`;
+
+export const isRuntimeChunkFilePath = (distPath: string): boolean => {
+  const normalizedPath = distPath.replace(/\\/g, '/');
+  const lastSlashIndex = normalizedPath.lastIndexOf('/');
+  const basename =
+    lastSlashIndex === -1
+      ? normalizedPath
+      : normalizedPath.slice(lastSlashIndex + 1);
+
+  return (
+    basename.startsWith(RSTEST_RUNTIME_CHUNK_PREFIX) &&
+    basename.endsWith('.mjs')
+  );
+};

--- a/rstest.config.mts
+++ b/rstest.config.mts
@@ -2,4 +2,5 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   projects: ['packages/*'],
+  name: 'rstest:unit',
 });


### PR DESCRIPTION
## Summary
### Background
Adding `name` to the root and e2e rstest configs changes the emitted runtime chunk filename for ESM test builds. The worker still inferred runtime chunks from a legacy filename shape, which caused `import.meta.url` to resolve relative assets like wasm files against setup-file paths instead of the runtime chunk.

### Implementation
- keep the current branch's `name` additions in [/Users/bytedance/Desktop/projects/rstest/rstest.config.mts](/Users/bytedance/Desktop/projects/rstest/rstest.config.mts) and [/Users/bytedance/Desktop/projects/rstest/e2e/rstest.config.mts](/Users/bytedance/Desktop/projects/rstest/e2e/rstest.config.mts)
- record each entry's runtime chunk path during Rsbuild manifest processing and pass it through the worker entry metadata
- use the explicit runtime chunk path when initializing ESM `import.meta.url`, instead of guessing from emitted filenames

### User Impact
Named rstest projects keep working with ESM runtime features such as wasm URL loading.

## Related Links
None

## Checklist
- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).