### PR TITLE
chore: clear existing lint warnings

### DIFF
--- a/e2e/watch/index.test.ts
+++ b/e2e/watch/index.test.ts
@@ -84,6 +84,7 @@ describe.skipIf(process.platform === 'win32')('watch', () => {
     // Modify src/shared.ts (shared): both test files rerun
     cli.resetStd();
     fs.update(path.join(fixturesTargetPath, 'src/shared.ts'), () => {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: write literal source text with ${name}.
       return 'export const greet = (name: string) => `Hi, ${name}!`;';
     });
 

--- a/examples/svelte-rsbuild/src/components/Counter.svelte
+++ b/examples/svelte-rsbuild/src/components/Counter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+/* biome-ignore-all lint/correctness/noUnusedVariables: Svelte template references are consumed outside the script AST. */
 import { getDefaultStep } from '@/utils/step';
 
 export let initialValue = 0;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check-unused": "knip",
     "e2e": "cd e2e && pnpm test && pnpm test:commonjs && pnpm test:no-isolate",
     "format": "biome check --write && prettier --write '**/*.{md,mdx,css,less,scss,json,jsonc,json5}' && heading-case --write",
-    "lint": "biome check . --diagnostic-level=warn && pnpm run check-spell && pnpm lint:type",
+    "lint": "biome check . --error-on-warnings && pnpm run check-spell && pnpm lint:type",
     "lint:type": "rslint",
     "prepare": "lefthook install && pnpm run build",
     "test": "rstest",

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -168,7 +168,6 @@ const getMockImplementation = (mockType = 'mock') => {
         );
       }
       const originalModule = requiredModule;
-      const isEsModule = originalModule.__esModule === true;
       const mockedModule =
         globalThis.RSTEST_API?.rstest?.mockObject(originalModule, {
           spy: isSpy,


### PR DESCRIPTION
## Summary

### Background
Biome reported existing warnings in the core mock runtime, a watch e2e fixture string, and the Svelte example component, which kept the repository from a clean lint run.

### Implementation
- Removed the unused `isEsModule` variable from the core mock runtime.
- Added targeted Biome suppressions for the watch fixture source string and the Svelte template-backed script variables.

### User Impact
`pnpm lint` now completes without warning noise from these known cases.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).