### PR TITLE
docs(api): add environment variables reference page

### DIFF
--- a/e2e/browser-mode/fixtures/env/tests/env.test.ts
+++ b/e2e/browser-mode/fixtures/env/tests/env.test.ts
@@ -31,4 +31,8 @@ describe('browser env injection', () => {
     expect(process.env.RSTEST_E2E_ENV_FOO).toBe(originalFoo);
     expect(process.env.RSTEST_E2E_ENV_DYNAMIC).toBeUndefined();
   });
+
+  it('should expose NODE_ENV via import.meta.env in browser mode', () => {
+    expect(import.meta.env.NODE_ENV).toBe('test');
+  });
 });

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -800,7 +800,13 @@ const getRuntimeConfigFromProject = (
   } = project.normalizedConfig;
 
   return {
-    env,
+    // Propagate NODE_ENV from the host so `import.meta.env.NODE_ENV` resolves
+    // to `'test'` in browser tests (matches Node mode). User-supplied `env`
+    // wins so explicit overrides still take effect.
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+      ...env,
+    },
     testNamePattern,
     testTimeout,
     hookTimeout,

--- a/website/docs/en/api/runtime-api/_meta.json
+++ b/website/docs/en/api/runtime-api/_meta.json
@@ -18,5 +18,10 @@
     "type": "dir",
     "name": "rstest",
     "label": "Rstest Utility"
+  },
+  {
+    "type": "file",
+    "name": "environment-variables",
+    "label": "Environment Variables"
   }
 ]

