### PR TITLE
feat(core): resolve dynamic imports against source module origin

### DIFF
--- a/e2e/dom/fixtures/package.json
+++ b/e2e/dom/fixtures/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/externals/dynamic-import-interop/babelStyle.cjs
+++ b/e2e/externals/dynamic-import-interop/babelStyle.cjs
@@ -1,0 +1,7 @@
+// Babel/TSC-style CJS: `__esModule: true` plus an explicit `exports.default`.
+// User contract: `import x from 'lib'` should give the inner default value
+// (not the whole `module.exports`).
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.a = 'world';
+exports.default = () => 'hello';

--- a/e2e/externals/dynamic-import-interop/plain.cjs
+++ b/e2e/externals/dynamic-import-interop/plain.cjs
@@ -1,0 +1,6 @@
+// Plain CJS without `__esModule`. User contract: `default` should be the
+// whole `module.exports`; named exports may be reachable via lexer detection
+// or default-fallback.
+'use strict';
+exports.foo = 'foo';
+exports.bar = 'bar';

--- a/e2e/externals/dynamic-import-interop/webpackStyle.cjs
+++ b/e2e/externals/dynamic-import-interop/webpackStyle.cjs
@@ -1,0 +1,7 @@
+// Webpack/rspack-style CJS bundle: `__esModule: true` is stamped via
+// `Object.defineProperty`, named exports are mirrored onto `exports`. This
+// is the rslib eco-ci format-snapshot shape.
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.bar = 'bar';
+exports.foo = 'foo';

--- a/e2e/externals/dynamic-import-origin/index.js
+++ b/e2e/externals/dynamic-import-origin/index.js
@@ -1,0 +1,5 @@
+// Template-literal dynamic import. Without `injectDynamicImportOrigin`,
+// rstest used to resolve the relative specifier against the test entry,
+// which sits in a different directory and does not contain `./translations`.
+export const fetchStrings = (locale) =>
+  import(`./translations/${locale}/strings.json`);

--- a/e2e/externals/dynamic-import-origin/translations/en-us/strings.json
+++ b/e2e/externals/dynamic-import-origin/translations/en-us/strings.json
@@ -1,0 +1,1 @@
+{ "greeting": "Hello" }

--- a/e2e/externals/dynamicImportInterop.test.ts
+++ b/e2e/externals/dynamicImportInterop.test.ts
@@ -1,0 +1,103 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Runtime-computed specifier so rspack rewrites `import()` to
+// `__rstest_dynamic_import__()`. Static-literal `import('./...')` would be
+// bundled into a chunk and short-circuit the interop path that handles
+// CJS-as-ESM dynamic imports.
+const dyn = (rel: string) => import(join(__dirname, rel));
+
+// User contract: a dynamic-imported CJS module should look like an ESM
+// namespace with `default` always present (CJS interop convention) plus the
+// named keys cjs-module-lexer detected. Behavior should be intuitive across
+// `get`, `'x' in ns`, `Object.keys`, spread, and pretty-format — these are
+// what Jest/vitest/Node native produce, and what users carry over from
+// other test runners.
+describe('dynamic-imported CJS namespace', () => {
+  describe('webpack-style __esModule with only named exports', () => {
+    it('exposes named keys directly', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/webpackStyle.cjs');
+      expect(ns.bar).toBe('bar');
+      expect(ns.foo).toBe('foo');
+    });
+
+    it('exposes a default (no inner `.default` → the module.exports)', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/webpackStyle.cjs');
+      expect('default' in ns).toBe(true);
+      expect(ns.default).toBeDefined();
+      // Whatever default is, it should expose the same named keys.
+      expect(ns.default.bar).toBe('bar');
+      expect(ns.default.foo).toBe('foo');
+    });
+
+    it('lists default + named keys in Object.keys', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/webpackStyle.cjs');
+      expect(Object.keys(ns).sort()).toEqual(['bar', 'default', 'foo']);
+    });
+
+    it('serializes to a stable pretty-format shape', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/webpackStyle.cjs');
+      // Snapshot intentionally empty — inspected on first run to verify
+      // it matches the user contract above before being committed.
+      expect({ ...ns }).toMatchInlineSnapshot(`
+        {
+          "bar": "bar",
+          "default": {
+            "bar": "bar",
+            "foo": "foo",
+          },
+          "foo": "foo",
+        }
+      `);
+    });
+  });
+
+  describe('babel-style __esModule with `exports.default`', () => {
+    it('unwraps `default` to the inner value', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/babelStyle.cjs');
+      expect(typeof ns.default).toBe('function');
+      expect(ns.default()).toBe('hello');
+    });
+
+    it('exposes named exports alongside default', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/babelStyle.cjs');
+      expect(ns.a).toBe('world');
+      expect('a' in ns).toBe(true);
+      expect('default' in ns).toBe(true);
+    });
+
+    it('lists default + named keys in Object.keys', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/babelStyle.cjs');
+      expect(Object.keys(ns).sort()).toEqual(['a', 'default']);
+    });
+  });
+
+  describe('plain CJS (no __esModule)', () => {
+    it('exposes named exports', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/plain.cjs');
+      expect(ns.foo).toBe('foo');
+      expect(ns.bar).toBe('bar');
+    });
+
+    it('exposes module.exports as default', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/plain.cjs');
+      expect(ns.default).toBeDefined();
+      expect(ns.default.foo).toBe('foo');
+      expect(ns.default.bar).toBe('bar');
+    });
+
+    it('lists default + named keys in Object.keys', async () => {
+      const ns: any = await dyn('./dynamic-import-interop/plain.cjs');
+      // Node 24 adds an internal `'module.exports'` key to CJS-via-ESM
+      // namespaces that earlier versions don't surface; assert the
+      // user-meaningful subset and ignore implementation-detail keys.
+      expect(Object.keys(ns)).toEqual(
+        expect.arrayContaining(['bar', 'default', 'foo']),
+      );
+    });
+  });
+});

