### PR TITLE
feat(core): include flaky tests in github actions summary

### DIFF
--- a/e2e/reporter/flaky-fixtures/githubActionsFlaky.test.ts
+++ b/e2e/reporter/flaky-fixtures/githubActionsFlaky.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from '@rstest/core';
+
+let attempts = 0;
+
+it('passes after retry', () => {
+  attempts += 1;
+  expect(attempts).toBe(2);
+});

--- a/e2e/reporter/githubActions.test.ts
+++ b/e2e/reporter/githubActions.test.ts
@@ -222,6 +222,7 @@ it.skipIf(!process.env.CI)(
 
     expect(stepSummary).toContain('<summary>Rstest Test Reporter ✅</summary>');
     expectWorkspacePath(stepSummary);
+    expect(stepSummary).toContain('| **Flaky Tests** | 1 passed after retry |');
     expect(stepSummary).toContain('## Flaky Tests');
     expect(stepSummary).toContain(
       '- `flaky-fixtures/githubActionsFlaky.test.ts > passes after retry` (passed after retry x1)',

--- a/e2e/reporter/githubActions.test.ts
+++ b/e2e/reporter/githubActions.test.ts
@@ -183,6 +183,60 @@ it.skipIf(!process.env.CI)('github-actions summary on pass', async () => {
 });
 
 it.skipIf(!process.env.CI)(
+  'github-actions summary includes flaky tests with previous failure summaries',
+  async () => {
+    const stepSummaryPath = join(
+      __dirname,
+      '.tmp',
+      'github-step-summary-flaky.md',
+    );
+    fs.rmSync(stepSummaryPath, { force: true });
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        '-c',
+        './rstest.githubActions.flaky.config.mts',
+        '--reporter',
+        'github-actions',
+      ],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+          env: {
+            GITHUB_WORKSPACE: githubWorkspace,
+            GITHUB_STEP_SUMMARY: stepSummaryPath,
+          },
+        },
+      },
+    });
+
+    await cli.exec;
+    await cli.waitForStreamsEnd();
+    expect(cli.exec.process?.exitCode).toBe(0);
+
+    const stepSummary = fs
+      .readFileSync(stepSummaryPath, 'utf-8')
+      .replaceAll(process.cwd(), '<ROOT>');
+
+    expect(stepSummary).toContain('<summary>Rstest Test Reporter ✅</summary>');
+    expectWorkspacePath(stepSummary);
+    expect(stepSummary).toContain('## Flaky Tests');
+    expect(stepSummary).toContain(
+      '- `flaky-fixtures/githubActionsFlaky.test.ts > passes after retry` (passed after retry x1)',
+    );
+    expect(stepSummary).toContain(
+      'Previous failure: AssertionError: expected 1 to be 2 // Object.is equality',
+    );
+    expect(stepSummary).not.toContain('## Failures');
+
+    fs.rmSync(stepSummaryPath, { force: true });
+    fs.rmSync(join(__dirname, '.tmp'), { recursive: true, force: true });
+  },
+);
+
+it.skipIf(!process.env.CI)(
   'github-actions summary includes explicit project name in title',
   async () => {
     const stepSummaryPath = join(

--- a/e2e/reporter/rstest.githubActions.flaky.config.mts
+++ b/e2e/reporter/rstest.githubActions.flaky.config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  include: ['**/fixtures/**'],
-  exclude: ['**/flaky-fixtures/**'],
+  include: ['flaky-fixtures/githubActionsFlaky.test.ts'],
+  retry: 1,
 });

--- a/e2e/rstest.config.mts
+++ b/e2e/rstest.config.mts
@@ -50,5 +50,6 @@ export default defineConfig({
     '**/dist/**',
     '**/fixtures/**',
     '**/fixtures-*/**',
+    '**/flaky-fixtures/**',
   ].concat(process.env.ISOLATE === 'false' ? NO_ISOLATE_EXCLUDES : []),
 });

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -317,6 +317,11 @@ async function renderStepSummary({
   lines.push(
     `| **Duration** | ${prettyTime(duration.totalTime)} (build ${prettyTime(duration.buildTime)}, tests ${prettyTime(duration.testTime)}) |`,
   );
+  if (flakyTests.length > 0) {
+    lines.push(
+      `| **Flaky Tests** | ${formatFlakyTestCount(flakyTests.length)} |`,
+    );
+  }
   lines.push('');
 
   if (flakyTests.length > 0) {
@@ -473,4 +478,8 @@ function getPreviousFailureSummary(testResult: TestResult): string | undefined {
   }
 
   return `${summary.slice(0, STEP_SUMMARY_MAX_FLAKY_MESSAGE_LENGTH - 1)}…`;
+}
+
+function formatFlakyTestCount(count: number): string {
+  return count === 1 ? '1 passed after retry' : `${count} passed after retry`;
 }

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -174,7 +174,9 @@ function escapeData(s: string): string {
 }
 
 const STEP_SUMMARY_MAX_FAILURES = 20;
+const STEP_SUMMARY_MAX_FLAKY_TESTS = 20;
 const STEP_SUMMARY_MAX_MESSAGE_LENGTH = 400;
+const STEP_SUMMARY_MAX_FLAKY_MESSAGE_LENGTH = 160;
 const ROOT_PATH_PLACEHOLDER = '<ROOT>';
 const DEFAULT_PROJECT_NAME = 'rstest';
 
@@ -282,6 +284,7 @@ async function renderStepSummary({
   const packageManagerAgent = await detectPackageManagerAgent(rootPath);
   const displayPath = getStepSummaryDisplayPath(rootPath);
   const hasUnhandledErrors = (unhandledErrors?.length ?? 0) > 0;
+  const flakyTests = collectFlakyTests(testResults);
   const isSuccess = failures.length === 0 && !hasUnhandledErrors;
   const reportIcon = isSuccess ? '✅' : '❌';
   const projectLabel = getStepSummaryProjectLabel({
@@ -315,6 +318,33 @@ async function renderStepSummary({
     `| **Duration** | ${prettyTime(duration.totalTime)} (build ${prettyTime(duration.buildTime)}, tests ${prettyTime(duration.testTime)}) |`,
   );
   lines.push('');
+
+  if (flakyTests.length > 0) {
+    pushHeading(lines, 2, 'Flaky Tests');
+
+    if (flakyTests.length > STEP_SUMMARY_MAX_FLAKY_TESTS) {
+      lines.push(
+        `Showing first ${STEP_SUMMARY_MAX_FLAKY_TESTS} of ${flakyTests.length} flaky tests.`,
+      );
+      lines.push('');
+    }
+
+    for (const flakyTest of flakyTests.slice(0, STEP_SUMMARY_MAX_FLAKY_TESTS)) {
+      const relativePath = relative(rootPath, flakyTest.testPath);
+      const fullName = formatFullTestName(flakyTest);
+      const title = fullName ? `${relativePath} > ${fullName}` : relativePath;
+      lines.push(
+        `- \`${title}\` (passed after retry x${flakyTest.retryCount})`,
+      );
+
+      const previousFailureSummary = getPreviousFailureSummary(flakyTest);
+      if (previousFailureSummary) {
+        lines.push(`  Previous failure: ${previousFailureSummary}`);
+      }
+    }
+
+    lines.push('');
+  }
 
   if (!isSuccess) {
     pushHeading(lines, 2, 'Failures');
@@ -411,4 +441,36 @@ function trimForSummary(input: string): string {
   }
 
   return `${input.slice(0, STEP_SUMMARY_MAX_MESSAGE_LENGTH - 1)}…`;
+}
+
+function collectFlakyTests(testResults: TestResult[]): TestResult[] {
+  return testResults.filter(
+    (result) => result.status === 'pass' && (result.retryCount ?? 0) > 0,
+  );
+}
+
+function getPreviousFailureSummary(testResult: TestResult): string | undefined {
+  const parts = (testResult.retryErrors || testResult.errors || [])
+    .map((error) => {
+      const message = stripAnsi(error.message).replace(/\s+/g, ' ').trim();
+      if (!message) {
+        return undefined;
+      }
+
+      return `${getErrorType(error)}: ${message}`;
+    })
+    .filter((part, index, items): part is string => {
+      return Boolean(part) && items.indexOf(part) === index;
+    });
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  const summary = parts.join('; ');
+  if (summary.length <= STEP_SUMMARY_MAX_FLAKY_MESSAGE_LENGTH) {
+    return summary;
+  }
+
+  return `${summary.slice(0, STEP_SUMMARY_MAX_FLAKY_MESSAGE_LENGTH - 1)}…`;
 }

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -383,6 +383,7 @@ export class TestRunner {
       } else {
         const start = RealDate.now();
         let retryCount = 0;
+        const retryErrors: FormattedError[] = [];
         // Call onTestCaseStart hook before running the test
         hooks.onTestCaseStart?.({
           testId: test.testId,
@@ -400,11 +401,15 @@ export class TestRunner {
         do {
           const currentResult = await runTestsCase(test, parentHooks);
 
+          if (currentResult.status === 'fail') {
+            retryErrors.push(...(currentResult.errors || []));
+          }
+
           result = {
             ...currentResult,
             errors:
-              currentResult.status === 'fail' && result && result.errors
-                ? result.errors.concat(...(currentResult.errors || []))
+              currentResult.status === 'fail'
+                ? [...retryErrors]
                 : currentResult.errors,
           };
 
@@ -413,6 +418,9 @@ export class TestRunner {
 
         result.duration = RealDate.now() - start;
         result.retryCount = retryCount - 1;
+        if (result.status === 'pass' && retryErrors.length > 0) {
+          result.retryErrors = retryErrors;
+        }
         result.heap = state.runtimeConfig.logHeapUsage
           ? process.memoryUsage().heapUsed
           : undefined;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -151,6 +151,7 @@ export type TestResult = {
   parentNames?: string[];
   duration?: number;
   errors?: FormattedError[];
+  retryErrors?: FormattedError[];
   retryCount?: number;
   project: string;
   heap?: number;

--- a/packages/core/tests/reporter/githubActions.test.ts
+++ b/packages/core/tests/reporter/githubActions.test.ts
@@ -236,4 +236,81 @@ describe('GithubActionsReporter step summary', () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('renders flaky tests with a short summary of previous failures', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rstest-gha-'));
+    const summaryPath = path.join(tempDir, 'summary.md');
+    const previousSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+    const previousWorkspacePath = process.env.GITHUB_WORKSPACE;
+    const testPath = path.join(tempDir, 'tests/flaky.test.ts');
+
+    process.env.GITHUB_STEP_SUMMARY = summaryPath;
+    process.env.GITHUB_WORKSPACE = tempDir;
+
+    try {
+      const reporter = new GithubActionsReporter({
+        rootPath: tempDir,
+        options: {
+          onWritePath: (value) => value,
+          annotations: false,
+        },
+      });
+
+      await reporter.onTestRunEnd({
+        results: [
+          {
+            testId: 'file-1',
+            status: 'pass',
+            name: 'flaky.test.ts',
+            testPath,
+            project: 'rstest',
+            results: [],
+          },
+        ],
+        testResults: [
+          {
+            testId: 'test-1',
+            status: 'pass',
+            name: 'retries then passes',
+            parentNames: ['describe flaky'],
+            testPath,
+            project: 'rstest',
+            retryCount: 2,
+            errors: [
+              {
+                name: 'AssertionError',
+                message: 'expected 1 to be 2\n\nExpected: 2\nReceived: 1',
+              },
+            ],
+          },
+        ],
+        duration: emptyDuration,
+        snapshotSummary: emptySnapshotSummary,
+        getSourcemap: () => null,
+      });
+
+      const summary = await fs.readFile(summaryPath, 'utf-8');
+      expect(summary).toContain('## Flaky Tests');
+      expect(summary).toContain(
+        '- `tests/flaky.test.ts > describe flaky > retries then passes` (passed after retry x2)',
+      );
+      expect(summary).toContain(
+        'Previous failure: AssertionError: expected 1 to be 2 Expected: 2 Received: 1',
+      );
+    } finally {
+      if (previousSummaryPath === undefined) {
+        delete process.env.GITHUB_STEP_SUMMARY;
+      } else {
+        process.env.GITHUB_STEP_SUMMARY = previousSummaryPath;
+      }
+
+      if (previousWorkspacePath === undefined) {
+        delete process.env.GITHUB_WORKSPACE;
+      } else {
+        process.env.GITHUB_WORKSPACE = previousWorkspacePath;
+      }
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/tests/reporter/githubActions.test.ts
+++ b/packages/core/tests/reporter/githubActions.test.ts
@@ -290,6 +290,7 @@ describe('GithubActionsReporter step summary', () => {
       });
 
       const summary = await fs.readFile(summaryPath, 'utf-8');
+      expect(summary).toContain('| **Flaky Tests** | 1 passed after retry |');
       expect(summary).toContain('## Flaky Tests');
       expect(summary).toContain(
         '- `tests/flaky.test.ts > describe flaky > retries then passes` (passed after retry x2)',

--- a/website/docs/en/guide/basic/reporters.mdx
+++ b/website/docs/en/guide/basic/reporters.mdx
@@ -201,6 +201,7 @@ These outputs are parsed by GitHub Actions and generate comments at the correspo
 When `GITHUB_STEP_SUMMARY` is available (GitHub Actions sets this automatically), Rstest also appends a Markdown summary that includes:
 
 - a test summary table (files/tests/duration)
+- a flaky test section for tests that passed after retries, with short summaries of the previous failure messages when available
 - failure sections with error message, diff, and stack trace
 - repro commands for each failed test
 - a status-marked report title (`✅` / `❌`)

--- a/website/docs/zh/guide/basic/reporters.mdx
+++ b/website/docs/zh/guide/basic/reporters.mdx
@@ -199,6 +199,7 @@ export default defineConfig({
 当存在 `GITHUB_STEP_SUMMARY`（GitHub Actions 会自动注入）时，Rstest 还会追加一份 Markdown 摘要，包含：
 
 - 测试汇总表（files/tests/duration）
+- flaky tests 区块：展示重试后通过的用例，并在可用时附带之前失败信息的简短摘要
 - 失败用例详情（错误信息、diff、错误堆栈）
 - 每个失败用例的复现命令
 - 带状态标记的标题（`✅` / `❌`）


### PR DESCRIPTION
## Summary

### Background
GitHub Actions step summaries showed failures and repro commands, but they did not surface tests that only passed after retries. That made flaky runs harder to spot in CI, and there was no short clue about what failed before the retry succeeded.

### Implementation
- Added a `Flaky Tests` section to the GitHub Actions step summary for tests that pass after retries.
- Preserved retry-time error details on passing test results via `retryErrors`, and rendered a short deduplicated failure summary when available.
- Added unit and e2e coverage for the new summary output, and isolated the flaky-only reporter fixture from the default e2e discovery configs.

### User Impact
GitHub Actions summaries now call out flaky tests directly and include a short hint about the previous failure, so CI triage is faster.

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `pnpm format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run test`
- `cd e2e && pnpm test`
- `pnpm run check-unused`

## Notes

- `pnpm format` and `pnpm run lint` report existing repository-wide Biome warnings outside this change set, but they completed successfully.