### PR TITLE
perf(core): optimize updateTestModes traversal

### DIFF
--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -27,33 +27,127 @@ export const getTestStatus = (
         : 'pass';
 };
 
-function hasOnlyTest(test: Test[]): boolean {
-  return test.some((t) => {
-    return t.runMode === 'only' || (t.type === 'suite' && hasOnlyTest(t.tests));
-  });
-}
+type TestModeContext = {
+  shouldSkipByName?: (test: TestCase) => boolean;
+  suiteHasOnlyDescendants: WeakMap<TestSuite, boolean>;
+};
+
+const collectOnlyTests = (
+  tests: Test[],
+  suiteHasOnlyDescendants: WeakMap<TestSuite, boolean>,
+): boolean => {
+  let hasOnly = false;
+
+  for (const test of tests) {
+    const childrenHaveOnly =
+      test.type === 'suite'
+        ? collectOnlyTests(test.tests, suiteHasOnlyDescendants)
+        : false;
+
+    if (test.type === 'suite') {
+      suiteHasOnlyDescendants.set(test, childrenHaveOnly);
+    }
+
+    if (test.runMode === 'only' || childrenHaveOnly) {
+      hasOnly = true;
+    }
+  }
+
+  return hasOnly;
+};
+
+const createShouldSkipByName = (
+  testNamePattern?: RegExp | string,
+): ((test: TestCase) => boolean) | undefined => {
+  if (!testNamePattern) {
+    return undefined;
+  }
+
+  const delimiter = testNamePattern.toString().includes(TEST_DELIMITER)
+    ? TEST_DELIMITER
+    : '';
+
+  return (test: TestCase) => {
+    return !getTaskNameWithPrefix(test, delimiter).match(testNamePattern);
+  };
+};
 
 const shouldTestSkip = (
   test: TestCase,
   runOnly: boolean,
-  testNamePattern?: RegExp | string,
+  shouldSkipByName?: (test: TestCase) => boolean,
 ) => {
   if (runOnly && test.runMode !== 'only') {
     return true;
   }
 
-  const delimiter = testNamePattern?.toString().includes(TEST_DELIMITER)
-    ? TEST_DELIMITER
-    : '';
-
-  if (
-    testNamePattern &&
-    !getTaskNameWithPrefix(test, delimiter).match(testNamePattern)
-  ) {
+  if (shouldSkipByName?.(test)) {
     return true;
   }
 
   return false;
+};
+
+const traverseUpdateTestRunModeWithContext = (
+  testSuite: TestSuite,
+  parentRunMode: TestRunMode,
+  runOnly: boolean,
+  context: TestModeContext,
+): void => {
+  if (testSuite.tests.length === 0) {
+    return;
+  }
+
+  const childrenHaveOnly =
+    context.suiteHasOnlyDescendants.get(testSuite) ?? false;
+
+  if (runOnly && testSuite.runMode !== 'only' && !childrenHaveOnly) {
+    testSuite.runMode = 'skip';
+  } else if (['skip', 'todo'].includes(parentRunMode)) {
+    testSuite.runMode = parentRunMode;
+  }
+
+  const runSubOnly =
+    runOnly && testSuite.runMode !== 'only' ? runOnly : childrenHaveOnly;
+  let hasRunTest = false;
+  let allTodoTest = true;
+
+  for (const test of testSuite.tests) {
+    if (test.type === 'case') {
+      if (['skip', 'todo'].includes(testSuite.runMode)) {
+        test.runMode = testSuite.runMode;
+      }
+      if (shouldTestSkip(test, runSubOnly, context.shouldSkipByName)) {
+        test.runMode = 'skip';
+      }
+    } else {
+      traverseUpdateTestRunModeWithContext(
+        test,
+        testSuite.runMode,
+        runSubOnly,
+        context,
+      );
+    }
+
+    if (test.runMode === 'run' || test.runMode === 'only') {
+      hasRunTest = true;
+    }
+
+    if (test.runMode !== 'todo') {
+      allTodoTest = false;
+    }
+  }
+
+  if (testSuite.runMode !== 'run') {
+    return;
+  }
+
+  if (hasRunTest) {
+    testSuite.runMode = 'run';
+    return;
+  }
+
+  testSuite.runMode = allTodoTest ? 'todo' : 'skip';
 };
 
 export const traverseUpdateTestRunMode = (
@@ -62,60 +156,13 @@ export const traverseUpdateTestRunMode = (
   runOnly: boolean,
   testNamePattern?: RegExp | string,
 ): void => {
-  if (testSuite.tests.length === 0) {
-    return;
-  }
+  const suiteHasOnlyDescendants = new WeakMap<TestSuite, boolean>();
+  collectOnlyTests([testSuite], suiteHasOnlyDescendants);
 
-  if (
-    runOnly &&
-    testSuite.runMode !== 'only' &&
-    !hasOnlyTest(testSuite.tests)
-  ) {
-    testSuite.runMode = 'skip';
-  } else if (['skip', 'todo'].includes(parentRunMode)) {
-    testSuite.runMode = parentRunMode;
-  }
-
-  const tests = testSuite.tests.map((test) => {
-    const runSubOnly =
-      runOnly && testSuite.runMode !== 'only'
-        ? runOnly
-        : hasOnlyTest(testSuite.tests);
-
-    if (test.type === 'case') {
-      if (['skip', 'todo'].includes(testSuite.runMode)) {
-        test.runMode = testSuite.runMode;
-      }
-      if (shouldTestSkip(test, runSubOnly, testNamePattern)) {
-        test.runMode = 'skip';
-      }
-      return test;
-    }
-    traverseUpdateTestRunMode(
-      test,
-      testSuite.runMode,
-      runSubOnly,
-      testNamePattern,
-    );
-    return test;
+  traverseUpdateTestRunModeWithContext(testSuite, parentRunMode, runOnly, {
+    shouldSkipByName: createShouldSkipByName(testNamePattern),
+    suiteHasOnlyDescendants,
   });
-
-  if (testSuite.runMode !== 'run') {
-    return;
-  }
-
-  const hasRunTest = tests.some(
-    (test) => test.runMode === 'run' || test.runMode === 'only',
-  );
-
-  if (hasRunTest) {
-    testSuite.runMode = 'run';
-    return;
-  }
-
-  const allTodoTest = tests.every((test) => test.runMode === 'todo');
-
-  testSuite.runMode = allTodoTest ? 'todo' : 'skip';
 };
 
 /**
@@ -136,12 +183,17 @@ export const updateTestModes = (
   tests: Test[],
   testNamePattern?: RegExp | string,
 ): void => {
-  const hasOnly = hasOnlyTest(tests);
+  const suiteHasOnlyDescendants = new WeakMap<TestSuite, boolean>();
+  const hasOnly = collectOnlyTests(tests, suiteHasOnlyDescendants);
+  const shouldSkipByName = createShouldSkipByName(testNamePattern);
 
   for (const test of tests) {
     if (test.type === 'suite') {
-      traverseUpdateTestRunMode(test, 'run', hasOnly, testNamePattern);
-    } else if (shouldTestSkip(test, hasOnly, testNamePattern)) {
+      traverseUpdateTestRunModeWithContext(test, 'run', hasOnly, {
+        shouldSkipByName,
+        suiteHasOnlyDescendants,
+      });
+    } else if (shouldTestSkip(test, hasOnly, shouldSkipByName)) {
       test.runMode = 'skip';
     }
   }

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -63,12 +63,20 @@ const createShouldSkipByName = (
     return undefined;
   }
 
-  const delimiter = testNamePattern.toString().includes(TEST_DELIMITER)
+  const regex =
+    typeof testNamePattern === 'string'
+      ? new RegExp(testNamePattern)
+      : testNamePattern;
+  const delimiter = regex.toString().includes(TEST_DELIMITER)
     ? TEST_DELIMITER
     : '';
 
   return (test: TestCase) => {
-    return !getTaskNameWithPrefix(test, delimiter).match(testNamePattern);
+    if (regex.global || regex.sticky) {
+      regex.lastIndex = 0;
+    }
+
+    return !regex.test(getTaskNameWithPrefix(test, delimiter));
   };
 };
 

--- a/packages/core/tests/runner/runner.test.ts
+++ b/packages/core/tests/runner/runner.test.ts
@@ -339,4 +339,66 @@ describe('traverseUpdateTest', () => {
       ]
     `);
   });
+
+  it('updateTestMode with string and global regex patterns', () => {
+    const createTests = (): [TestSuite, TestCase] => [
+      {
+        name: 'testA',
+        runMode: 'run',
+        type: 'suite',
+        tests: [
+          {
+            name: 'test-0',
+            type: 'case',
+            runMode: 'run',
+          },
+          {
+            name: 'test-1',
+            type: 'case',
+            runMode: 'run',
+          },
+          {
+            name: 'test-2',
+            type: 'suite',
+            runMode: 'run',
+            tests: [
+              {
+                name: 'test-2-1',
+                type: 'case',
+                runMode: 'run',
+              },
+              {
+                name: 'test-2-2',
+                type: 'case',
+                runMode: 'run',
+              },
+            ],
+          },
+        ],
+      } as TestSuite,
+      {
+        name: 'testB',
+        runMode: 'run',
+        type: 'case',
+      } as TestCase,
+    ];
+
+    const stringPatternTests = createTests();
+    traverseUpdateTest(stringPatternTests, '2-1');
+
+    expect(stringPatternTests[0].tests[0]?.runMode).toBe('skip');
+    expect(stringPatternTests[0].tests[1]?.runMode).toBe('skip');
+    expect(
+      (stringPatternTests[0].tests[2] as TestSuite).tests[0]?.runMode,
+    ).toBe('run');
+    expect(
+      (stringPatternTests[0].tests[2] as TestSuite).tests[1]?.runMode,
+    ).toBe('skip');
+    expect(stringPatternTests[1].runMode).toBe('skip');
+
+    const globalRegexTests = createTests();
+    traverseUpdateTest(globalRegexTests, /2-1/g);
+
+    expect(globalRegexTests).toEqual(stringPatternTests);
+  });
 });


### PR DESCRIPTION
## Summary

### Background

`updateTestModes` was repeatedly rescanning suite subtrees for `only` handling and rebuilding name-match work per test, which showed up in synthetic runner benchmarks.

### Implementation

- Precompute whether each suite has `only` descendants with a `WeakMap`, then reuse that state during the run-mode traversal.
- Collapse suite status aggregation into the main traversal loop and reuse a single `testNamePattern` matcher; 

### User Impact

Large collected test trees spend less time normalizing run modes before execution; no user-facing API changes.

## Benchmark

```ts
describe('synthetic rstest suite', () => {
  for (let i = 0; i < 10000; i++) {
    it('adds numbers ' + i, () => {
      expect(1 + 1).toBe(2);
    });
  }
});
```

Result:

- Before: `681ms` (`build 78ms`, `tests 603ms`), wall clock `real 1.53s`
- After: `562ms` (`build 70ms`, `tests 492ms`), wall clock `real 1.21s`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).