### PR TITLE
docs(website): improve rstest feature messaging

### DIFF
--- a/website/docs/en/guide/start/features.mdx
+++ b/website/docs/en/guide/start/features.mdx
@@ -1,75 +1,75 @@
 ---
-description: Here you can learn about the key features supported by Rstest.
+description: Explore Rstest features for build-integrated testing, including Rstack config reuse, browser mode, sharding, and coverage.
 ---
 
 # Features
 
-Here you can learn about the key features supported by Rstest.
+Rstest brings testing into the Rsbuild and Rspack build pipeline. It reuses build configuration where possible, runs tests through a bundle-based execution model, and provides the core testing features needed for local development and CI.
 
-## Reuse the Rstack ecosystem
+## Reuse existing build setup
 
-Rstest can directly reuse Rsbuild and Rspack configurations and plugin ecosystems. You can use the same configuration for both development and testing to enjoy a consistent experience across the Rstack toolchain.
+Rstest can reuse Rsbuild and Rspack configuration, including module resolution, transforms, and plugin behavior. This reduces the need for a separate test-only build setup and keeps tests aligned with the code that ships.
 
 Learn more about [Configuring Rstest](/guide/basic/configure-rstest).
 
 ### Built on Rspack
 
-Rstest is powered by Rspack, enabling high-performance builds and optimizations such as Tree Shaking and [lazyBarrel](https://rspack.rs/guide/optimization/lazy-barrel).
+Rstest runs tests on top of Rspack's bundling pipeline, so it can benefit from build-time optimizations such as Tree Shaking and [lazyBarrel](https://rspack.rs/guide/optimization/lazy-barrel) while keeping test behavior closer to real output.
 
 ### Transpiled with SWC
 
-Rstest includes a built-in SWC transpiler, providing out-of-the-box JavaScript/TypeScript transpilation. You can easily customize SWC behavior through the configuration file to meet different project needs.
+By default, Rstest uses Rspack's built-in SWC loader to transform JavaScript and TypeScript. You can customize SWC options in the configuration file when a project needs different syntax or transform behavior.
 
 Learn more about [Configuring SWC](/guide/basic/configure-rstest#configure-swc).
 
 ## Multi-project testing
 
-Rstest provides multi-project testing capabilities, allowing you to run tests for multiple projects in parallel within a single Rstest process.
+Rstest can run multiple test projects in one process, with each project keeping its own configuration and environment. This is useful for monorepos, multi-app workspaces, and projects that need separate Node, DOM, or Browser Mode test targets.
 
 Learn more about [Test projects](/guide/basic/projects).
 
 ## Test sharding
 
-Rstest supports splitting test files into multiple shards for parallel execution. In CI, you can distribute the same test suite across multiple machines to reduce overall execution time. With the `blob` reporter and `rstest merge-reports`, you can merge test results and coverage data after all shards complete.
+Rstest can split test files into shards for parallel execution. In CI, you can distribute the same test suite across multiple machines to reduce total runtime, then use the `blob` reporter and `rstest merge-reports` to merge test results and coverage data after all shards complete.
 
 Learn more about [Test sharding](/config/test/shard).
 
 ## In-source tests
 
-Rstest supports a Rust-like module testing style, allowing you to write test blocks directly inside source files. This approach is ideal for small utility functions and helpers, enabling quick verification and debugging.
+Rstest supports a Rust-like module testing style that lets you write test blocks directly inside source files. It works well for small utilities and helpers where keeping fast checks next to the implementation makes development easier.
 
 Learn more about [In-source tests](/config/test/include-source).
 
 ## Watch mode
 
-When you modify a test file or one of its dependencies, Rstest analyzes the module graph and only re-runs the affected test files, significantly improving local feedback speed.
+When you modify a test file or one of its dependencies, Rstest analyzes the module graph and only reruns the affected test files. This keeps local feedback fast as the test suite grows.
 
 ## DOM testing
 
-Rstest supports simulating the DOM and browser APIs using jsdom and happy-dom. It provides solid support for frameworks such as React and Vue, and is compatible with Testing Library and CSS Modules.
+Rstest can simulate the DOM and browser APIs with jsdom or happy-dom. It supports common framework testing workflows for React and Vue, and works with Testing Library and CSS Modules.
 
 Learn more about [DOM testing](/config/test/test-environment#dom-testing).
 
 ## Browser mode
 
-Rstest provides Browser Mode, allowing you to run tests in real browsers instead of relying on simulated environments like jsdom or happy-dom. This helps validate real browser API behavior and reduces gaps between test and production environments.
+Rstest provides Browser Mode for tests that need a real browser instead of a simulated environment such as jsdom or happy-dom. This helps validate browser APIs, rendering behavior, and interactions that are difficult to cover in DOM simulators.
 
-Browser Mode is powered by [Playwright](https://playwright.dev/) and can run tests in Chromium, Firefox, and WebKit, which is a good fit for cross-browser verification and scenarios that depend on real rendering behavior.
+Browser Mode is powered by [Playwright](https://playwright.dev/) and can run tests in Chromium, Firefox, and WebKit, making it suitable for cross-browser verification.
 
 Learn more about [Browser mode](/guide/browser-testing).
 
 ## Code coverage
 
-Rstest supports code coverage collection using [istanbul](https://istanbul.js.org/). You can enable code coverage collection by setting `coverage.enabled` to `true` in your Rstest configuration file.
+Rstest can collect code coverage with [istanbul](https://istanbul.js.org/). Enable it by setting `coverage.enabled` to `true` in your Rstest configuration file.
 
 Learn more about [Code coverage](/config/test/coverage).
 
 ## More capabilities
 
-- Jest-compatible assertions and snapshot testing
-- Mock / Spy utilities
+- Jest-compatible assertions and snapshots
+- Mock and spy utilities
 - File-level sandbox isolation
-- Rich lifecycle hooks
-- Reporters and CI integration
-- Filtering by directory / project / test name
+- Lifecycle hooks for setup and teardown
+- Built-in reporters and CI output
+- Filtering by directory, project, file, or test name
 - VS Code extension

--- a/website/docs/zh/guide/start/features.mdx
+++ b/website/docs/zh/guide/start/features.mdx
@@ -1,75 +1,75 @@
 ---
-description: 在这里，你可以了解到 Rstest 支持的主要功能。
+description: 了解 Rstest 面向构建一体化测试提供的能力，包括 Rstack 配置复用、浏览器模式、测试分片和覆盖率。
 ---
 
 # 功能导航
 
-在这里，你可以了解到 Rstest 支持的主要功能。
+Rstest 将测试融入 Rsbuild 与 Rspack 构建链路。它会尽可能复用构建配置，通过基于 bundle 的执行模型运行测试，并提供本地开发和 CI 所需的核心测试能力。
 
-## 复用 Rstack 生态
+## 复用现有构建配置
 
-Rstest 可直接复用 Rsbuild、Rspack 等构建配置与插件生态。你可以使用同一套配置进行开发与测试，享受 Rstack 工具链带来的一致化体验。
+Rstest 可以复用 Rsbuild 与 Rspack 配置，包括模块解析、代码转换和插件行为。这样可以减少测试专用构建配置的重复维护，让测试环境与最终交付代码保持一致。
 
 了解更多关于 [配置 Rstest](/guide/basic/configure-rstest)。
 
 ### 基于 Rspack 构建
 
-Rstest 底层使用 Rspack 构建，能够在 Rstest 中享受 Rspack 带来的高性能构建和 Tree-shaking、[lazyBarrel](https://rspack.rs/zh/guide/optimization/lazy-barrel) 等优化。
+Rstest 基于 Rspack 的 bundling pipeline 运行测试，因此可以利用 Tree Shaking、[lazyBarrel](https://rspack.rs/zh/guide/optimization/lazy-barrel) 等构建期优化，同时让测试行为更贴近真实产物。
 
 ### 基于 SWC 转译
 
-Rstest 内置 SWC 转译器，提供开箱即用的 JavaScript/TypeScript 转译能力。你可以通过配置文件轻松定制 SWC 行为，以满足不同项目的需求。
+默认情况下，Rstest 使用 Rspack 内置的 SWC loader 转换 JavaScript 和 TypeScript。当项目需要不同的语法或转换行为时，你可以在配置文件中自定义 SWC 选项。
 
 了解更多关于 [配置 SWC](/guide/basic/configure-rstest#配置-swc)。
 
 ## 多项目测试
 
-Rstest 提供了多项目测试的能力，支持在单个 Rstest 进程中并行对多个项目进行测试。
+Rstest 可以在同一个进程中运行多个测试项目，每个项目都可以保留自己的配置和环境。这适合 monorepo、多应用工作区，以及需要分别覆盖 Node、DOM 或 Browser Mode 的项目。
 
 了解更多关于 [多项目测试](/guide/basic/projects)。
 
 ## 测试分片（Sharding）
 
-Rstest 支持将测试文件拆分为多个分片并行执行。你可以在 CI 中将同一套测试分发到多台机器，以缩短整体执行时间。配合 `blob` 报告器与 `rstest merge-reports`，还能在执行完成后合并测试结果与代码覆盖率。
+Rstest 可以将测试文件拆分为多个分片并行执行。你可以在 CI 中把同一套测试分发到多台机器以缩短总耗时，并在所有分片完成后通过 `blob` 报告器与 `rstest merge-reports` 合并测试结果和代码覆盖率。
 
 了解更多关于 [测试分片](/config/test/shard)。
 
 ## 源码内联测试
 
-Rstest 支持类 [Rust 的模块测试](https://doc.rust-lang.org/book/ch11-03-test-organization.html#the-tests-module-and-cfgtest)方式，可在源码文件内直接书写测试块。此方式适用于小型功能函数与工具方法，便于快速验证和调试。
+Rstest 支持类 [Rust 的模块测试](https://doc.rust-lang.org/book/ch11-03-test-organization.html#the-tests-module-and-cfgtest)风格，可以在源码文件中直接编写测试块。对于小型工具函数和 helper，将快速检查放在实现旁边会让开发更顺手。
 
 了解更多关于 [源码内联测试](/config/test/include-source)。
 
 ## Watch 模式
 
-当你修改测试文件或其依赖模块时，Rstest 会基于模块图分析，仅重新运行受影响的测试文件，从而显著提升本地测试效率。
+当你修改测试文件或其依赖模块时，Rstest 会基于模块图分析，仅重新运行受影响的测试文件。随着测试规模增长，这可以让本地反馈保持快速。
 
 ## DOM 测试
 
-Rstest 支持使用 jsdom 与 happy-dom 模拟 DOM 与浏览器 API，并对 React、Vue 等框架提供良好支持，兼容 Testing Library、CSS Modules 等。
+Rstest 可以通过 jsdom 或 happy-dom 模拟 DOM 与浏览器 API。它支持 React、Vue 等常见框架测试流程，并兼容 Testing Library 和 CSS Modules。
 
 了解更多关于 [DOM 测试](/config/test/test-environment#dom-测试)。
 
 ## 浏览器模式（Browser Mode）
 
-Rstest 提供 Browser Mode，允许你在真实浏览器中运行测试，而不是依赖 jsdom 或 happy-dom 这类模拟环境。这样可以直接验证真实浏览器 API 行为，减少测试环境与生产环境之间的差异。
+Rstest 提供 Browser Mode，适用于需要真实浏览器、而不是 jsdom 或 happy-dom 这类模拟环境的测试。它可以帮助你验证浏览器 API、渲染行为，以及 DOM 模拟器难以覆盖的交互。
 
-Browser Mode 基于 [Playwright](https://playwright.dev/) 运行，可在 Chromium、Firefox、WebKit 中执行测试，适合需要跨浏览器验证或依赖真实渲染能力的场景。
+Browser Mode 基于 [Playwright](https://playwright.dev/) 运行，可在 Chromium、Firefox 和 WebKit 中执行测试，适合跨浏览器验证。
 
 了解更多关于 [浏览器模式](/guide/browser-testing)。
 
 ## 代码覆盖率
 
-Rstest 支持使用 [istanbul](https://istanbul.js.org/) 收集代码覆盖率。你可以通过设置 `coverage.enabled` 为 `true` 来启用代码覆盖率收集。
+Rstest 可以使用 [istanbul](https://istanbul.js.org/) 收集代码覆盖率。你可以在 Rstest 配置文件中将 `coverage.enabled` 设置为 `true` 来启用覆盖率。
 
 了解更多关于 [代码覆盖率](/config/test/coverage)。
 
 ## 更多能力
 
-- 与 Jest 兼容的断言与快照测试
-- Mock / Spy 能力
+- 与 Jest 兼容的断言和快照
+- Mock 和 spy 工具
 - 文件级沙箱隔离
-- 多种生命周期钩子
-- 多种报告器与 CI 集成
-- 支持按文件夹 / 项目 / 测试名进行过滤
+- 用于 setup 和 teardown 的生命周期钩子
+- 内置报告器和 CI 输出
+- 支持按目录、项目、文件或测试名过滤
 - VS Code 插件

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -39,13 +39,13 @@
     "en": "Rspack-powered bundling keeps startup and reruns fast, even in larger projects.",
     "zh": "基于 Rspack 的构建与优化能力，在大型项目中也能保持快速启动和重新运行。"
   },
-  "unifiedRstackExperience": {
-    "en": "Built for the Rstack workflow",
-    "zh": "融入 Rstack 工作流"
+  "realBrowserTesting": {
+    "en": "Real browser testing",
+    "zh": "真实浏览器测试"
   },
-  "unifiedRstackExperienceDesc": {
-    "en": "Works naturally with Rsbuild, Rspack, and Rslib projects without duplicating tooling.",
-    "zh": "自然接入 Rsbuild、Rspack 和 Rslib 项目，减少重复工具链维护。"
+  "realBrowserTestingDesc": {
+    "en": "Run tests in Chromium, Firefox, or WebKit through Playwright when jsdom isn't enough.",
+    "zh": "基于 Playwright 在 Chromium、Firefox、WebKit 中运行测试，覆盖 jsdom 难以验证的场景。"
   },
   "modernByDefault": {
     "en": "Modern by default",

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -14,5 +14,53 @@
   "slogan": {
     "en": "Provide first-class support for Rspack ecosystem",
     "zh": "为 Rspack 生态提供全面、一流的支持"
+  },
+  "reuseBuildConfig": {
+    "en": "Reuse your build setup",
+    "zh": "复用现有构建配置"
+  },
+  "reuseBuildConfigDesc": {
+    "en": "Use existing Rsbuild or Rspack config so aliases, transforms, and plugins stay consistent in tests.",
+    "zh": "直接使用 Rsbuild 或 Rspack 配置，让 alias、transform 和插件能力在测试中保持一致。"
+  },
+  "productionAccurateTesting": {
+    "en": "Test through the build pipeline",
+    "zh": "沿用构建链路测试"
+  },
+  "productionAccurateTestingDesc": {
+    "en": "Run tests through Rspack's bundling model to match production behavior more closely.",
+    "zh": "通过 Rspack 的 bundle 模型运行测试，让测试行为更贴近生产产物。"
+  },
+  "blazingFast": {
+    "en": "Fast by design",
+    "zh": "高效执行"
+  },
+  "blazingFastDesc": {
+    "en": "Rspack-powered bundling keeps startup and reruns fast, even in larger projects.",
+    "zh": "基于 Rspack 的构建与优化能力，在大型项目中也能保持快速启动和重新运行。"
+  },
+  "unifiedRstackExperience": {
+    "en": "Built for the Rstack workflow",
+    "zh": "融入 Rstack 工作流"
+  },
+  "unifiedRstackExperienceDesc": {
+    "en": "Works naturally with Rsbuild, Rspack, and Rslib projects without duplicating tooling.",
+    "zh": "自然接入 Rsbuild、Rspack 和 Rslib 项目，减少重复工具链维护。"
+  },
+  "modernByDefault": {
+    "en": "Modern by default",
+    "zh": "现代能力默认可用"
+  },
+  "modernByDefaultDesc": {
+    "en": "TypeScript, ESM, CJS, CSS Modules, and modern JavaScript work out of the box.",
+    "zh": "TypeScript、ESM、CJS、CSS Modules 和现代 JavaScript 开箱即用。"
+  },
+  "testingReady": {
+    "en": "Testing essentials included",
+    "zh": "核心测试能力内置"
+  },
+  "testingReadyDesc": {
+    "en": "Assertions, snapshots, mocks, coverage, and lifecycle hooks are ready when you start.",
+    "zh": "断言、快照、Mock、覆盖率和生命周期钩子等能力开箱即用。"
   }
 }

--- a/website/theme/components/Features.module.scss
+++ b/website/theme/components/Features.module.scss
@@ -1,0 +1,13 @@
+:global {
+  .max-w-6xl.flex.m-auto {
+    max-width: 1200px;
+  }
+
+  html.dark {
+    --rp-home-feature-bg: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 0.03)
+    );
+  }
+}

--- a/website/theme/components/Features.tsx
+++ b/website/theme/components/Features.tsx
@@ -35,9 +35,9 @@ export function Features() {
       icon: '🧰',
     },
     {
-      title: t('unifiedRstackExperience'),
-      details: t('unifiedRstackExperienceDesc'),
-      icon: '🧩',
+      title: t('realBrowserTesting'),
+      details: t('realBrowserTestingDesc'),
+      icon: '🌐',
     },
   ];
 

--- a/website/theme/components/Features.tsx
+++ b/website/theme/components/Features.tsx
@@ -1,0 +1,51 @@
+import { useI18n } from '@rspress/core/runtime';
+import {
+  containerStyle,
+  innerContainerStyle,
+} from '@rstack-dev/doc-ui/section-style';
+import { HomeFeature } from '@theme';
+import './Features.module.scss';
+
+export function Features() {
+  const t = useI18n<typeof import('i18n')>();
+  const features = [
+    {
+      title: t('reuseBuildConfig'),
+      details: t('reuseBuildConfigDesc'),
+      icon: '♻️',
+    },
+    {
+      title: t('productionAccurateTesting'),
+      details: t('productionAccurateTestingDesc'),
+      icon: '🎯',
+    },
+    {
+      title: t('blazingFast'),
+      details: t('blazingFastDesc'),
+      icon: '⚡',
+    },
+    {
+      title: t('modernByDefault'),
+      details: t('modernByDefaultDesc'),
+      icon: '🧠',
+    },
+    {
+      title: t('testingReady'),
+      details: t('testingReadyDesc'),
+      icon: '🧰',
+    },
+    {
+      title: t('unifiedRstackExperience'),
+      details: t('unifiedRstackExperienceDesc'),
+      icon: '🧩',
+    },
+  ];
+
+  return (
+    <section className={containerStyle}>
+      <div className={innerContainerStyle}>
+        <HomeFeature features={features} />
+      </div>
+    </section>
+  );
+}

--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -1,5 +1,6 @@
 import { BackgroundImage } from '@rstack-dev/doc-ui/background-image';
 import { CopyRight } from '../components/Copyright';
+import { Features } from '../components/Features';
 import { Hero } from '../components/Hero';
 import { ToolStack } from '../components/ToolStack';
 
@@ -8,6 +9,7 @@ export function HomeLayout() {
     <div style={{ position: 'relative' }}>
       <BackgroundImage />
       <Hero />
+      <Features />
       <ToolStack />
       <CopyRight />
     </div>


### PR DESCRIPTION
## Summary

### Background

The feature docs and homepage cards used generic wording that did not clearly explain Rstest's build-integrated testing position.

### Implementation

- Add localized homepage feature card copy for build setup reuse, bundle-based testing, Rstack workflow fit, and built-in testing essentials.
- Rewrite the English and Chinese feature docs around user impact across config reuse, sharding, browser mode, coverage, and local feedback.

### User Impact

Readers get clearer Rstest feature positioning across the homepage and documentation.

## Related Links

None

## Checklist

- [x] Tests updated (or not required). Docs-only / website validation: `pnpm format`, `pnpm run lint`, `pnpm --filter rstest-website build`.
- [x] Documentation updated (or not required).