--- a/e2e/externals/dynamicImportRelative.test.ts
+++ b/e2e/externals/dynamicImportRelative.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from '@rstest/core';
+// @ts-expect-error: plain .js module, no declaration file needed
+import { fetchStrings } from './dynamic-import-origin/index.js';
+
+it('should resolve template-literal dynamic imports against the source module', async () => {
+  const strings = (await fetchStrings('en-us')) as { greeting: string };
+
+  expect(strings.greeting).toBe('Hello');
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rslib/core": "0.21.3",
     "@rstest/browser": "workspace:*",

--- a/e2e/projects/fixtures-shard/packages/client-vue/package.json
+++ b/e2e/projects/fixtures-shard/packages/client-vue/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.33"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rstest/core": "workspace:*",
     "@vue/compiler-dom": "^3.5.33",

--- a/e2e/projects/fixtures-shard/packages/client/package.json
+++ b/e2e/projects/fixtures-shard/packages/client/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/projects/fixtures/packages/client-vue/package.json
+++ b/e2e/projects/fixtures/packages/client-vue/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.33"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rstest/core": "workspace:*",
     "@vue/compiler-dom": "^3.5.33",

--- a/e2e/projects/fixtures/packages/client/package.json
+++ b/e2e/projects/fixtures/packages/client/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/test-api/json.test.ts
+++ b/e2e/test-api/json.test.ts
@@ -7,6 +7,10 @@ it('should test json file correctly', async () => {
   // will bundle json file during build
   const jsonA = await import('./test.json');
 
+  // Compare fields, not the namespace wrapper — runtime and bundled paths
+  // produce different shells (runtime: plain `{ ...content, default }`;
+  // bundled: webpack's `__esModule`/`Symbol.toStringTag` namespace).
   expect(json.value).toBe(123);
-  expect(json).toEqual(jsonA);
+  expect(jsonA.value).toBe(123);
+  expect(json.default).toEqual(jsonA.default);
 });

--- a/e2e/vue/fixtures/package.json
+++ b/e2e/vue/fixtures/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.33"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rsbuild/plugin-vue-jsx": "^2.0.0",

--- a/examples/react-rsbuild/package.json
+++ b/examples/react-rsbuild/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rstest/adapter-rsbuild": "workspace:*",
     "@testing-library/dom": "^10.4.1",

--- a/examples/react-rspack-browser/package.json
+++ b/examples/react-rspack-browser/package.json
@@ -14,8 +14,8 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rspack/cli": "2.0.1",
-    "@rspack/core": "2.0.1",
+    "@rspack/cli": "2.0.2",
+    "@rspack/core": "2.0.2",
     "@rspack/dev-server": "2.0.1",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@rstest/adapter-rspack": "workspace:*",

--- a/examples/react-rspack/package.json
+++ b/examples/react-rspack/package.json
@@ -15,8 +15,8 @@
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "^2.0.0",
-    "@rspack/cli": "2.0.1",
-    "@rspack/core": "2.0.1",
+    "@rspack/cli": "2.0.2",
+    "@rspack/core": "2.0.2",
     "@rspack/dev-server": "2.0.1",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@rstest/adapter-rspack": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rstest/core": "workspace:*",
     "@testing-library/dom": "^10.4.1",

--- a/examples/svelte-rsbuild/package.json
+++ b/examples/svelte-rsbuild/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-svelte": "^1.1.1",
     "@rstest/adapter-rsbuild": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -13,7 +13,7 @@
     "vue": "^3.5.33"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rsbuild/plugin-vue-jsx": "^2.0.0",

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -35,7 +35,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rslib/core": "0.21.3",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*"

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -37,8 +37,8 @@
   },
   "devDependencies": {
     "@rslib/core": "0.21.3",
-    "@rspack/cli": "2.0.1",
-    "@rspack/core": "2.0.1",
+    "@rspack/cli": "2.0.2",
+    "@rspack/core": "2.0.2",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*"
   },

--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-svgr": "^2.0.2",
     "@tailwindcss/postcss": "^4.2.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "typecheck": "pnpm -w exec tsc --noEmit -p packages/core/tsconfig.json"
   },
   "dependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@types/chai": "^5.2.3"
   },
   "devDependencies": {

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -105,6 +105,12 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
               config.output ??= {};
               config.output.iife = false;
               // polyfill interop
+              // TODO: if we ever expose `output.importFunctionName` as a user
+              // option, rspack#13849's rewrite still reads it directly to pick
+              // the callee for non-string-literal `import()`. Either bind the
+              // runtime helper under the user-configured name as well, or move
+              // the dynamic-import-origin rewrite onto a dedicated rspack
+              // option so the two concerns stop sharing one identifier.
               config.output.importFunctionName = outputModule
                 ? 'import.meta.__rstest_dynamic_import__'
                 : '__rstest_dynamic_import__';
@@ -124,6 +130,10 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                   importMetaPathName: true,
                   hoistMockModule: true,
                   manualMockRoot: pathe.resolve(rootPath, '__mocks__'),
+                  // The runtime hook below resolves relative dynamic-import
+                  // specifiers against the source module that produced the
+                  // call, instead of the test entry, fixing #1207.
+                  injectDynamicImportOrigin: true,
                 }),
               );
 

--- a/packages/core/src/runtime/worker/interop.ts
+++ b/packages/core/src/runtime/worker/interop.ts
@@ -40,6 +40,69 @@ export function interopModule(mod: any): { mod: any; defaultExport: any } {
   return { mod, defaultExport };
 }
 
+/**
+ * Wrap an interop'd module in a Proxy that exposes a synthetic `default`
+ * (the unwrapped value from `interopModule`) across property access, `in`,
+ * descriptor lookup, and enumeration. Without an `ownKeys` trap, spread /
+ * `Object.keys` / pretty-format silently drop the synthetic key and diverge
+ * from a real Module Namespace.
+ *
+ * When `mod` is non-extensible (e.g., `module.exports = Object.freeze({...})`),
+ * `ownKeys` / `getOwnPropertyDescriptor` skip synthesis — Proxy invariants
+ * forbid reporting keys absent from a non-extensible target. `get` / `has`
+ * still resolve `ns.default` and `'default' in ns`. Mirrors
+ * https://github.com/vitest-dev/vitest/issues/2596.
+ */
+export function createInteropProxy(mod: any, defaultExport: any): any {
+  return new Proxy(mod, {
+    get(mod, prop) {
+      if (prop === 'default') {
+        return defaultExport;
+      }
+      /**
+       * interop invalid named exports. eg:
+       * exports: module.exports = { a: 1 }
+       * import: import { a } from 'mod';
+       */
+      return mod[prop] ?? defaultExport?.[prop];
+    },
+    has(mod, prop) {
+      if (prop === 'default') {
+        return defaultExport !== undefined;
+      }
+      return prop in mod || (defaultExport && prop in defaultExport);
+    },
+    getOwnPropertyDescriptor(mod, prop): any {
+      const descriptor = Reflect.getOwnPropertyDescriptor(mod, prop);
+      if (descriptor) {
+        return descriptor;
+      }
+      if (
+        prop === 'default' &&
+        defaultExport !== undefined &&
+        Object.isExtensible(mod)
+      ) {
+        return {
+          value: defaultExport,
+          enumerable: true,
+          configurable: true,
+        };
+      }
+    },
+    ownKeys(mod) {
+      const keys = Reflect.ownKeys(mod);
+      if (
+        defaultExport !== undefined &&
+        !keys.includes('default') &&
+        Object.isExtensible(mod)
+      ) {
+        keys.push('default');
+      }
+      return keys;
+    },
+  });
+}
+
 // Caches vm.SyntheticModule by resolved module id to avoid nodejs/node#54735:
 // repeatedly wrapping the same exports in fresh SyntheticModule instances
 // races the V8 module-graph evaluation and segfaults the worker. One instance

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -7,6 +7,7 @@ import { logger } from '../../utils/logger';
 import {
   asModule,
   clearSyntheticModuleCache,
+  createInteropProxy,
   interopModule,
   shouldInterop,
 } from './interop';
@@ -63,7 +64,11 @@ const defineRstestDynamicImport =
     testPath: string;
     interopDefault: boolean;
   }) =>
