### PR TITLE
chore(core): silence pool unit test stderr noise on CI

### DIFF
--- a/packages/core/src/pool/types.ts
+++ b/packages/core/src/pool/types.ts
@@ -16,4 +16,11 @@ export type PoolOptions = {
   isolate: boolean;
   env?: Record<string, string>;
   execArgv?: string[];
+  /**
+   * Whether to forward worker stdio to the host process. Defaults to `true`
+   * to preserve Tinypool parity (native crash logs / warnings stay visible).
+   * Set to `false` in tests that intentionally write crash-like output to
+   * stderr so the simulated noise doesn't leak into the host log.
+   */
+  forwardStdio?: boolean;
 };

--- a/packages/core/src/pool/workers/forksPoolWorker.ts
+++ b/packages/core/src/pool/workers/forksPoolWorker.ts
@@ -37,6 +37,7 @@ type ForksPoolWorkerOptions = {
   filename: string;
   env?: NodeJS.ProcessEnv;
   execArgv?: string[];
+  forwardStdio?: boolean;
 };
 
 /**
@@ -52,6 +53,7 @@ export class ForksPoolWorker implements PoolWorker {
   private readonly filename: string;
   private readonly env?: NodeJS.ProcessEnv;
   private readonly execArgv?: string[];
+  private readonly forwardStdio: boolean;
   private childProcess: ChildProcess | undefined;
   private stderrBuffer = '';
   private stderrBytes = 0;
@@ -64,6 +66,7 @@ export class ForksPoolWorker implements PoolWorker {
     this.filename = options.filename;
     this.env = options.env;
     this.execArgv = options.execArgv;
+    this.forwardStdio = options.forwardStdio ?? true;
   }
 
   get pid(): number | undefined {
@@ -93,7 +96,10 @@ export class ForksPoolWorker implements PoolWorker {
       const forkOptions: ForkOptions = {
         env: this.env,
         execArgv: this.execArgv,
-        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        // stderr stays piped so we can capture it for error enrichment even
+        // when host forwarding is off; stdout is unused for capture, so drop
+        // the pipe entirely when we're not forwarding.
+        stdio: ['ignore', this.forwardStdio ? 'pipe' : 'ignore', 'pipe', 'ipc'],
         serialization: getWorkerSerialization(),
       };
 
@@ -109,12 +115,14 @@ export class ForksPoolWorker implements PoolWorker {
 
       // Pipe child stdio to the host process so native crash logs / warnings
       // remain visible. Tinypool did this by default; preserve the behavior.
-      child.stdout?.on('data', (chunk: Buffer) => {
-        process.stdout.write(chunk);
-      });
+      if (this.forwardStdio) {
+        child.stdout?.on('data', (chunk: Buffer) => {
+          process.stdout.write(chunk);
+        });
+      }
       child.stderr?.on('data', (chunk: Buffer) => {
         this.appendStderr(chunk.toString());
-        process.stderr.write(chunk);
+        if (this.forwardStdio) process.stderr.write(chunk);
       });
       if (child.stderr) {
         this.stderrClosePromise = new Promise<void>((resolve) => {

--- a/packages/core/src/pool/workers/index.ts
+++ b/packages/core/src/pool/workers/index.ts
@@ -14,6 +14,7 @@ export function createPoolWorker(
         filename: options.workerEntry,
         env: options.env,
         execArgv: options.execArgv,
+        forwardStdio: options.forwardStdio,
       });
     }
     default: {

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -9,6 +9,11 @@ const createPoolOptions = (overrides?: Partial<PoolOptions>): PoolOptions => ({
   maxWorkers: 2,
   minWorkers: 0,
   isolate: true,
+  // The fixture worker intentionally writes crash-like output to stderr
+  // (e.g. `segfault at 0x0`, 100 KB of `x`) to exercise stderr capture and
+  // truncation. Suppress host forwarding so this simulated noise doesn't
+  // leak into the parent rstest log on CI.
+  forwardStdio: false,
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary

### Background

`pool.test.ts` exercises stderr-handling fixtures that intentionally write crash-like output (`segfault at 0x0`, 100 KB of `x`, `late-stderr-marker`, missing-module errors). `ForksPoolWorker` mirrors Tinypool by forwarding child stdio to the host process, so this fixture noise leaked into the GitHub Actions log on every CI run — looking exactly like a real macOS segfault even though every job passed.

### Implementation

- Add an internal `forwardStdio?: boolean` to `PoolOptions` (default `true`, preserves Tinypool parity for the production caller). Thread it through `createPoolWorker` into `ForksPoolWorker`.
- When `forwardStdio` is false, skip the host-stdout listener entirely and switch the child's stdout slot to `'ignore'` so the OS pipe is never created. Stderr stays piped because the capture path used for error enrichment still needs it; the host write is gated inside the same listener.
- `pool.test.ts` `createPoolOptions` now defaults to `forwardStdio: false`. Fixture bytes still reach `appendStderr` (so `expect(err.message).toContain(...)` assertions hold), they just don't reach `process.stderr`.

### User Impact

None — internal pool option, not exposed through public config.