--- a/website/docs/en/api/runtime-api/environment-variables.mdx
+++ b/website/docs/en/api/runtime-api/environment-variables.mdx
@@ -1,0 +1,59 @@
+---
+description: Environment variables that Rstest sets in the test process and worker processes.
+---
+
+# Environment variables
+
+Rstest sets a small set of environment variables you can read from tests, setup files, and source code.
+
+## `NODE_ENV`
+
+Set to `'test'` when the test runner starts (if not already defined). Existing values are preserved, so you can override it from your shell or `package.json` script.
+
+Available as both `process.env.NODE_ENV` and `import.meta.env.NODE_ENV` across all test environments, including [browser mode](/guide/browser-testing/). Prefer `import.meta.env.NODE_ENV` in ESM source code where `process` may not be available.
+
+```ts
+if (import.meta.env.NODE_ENV === 'test') {
+  // running under Rstest
+}
+```
+
+## `RSTEST`
+
+`process.env.RSTEST` is set to `'true'` whenever the test runner is active. Use it to gate test-only branches in source code.
+
+```ts
+if (process.env.RSTEST) {
+  // running under Rstest
+}
+```
+
+For production builds, define `process.env.RSTEST` as `false` so the bundler can eliminate the dead branch — see [Detect Rstest environment](/guide/basic/configure-rstest#detect-rstest-environment).
+
+For [in-source tests](/config/test/include-source), prefer `import.meta.rstest` — it exposes the Rstest test API directly and is `undefined` in production builds.
+
+## `RSTEST_WORKER_ID`
+
+A stringified integer that uniquely identifies the worker process running the current test file. The first worker is `'1'`. Equivalent to Jest's [`JEST_WORKER_ID`](https://jestjs.io/docs/environment-variables#jest_worker_id).
+
+Use it to isolate shared external resources across parallel workers — typically database schemas, ports, temp directories, or any resource that would collide if two workers used the same name.
+
+```ts title="db.test.ts"
+import { afterAll, beforeAll, test } from '@rstest/core';
+
+const dbName = `myapp_test_${process.env.RSTEST_WORKER_ID}`;
+
+beforeAll(async () => {
+  await createDatabase(dbName);
+});
+
+afterAll(async () => {
+  await dropDatabase(dbName);
+});
+
+test('inserts a row', async () => {
+  // ...
+});
+```
+
+Concurrent workers are always given different IDs, so the value is safe to use as part of a resource name during a worker's lifetime. The maximum number of concurrent workers is bounded by [`pool.maxWorkers`](/config/test/pool); IDs are assigned monotonically as workers spawn and are not recycled within a single Rstest run.

--- a/website/docs/en/guide/migration/jest.mdx
+++ b/website/docs/en/guide/migration/jest.mdx
@@ -157,6 +157,24 @@ export default defineConfig({
 });
 ```
 
+## Environment variables
+
+Rstest mirrors Jest's two main injected variables under different names:
+
+| Jest             | Rstest             | Notes                                                                                                                                                                                                                          |
+| ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `JEST_WORKER_ID` | `RSTEST_WORKER_ID` | Same semantics — a stringified integer, unique among workers active at the same time. Use it to isolate per-worker DBs / ports / temp dirs. See [`RSTEST_WORKER_ID`](/api/runtime-api/environment-variables#rstest_worker_id). |
+| `NODE_ENV`       | `NODE_ENV`         | Both default to `'test'` when not set.                                                                                                                                                                                         |
+
+Replace any references in tests, fixtures, or `setupFiles`:
+
+```diff
+- const dbName = `myapp_test_${process.env.JEST_WORKER_ID}`;
++ const dbName = `myapp_test_${process.env.RSTEST_WORKER_ID}`;
+```
+
+See [Environment variables](/api/runtime-api/environment-variables) for the full list.
+
 ## Update test API
 
 ### Test API

--- a/website/docs/zh/api/runtime-api/_meta.json
+++ b/website/docs/zh/api/runtime-api/_meta.json
@@ -18,5 +18,10 @@
     "type": "dir",
     "name": "rstest",
     "label": "Rstest 实用工具"
+  },
+  {
+    "type": "file",
+    "name": "environment-variables",
+    "label": "环境变量"
   }
 ]

--- a/website/docs/zh/api/runtime-api/environment-variables.mdx
+++ b/website/docs/zh/api/runtime-api/environment-variables.mdx
@@ -1,0 +1,59 @@
+---
+description: Rstest 注入到测试进程和 worker 进程中的环境变量。
+---
+
+# 环境变量
+
+Rstest 在测试进程和 worker 进程中会设置一些环境变量，你可以在测试、setup 文件以及源码中读取它们。
+
+## `NODE_ENV`
+
+如果 `NODE_ENV` 还没被设置，Rstest 在执行测试时会把它设为 `'test'`。Rstest 不会覆盖已有的值，因此你可以通过 shell 或 `package.json` 脚本指定。
+
+`process.env.NODE_ENV` 和 `import.meta.env.NODE_ENV` 在所有测试环境（包括 [browser mode](/guide/browser-testing/)）下都可用。在 ESM 源码中（尤其是浏览器构建等没有 `process` 的场景），更推荐使用 `import.meta.env.NODE_ENV`。
+
+```ts
+if (import.meta.env.NODE_ENV === 'test') {
+  // 运行在 Rstest 中
+}
+```
+
+## `RSTEST`
+
+Rstest 在执行测试时会把 `process.env.RSTEST` 设为 `'true'`，可以用来在源码中标记仅在测试中执行的代码分支。
+
+```ts
+if (process.env.RSTEST) {
+  // 运行在 Rstest 中
+}
+```
+
+在生产构建中把 `process.env.RSTEST` 替换为 `false`，这样打包工具就能消除对应的死代码 — 详见 [检测 Rstest 环境](/guide/basic/configure-rstest#检测-rstest-环境)。
+
+如果想把测试代码直接写在源文件里，更推荐使用 [`import.meta.rstest`](/config/test/include-source) — 它直接暴露 Rstest 的测试 API，并且在生产构建中为 `undefined`。
+
+## `RSTEST_WORKER_ID`
+
+标识当前测试文件所在 worker 进程的整数（以字符串形式表示）。第一个 worker 为 `'1'`。等价于 Jest 的 [`JEST_WORKER_ID`](https://jestjs.io/zh-Hans/docs/environment-variables#jest_worker_id)。
+
+可以在并行 worker 之间隔离共享的外部资源 — 比如数据库 schema、端口、临时目录，以及其他可能因多 worker 同名而冲突的资源。
+
+```ts title="db.test.ts"
+import { afterAll, beforeAll, test } from '@rstest/core';
+
+const dbName = `myapp_test_${process.env.RSTEST_WORKER_ID}`;
+
+beforeAll(async () => {
+  await createDatabase(dbName);
+});
+
+afterAll(async () => {
+  await dropDatabase(dbName);
+});
+
+test('inserts a row', async () => {
+  // ...
+});
+```
+
+同时运行的 worker 之间 ID 一定不同，所以在 worker 生命周期内可以放心地把它用作资源名的一部分。并发 worker 的数量上限由 [`pool.maxWorkers`](/config/test/pool) 控制；ID 会按 worker 启动顺序递增，单次 Rstest 运行内不会回收复用。

--- a/website/docs/zh/guide/migration/jest.mdx
+++ b/website/docs/zh/guide/migration/jest.mdx
@@ -157,6 +157,24 @@ export default defineConfig({
 });
 ```
 
+## 环境变量
+
+Rstest 提供了与 Jest 这两个主要环境变量对应的实现，只是变量名不同：
+
+| Jest             | Rstest             | 说明                                                                                                                                                                                                    |
+| ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JEST_WORKER_ID` | `RSTEST_WORKER_ID` | 语义一致 — 整数（以字符串形式表示），同时运行的 worker 之间互不相同。可用于按 worker 隔离数据库 / 端口 / 临时目录。详见 [`RSTEST_WORKER_ID`](/api/runtime-api/environment-variables#rstest_worker_id)。 |
+| `NODE_ENV`       | `NODE_ENV`         | 未设置时两者都默认为 `'test'`。                                                                                                                                                                         |
+
+替换测试、fixture 或 `setupFiles` 中的引用：
+
+```diff
+- const dbName = `myapp_test_${process.env.JEST_WORKER_ID}`;
++ const dbName = `myapp_test_${process.env.RSTEST_WORKER_ID}`;
+```
+
+完整列表参见 [环境变量](/api/runtime-api/environment-variables)。
+
 ## 更新测试 API
 
 ### 测试 API


### PR DESCRIPTION
## Summary

### Background

Issue #1217 reported that Rstest had no documented equivalent of Jest's `JEST_WORKER_ID`. The variable (`RSTEST_WORKER_ID`) existed but was undocumented, and `RSTEST` / `NODE_ENV` were only mentioned scattered across the docs. Browser mode also exposed `import.meta.env.NODE_ENV` as `undefined` — inconsistent with Node mode.

### Implementation

- Add `api/runtime-api/environment-variables` (en + zh) covering `NODE_ENV`, `RSTEST`, `RSTEST_WORKER_ID`. Cross-linked from the Jest migration guide so users searching for `JEST_WORKER_ID` discover `RSTEST_WORKER_ID`.
- Fix `getRuntimeConfigFromProject` in `@rstest/browser` to propagate the host's `process.env.NODE_ENV` into the browser runtime env store; user-supplied `env` config still wins.
- Add an e2e assertion in `e2e/browser-mode/fixtures/env` confirming `import.meta.env.NODE_ENV === 'test'` in browser mode.

### User Impact

`import.meta.env.NODE_ENV === 'test'` now works consistently in browser mode (previously `undefined`), giving users a portable signal across Node and browser test environments.

## Related Links

Closes #1217

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).