### PR TITLE
release: 0.9.9

### DIFF
--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(core): include flaky tests in github actions summary by @9aoy in https://github.com/web-infra-dev/rstest/pull/1193
* feat(deps): upgrade Rsbuild to 2.0.0 by @9aoy in https://github.com/web-infra-dev/rstest/pull/1199
### Bug Fixes 🐞
* fix: should respect user's resolve.conditionNames configuration by @9aoy in https://github.com/web-infra-dev/rstest/pull/1186
* fix(core): preserve runtime meta url for named projects by @9aoy in https://github.com/web-infra-dev/rstest/pull/1188
* fix(core): prefer root name in github actions summary by @9aoy in https://github.com/web-infra-dev/rstest/pull/1187
* fix(core): warn on flaky github actions summary by @9aoy in https://github.com/web-infra-dev/rstest/pull/1197
### Document 📖
* docs(migration): rework Jest/Vitest guides with config mapping tables by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1190
* docs: add `why rstest` by @9aoy in https://github.com/web-infra-dev/rstest/pull/1183
* docs(migration): add shim/test-name guidance and snapshot format notes by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1192
* docs(agent-install): route to migration when Jest/Vitest is detected by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1180
### Other Changes
* ci(codspeed): run CPU benchmark weekly instead of every 6 hours by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1191


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.9.8...v0.9.9