### PR TITLE
fix(core): warn on flaky github actions summary

### DIFF
--- a/e2e/reporter/githubActions.test.ts
+++ b/e2e/reporter/githubActions.test.ts
@@ -220,7 +220,9 @@ it.skipIf(!process.env.CI)(
       .readFileSync(stepSummaryPath, 'utf-8')
       .replaceAll(process.cwd(), '<ROOT>');
 
-    expect(stepSummary).toContain('<summary>Rstest Test Reporter ✅</summary>');
+    expect(stepSummary).toContain('<details open>');
+    expect(stepSummary).toContain('<summary>Rstest Test Reporter ⚠️</summary>');
+    expect(stepSummary).toContain('# Rstest Test Reporter ⚠️');
     expectWorkspacePath(stepSummary);
     expect(stepSummary).toContain('| **Flaky Tests** | 1 passed after retry |');
     expect(stepSummary).toContain('## Flaky Tests');

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -285,8 +285,9 @@ async function renderStepSummary({
   const displayPath = getStepSummaryDisplayPath(rootPath);
   const hasUnhandledErrors = (unhandledErrors?.length ?? 0) > 0;
   const flakyTests = collectFlakyTests(testResults);
+  const hasFlakyTests = flakyTests.length > 0;
   const isSuccess = failures.length === 0 && !hasUnhandledErrors;
-  const reportIcon = isSuccess ? '✅' : '❌';
+  const reportIcon = isSuccess ? (hasFlakyTests ? '⚠️' : '✅') : '❌';
   const projectLabel = getStepSummaryProjectLabel({
     reportName,
     results,
@@ -298,7 +299,7 @@ async function renderStepSummary({
     : `Rstest Test Reporter ${reportIcon}`;
 
   const lines: string[] = [];
-  lines.push(isSuccess ? '<details>' : '<details open>');
+  lines.push(isSuccess && !hasFlakyTests ? '<details>' : '<details open>');
   lines.push(`<summary>${reportTitle}</summary>`);
   lines.push('');
   lines.push(`# ${reportTitle}`);

--- a/packages/core/tests/reporter/githubActions.test.ts
+++ b/packages/core/tests/reporter/githubActions.test.ts
@@ -290,6 +290,8 @@ describe('GithubActionsReporter step summary', () => {
       });
 
       const summary = await fs.readFile(summaryPath, 'utf-8');
+      expect(summary).toContain('<details open>');
+      expect(summary).toContain('<summary>Rstest Test Reporter ⚠️</summary>');
       expect(summary).toContain('| **Flaky Tests** | 1 passed after retry |');
       expect(summary).toContain('## Flaky Tests');
       expect(summary).toContain(


### PR DESCRIPTION
## Summary

### Background

GitHub step summaries currently treat retry-passed flaky tests the same as stable successes, so the collapsed green report can hide flaky results.

### Implementation

- Use a warning icon when the run succeeds with flaky tests.
- Keep flaky summaries expanded by default and cover the behavior in the reporter test.

### User Impact

GitHub Actions summaries make flaky results visible without changing pass/fail status.

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
