### PR TITLE
fix(pool): restore stderr truncation and settle wait lost in #1171

### DIFF
--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -13,6 +13,19 @@ import type { PoolTask } from './types';
 
 const WORKER_START_TIMEOUT_MS = 90_000;
 const WORKER_STOP_TIMEOUT_MS = 60_000;
+const MAX_STDERR_MESSAGE_BYTES = 64 * 1024;
+
+function formatCapturedStderr(text: string): string {
+  const bytes = Buffer.byteLength(text);
+  if (bytes <= MAX_STDERR_MESSAGE_BYTES) {
+    return text;
+  }
+  const half = Math.floor(MAX_STDERR_MESSAGE_BYTES / 2);
+  const head = text.slice(0, half);
+  const tail = text.slice(-half);
+  const hiddenBytes = bytes - Buffer.byteLength(head) - Buffer.byteLength(tail);
+  return `${head}\n\n... [truncated ${hiddenBytes} bytes of stderr] ...\n\n${tail}`;
+}
 
 type RunnerState =
   | 'IDLE'
@@ -435,13 +448,21 @@ export class PoolRunner {
     const task = this.currentTask;
     if (!task) return;
     this.currentTask = undefined;
-    this.attachStderrToError(err);
-    task.reject(err);
+
+    // Defer rejection briefly so pending stderr `data` events drain before
+    // reading the buffer. The worker's `exit` event fires before stderr's
+    // `close`; without this wait, crash output written right before exit
+    // may be missed.
+    void this.worker.waitForStderrSettle().then(() => {
+      this.attachStderrToError(err);
+      task.reject(err);
+    });
   }
 
   private attachStderrToError(err: Error): void {
-    const stderr = this.worker.getCapturedStderr().trim();
-    if (stderr.length === 0) return;
+    const raw = this.worker.getCapturedStderr().trim();
+    if (raw.length === 0) return;
+    const stderr = formatCapturedStderr(raw);
     if (err.message.includes(stderr)) return;
     err.message = `${err.message}\n\nMaybe related stderr:\n${stderr}`;
   }