-  async (specifier: string, importAttributes: ImportCallOptions) => {
+  async (
+    specifier: string,
+    importAttributes: ImportCallOptions,
+    origin?: string,
+  ) => {
     const currentDirectory = path.dirname(distPath);
 
     const joinedPath = isRelativePath(specifier)
@@ -104,12 +109,18 @@ const defineRstestDynamicImport =
       }
     }
 
+    // `origin` is the absolute path of the source module that produced the
+    // `import()` call. It is injected by rspack's `RstestPlugin` when
+    // `injectDynamicImportOrigin` is enabled, so relative specifiers in
+    // bundled deps resolve against the dep's own directory rather than the
+    // test entry's. Fallback to `testPath` keeps the link/vm-callback paths
+    // (which have no origin to pass) working as before.
+    const resolveBase = origin ?? testPath;
     const resolvedPath = isAbsolute(specifier)
       ? pathToFileURL(specifier)
       : isBuiltinSpecifier(specifier)
         ? specifier
-        : // TODO: use module path instead of testPath
-          import.meta.resolve(specifier, pathToFileURL(testPath));
+        : import.meta.resolve(specifier, pathToFileURL(resolveBase));
 
     // Use `.href` (full file:// URL) rather than `.pathname` so absolute
     // Windows specifiers (`D:\a\foo.mjs`) remain valid import targets. With
@@ -151,38 +162,7 @@ const defineRstestDynamicImport =
         return asModule(mod, modulePath, defaultExport);
       }
 
-      return new Proxy(mod, {
-        get(mod, prop) {
-          if (prop === 'default') {
-            return defaultExport;
-          }
-          /**
-           * interop invalid named exports. eg:
-           * exports: module.exports = { a: 1 }
-           * import: import { a } from 'mod';
-           */
-          return mod[prop] ?? defaultExport?.[prop];
-        },
-        has(mod, prop) {
-          if (prop === 'default') {
-            return defaultExport !== undefined;
-          }
-          return prop in mod || (defaultExport && prop in defaultExport);
-        },
-        getOwnPropertyDescriptor(mod, prop): any {
-          const descriptor = Reflect.getOwnPropertyDescriptor(mod, prop);
-          if (descriptor) {
-            return descriptor;
-          }
-          if (prop === 'default' && defaultExport !== undefined) {
-            return {
-              value: defaultExport,
-              enumerable: true,
-              configurable: true,
-            };
-          }
-        },
-      });
+      return createInteropProxy(mod, defaultExport);
     }
 
     if (returnModule) {

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -7,6 +7,7 @@ import { logger } from '../../utils/logger';
 import {
   asModule,
   clearSyntheticModuleCache,
+  createInteropProxy,
   interopModule,
   shouldInterop,
 } from './interop';
@@ -75,10 +76,20 @@ const defineRstestDynamicImport =
     interopDefault: boolean;
     assetFiles: Record<string, string>;
   }) =>
-  async (specifier: string, importAttributes: ImportCallOptions) => {
+  async (
+    specifier: string,
+    importAttributes: ImportCallOptions,
+    origin?: string,
+  ) => {
+    // `origin` is the absolute path of the source module that produced the
+    // `import()` call, injected by rspack's `RstestPlugin` when
+    // `injectDynamicImportOrigin` is enabled. Falling back to `testPath`
+    // keeps the vm `importModuleDynamically` callback (which has no origin
+    // to pass) working as before.
+    const resolveBase = origin ?? testPath;
     const resolvedPath = isAbsolute(specifier)
       ? pathToFileURL(specifier)
-      : import.meta.resolve(specifier, pathToFileURL(testPath));
+      : import.meta.resolve(specifier, pathToFileURL(resolveBase));
 
     // Use `.href` rather than `.pathname` so Windows absolute specifiers
     // round-trip through Node's ESM loader as valid `file:///D:/...` URLs
@@ -139,38 +150,7 @@ const defineRstestDynamicImport =
         return asModule(mod, modulePath, defaultExport);
       }
 
-      return new Proxy(mod, {
-        get(mod, prop) {
-          if (prop === 'default') {
-            return defaultExport;
-          }
-          /**
-           * interop invalid named exports. eg:
-           * exports: module.exports = { a: 1 }
-           * import: import { a } from 'mod';
-           */
-          return mod[prop] ?? defaultExport?.[prop];
-        },
-        has(mod, prop) {
-          if (prop === 'default') {
-            return defaultExport !== undefined;
-          }
-          return prop in mod || (defaultExport && prop in defaultExport);
-        },
-        getOwnPropertyDescriptor(mod, prop): any {
-          const descriptor = Reflect.getOwnPropertyDescriptor(mod, prop);
-          if (descriptor) {
-            return descriptor;
-          }
-          if (prop === 'default' && defaultExport !== undefined) {
-            return {
-              value: defaultExport,
-              enumerable: true,
-              configurable: true,
-            };
-          }
-        },
-      });
+      return createInteropProxy(mod, defaultExport);
     }
     return importedModule;
   };

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -49,7 +49,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -265,7 +265,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -296,7 +296,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -327,7 +327,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -358,7 +358,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -503,6 +503,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
         {
           "hoistMockModule": true,
           "importMetaPathName": true,
+          "injectDynamicImportOrigin": true,
           "injectModulePathName": true,
           "manualMockRoot": "<ROOT>/packages/core/__mocks__",
         },
@@ -623,7 +624,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -839,7 +840,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -870,7 +871,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -901,7 +902,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -932,7 +933,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1077,6 +1078,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
         {
           "hoistMockModule": true,
           "importMetaPathName": true,
+          "injectDynamicImportOrigin": true,
           "injectModulePathName": true,
           "manualMockRoot": "<ROOT>/packages/core/__mocks__",
         },
@@ -1184,7 +1186,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -1400,7 +1402,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1431,7 +1433,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1462,7 +1464,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1493,7 +1495,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1637,6 +1639,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
         {
           "hoistMockModule": true,
           "importMetaPathName": true,
+          "injectDynamicImportOrigin": true,
           "injectModulePathName": true,
           "manualMockRoot": "<ROOT>/packages/core/__mocks__",
         },
@@ -1743,7 +1746,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -1959,7 +1962,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -1990,7 +1993,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -2021,7 +2024,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -2052,7 +2055,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -2199,6 +2202,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
         {
           "hoistMockModule": true,
           "importMetaPathName": true,
+          "injectDynamicImportOrigin": true,
           "injectModulePathName": true,
           "manualMockRoot": "<ROOT>/packages/core/__mocks__",
         },
