### PR TITLE
ci(codspeed): run after e2e succeeds

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,21 +1,12 @@
 name: CodSpeed
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - 'packages/**'
-      - 'benchmarks/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/codspeed.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/**'
-      - 'benchmarks/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/codspeed.yml'
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to benchmark.'
+        required: false
+        type: string
   schedule:
     # Run once a week on main to build a continuous baseline for CPU benchmark
     - cron: '0 0 * * 0'
@@ -28,10 +19,11 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: codspeed-${{ github.event.pull_request.number || inputs.ref || github.sha }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,6 +214,20 @@ jobs:
         if: matrix.test_script == 'test'
         run: pnpm run test:vscode
 
+  # ======== codspeed ========
+  codspeed:
+    needs: e2e
+    if: |
+      needs.e2e.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'pull_request')
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/codspeed.yml
+    with:
+      ref: ${{ github.sha }}
+
   # ======== gate ========
   test-gate:
     needs: [prepare, lint, ut, e2e]


### PR DESCRIPTION
## Summary

### Background

CodSpeed can currently start before the main Test workflow proves that a commit passes e2e, which spends benchmark capacity on commits that may already be broken.

### Implementation

- Converted the CodSpeed workflow to a reusable workflow while keeping schedule/manual entry points.
- Added a Test workflow job that calls CodSpeed only after the e2e matrix succeeds.
- Used a CodSpeed-specific concurrency group and explicit `actions: read` permission for duplicate-run checks.

```
Test workflow
prepare + lint + ut
        |
       e2e
        |
   CodSpeed workflow
```

### User Impact

None — CI orchestration only.

## Validation

- [x] `pnpm format`
- [x] `pnpm run lint` with Node v22.22.1
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] `actionlint` for changed workflows, ignoring the existing custom runner label `codspeed-macro`
- [x] Failed e2e cases rerun individually:
  - `pnpm exec rstest 'browser-mode/browserReact.test.ts' --testNamePattern 'browser mode - @rstest/browser-react > should work with render, renderHook, cleanup, and @testing-library/dom'`
  - `pnpm exec rstest 'browser-mode/entryOverride.test.ts'`
- [x] `cd e2e && pnpm test` full run: blocked locally by another worktree's `rstest-node` processes occupying browser fixture ports 5180-5228 (`/Users/bytedance/Projects/worktrees/tree/dev1`)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).