### PR TITLE
ci(codspeed): temporarily disable on PR/push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,11 +215,11 @@ jobs:
         run: pnpm run test:vscode
 
   # ======== codspeed ========
+  # Temporarily disabled: CodSpeed runner quota exhausted.
+  # Re-enable once quota resets.
   codspeed:
     needs: e2e
-    if: |
-      needs.e2e.result == 'success' &&
-      (github.event_name == 'push' || github.event_name == 'pull_request')
+    if: false
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary

- CodSpeed runner quota is exhausted; flip the `codspeed` gate in `test.yml` to `if: false` so it stops firing on every PR and push to `main`.
- `schedule` (weekly) and `workflow_dispatch` (manual) in `codspeed.yml` are untouched.
- Revert by restoring the previous `if:` expression once the quota resets.

## Test plan

- [ ] CI for this PR shows the `codspeed` job as skipped.