@@ -2269,7 +2273,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with less / sa
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -2422,7 +2426,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with less / sa
     },
     "oneOf": [
       {
-        "resourceQuery": /\\^\\\\\\?url\\$/,
+        "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
         "use": [
           {
             "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -2642,7 +2646,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -2858,7 +2862,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -2889,7 +2893,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -2920,7 +2924,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -2951,7 +2955,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -3096,6 +3100,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
         {
           "hoistMockModule": true,
           "importMetaPathName": true,
+          "injectDynamicImportOrigin": true,
           "injectModulePathName": true,
           "manualMockRoot": "<ROOT>/packages/core/__mocks__",
         },
@@ -3203,7 +3208,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "resolve": {
               "preferRelative": true,
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "use": [
               {
                 "loader": "<PNPM_INNER>/@rsbuild/core/dist/cssUrlLoader.mjs",
@@ -3419,7 +3424,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/image/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -3450,7 +3455,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/svg/[name].[contenthash:10].svg",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -3481,7 +3486,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/media/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -3512,7 +3517,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
             "generator": {
               "filename": "static/font/[name].[contenthash:10][ext]",
             },
-            "resourceQuery": /\\^\\\\\\?url\\$/,
+            "resourceQuery": /\\[\\?&\\]url\\(\\?:&\\|=\\|\\$\\)/,
             "type": "asset/resource",
           },
           {
@@ -3657,6 +3662,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
         {
           "hoistMockModule": true,
           "importMetaPathName": true,
+          "injectDynamicImportOrigin": true,
           "injectModulePathName": true,
           "manualMockRoot": "<ROOT>/packages/core/__mocks__",
         },

--- a/packages/core/tests/runner/interop.test.ts
+++ b/packages/core/tests/runner/interop.test.ts
@@ -1,0 +1,143 @@
+import {
+  createInteropProxy,
+  interopModule,
+} from '../../src/runtime/worker/interop';
+
+// Build a Module-Namespace-shaped object matching what Node's CJS-as-ESM
+// importer produces (verified against `node --input-type=module` against
+// real .cjs fixtures). `default` is always `module.exports` (Node never
+// uses the lexer-detected `default` value for the namespace's default
+// slot); other lexer-detected named keys appear as enumerable own keys.
+const buildNamespace = (cjsExports: any, namedKeys: string[]) => {
+  const ns: any = { default: cjsExports };
+  for (const k of namedKeys) {
+    if (k === 'default') continue;
+    ns[k] = cjsExports[k];
+  }
+  if ('__esModule' in cjsExports) ns.__esModule = cjsExports.__esModule;
+  return ns;
+};
+
+// Run the dynamic-import interop pipeline for a CJS-shaped Node namespace.
+// This is the path `meta.__rstest_dynamic_import__` takes for non-builtin,
+// non-asset specifiers.
+const interop = (importedModule: any) => {
+  const { mod, defaultExport } = interopModule(importedModule);
+  return createInteropProxy(mod, defaultExport);
+};
+
+// User contract for a dynamic-imported CJS namespace:
+// - `default` is always present (CJS interop convention; Babel/TS/vitest all
+//   guarantee this). For `__esModule` + `exports.default = X`, `default` is
+//   unwrapped to X. Otherwise `default` is `module.exports`.
+// - Named exports are reachable directly (`ns.foo`).
+// - `__esModule` is an internal interop signal, not a user-facing export —
+//   it should NOT appear in enumeration.
+// - `Object.keys` / spread / pretty-format must agree with `get` / `has`.
+describe('dynamic-import CJS interop pipeline', () => {
+  describe('webpack/rspack-style: __esModule + named, no inner default', () => {
+    const cjsExports: any = { bar: 'bar', foo: 'foo' };
+    Object.defineProperty(cjsExports, '__esModule', { value: true });
+    const ns = interop(buildNamespace(cjsExports, ['bar', 'foo']));
+
+    it('exposes named exports and default', () => {
+      expect(ns.bar).toBe('bar');
+      expect(ns.foo).toBe('foo');
+      expect('default' in ns).toBe(true);
+      expect(ns.default).toBeDefined();
+      // No inner default → `default` carries `module.exports`, so the same
+      // named keys are reachable through it.
+      expect(ns.default.bar).toBe('bar');
+    });
+
+    it('does not leak __esModule into enumeration', () => {
+      expect(Object.keys(ns).sort()).toEqual(['bar', 'default', 'foo']);
+      expect(Object.keys(ns)).not.toContain('__esModule');
+    });
+
+    it('describes default as enumerable + configurable', () => {
+      const d = Object.getOwnPropertyDescriptor(ns, 'default');
+      expect(d).toMatchObject({ enumerable: true, configurable: true });
+    });
+
+    it('round-trips through spread without losing default (rslib format case)', () => {
+      const spread: any = { ...ns };
+      expect(spread.bar).toBe('bar');
+      expect(spread.foo).toBe('foo');
+      expect('default' in spread).toBe(true);
+    });
+  });
+
+  describe('babel/TS-style: __esModule + exports.default = X', () => {
+    const fn = () => 'hello';
+    const cjsExports: any = { a: 'world', default: fn };
+    Object.defineProperty(cjsExports, '__esModule', { value: true });
+    const ns = interop(buildNamespace(cjsExports, ['a', 'default']));
+
+    it('unwraps default to the inner value (Babel/vitest convention)', () => {
+      expect(ns.default).toBe(fn);
+      expect(ns.default()).toBe('hello');
+    });
+
+    it('exposes named exports alongside default', () => {
+      expect(ns.a).toBe('world');
+      expect(Object.keys(ns).sort()).toEqual(['a', 'default']);
+    });
+  });
+
+  // Regression: frozen `module.exports` — see `createInteropProxy` JSDoc
+  // for the Proxy invariant trade-off this scenario exercises.
+  describe('frozen module.exports', () => {
+    const cjsExports: any = { foo: 'foo', bar: 'bar' };
+    Object.defineProperty(cjsExports, '__esModule', { value: true });
+    Object.freeze(cjsExports);
+    const ns = interop(buildNamespace(cjsExports, ['foo', 'bar']));
+
+    it('does not throw on Object.keys / spread / descriptor lookup', () => {
+      expect(() => Object.keys(ns)).not.toThrow();
+      expect(() => ({ ...ns })).not.toThrow();
+      expect(() =>
+        Object.getOwnPropertyDescriptor(ns, 'default'),
+      ).not.toThrow();
+    });
+
+    it('still resolves default via get and has', () => {
+      expect(ns.default).toBe(cjsExports);
+      expect('default' in ns).toBe(true);
+    });
+
+    it('omits `default` from enumeration as the documented trade-off', () => {
+      expect(Object.keys(ns)).not.toContain('default');
+      expect(Object.keys({ ...ns })).not.toContain('default');
+    });
+
+    it('exposes named exports', () => {
+      expect(ns.foo).toBe('foo');
+      expect(ns.bar).toBe('bar');
+    });
+  });
+
+  describe('plain CJS: no __esModule', () => {
+    const cjsExports = { foo: 'foo', bar: 'bar' };
+    const ns = interop(buildNamespace(cjsExports, ['foo', 'bar']));
+
+    it('uses module.exports as default', () => {
+      expect(ns.default).toBe(cjsExports);
+    });
+
+    it('exposes named exports', () => {
+      expect(ns.foo).toBe('foo');
+      expect(ns.bar).toBe('bar');
+      expect(Object.keys(ns).sort()).toEqual(['bar', 'default', 'foo']);
+    });
+
+    it('falls through to default for keys cjs-module-lexer missed', () => {
+      // Construct a namespace where the lexer detected `foo` but missed `bar`
+      // — i.e., `bar` exists on `module.exports` but not on the outer ns.
+      const partial: any = { default: { foo: 'foo', bar: 'bar' }, foo: 'foo' };
+      const lossy = interop(partial);
+      expect(lossy.bar).toBe('bar');
+      expect('bar' in lossy).toBe(true);
+    });
+  });
+});

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -105,7 +105,7 @@
     "workspaceContains:**/*rstest.{workspace,projects}*.{ts,js,mjs,cjs,cts,mts,json}"
   ],
   "devDependencies": {
-    "@rsbuild/core": "^2.0.3",
+    "@rsbuild/core": "^2.0.5",
     "@rslib/core": "0.21.3",
     "@rstest/core": "workspace:*",
     "@swc/core": "^1.15.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.9
-        version: 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
+        version: 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
       '@rslint/core':
         specifier: ^0.5.1
         version: 0.5.1(jiti@2.6.1)
@@ -86,11 +86,11 @@ importers:
   e2e:
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rslib/core':
         specifier: 0.21.3
         version: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)
@@ -207,11 +207,11 @@ importers:
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -300,7 +300,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -354,11 +354,11 @@ importers:
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -388,11 +388,11 @@ importers:
         version: 3.5.33(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -416,11 +416,11 @@ importers:
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -450,11 +450,11 @@ importers:
         version: 3.5.33(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -504,7 +504,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -540,17 +540,17 @@ importers:
         version: 3.5.33(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.3)
+        version: 1.1.2(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.3)
+        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.5)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -581,7 +581,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -629,11 +629,11 @@ importers:
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -669,11 +669,11 @@ importers:
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -710,7 +710,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
       '@rspack/cli':
         specifier: 2.0.1
         version: 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21)))
@@ -803,11 +803,11 @@ importers:
   examples/svelte-rsbuild:
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-svelte':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.3)(less@4.6.4)(postcss@8.5.12)(sass@1.99.0)(svelte@5.55.5)(typescript@6.0.3)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.5)(less@4.6.4)(postcss@8.5.12)(sass@1.99.0)(svelte@5.55.5)(typescript@6.0.3)
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -831,17 +831,17 @@ importers:
         version: 3.5.33(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.3)
+        version: 1.1.2(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.3)
+        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.5)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -864,8 +864,8 @@ importers:
   packages/adapter-rsbuild:
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rslib/core':
         specifier: 0.21.3
         version: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)
@@ -1016,14 +1016,14 @@ importers:
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@6.0.3)
+        version: 2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
@@ -1043,8 +1043,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@types/chai':
         specifier: ^5.2.3
         version: 5.2.3
@@ -1063,13 +1063,13 @@ importers:
         version: 7.58.7(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^1.6.3
-        version: 1.6.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
+        version: 1.6.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.3)
+        version: 1.4.4(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rslib/core':
         specifier: 0.21.3
         version: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)
@@ -1228,8 +1228,8 @@ importers:
   packages/vscode:
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.5
+        version: 2.0.5
       '@rslib/core':
         specifier: 0.21.3
         version: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)
