### PR TITLE
fix: handle `toNotFake` option in useFakeTimers properly

### DIFF
--- a/packages/core/src/runtime/api/fakeTimers.ts
+++ b/packages/core/src/runtime/api/fakeTimers.ts
@@ -137,19 +137,21 @@ export class FakeTimers {
     }
   }
 
-  useFakeTimers(fakeTimersConfig: FakeTimerInstallOpts = {}): void {
+  useFakeTimers({
+    toNotFake = [],
+    ...restFakeTimersConfig
+  }: FakeTimerInstallOpts = {}): void {
     if (this._fakingTime) {
       this._clock.uninstall();
     }
 
+    const ignoreTimers = ['Intl', 'nextTick', 'queueMicrotask'].concat(
+      toNotFake,
+    );
+
     const toFake = Object.keys(this._fakeTimers.timers)
       // Do not mock timers internally used by node by default. It can still be mocked through userConfig.
-      .filter(
-        (timer): timer is FakeMethod =>
-          timer !== 'Intl' &&
-          timer !== 'nextTick' &&
-          timer !== 'queueMicrotask',
-      );
+      .filter((timer): timer is FakeMethod => !ignoreTimers.includes(timer));
 
     const isChildProcess = typeof process !== 'undefined' && !!process.send;
 
@@ -163,7 +165,7 @@ export class FakeTimers {
       now: Date.now(),
       toFake: [...toFake],
       ignoreMissingTimers: true,
-      ...fakeTimersConfig,
+      ...restFakeTimersConfig,
     });
 
     // temporary fix fake-timers 15.1.1 → 15.2.0 timerHeap.push error

--- a/packages/core/tests/runtime/api/fakeTimers.test.ts
+++ b/packages/core/tests/runtime/api/fakeTimers.test.ts
@@ -1,0 +1,52 @@
+import { createRstestUtilities } from '../../../src/runtime/api/utilities';
+import { setRealTimers } from '../../../src/runtime/util';
+import type { WorkerState } from '../../../src/types';
+
+function createWorkerState(): WorkerState {
+  return {
+    runtimeConfig: {
+      testTimeout: 1_000,
+      hookTimeout: 1_000,
+      clearMocks: false,
+      resetMocks: false,
+      restoreMocks: false,
+      maxConcurrency: 5,
+      retry: 0,
+    },
+  } as WorkerState;
+}
+
+describe('fake timers API', () => {
+  beforeEach(() => {
+    setRealTimers();
+  });
+
+  it('useFakeTimers not throws when specifies `toNotFake`', async () => {
+    const rs = await createRstestUtilities(createWorkerState());
+
+    expect(() =>
+      rs.useFakeTimers({ toNotFake: ['setImmediate'] }),
+    ).not.toThrow();
+
+    rs.useRealTimers();
+  });
+
+  it('useFakeTimers filters out timers in toNotFake', async () => {
+    const rs = await createRstestUtilities(createWorkerState());
+
+    rs.useFakeTimers({ toNotFake: ['setTimeout'] });
+
+    let fired = false;
+    setTimeout(() => {
+      fired = true;
+    }, 5);
+
+    rs.advanceTimersByTime(10); // proves that setTimeout is not mocked
+    expect(fired).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fired).toBe(true);
+
+    rs.useRealTimers();
+  });
+});


### PR DESCRIPTION
instead of passing it to @sinonjs/fake-timers, closes #1218

## Summary

Since the lib provides `toFake` property for `@sinonjs/fake-timers` and the lib throws when there are `toFake` & `toNotFake`, we should make sure not to pass them both.

## Related Links

[<!--- Provide links of related issues or pages -->](https://github.com/sinonjs/fake-timers/blob/main/src/fake-timers-src.js#L2581-L2584)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