--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -16,14 +16,14 @@ const WORKER_STOP_TIMEOUT_MS = 60_000;
 const MAX_STDERR_MESSAGE_BYTES = 64 * 1024;
 
 function formatCapturedStderr(text: string): string {
-  const bytes = Buffer.byteLength(text);
-  if (bytes <= MAX_STDERR_MESSAGE_BYTES) {
+  const buf = Buffer.from(text);
+  if (buf.length <= MAX_STDERR_MESSAGE_BYTES) {
     return text;
   }
   const half = Math.floor(MAX_STDERR_MESSAGE_BYTES / 2);
-  const head = text.slice(0, half);
-  const tail = text.slice(-half);
-  const hiddenBytes = bytes - Buffer.byteLength(head) - Buffer.byteLength(tail);
+  const head = buf.subarray(0, half).toString('utf-8');
+  const tail = buf.subarray(-half).toString('utf-8');
+  const hiddenBytes = buf.length - half * 2;
   return `${head}\n\n... [truncated ${hiddenBytes} bytes of stderr] ...\n\n${tail}`;
 }
 

--- a/packages/core/src/pool/poolWorker.ts
+++ b/packages/core/src/pool/poolWorker.ts
@@ -43,6 +43,11 @@ export interface PoolWorker {
    */
   resetCapturedStderr(): void;
   /**
+   * Wait for pending stderr data events to drain after the process has
+   * exited. Resolves when stderr emits `close` or a short timeout expires.
+   */
+  waitForStderrSettle(): Promise<void>;
+  /**
    * True when the worker still has a running child process that needs to be
    * terminated. Used by `PoolRunner.stop` to decide whether the STOPPING
    * path must wait for an `exit`/`close` event (and therefore whether it is

--- a/packages/core/src/pool/workers/forksPoolWorker.ts
+++ b/packages/core/src/pool/workers/forksPoolWorker.ts
@@ -10,6 +10,7 @@ import type { Envelope, WorkerRequest } from '../protocol';
 import { wrapWorkerRequest } from '../protocol';
 
 const MAX_CAPTURED_STDERR_BYTES = 1024 * 1024; // 1 MB
+const STDERR_SETTLE_MAX_WAIT = 200; // ms
 
 const BENIGN_IPC_ERROR_CODES = new Set([
   'ERR_IPC_CHANNEL_CLOSED',
@@ -54,6 +55,7 @@ export class ForksPoolWorker implements PoolWorker {
   private childProcess: ChildProcess | undefined;
   private stderrBuffer = '';
   private stderrBytes = 0;
+  private stderrClosePromise: Promise<void> | undefined;
   private startPromise?: Promise<void>;
   private exited = false;
 
@@ -114,6 +116,11 @@ export class ForksPoolWorker implements PoolWorker {
         this.appendStderr(chunk.toString());
         process.stderr.write(chunk);
       });
+      if (child.stderr) {
+        this.stderrClosePromise = new Promise<void>((resolve) => {
+          child.stderr!.once('close', resolve);
+        });
+      }
 
       child.on('message', (message: unknown) => {
         this.emitter.emit('message', message);
@@ -190,6 +197,17 @@ export class ForksPoolWorker implements PoolWorker {
     listener: PoolWorkerEvents[E],
   ): void {
     this.emitter.off(event, listener as (...args: any[]) => void);
+  }
+
+  async waitForStderrSettle(): Promise<void> {
+    if (!this.stderrClosePromise) return;
+    await Promise.race([
+      this.stderrClosePromise,
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, STDERR_SETTLE_MAX_WAIT);
+        timer.unref();
+      }),
+    ]);
   }
 
   getCapturedStderr(): string {

--- a/packages/core/tests/pool/fixtures/testWorker.mjs
+++ b/packages/core/tests/pool/fixtures/testWorker.mjs
@@ -7,6 +7,8 @@
  *   - 'fatal'              → send `fatal_error` then exit(1)
  *   - 'exit-silent'        → exit(1) without any response
  *   - 'stderr-crash'       → write to stderr then exit(1)
+ *   - 'stderr-large'       → write >64KB of stderr then exit(1)
+ *   - 'stderr-late'        → write to stderr and exit(1) immediately
  *   - 'spawn-orphan'       → spawn a long-lived grandchild that inherits
  *                             stdio, then send result and exit normally.
  *                             Tests that `exit` (not `close`) drives the
@@ -88,6 +90,22 @@ const handleRun = (request) => {
   if (mode === 'stderr-crash') {
     process.stderr.write('segfault at 0x0\n');
     setTimeout(() => process.exit(1), 10);
+    return;
+  }
+
+  if (mode === 'stderr-large') {
+    const chunk = 'x'.repeat(1024) + '\n';
+    for (let i = 0; i < 100; i++) {
+      process.stderr.write(chunk);
+    }
+    process.stderr.write('STDERR_TAIL_MARKER\n');
+    setTimeout(() => process.exit(1), 10);
+    return;
+  }
+
+  if (mode === 'stderr-late') {
+    process.stderr.write('late-stderr-marker\n');
+    process.exit(1);
     return;
   }
 

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -101,6 +101,39 @@ describe('Pool - fatal error', () => {
   });
 });
 
+// ── stderr handling ───────────────────────────────────────────────────────
+
+describe('Pool - stderr handling', () => {
+  it('should truncate large stderr in error messages', async () => {
+    const pool = new Pool(createPoolOptions());
+    try {
+      const err: Error = await pool
+        .runTest(createTask('run', { __testMode: 'stderr-large' }))
+        .catch((e: Error) => e);
+      expect(err.message).toContain('[truncated');
+      expect(err.message).toContain('bytes of stderr]');
+      // Tail is preserved
+      expect(err.message).toContain('STDERR_TAIL_MARKER');
+      // Total message should be bounded
+      expect(Buffer.byteLength(err.message)).toBeLessThan(200 * 1024);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('should capture stderr written immediately before exit', async () => {
+    const pool = new Pool(createPoolOptions());
+    try {
+      const err: Error = await pool
+        .runTest(createTask('run', { __testMode: 'stderr-late' }))
+        .catch((e: Error) => e);
+      expect(err.message).toContain('late-stderr-marker');
+    } finally {
+      await pool.close();
+    }
+  });
+});
+
 // ── isolate behavior ───────────────────────────────────────────────────────
 
 describe('Pool - isolate', () => {


### PR DESCRIPTION
## Summary

### Background

PR #1171 replaced tinypool with a self-owned worker pool and deleted `stderrCapture.ts`, internalizing its behavior into `ForksPoolWorker` and `PoolRunner`. Two behaviors from #956 were lost in the process: message-level stderr truncation (64 KB cap with head/tail marker) and a settle wait that lets pending stderr `data` events drain before reading the buffer on worker exit.

### Implementation

- Add `formatCapturedStderr` to `poolRunner.ts` — truncates stderr to 64 KB in error messages using head/tail halves with a `[truncated N bytes of stderr]` marker, matching the old `stderrCapture.ts` behavior.
- Add `waitForStderrSettle()` to the `PoolWorker` interface and `ForksPoolWorker` — waits for stderr stream `close` or a 200 ms timeout before the rejection path reads the buffer, closing the race window between the `exit` event and pending `data` callbacks.
- `rejectCurrentTaskWithStderr` now defers rejection through `waitForStderrSettle()` so crash output written immediately before `process.exit()` is captured.

### User Impact

Worker crash error messages are now bounded at ~64 KB instead of up to 1 MB, and stderr written right before a crash is less likely to be silently dropped.

## Related Links

- #1171 — pool rewrite that introduced the regression
- #956 — original fix that added stderr capture for crash diagnostics

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).