@@ -1300,13 +1300,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rspress/core':
         specifier: 2.0.10
-        version: 2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.10
-        version: 2.0.10(@rspress/core@2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 2.0.10(@rspress/core@2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@rstack-dev/doc-ui':
         specifier: 1.13.3
         version: 1.13.3
@@ -1330,13 +1330,13 @@ importers:
         version: 19.2.5(react@19.2.5)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.3)
+        version: 1.0.5(@rsbuild/core@2.0.5)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.3)
+        version: 1.1.2(@rsbuild/core@2.0.5)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.3
-        version: 1.0.3(@rspress/core@2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.0.3(@rspress/core@2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
       rspress-plugin-sitemap:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2709,8 +2709,8 @@ packages:
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
 
-  '@rsbuild/core@2.0.3':
-    resolution: {integrity: sha512-2myp7jUgGen50saxW8OJD/eMVKp7HnuBN5MUzwRb6mDbRZZVpoorfI4LQqiGSBNjGLB6jltvx/R2yHmcmnchwg==}
+  '@rsbuild/core@2.0.5':
+    resolution: {integrity: sha512-KajO50hbXb32S8MsyDh2f+xKcVeRy9Gfzdcy0JjpMLj22djHugly6jrGo7jH7ls9X6/TDcyCTncSuNK4+D2lTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2890,8 +2890,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.2':
+    resolution: {integrity: sha512-0o7lbgBBsDlICWdjIH0q3e0BsSco4GRiImHWVfZSVEG+q2+ykZJvSvYCVhPM1Co375Z0S3VMPa/8SjcY1FHwlw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.1':
     resolution: {integrity: sha512-2vvBNBoS09/PurupBwSrlTZd8283o00B8v20ncsNUdEff41uCR/hzIrYoTIVWnVST+Gt5O1+cfcfORp397lajg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.2':
+    resolution: {integrity: sha512-tOwxZpoPlTlRs/w6UyUinXJ4TYRVHMlR7+eQxO1R3muKpixvhXQjtvoaY16HuFyTVky5F0IfOoWr3x9FEsgdLg==}
     cpu: [x64]
     os: [darwin]
 
@@ -2900,8 +2910,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@2.0.2':
+    resolution: {integrity: sha512-1ZD4YFhG1rmgqj+W8hfwHyKV8xDxGsc/3KgU0FwmiVEX7JfzhCkgBO/xlCG79kRKSrzuVzt4icO/G3cCKn0pag==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@2.0.1':
     resolution: {integrity: sha512-S/a6uN9PiZ5O/PjSqyIXhuRC1lVzeJkJV69NeLk5sIEUiDQ/aQGZG97uN+tluwpbo1tPbLJkdHYETfjspOX4Pg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@2.0.2':
+    resolution: {integrity: sha512-/PtTkM/DsDLjeuXTmeJeRfbjCDbcL9jvoVgZrgxYFZ28y2cdLvbChbW9uigOzs5dQEs1CIBQXMTTj7KhdBTuQg==}
     cpu: [arm64]
     os: [linux]
 
@@ -2910,8 +2930,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@2.0.2':
+    resolution: {integrity: sha512-bBjsZxMHRaPo6X9SokApm6ucs+UhXtAJFyJJyuk2BH4XJsLeCU9Dz1vMwioeohFbJUUeTASVPm6/BL+RhSaunw==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@2.0.1':
     resolution: {integrity: sha512-TQsiBFpEDGkuvK9tNdGj/Uc+AIytzqhxXH/1jKU6M24cWB1DTw/Cx7DdrkCBDyq3129K3POLdujvbWCGqBzQUw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@2.0.2':
+    resolution: {integrity: sha512-HjlpInqzabDNkhVsUJpsHPqa9QYVWBViJoyWNjzXCAW0vKMDvwaphyUvokSinX8FGTlZi/sr5UEaHJo6XtQ35g==}
     cpu: [x64]
     os: [linux]
 
@@ -2919,8 +2949,17 @@ packages:
     resolution: {integrity: sha512-wk3gyUgBW/ayP49bI54bkY8+EQnfBHxdoe9dz3oobSTZQc8AOWwmUUDEPltW8rUvPOM6dfHECTOUMnfaf2f5yA==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.0.2':
+    resolution: {integrity: sha512-YaRYNFLJRpkGfYjSWR7n9f+nQKtrlmrrffpAn/blc2geHcRvXoBc5SCs1idPtsLhj7H9qWWhs7ucjyHy4csWFg==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.0.1':
     resolution: {integrity: sha512-rHjLcy3VcAC3+x+PxH+gwhwv6tPe0JdXTNT5eAOs9wgZIM6T9p4wre49+K4Qy98+Fb7TTbLX0ObUitlOkGwTSA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.2':
+    resolution: {integrity: sha512-d/3kTEKq+asLjRFPO96t+wfWiM7DLN76VQEPDD9bc1kdsZXlVJBuvyXfsgK8bbEvKplWXYcSsokhmEnuXrLOpg==}
     cpu: [arm64]
     os: [win32]
 
@@ -2929,13 +2968,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.2':
+    resolution: {integrity: sha512-161cWineq3RW+Jdm1FAfSpXeUtYWvhB3kAbm46vNT9h/YYz+spwsFMvveAZ1nsVSVL0IC5lDBGUte7yUAY8K2g==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.1':
     resolution: {integrity: sha512-oPM2Jtm7HOlmxl/aBfleAVlL6t9VeHx6WvEets7BBJMInemFXAQd4CErRqybf7rXutACzLeUWBOue4Jpd1/ykw==}
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.0.2':
+    resolution: {integrity: sha512-y7Q0S1FE+OlkL5GMqLG0PwxrPw6E1r892KhGrGKE1Vdufe5YTEx6xTPxzZ+b7N2KPD7s9G1/iJmWHQxb1+Bjkg==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.0.1':
     resolution: {integrity: sha512-ynV1gw4KqFtQ0P+ZZh76SUj49wBb2FuHW3zSmHverHWuxBhzvrZS6/dZ+fCFQG8bTTPtrPz0RQUTN3uEDbPVBQ==}
+
+  '@rspack/binding@2.0.2':
+    resolution: {integrity: sha512-0kZPplW9GWx8mfC6DfsaRY3QBIYPuUs42JfmSM6aSb8tMHZAXQeLeMB8M+h8i4SeI+aFtCgO6UuYGtyWf7+L+A==}
 
   '@rspack/cli@2.0.1':
     resolution: {integrity: sha512-UwqLnShg6ui3LOsJfJvyGNfHtgkGd/Cjjm2T7jR6lTkoX9Jj7YKl55gkPqNw34et8+gp/5Ehso6tsga8bqZi5Q==}
@@ -2949,6 +3001,18 @@ packages:
 
   '@rspack/core@2.0.1':
     resolution: {integrity: sha512-lgfZiExh8kDR/3obgi3RQKwKG5av1Xf5qDN1aVde777W9pbmx0Pqvrww1qtNvJ+gobEjbrrn5HEZWYGe0VLmcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.2':
+    resolution: {integrity: sha512-VM3UHOo26uC+4QSqY5tU1ybI7KuXY5rTof8nhFOaBY9SYau0Smvr+hMSAPmrmHwknB6dXT8yaNVxrj7I+qxE1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -9335,14 +9399,14 @@ snapshots:
 
   '@remix-run/router@1.23.2': {}
 
-  '@rsbuild/core@2.0.3':
+  '@rsbuild/core@2.0.5':
     dependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -9351,11 +9415,11 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.5)':
     dependencies:
       acorn: 8.16.0
       browserslist-to-es-version: 1.2.0
@@ -9363,21 +9427,21 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
 
-  '@rsbuild/plugin-less@1.6.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)':
+  '@rsbuild/plugin-less@1.6.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.2(@rspack/core@2.0.1(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.106.2)
+      less-loader: 12.3.2(@rspack/core@2.0.2(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.106.2)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.5)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9403,18 +9467,27 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.1(@swc/helpers@0.5.21))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.1(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.5
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.5)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9422,14 +9495,14 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.99.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
 
-  '@rsbuild/plugin-svelte@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.3)(less@4.6.4)(postcss@8.5.12)(sass@1.99.0)(svelte@5.55.5)(typescript@6.0.3)':
+  '@rsbuild/plugin-svelte@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.5)(less@4.6.4)(postcss@8.5.12)(sass@1.99.0)(svelte@5.55.5)(typescript@6.0.3)':
     dependencies:
       svelte-loader: 3.2.4(svelte@5.55.5)
       svelte-preprocess: 6.0.3(@babel/core@7.29.0)(less@4.6.4)(postcss@8.5.12)(sass@1.99.0)(svelte@5.55.5)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -9443,37 +9516,37 @@ snapshots:
       - svelte
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-vue-jsx@2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-vue-jsx@2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.5)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.3)
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.5)
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       babel-plugin-vue-jsx-hmr: 1.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.1(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3))
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -9481,13 +9554,13 @@ snapshots:
 
   '@rsdoctor/client@1.5.9': {}
 
-  '@rsdoctor/core@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)':
+  '@rsdoctor/core@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.3)
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.5)
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
       '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       browserslist-load-config: 1.0.1
       es-toolkit: 1.45.1
@@ -9505,10 +9578,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)':
+  '@rsdoctor/graph@1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)':
     dependencies:
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
       es-toolkit: 1.45.1
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -9516,15 +9589,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)':
+  '@rsdoctor/rspack-plugin@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)':
     dependencies:
-      '@rsdoctor/core': 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/core': 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
     optionalDependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9534,12 +9607,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)':
+  '@rsdoctor/sdk@1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)':
     dependencies:
       '@rsdoctor/client': 1.5.9
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -9551,20 +9624,20 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)':
+  '@rsdoctor/types@1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
       webpack: 5.106.2
 
-  '@rsdoctor/utils@1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)':
+  '@rsdoctor/utils@1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.1(@swc/helpers@0.5.21))(webpack@5.106.2)
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.2(@swc/helpers@0.5.21))(webpack@5.106.2)
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -9584,8 +9657,8 @@ snapshots:
 
   '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.3
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@rsbuild/core@2.0.3)(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5
+      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@22.18.6)
       typescript: 6.0.3
@@ -9628,19 +9701,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.1':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.2':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.2':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.1':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.2':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.2':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.1':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.2':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.2':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.1':
@@ -9650,13 +9741,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.1':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.1':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.2':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.2':
     optional: true
 
   '@rspack/binding@2.0.1':
@@ -9672,6 +9779,19 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.1
       '@rspack/binding-win32-x64-msvc': 2.0.1
 
+  '@rspack/binding@2.0.2':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.2
+      '@rspack/binding-darwin-x64': 2.0.2
+      '@rspack/binding-linux-arm64-gnu': 2.0.2
+      '@rspack/binding-linux-arm64-musl': 2.0.2
+      '@rspack/binding-linux-x64-gnu': 2.0.2
+      '@rspack/binding-linux-x64-musl': 2.0.2
+      '@rspack/binding-wasm32-wasi': 2.0.2
+      '@rspack/binding-win32-arm64-msvc': 2.0.2
+      '@rspack/binding-win32-ia32-msvc': 2.0.2
+      '@rspack/binding-win32-x64-msvc': 2.0.2
+
   '@rspack/cli@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21)))':
     dependencies:
       '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
@@ -9681,6 +9801,12 @@ snapshots:
   '@rspack/core@2.0.1(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.1
+    optionalDependencies:
+      '@swc/helpers': 0.5.21
+
+  '@rspack/core@2.0.2(@swc/helpers@0.5.21)':
+    dependencies:
+      '@rspack/binding': 2.0.2
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
@@ -9700,6 +9826,12 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -9752,12 +9884,12 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspress/core@2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@rsbuild/core': 2.0.3
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+      '@rsbuild/core': 2.0.5
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rspress/shared': 2.0.10
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -9802,11 +9934,11 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-algolia@2.0.10(@rspress/core@2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@rspress/plugin-algolia@2.0.10(@rspress/core@2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docsearch/css': 4.6.2
       '@docsearch/react': 4.6.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@rspress/core': 2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -9817,7 +9949,7 @@ snapshots:
 
   '@rspress/shared@2.0.10':
     dependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
       '@shikijs/rehype': 4.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -12761,11 +12893,11 @@ snapshots:
       lefthook-windows-arm64: 2.1.6
       lefthook-windows-x64: 2.1.6
 
-  less-loader@12.3.2(@rspack/core@2.0.1(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.106.2):
+  less-loader@12.3.2(@rspack/core@2.0.2(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.106.2):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
       webpack: 5.106.2
 
   less@4.6.4:
@@ -14288,38 +14420,38 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@rsbuild/core@2.0.3)(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@22.18.6)
       '@typescript/native-preview': 7.0.0-dev.20260505.1
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.3):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.5):
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.3):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.5):
     optionalDependencies:
-      '@rsbuild/core': 2.0.3
+      '@rsbuild/core': 2.0.5
 
   rslog@1.3.2: {}
 
   rslog@2.1.1: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.1(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(vue@3.5.33(typescript@6.0.3)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
       vue: 3.5.33(typescript@6.0.3)
 
-  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)):
     dependencies:
-      '@rspress/core': 2.0.10(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   rspress-plugin-sitemap@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,19 +710,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rspack/cli':
-        specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21)))
+        specifier: 2.0.2
+        version: 2.0.2(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21)))
       '@rspack/core':
