### PR TITLE
ci(codspeed): run CPU benchmark weekly instead of every 6 hours

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -17,8 +17,8 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/codspeed.yml'
   schedule:
-    # Run every 6 hours on main to build a continuous baseline for CPU benchmark
-    - cron: '0 */6 * * *'
+    # Run once a week on main to build a continuous baseline for CPU benchmark
+    - cron: '0 0 * * 0'
   # Allow manual runs on any branch (CodSpeed backtest + on-demand profiling)
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

hit 600min/M limitation so reduce the frequency.

### Background

The scheduled CPU benchmark on `codspeed-macro` runs every 6 hours, which is overkill for building a baseline and consumes expensive bare-metal runner time.

### Implementation

- Change schedule cron from `0 */6 * * *` to `0 0 * * 0` (weekly, Sunday 00:00 UTC).
- Update the adjacent comment to match the new cadence.

### User Impact

None — internal CI cadence change. Manual runs via `workflow_dispatch` remain available.

## Validation

Scoped to the workflow YAML file — no runtime/test source touched. Full build/test/e2e suites skipped as not applicable.