-        specifier: 2.0.1
-        version: 2.0.1(@swc/helpers@0.5.21)
+        specifier: 2.0.2
+        version: 2.0.2(@swc/helpers@0.5.21)
       '@rspack/dev-server':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.0
-        version: 2.0.0(@rspack/core@2.0.1(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+        version: 2.0.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -764,17 +764,17 @@ importers:
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rspack/cli':
-        specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21)))
+        specifier: 2.0.2
+        version: 2.0.2(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21)))
       '@rspack/core':
-        specifier: 2.0.1
-        version: 2.0.1(@swc/helpers@0.5.21)
+        specifier: 2.0.2
+        version: 2.0.2(@swc/helpers@0.5.21)
       '@rspack/dev-server':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+        version: 2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21))
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.0
-        version: 2.0.0(@rspack/core@2.0.1(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+        version: 2.0.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -900,11 +900,11 @@ importers:
         specifier: 0.21.3
         version: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260505.1)(typescript@6.0.3)
       '@rspack/cli':
-        specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21)))
+        specifier: 2.0.2
+        version: 2.0.2(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21)))
       '@rspack/core':
-        specifier: 2.0.1
-        version: 2.0.1(@swc/helpers@0.5.21)
+        specifier: 2.0.2
+        version: 2.0.2(@swc/helpers@0.5.21)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -2885,19 +2885,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.0.1':
-    resolution: {integrity: sha512-CGFO5zmajD1Itch1lxAI7+gvKiagzyqXopHv/jHG9Su2WWQ2/Nhn2/rkSpdp6ptE9ri6+6tCOOahf099/v/Xog==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.0.2':
     resolution: {integrity: sha512-0o7lbgBBsDlICWdjIH0q3e0BsSco4GRiImHWVfZSVEG+q2+ykZJvSvYCVhPM1Co375Z0S3VMPa/8SjcY1FHwlw==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.0.1':
-    resolution: {integrity: sha512-2vvBNBoS09/PurupBwSrlTZd8283o00B8v20ncsNUdEff41uCR/hzIrYoTIVWnVST+Gt5O1+cfcfORp397lajg==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@2.0.2':
@@ -2905,18 +2895,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.1':
-    resolution: {integrity: sha512-uvNXk6ahE3AH3h2avnd1Mgno68YQpS4cfX1OkOGWIC/roL+NrOP2XVXV4yfVAoydPALDO7AfbIfN0QdmBK3rsA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@2.0.2':
     resolution: {integrity: sha512-1ZD4YFhG1rmgqj+W8hfwHyKV8xDxGsc/3KgU0FwmiVEX7JfzhCkgBO/xlCG79kRKSrzuVzt4icO/G3cCKn0pag==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@2.0.1':
-    resolution: {integrity: sha512-S/a6uN9PiZ5O/PjSqyIXhuRC1lVzeJkJV69NeLk5sIEUiDQ/aQGZG97uN+tluwpbo1tPbLJkdHYETfjspOX4Pg==}
     cpu: [arm64]
     os: [linux]
 
@@ -2925,18 +2905,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@2.0.1':
-    resolution: {integrity: sha512-C13Kk0OkZiocZVj187Sf753UH6pDXnuEu6vzUvi3qv9ltibG1ki0H2Y8isXBYL2cHQOV+hk0g1S6/4z3TTB97A==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@2.0.2':
     resolution: {integrity: sha512-bBjsZxMHRaPo6X9SokApm6ucs+UhXtAJFyJJyuk2BH4XJsLeCU9Dz1vMwioeohFbJUUeTASVPm6/BL+RhSaunw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@2.0.1':
-    resolution: {integrity: sha512-TQsiBFpEDGkuvK9tNdGj/Uc+AIytzqhxXH/1jKU6M24cWB1DTw/Cx7DdrkCBDyq3129K3POLdujvbWCGqBzQUw==}
     cpu: [x64]
     os: [linux]
 
@@ -2945,27 +2915,13 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-wasm32-wasi@2.0.1':
-    resolution: {integrity: sha512-wk3gyUgBW/ayP49bI54bkY8+EQnfBHxdoe9dz3oobSTZQc8AOWwmUUDEPltW8rUvPOM6dfHECTOUMnfaf2f5yA==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.0.2':
     resolution: {integrity: sha512-YaRYNFLJRpkGfYjSWR7n9f+nQKtrlmrrffpAn/blc2geHcRvXoBc5SCs1idPtsLhj7H9qWWhs7ucjyHy4csWFg==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.1':
-    resolution: {integrity: sha512-rHjLcy3VcAC3+x+PxH+gwhwv6tPe0JdXTNT5eAOs9wgZIM6T9p4wre49+K4Qy98+Fb7TTbLX0ObUitlOkGwTSA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@2.0.2':
     resolution: {integrity: sha512-d/3kTEKq+asLjRFPO96t+wfWiM7DLN76VQEPDD9bc1kdsZXlVJBuvyXfsgK8bbEvKplWXYcSsokhmEnuXrLOpg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.0.1':
-    resolution: {integrity: sha512-Ad1vVqMBBnd4T8rsORngu9sl2kyRTlS4kMlvFudjzl1X2UFArEDBe0YVGNN7ZvahM12CErUx2WiN8Sd8pb+qXQ==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@2.0.2':
@@ -2973,42 +2929,22 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.1':
-    resolution: {integrity: sha512-oPM2Jtm7HOlmxl/aBfleAVlL6t9VeHx6WvEets7BBJMInemFXAQd4CErRqybf7rXutACzLeUWBOue4Jpd1/ykw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@2.0.2':
     resolution: {integrity: sha512-y7Q0S1FE+OlkL5GMqLG0PwxrPw6E1r892KhGrGKE1Vdufe5YTEx6xTPxzZ+b7N2KPD7s9G1/iJmWHQxb1+Bjkg==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.1':
-    resolution: {integrity: sha512-ynV1gw4KqFtQ0P+ZZh76SUj49wBb2FuHW3zSmHverHWuxBhzvrZS6/dZ+fCFQG8bTTPtrPz0RQUTN3uEDbPVBQ==}
-
   '@rspack/binding@2.0.2':
     resolution: {integrity: sha512-0kZPplW9GWx8mfC6DfsaRY3QBIYPuUs42JfmSM6aSb8tMHZAXQeLeMB8M+h8i4SeI+aFtCgO6UuYGtyWf7+L+A==}
 
-  '@rspack/cli@2.0.1':
-    resolution: {integrity: sha512-UwqLnShg6ui3LOsJfJvyGNfHtgkGd/Cjjm2T7jR6lTkoX9Jj7YKl55gkPqNw34et8+gp/5Ehso6tsga8bqZi5Q==}
+  '@rspack/cli@2.0.2':
+    resolution: {integrity: sha512-rwuzo/V59ck/ChNkxMEEjuXLFs8nPJ37K0PMuUeIMmzFJNdUcPLxSV3qaV9azDLGcyq4XwcyQvexH3okWbfUfQ==}
     hasBin: true
     peerDependencies:
       '@rspack/core': ^2.0.0-0
       '@rspack/dev-server': ^2.0.0-0
     peerDependenciesMeta:
       '@rspack/dev-server':
-        optional: true
-
-  '@rspack/core@2.0.1':
-    resolution: {integrity: sha512-lgfZiExh8kDR/3obgi3RQKwKG5av1Xf5qDN1aVde777W9pbmx0Pqvrww1qtNvJ+gobEjbrrn5HEZWYGe0VLmcA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
         optional: true
 
   '@rspack/core@2.0.2':
@@ -9469,15 +9405,6 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.5
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.1(@swc/helpers@0.5.21))':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.1(@swc/helpers@0.5.21))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.0.5
-    transitivePeerDependencies:
-      - '@rspack/core'
-
   '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(react-refresh@0.18.0)
@@ -9698,47 +9625,22 @@ snapshots:
   '@rslint/win32-x64@0.5.1':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.1':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.0.2':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.0.1':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.1':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.0.2':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.0.1':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.1':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.0.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.1':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@2.0.2':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.0.1':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.2':
@@ -9748,36 +9650,14 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.1':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.0.2':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.0.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.1':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@2.0.2':
     optional: true
-
-  '@rspack/binding@2.0.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.1
-      '@rspack/binding-darwin-x64': 2.0.1
-      '@rspack/binding-linux-arm64-gnu': 2.0.1
-      '@rspack/binding-linux-arm64-musl': 2.0.1
-      '@rspack/binding-linux-x64-gnu': 2.0.1
-      '@rspack/binding-linux-x64-musl': 2.0.1
-      '@rspack/binding-wasm32-wasi': 2.0.1
-      '@rspack/binding-win32-arm64-msvc': 2.0.1
-      '@rspack/binding-win32-ia32-msvc': 2.0.1
-      '@rspack/binding-win32-x64-msvc': 2.0.1
 
   '@rspack/binding@2.0.2':
     optionalDependencies:
@@ -9792,17 +9672,11 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.2
       '@rspack/binding-win32-x64-msvc': 2.0.2
 
-  '@rspack/cli@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21)))':
+  '@rspack/cli@2.0.2(@rspack/core@2.0.2(@swc/helpers@0.5.21))(@rspack/dev-server@2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21)))':
     dependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
     optionalDependencies:
-      '@rspack/dev-server': 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))
-
-  '@rspack/core@2.0.1(@swc/helpers@0.5.21)':
-    dependencies:
-      '@rspack/binding': 2.0.1
-    optionalDependencies:
-      '@swc/helpers': 0.5.21
+      '@rspack/dev-server': 2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21))
 
   '@rspack/core@2.0.2(@swc/helpers@0.5.21)':
     dependencies:
@@ -9810,22 +9684,16 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
-  '@rspack/dev-middleware@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))':
+  '@rspack/dev-middleware@2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21))':
     optionalDependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
 
-  '@rspack/dev-server@2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))':
+  '@rspack/dev-server@2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21))':
     dependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
-      '@rspack/dev-middleware': 2.0.1(@rspack/core@2.0.1(@swc/helpers@0.5.21))
+      '@rspack/core': 2.0.2(@swc/helpers@0.5.21)
+      '@rspack/dev-middleware': 2.0.1(@rspack/core@2.0.2(@swc/helpers@0.5.21))
 
   '@rspack/lite-tapable@1.1.0': {}
-
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.1(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
-    dependencies:
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
 
   '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.2(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
     dependencies:


### PR DESCRIPTION
## Summary

`RstestPlugin` now sets `injectDynamicImportOrigin: true`, and `defineRstestDynamicImport` (ESM + CJS) handles the third `origin` arg that rspack's matching rewrite (web-infra-dev/rspack#13849) appends to rewritten `import()` calls.

- `import.meta.resolve` uses `origin ?? testPath` as the base, so a template-literal `import()` inside a bundled dep resolves against the dep's own directory instead of the test entry's.
- When `origin` is set, the runtime returns Node's raw Module Namespace Object directly. The existing CJS interop `Proxy` is bypassed on this path: it doesn't define `ownKeys`, so `Object.keys(ns)` would miss `default` — observably different from the `SyntheticModule` namespace that string-literal `import()` produces today. String-literal specifiers and the vm `importModuleDynamically`/`link` callbacks (no `origin`) keep their existing interop path.

Fixes #1207.

## Companion change

Depends on **web-infra-dev/rspack#13849**. Until `@rspack/core` ships the option, the call-site rewrite is a no-op and the new e2e is `it.todo`. A single `@ts-expect-error` next to `injectDynamicImportOrigin: true` bridges the TS-level mismatch — when rspack ships the new binding type, that comment will error out and force removal.

## Test plan

- [x] `pnpm --filter @rstest/core test`
- [x] `pnpm --filter @rstest/core typecheck`, `pnpm typecheck`, `pnpm lint`
- [x] e2e externals — existing tests pass; new e2e is `it.todo` so CI isn't blocked
- [ ] After web-infra-dev/rspack#13849 ships: bump `@rspack/core`, switch e2e to `it`, drop the `@ts-expect-error`

Refs #1207, #358