### PR TITLE
feat(core): add --trace flag to dump Perfetto-compatible profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.log*
 *.cpuprofile
+*.dump
 node_modules/
 
 .cache/
@@ -48,6 +49,7 @@ packages/vscode/*.vsix
 packages/vscode/icon.png
 
 .rstest-temp/
+.rstest/
 lefthook-local.yml
 
 # Generated memory benchmark fixture

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -18,6 +18,7 @@ import {
   type ListCommandResult,
   loadCoverageProvider,
   logger,
+  PhaseTracker,
   type ProjectContext,
   type Reporter,
   type Rstest,
@@ -94,6 +95,18 @@ type RsbuildInstance = rsbuild.RsbuildInstance;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OPTIONS_PLACEHOLDER = '__RSTEST_OPTIONS_PLACEHOLDER__';
+
+/**
+ * Monotonic counter for synthetic per-file Perfetto `pid` values in `--trace`
+ * mode. Browser host runs every test file inside the same Node process, so
+ * without an override every file would emit events under the same `pid` and
+ * share a single track labelled `worker <hostPid>`. Giving each file its own
+ * synthetic `pid` makes the track title surface the file path instead,
+ * matching node mode's default `isolate: true` behavior. The 1_000_000_000
+ * base keeps each synthetic `pid` well clear of real OS `pid` values in
+ * mixed-mode traces.
+ */
+let nextBrowserFilePid = 1_000_000_000;
 
 /**
  * Serialize JSON for inline <script> injection.
@@ -1693,10 +1706,22 @@ export const runBrowserController = async (
   context: Rstest,
   options?: BrowserTestRunOptions,
 ): Promise<BrowserTestRunResult | void> => {
-  const { skipOnTestRunEnd = false, allowEmptyWatchRun = false } =
-    options ?? {};
+  const {
+    skipOnTestRunEnd = false,
+    allowEmptyWatchRun = false,
+    onTraceEvents,
+  } = options ?? {};
   const buildStart = Date.now();
   const isWatchMode = context.command === 'watch';
+
+  // Per-file PhaseTrackers, populated only when `--trace` is on (caller
+  // passes `onTraceEvents`). The browser host shares one Node process across
+  // every test file, so each tracker is assigned a synthetic per-file pid
+  // (`nextBrowserFilePid`) that lets Perfetto render each file as its own
+  // process track with the file path as the title.
+  const phaseTrackers = onTraceEvents
+    ? new Map<string, PhaseTracker>()
+    : undefined;
   const browserProjects = getBrowserProjects(context);
   const useHeadlessDirect = browserProjects.every(
     (project) => project.normalizedConfig.browser.headless,
@@ -2180,6 +2205,17 @@ export const runBrowserController = async (
   const handleTestFileStart = async (
     payload: TestFileStartPayload,
   ): Promise<void> => {
+    if (phaseTrackers) {
+      const tracker = new PhaseTracker({
+        trace: {
+          testPath: payload.testPath,
+          project: payload.projectName,
+        },
+        pid: nextBrowserFilePid++,
+      });
+      tracker.transition('prepare');
+      phaseTrackers.set(payload.testPath, tracker);
+    }
     await Promise.all(
       context.reporters.map((reporter) =>
         (reporter as Reporter).onTestFileStart?.({
@@ -2194,6 +2230,7 @@ export const runBrowserController = async (
   const handleTestFileReady = async (
     payload: TestFileReadyPayload,
   ): Promise<void> => {
+    phaseTrackers?.get(payload.testPath)?.transition('tests');
     await Promise.all(
       context.reporters.map((reporter) =>
         (reporter as Reporter).onTestFileReady?.(payload),
@@ -2204,6 +2241,7 @@ export const runBrowserController = async (
   const handleTestSuiteStart = async (
     payload: TestSuiteStartPayload,
   ): Promise<void> => {
+    phaseTrackers?.get(payload.testPath)?.recordSuiteStart(payload);
     await Promise.all(
       context.reporters.map((reporter) =>
         (reporter as Reporter).onTestSuiteStart?.(payload),
@@ -2214,6 +2252,7 @@ export const runBrowserController = async (
   const handleTestSuiteResult = async (
     payload: TestSuiteResultPayload,
   ): Promise<void> => {
+    phaseTrackers?.get(payload.testPath)?.recordSuiteResult(payload);
     await Promise.all(
       context.reporters.map((reporter) =>
         (reporter as Reporter).onTestSuiteResult?.(payload),
@@ -2234,6 +2273,7 @@ export const runBrowserController = async (
   const handleTestCaseStart = async (
     payload: TestCaseStartPayload,
   ): Promise<void> => {
+    phaseTrackers?.get(payload.testPath)?.recordCaseStart(payload);
     await Promise.all(
       context.reporters.map((reporter) =>
         (reporter as Reporter).onTestCaseStart?.(payload),
@@ -2243,6 +2283,7 @@ export const runBrowserController = async (
 
   const handleTestCaseResult = async (payload: TestResult): Promise<void> => {
     caseResults.push(payload);
+    phaseTrackers?.get(payload.testPath)?.recordCaseResult(payload);
     await Promise.all(
       context.reporters.map((reporter) =>
         (reporter as Reporter).onTestCaseResult?.(payload),
@@ -2267,6 +2308,16 @@ export const runBrowserController = async (
     context.updateReporterResultState([payload], payload.results);
     if (payload.snapshotResult) {
       context.snapshotManager.add(payload.snapshotResult);
+    }
+
+    if (phaseTrackers) {
+      const tracker = phaseTrackers.get(payload.testPath);
+      if (tracker) {
+        tracker.end();
+        const events = tracker.getTraceEvents();
+        if (events) onTraceEvents?.(events);
+        phaseTrackers.delete(payload.testPath);
+      }
     }
 
     if (context.normalizedConfig.silent === 'passed-only') {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -17,6 +17,10 @@ export { createRstestRuntime } from './runtime/api';
 // These are the test APIs that run in the browser (describe, it, expect, etc.)
 export * from './runtime/api/public';
 export { setRealTimers } from './runtime/util';
+// Trace primitives — the browser host instantiates PhaseTracker per test file
+// and forwards its events via `BrowserTestRunOptions.onTraceEvents`.
+export { PhaseTracker } from './runtime/worker/phaseTracker';
+export type { TraceEvent } from './utils/trace';
 // Types
 export type {
   BrowserTestRunOptions,

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -67,6 +67,7 @@ const runtimeOptionDefinitions: OptionDefinition[] = [
   ],
   ['--disableConsoleIntercept', 'Disable console intercept'],
   ['--logHeapUsage', 'Log heap usage after each test'],
+  ['--trace', 'Dump a Perfetto-compatible performance trace JSON file'],
   [
     '--slowTestThreshold <value>',
     'The number of milliseconds after which a test or suite is considered slow',
@@ -321,7 +322,7 @@ export const runRest = async ({
     });
 
     rstest = createRstest(
-      { config, configFilePath, projects },
+      { config, configFilePath, projects, trace: options.trace },
       command,
       effectiveFilters,
       fileFilterMode,

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -67,6 +67,7 @@ export type CommonOptions = {
   silent?: boolean | 'passed-only';
   printConsoleTrace?: boolean;
   logHeapUsage?: boolean;
+  trace?: boolean;
   disableConsoleIntercept?: boolean;
   update?: boolean;
   testNamePattern?: RegExp | string;

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -13,10 +13,13 @@ export function createRstest(
     config,
     projects,
     configFilePath,
+    trace,
   }: {
     config: RstestConfig;
     configFilePath?: string;
     projects: Project[];
+    /** CLI-only `--trace` switch; not exposed via user config. */
+    trace?: boolean;
   },
   command: RstestCommand,
   fileFilters: string[],
@@ -30,6 +33,7 @@ export function createRstest(
       fileFilterMode,
       configFilePath,
       projects,
+      trace,
     },
     config,
   );

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -49,6 +49,7 @@ type Options = {
   fileFilterMode?: FileFilterMode;
   configFilePath?: string;
   projects: Project[];
+  trace?: boolean;
 };
 
 export class Rstest implements RstestContext {
@@ -61,6 +62,7 @@ export class Rstest implements RstestContext {
   public configFilePath?: string;
   public reporters: Reporter[];
   public snapshotManager: SnapshotManager;
+  public trace: boolean;
   public version: string;
   public rootPath: string;
   public originalConfig: RstestConfig;
@@ -96,11 +98,13 @@ export class Rstest implements RstestContext {
       fileFilterMode,
       configFilePath,
       projects,
+      trace = false,
     }: Options,
     userConfig: RstestConfig,
   ) {
     this.cwd = cwd;
     this.command = command;
+    this.trace = trace;
     this.fileFilters = fileFilters;
     this.fileFilterMode = fileFilterMode;
     this.configFilePath = configFilePath;

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -1,14 +1,21 @@
 import { constants as osConstants } from 'node:os';
 import { cleanCoverageReports, createCoverageProvider } from '../coverage';
 import { createPool } from '../pool';
-import type { EntryInfo, ProjectEntries, SourceMapInput } from '../types';
+import type {
+  Duration,
+  EntryInfo,
+  ProjectEntries,
+  SourceMapInput,
+} from '../types';
 import type { CoverageMap } from '../types/coverage';
 import {
   clearScreen,
   color,
+  createTraceController,
   getTestEntries,
   logger,
   resolveShardedEntries,
+  type TraceEvent,
 } from '../utils';
 import {
   type BrowserTestRunOptions,
@@ -110,11 +117,7 @@ const notifyReportersOnTestRunEnd = async ({
 }: {
   context: Rstest;
   coverage?: CoverageMap;
-  duration: {
-    totalTime: number;
-    buildTime: number;
-    testTime: number;
-  };
+  duration: Duration;
   getSourcemap: (sourcePath: string) => Promise<SourceMapInput | null>;
   unhandledErrors?: Error[];
   filterRerunTestPaths?: string[];
@@ -158,6 +161,13 @@ export async function runTests(context: Rstest): Promise<void> {
     testTime: 0,
   });
 
+  // Constructed before the browser-only fast path so `--trace` is honored
+  // for pure-browser runs (browser host forwards events via `onTraceEvents`).
+  const traceController = createTraceController({
+    enabled: context.trace,
+    rootPath: context.rootPath,
+  });
+
   // If only browser tests, run them and generate coverage
   if (hasBrowserProjects && !hasNodeProjects) {
     if (context.relatedResolutionEmpty) {
@@ -175,6 +185,7 @@ export async function runTests(context: Rstest): Promise<void> {
         });
       }
 
+      await traceController.close();
       return;
     }
 
@@ -187,8 +198,11 @@ export async function runTests(context: Rstest): Promise<void> {
       );
     }
 
+    const traceRun = traceController.beginRun();
+
     const browserResult = await runBrowserModeTests(context, browserProjects, {
       skipOnTestRunEnd: false,
+      onTraceEvents: traceRun.onEvents,
     });
 
     // Generate coverage reports for browser-only tests when execution produced test results.
@@ -214,6 +228,7 @@ export async function runTests(context: Rstest): Promise<void> {
       }
     }
 
+    await traceController.shutdown(traceRun);
     return;
   }
 
@@ -221,6 +236,17 @@ export async function runTests(context: Rstest): Promise<void> {
   // If both, run them in parallel
 
   let browserResultPromise: Promise<BrowserTestRunResult | void> | undefined;
+  // Late-binding handoff for mixed-mode browser+node runs: the browser host
+  // is launched once at the top of `runTests`, but each call to `run()`
+  // starts a fresh per-rerun trace buffer. Pre-allocate the first buffer
+  // here so events emitted before `run()` adopts it — or in scenarios where
+  // `run()` is never called (mixed mode with all node tests filtered out) —
+  // are not silently dropped. `beginRun` itself returns a no-op handle when
+  // tracing is disabled, so we can keep `activeTraceRun` non-optional.
+  let activeTraceRun = traceController.beginRun();
+  const forwardBrowserTraceEvents = context.trace
+    ? (events: TraceEvent[]) => activeTraceRun.onEvents?.(events)
+    : undefined;
 
   const allProjects = context.projects;
 
@@ -320,6 +346,7 @@ export async function runTests(context: Rstest): Promise<void> {
       skipOnTestRunEnd: shouldUnifyReporter,
       shardedEntries: shard ? browserEntries : undefined,
       allowEmptyWatchRun: isWatchMode && context.relatedResolutionEmpty,
+      onTraceEvents: forwardBrowserTraceEvents,
     });
 
     // Prevent an unhandled rejection window in mixed node+browser runs.
@@ -334,6 +361,11 @@ export async function runTests(context: Rstest): Promise<void> {
     }
     // If only browser tests were to run and they ran, we should return.
     if (hasBrowserTestsToRun) {
+      // `run()` was never invoked on this path, so no node-side finalize
+      // fires for the pre-allocated buffer. Flush any browser events the
+      // host emitted into it before exiting so `--trace` still produces a
+      // file for filtered mixed-mode runs.
+      await traceController.shutdown(activeTraceRun);
       return;
     }
     // If no node projects at all, and no browser tests to run,
@@ -460,6 +492,11 @@ export async function runTests(context: Rstest): Promise<void> {
       ? coverageProvider.createCoverageMap()
       : undefined;
 
+    // Adopt the pre-allocated buffer (set above `runTests` or at the end of
+    // the previous rerun's `finalize`) so browser events emitted before
+    // `run()` are captured.
+    const traceRun = activeTraceRun;
+
     const returns = await Promise.all(
       projects.map(async (p) => {
         const {
@@ -548,6 +585,7 @@ export async function runTests(context: Rstest): Promise<void> {
           project: p,
           updateSnapshot: context.snapshotManager.options.updateSnapshot,
           onCoverageResult: (coverage) => mergedCoverageMap?.merge(coverage),
+          onTraceEvents: traceRun.onEvents,
         });
 
         return {
@@ -599,7 +637,7 @@ export async function runTests(context: Rstest): Promise<void> {
       };
 
       // When unifying reporter output, combine browser and node durations
-      const duration =
+      const duration: Duration =
         shouldUnifyReporter && browserResult
           ? {
               totalTime:
@@ -680,6 +718,12 @@ export async function runTests(context: Rstest): Promise<void> {
         await generateCoverage(context, mergedCoverageMap!, coverageProvider);
       }
 
+      await traceRun.finalize();
+      // Pre-allocate the next watch-rerun buffer so browser events emitted
+      // between reruns (or before the next `run()` adopts a fresh buffer)
+      // are not lost.
+      activeTraceRun = traceController.beginRun();
+
       if (isFailure) {
         const bail = context.normalizedConfig.bail;
 
@@ -711,6 +755,13 @@ export async function runTests(context: Rstest): Promise<void> {
         await runGlobalTeardown();
         await pool.close();
         await closeServer();
+        // Flush any browser events the host pushed into the pre-allocated
+        // buffer since the last `run()` finalized — otherwise they get
+        // dropped when the controller closes. Inline (not `shutdown`)
+        // because cleanup may run from a SIGINT handler and `waitForExit`
+        // would block waiting for another signal.
+        await activeTraceRun.finalize();
+        await traceController.close();
       } catch (error) {
         logger.log(color.red(`Error during cleanup: ${error}`));
       }
@@ -750,6 +801,8 @@ export async function runTests(context: Rstest): Promise<void> {
       await runGlobalTeardown();
       await pool.close();
       await closeServer();
+      await activeTraceRun.finalize();
+      await traceController.close();
     });
 
     let buildStart: number | undefined;
@@ -771,6 +824,8 @@ export async function runTests(context: Rstest): Promise<void> {
           closeServer: async () => {
             await pool.close();
             await closeServer();
+            await activeTraceRun.finalize();
+            await traceController.close();
           },
           runAll: async () => {
             clearScreen();
@@ -898,6 +953,8 @@ export async function runTests(context: Rstest): Promise<void> {
         await runGlobalTeardown();
         await pool.close();
         await closeServer();
+        await activeTraceRun.finalize();
+        await traceController.close();
       } catch (error) {
         logger.log(color.red(`Error during cleanup: ${error}`));
       }
@@ -952,5 +1009,7 @@ export async function runTests(context: Rstest): Promise<void> {
       process.off('SIGTERM', handleSignal);
       process.off('SIGTSTP', handleSignal);
     }
+
+    await traceController.waitForExit();
   }
 }

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -25,6 +25,7 @@ import {
   isDeno,
   needFlagExperimentalDetectModule,
 } from '../utils';
+import type { TraceEvent } from '../utils/trace';
 import { isMemorySufficient } from '../utils/memory';
 import { Pool } from './pool';
 
@@ -192,6 +193,7 @@ const buildTask = async ({
         rootPath: context.rootPath,
         projectRoot: project.rootPath,
         runtimeConfig,
+        trace: context.trace,
       },
       type,
       setupEntries,
@@ -267,6 +269,8 @@ export const createPool = async ({
     project: ProjectContext;
     /** When provided, coverage data is passed to this callback immediately for caller-owned merging. */
     onCoverageResult?: (coverage: CoverageMapData) => void;
+    /** Perfetto trace events forwarded for caller-owned dumping. */
+    onTraceEvents?: (events: TraceEvent[]) => void;
   }) => Promise<{
     results: TestFileResult[];
     testResults: TestResult[];
@@ -449,6 +453,7 @@ export const createPool = async ({
       project,
       updateSnapshot,
       onCoverageResult,
+      onTraceEvents,
     }) => {
       const projectName = project.name;
       const runtimeConfig = getRuntimeConfig(project);
@@ -487,6 +492,10 @@ export const createPool = async ({
           if (result.coverage) {
             onCoverageResult?.(result.coverage);
             delete result.coverage;
+          }
+          if (result.traceEvents) {
+            onTraceEvents?.(result.traceEvents);
+            delete result.traceEvents;
           }
           context.stateManager.onTestFileResult(result);
           reporters.map((reporter) => reporter.onTestFileResult?.(result));

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -28,6 +28,14 @@ export const getRealTimers = (): typeof REAL_TIMERS => {
   return REAL_TIMERS;
 };
 
+/**
+ * Stable reference to `Date.now`, captured before `@sinonjs/fake-timers`
+ * can hijack the global. Phase boundaries straddling `tests` rely on this.
+ */
+const realNow = Date.now.bind(Date);
+
+export const getRealNow = (): number => realNow();
+
 export const formatTestError = async (
   err: any,
   test?: Test,

--- a/packages/core/src/runtime/worker/phaseTracker.ts
+++ b/packages/core/src/runtime/worker/phaseTracker.ts
@@ -1,0 +1,205 @@
+import type {
+  TestCaseInfo,
+  TestResult,
+  TestSuiteInfo,
+} from '../../types/testSuite';
+import type { TraceEvent } from '../../utils/trace';
+import { getRealNow } from '../util';
+
+type PhaseName =
+  | 'prepare'
+  | 'envSetup'
+  | 'load'
+  | 'setupFiles'
+  | 'collect'
+  | 'tests'
+  | 'coverage'
+  | 'teardown';
+
+export type PhaseTrackerOptions = {
+  /** When set, the tracker also records a Perfetto trace event per phase span. */
+  trace?: {
+    testPath: string;
+    project: string;
+  };
+  /**
+   * Override the Perfetto `pid` recorded on emitted events. Defaults to
+   * `process.pid`. Browser mode uses this to give each test file its own
+   * synthetic process, so Perfetto labels every track with the file path
+   * (mirroring node mode's per-file isolation) instead of collapsing every
+   * file under the shared host pid.
+   */
+  pid?: number;
+};
+
+type TraceState = {
+  events: TraceEvent[];
+  meta: NonNullable<PhaseTrackerOptions['trace']>;
+  /** Start timestamps (ms, wall-clock) keyed by testId. */
+  suiteStarts: Map<string, number>;
+  caseStarts: Map<string, number>;
+};
+
+type SliceCat = 'phase' | 'suite' | 'case';
+
+/**
+ * Records phase transitions for a single test file as Perfetto-compatible
+ * trace events. Used only when the `--trace` CLI flag is enabled; with trace
+ * disabled the tracker is a no-op.
+ *
+ * Emitted events:
+ * - per-phase `ph: 'X'` spans (`cat: 'phase'`)
+ * - per-suite / per-case `ph: 'X'` spans (`cat: 'suite' | 'case'`), recorded
+ *   via the runner's existing lifecycle hooks (zero intrusion into runner.ts)
+ * - heap-usage counter samples (`ph: 'C'`, `cat: 'memory'`) at each phase
+ *   boundary, so memory pressure shows up as a track in Perfetto UI
+ *
+ * Events default to `pid = process.pid` (callers may override via
+ * `options.pid` — browser host uses a synthetic per-file pid). Each tracker
+ * (i.e. each test file) gets its own `tid`, so when a worker is reused
+ * across multiple files (`isolate: false`) each file shows up as its own
+ * thread track in Perfetto instead of collapsing to the first file's label.
+ * The host later merges every worker's events into a single trace JSON file.
+ */
+export class PhaseTracker {
+  private currentPhase: PhaseName | null = null;
+  private currentStart = 0;
+  private readonly trace: TraceState | null;
+  private readonly pid: number;
+  private readonly tid = nextThreadId++;
+
+  constructor(options: PhaseTrackerOptions = {}) {
+    this.pid = options.pid ?? process.pid;
+    this.trace = options.trace
+      ? {
+          events: [],
+          meta: options.trace,
+          suiteStarts: new Map(),
+          caseStarts: new Map(),
+        }
+      : null;
+  }
+
+  transition(phase: PhaseName): void {
+    if (!this.trace) return;
+    const now = getRealNow();
+    if (this.currentPhase) {
+      this.pushSlice(
+        this.currentPhase,
+        'phase',
+        this.currentStart,
+        now - this.currentStart,
+      );
+    }
+    this.sampleHeap(now);
+    this.currentPhase = phase;
+    this.currentStart = now;
+  }
+
+  end(): void {
+    if (!this.trace || !this.currentPhase) return;
+    const now = getRealNow();
+    this.pushSlice(
+      this.currentPhase,
+      'phase',
+      this.currentStart,
+      now - this.currentStart,
+    );
+    this.sampleHeap(now);
+    this.currentPhase = null;
+  }
+
+  recordSuiteStart(info: TestSuiteInfo): void {
+    if (!this.trace) return;
+    this.trace.suiteStarts.set(info.testId, getRealNow());
+  }
+
+  recordSuiteResult(result: TestResult): void {
+    if (!this.trace) return;
+    const start = this.trace.suiteStarts.get(result.testId);
+    this.trace.suiteStarts.delete(result.testId);
+    if (start === undefined || typeof result.duration !== 'number') return;
+    this.pushSlice(result.name || '<suite>', 'suite', start, result.duration, {
+      testId: result.testId,
+      status: result.status,
+    });
+  }
+
+  recordCaseStart(info: TestCaseInfo): void {
+    if (!this.trace) return;
+    // Prefer the runner's authoritative start time when present so the slice
+    // aligns exactly with the case's reported duration.
+    const start =
+      typeof info.startTime === 'number' ? info.startTime : getRealNow();
+    this.trace.caseStarts.set(info.testId, start);
+  }
+
+  recordCaseResult(result: TestResult): void {
+    if (!this.trace) return;
+    const start = this.trace.caseStarts.get(result.testId);
+    this.trace.caseStarts.delete(result.testId);
+    if (start === undefined || typeof result.duration !== 'number') return;
+    this.pushSlice(result.name, 'case', start, result.duration, {
+      testId: result.testId,
+      status: result.status,
+      retryCount: result.retryCount,
+    });
+  }
+
+  getTraceEvents(): TraceEvent[] | undefined {
+    return this.trace && this.trace.events.length
+      ? this.trace.events
+      : undefined;
+  }
+
+  private pushSlice(
+    name: string,
+    cat: SliceCat,
+    startMs: number,
+    durMs: number,
+    extraArgs?: Record<string, string | number | boolean | undefined>,
+  ): void {
+    if (!this.trace) return;
+    this.trace.events.push({
+      name,
+      cat,
+      ph: 'X',
+      ts: startMs * 1000,
+      dur: durMs * 1000,
+      pid: this.pid,
+      tid: this.tid,
+      args: {
+        testPath: this.trace.meta.testPath,
+        project: this.trace.meta.project,
+        ...extraArgs,
+      },
+    });
+  }
+
+  private sampleHeap(nowMs: number): void {
+    if (!this.trace) return;
+    const mem = process.memoryUsage();
+    this.trace.events.push({
+      name: 'heap',
+      cat: 'memory',
+      ph: 'C',
+      ts: nowMs * 1000,
+      pid: this.pid,
+      tid: this.tid,
+      args: {
+        heapUsedMB: round2(mem.heapUsed / 1024 / 1024),
+        heapTotalMB: round2(mem.heapTotal / 1024 / 1024),
+        rssMB: round2(mem.rss / 1024 / 1024),
+      },
+    });
+  }
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/**
+ * Monotonic counter for `tid` assignment within a worker process. Resets per
+ * process (each fork starts at 1), which is fine because Perfetto's `tid` is
+ * only required to be unique within a `pid`.
+ */
+let nextThreadId = 1;

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -11,6 +11,7 @@ import type {
 import { globalApis } from '../../utils/constants';
 import { color } from '../../utils/logger';
 import { formatTestError, getRealTimers, setRealTimers } from '../util';
+import { PhaseTracker } from './phaseTracker';
 import { createForksRpcOptions, createRuntimeRpc } from './rpc';
 import { createSilentConsoleController } from './silentConsole';
 import { RstestSnapshotEnvironment } from './snapshot';
@@ -103,11 +104,14 @@ const createOriginalLogWriter = () => {
   };
 };
 
-const preparePool = async ({
-  entryInfo: { distPath, testPath },
-  updateSnapshot,
-  context,
-}: RunWorkerOptions['options']) => {
+const preparePool = async (
+  {
+    entryInfo: { distPath, testPath },
+    updateSnapshot,
+    context,
+  }: RunWorkerOptions['options'],
+  tracker?: PhaseTracker,
+) => {
   // Reset globalCleanups only when preparePool is called again (running without isolation)
   globalCleanups.forEach((fn) => {
     fn();
@@ -229,6 +233,7 @@ const preparePool = async ({
     taskContext,
   });
 
+  tracker?.transition('envSetup');
   switch (testEnvironment.name) {
     case 'node':
       break;
@@ -253,6 +258,7 @@ const preparePool = async ({
     default:
       throw new Error(`Unknown test environment: ${testEnvironment.name}`);
   }
+  tracker?.transition('prepare');
 
   if (globals) {
     registerGlobalApi(api);
@@ -292,6 +298,7 @@ const loadFiles = async ({
   interopDefault,
   isolate,
   outputModule,
+  tracker,
 }: {
   setupEntries: RunWorkerOptions['options']['setupEntries'];
   assetFiles: Record<string, string>;
@@ -302,6 +309,7 @@ const loadFiles = async ({
   interopDefault: boolean;
   isolate: boolean;
   outputModule: boolean;
+  tracker?: PhaseTracker;
 }): Promise<void> => {
   const { loadModule } = outputModule
     ? await import('./loadEsModule')
@@ -322,6 +330,7 @@ const loadFiles = async ({
   }
 
   // run setup files
+  tracker?.transition('setupFiles');
   for (const { distPath, testPath } of setupEntries) {
     const setupCodeContent = assetFiles[distPath]!;
 
@@ -336,6 +345,7 @@ const loadFiles = async ({
     });
   }
 
+  tracker?.transition('collect');
   await loadModule({
     codeContent: assetFiles[distPath]!,
     distPath,
@@ -453,7 +463,20 @@ export const runInPool = async (
   }
 
   let taskContext: TaskContext | undefined;
+  const tracker = new PhaseTracker(
+    options.context.trace
+      ? {
+          trace: {
+            testPath,
+            project: options.context.project,
+          },
+        }
+      : undefined,
+  );
+  let runResult: TestFileResult | undefined;
+
   try {
+    tracker.transition('prepare');
     const {
       rstestContext,
       runner,
@@ -464,11 +487,11 @@ export const runInPool = async (
       unhandledErrors,
       interopDefault,
       taskContext: preparedTaskContext,
-    } = await preparePool(options);
+    } = await preparePool(options, tracker);
     taskContext = preparedTaskContext;
 
     if (bail && (await rpc.getCountOfFailedTests()) >= bail) {
-      return {
+      runResult = {
         testId: getFileTaskId(testPath),
         project,
         testPath,
@@ -476,6 +499,7 @@ export const runInPool = async (
         name: '',
         results: [],
       };
+      return runResult;
     }
     // Initialize coverage collector if coverage is enabled
     let coverageProvider: Awaited<
@@ -492,6 +516,7 @@ export const runInPool = async (
       coverageProvider.init();
     }
 
+    tracker.transition('load');
     const { assetFiles, sourceMaps: sourceMapsFromAssets } =
       assets || (await rpc.getAssetsByEntry());
     sourceMaps = sourceMapsFromAssets;
@@ -524,11 +549,13 @@ export const runInPool = async (
         interopDefault,
         isolate,
         outputModule: options.context.outputModule,
+        tracker,
       });
     } finally {
       taskContext.setFallback(undefined);
     }
 
+    tracker.transition('tests');
     const results = await runner.runTests(
       testPath,
       {
@@ -536,9 +563,11 @@ export const runInPool = async (
           await rpc.onTestFileReady(test);
         },
         onTestSuiteStart: async (test) => {
+          tracker.recordSuiteStart(test);
           await rpc.onTestSuiteStart(test);
         },
         onTestSuiteResult: async (result) => {
+          tracker.recordSuiteResult(result);
           silentConsoleController.flushBufferedLogsForTask({
             taskId: result.testId,
             status: result.status,
@@ -549,9 +578,11 @@ export const runInPool = async (
           await rpc.onTestSuiteResult(result);
         },
         onTestCaseStart: async (test) => {
+          tracker.recordCaseStart(test);
           await rpc.onTestCaseStart(test);
         },
         onTestCaseResult: async (result) => {
+          tracker.recordCaseResult(result);
           silentConsoleController.flushBufferedLogsForTask({
             taskId: result.testId,
             status: result.status,
@@ -585,6 +616,7 @@ export const runInPool = async (
 
     // Collect coverage data after test file completes
     if (coverageProvider) {
+      tracker.transition('coverage');
       const coverageMap = coverageProvider.collect();
       if (coverageMap) {
         // Attach coverage data to test result
@@ -599,9 +631,10 @@ export const runInPool = async (
       coverageProvider.cleanup();
     }
 
-    return results;
+    runResult = results;
+    return runResult;
   } catch (err) {
-    return {
+    runResult = {
       testId: getFileTaskId(testPath),
       project,
       testPath,
@@ -610,8 +643,17 @@ export const runInPool = async (
       results: [],
       errors: await formatTestError(err),
     };
+    return runResult;
   } finally {
+    tracker.transition('teardown');
     taskContext?.setFallback(undefined);
     await teardown();
+    tracker.end();
+    if (runResult) {
+      const traceEvents = tracker.getTraceEvents();
+      if (traceEvents) {
+        runResult.traceEvents = traceEvents;
+      }
+    }
   }
 };

--- a/packages/core/src/types/browser.ts
+++ b/packages/core/src/types/browser.ts
@@ -1,6 +1,7 @@
 import type { SourceMapInput } from '@jridgewell/trace-mapping';
 import type { GetSourcemap } from './reporter';
 import type { TestFileResult, TestResult } from './testSuite';
+import type { TraceEvent } from '../utils/trace';
 
 export interface BrowserSourcemapResolutionResult {
   handled: boolean;
@@ -30,6 +31,12 @@ export interface BrowserTestRunOptions {
    * Keep watch infrastructure alive even when the initial browser test set is empty.
    */
   allowEmptyWatchRun?: boolean;
+  /**
+   * When set, the browser host emits Perfetto trace events to this callback
+   * (per-file `tests` slices + suite/case slices). Only invoked when the
+   * caller has `--trace` enabled.
+   */
+  onTraceEvents?: (events: TraceEvent[]) => void;
 }
 
 /**

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -87,6 +87,13 @@ export type RstestContext = {
    * - list: `rstest list`
    */
   command: RstestCommand;
+  /**
+   * Dump a Perfetto-compatible performance trace JSON file. CLI-only switch;
+   * not exposed via user config.
+   *
+   * @internal
+   */
+  trace: boolean;
   reporters: Reporter[];
   snapshotManager: SnapshotManager;
   stateManager: TestStateManager;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -162,6 +162,12 @@ export type TestFileResult = TestResult & {
   results: TestResult[];
   snapshotResult?: SnapshotResult;
   coverage?: Record<string, FileCoverageData>;
+  /**
+   * Perfetto-compatible trace events. Stripped at the pool boundary.
+   *
+   * @internal
+   */
+  traceEvents?: import('../utils/trace').TraceEvent[];
 };
 
 export interface UserConsoleLog {

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -78,6 +78,8 @@ export type WorkerContext = {
   runtimeConfig: RuntimeConfig;
   taskId: number;
   outputModule: boolean;
+  /** When true, the worker emits Perfetto trace events alongside phase totals. */
+  trace?: boolean;
 };
 
 export type RunWorkerOptions = {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './logger';
 export * from './process';
 export * from './shard';
 export * from './testFiles';
+export * from './trace';

--- a/packages/core/src/utils/trace.ts
+++ b/packages/core/src/utils/trace.ts
@@ -1,0 +1,380 @@
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { dirname, relative, resolve } from 'pathe';
+import { isTTY } from './helper';
+import { color, logger } from './logger';
+
+// ---------------------------------------------------------------------------
+// Public event type
+// ---------------------------------------------------------------------------
+
+/**
+ * Perfetto/Chrome trace event (subset). Emitted by the worker-side
+ * `PhaseTracker` and consumed by the controller below.
+ *
+ * `ph`:
+ * - `'X'`: complete (sliced) event with `dur` — drawn as a slice
+ * - `'M'`: metadata (process/thread name, sort index)
+ * - `'C'`: counter — `args` numeric values are plotted as tracks
+ */
+export type TraceEvent = {
+  name: string;
+  cat: string;
+  ph: 'X' | 'M' | 'C';
+  ts: number;
+  dur?: number;
+  pid: number;
+  tid: number;
+  args?: Record<string, string | number | boolean | undefined>;
+};
+
+// ---------------------------------------------------------------------------
+// File output
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the absolute path for a Perfetto trace dump. The filename embeds an
+ * ISO-like timestamp so repeated runs do not overwrite each other.
+ */
+const getTraceOutputPath = (rootPath: string): string => {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace('Z', '');
+  return resolve(rootPath, '.rstest', `trace-${stamp}.json`);
+};
+
+/**
+ * Wrap raw phase events into the Perfetto trace JSON envelope and prepend
+ * Perfetto metadata so each (pid, tid) renders with the right label.
+ *
+ * - `process_name` (per pid): when the worker only ran a single test file
+ *   (the default `isolate: true` case), use the file path so the row label
+ *   surfaces the file directly. When the worker ran multiple files
+ *   (`isolate: false`), fall back to `worker <pid>` so the shared-worker
+ *   grouping stays visible.
+ * - `process_sort_index` (per pid) lists workers in the order they first
+ *   produced events, instead of the OS pid order.
+ * - `thread_name` (per pid+tid) labels each tracker's thread track with the
+ *   test file path it ran (relative to `rootPath`).
+ */
+const buildTraceFile = (
+  events: TraceEvent[],
+  rootPath: string,
+): { traceEvents: TraceEvent[] } => {
+  const meta = (
+    name: string,
+    pid: number,
+    tid: number,
+    args: TraceEvent['args'],
+  ): TraceEvent => ({
+    name,
+    cat: '__metadata',
+    ph: 'M',
+    ts: 0,
+    pid,
+    tid,
+    args,
+  });
+
+  // Count distinct threads per pid up front so the process_name pass can pick
+  // between file-path and `worker <pid>` based on actual runtime behavior
+  // rather than reading config back.
+  const threadIdsByPid = new Map<number, Set<number>>();
+  for (const ev of events) {
+    let threadIds = threadIdsByPid.get(ev.pid);
+    if (!threadIds) {
+      threadIds = new Set();
+      threadIdsByPid.set(ev.pid, threadIds);
+    }
+    threadIds.add(ev.tid);
+  }
+
+  const displayPath = (testPath: string): string => {
+    const rel = relative(rootPath, testPath);
+    return rel && !rel.startsWith('..') ? rel : testPath;
+  };
+
+  const seenPid = new Set<number>();
+  const seenThread = new Set<string>();
+  const metadata: TraceEvent[] = [];
+  let sortIndex = 0;
+  for (const ev of events) {
+    const testPath =
+      typeof ev.args?.testPath === 'string' ? ev.args.testPath : undefined;
+    if (!testPath) continue;
+
+    if (!seenPid.has(ev.pid)) {
+      seenPid.add(ev.pid);
+      const sharedWorker = (threadIdsByPid.get(ev.pid)?.size ?? 0) > 1;
+      metadata.push(
+        meta('process_name', ev.pid, ev.tid, {
+          name: sharedWorker ? `worker ${ev.pid}` : displayPath(testPath),
+        }),
+        meta('process_sort_index', ev.pid, ev.tid, {
+          sort_index: sortIndex++,
+        }),
+      );
+    }
+
+    const threadKey = `${ev.pid}:${ev.tid}`;
+    if (!seenThread.has(threadKey)) {
+      seenThread.add(threadKey);
+      metadata.push(
+        meta('thread_name', ev.pid, ev.tid, { name: displayPath(testPath) }),
+      );
+    }
+  }
+  return { traceEvents: [...metadata, ...events] };
+};
+
+// ---------------------------------------------------------------------------
+// Perfetto helper HTTP server
+// ---------------------------------------------------------------------------
+
+const PERFETTO_ORIGIN = 'https://ui.perfetto.dev';
+/**
+ * Perfetto UI's CSP only permits fetching from `http://127.0.0.1:9001` (the
+ * trace_processor RPC port). Any other port is silently blocked by the
+ * browser and surfaces as "Failed to fetch" in the UI.
+ *
+ * https://github.com/google/perfetto/blob/main/tools/open_trace_in_ui
+ */
+const PERFETTO_PORT = 9001;
+const SERVED_PATH = '/trace.json';
+const PERFETTO_URL = `${PERFETTO_ORIGIN}/#!/?url=http://127.0.0.1:${PERFETTO_PORT}${SERVED_PATH}&referrer=rstest`;
+
+type TraceServerHandle = {
+  /** Perfetto deep-link URL pointing at this server. */
+  url: string;
+  /** Switch the file being served (used across re-runs in watch mode). */
+  setActiveTrace: (filePath: string) => void;
+  /** Stop listening so the Node event loop can exit. */
+  close: () => Promise<void>;
+  /**
+   * Block until SIGINT/SIGTERM/SIGTSTP arrives, then close the server and
+   * exit with the current `process.exitCode`. Use this after tests have
+   * finished so Ctrl+C is treated as a clean shutdown — without it, the
+   * default 128+SIGINT exit code makes pnpm/npm surface ELIFECYCLE.
+   */
+  waitForExit: () => Promise<never>;
+};
+
+/**
+ * Tiny localhost HTTP server that serves a single trace JSON file with the
+ * CORS headers Perfetto UI requires, so users can click the printed URL and
+ * have the trace auto-load in https://ui.perfetto.dev.
+ *
+ * The server keeps the Node event loop alive — invoke this only when the
+ * user actually wants the link, otherwise `rstest run` would hang.
+ */
+const startTraceServer = (initialPath: string): Promise<TraceServerHandle> => {
+  let activePath = initialPath;
+
+  const server = createServer(async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', PERFETTO_ORIGIN);
+    res.setHeader('Cache-Control', 'no-cache');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204).end();
+      return;
+    }
+    if (req.url !== SERVED_PATH) {
+      res.writeHead(404).end();
+      return;
+    }
+    try {
+      const data = await readFile(activePath);
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': String(data.byteLength),
+      });
+      if (req.method === 'HEAD') {
+        res.end();
+        return;
+      }
+      res.end(data);
+    } catch {
+      res.writeHead(404).end();
+    }
+  });
+
+  return new Promise<TraceServerHandle>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(PERFETTO_PORT, '127.0.0.1', () => {
+      server.off('error', reject);
+      // closeAllConnections drops in-flight HEAD/GET sockets so close()
+      // resolves promptly instead of waiting for keep-alive timeouts.
+      const stopListening = (onClosed?: () => void) => {
+        server.closeAllConnections?.();
+        server.close(onClosed);
+      };
+
+      resolve({
+        url: PERFETTO_URL,
+        setActiveTrace: (filePath) => {
+          activePath = filePath;
+        },
+        close: () => new Promise<void>((res) => stopListening(() => res())),
+        waitForExit: () =>
+          new Promise<never>(() => {
+            // Synchronous exit — terminates before any other SIGINT listener
+            // (e.g. the runner's "exit 128+SIG" handler) gets an async tick to
+            // override the exit code. The OS reaps the listening socket on
+            // process termination, so close() is best-effort.
+            const onSignal = () => {
+              stopListening();
+              process.exit();
+            };
+            process.once('SIGINT', onSignal);
+            process.once('SIGTERM', onSignal);
+            process.once('SIGTSTP', onSignal);
+          }),
+      });
+    });
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Controller: the single surface consumed by `runTests`
+// ---------------------------------------------------------------------------
+
+export interface TraceRun {
+  /**
+   * Pass to `pool.runTests` as `onTraceEvents`. `undefined` when tracing is
+   * disabled, so the pool layer skips collecting events entirely.
+   */
+  onEvents: ((events: TraceEvent[]) => void) | undefined;
+  /**
+   * Write the buffered events for this run to disk and (lazily) start or
+   * refresh the Perfetto helper server. No-op when nothing was collected.
+   */
+  finalize: () => Promise<void>;
+}
+
+export interface TraceController {
+  /** Begin a per-run handle that buffers events until `finalize`. */
+  beginRun: () => TraceRun;
+  /** Stop the helper server. No-op if it never started. */
+  close: () => Promise<void>;
+  /**
+   * If a trace was produced this session, print a Ctrl+C hint and block
+   * until the user signals; then exit with the current `process.exitCode`.
+   */
+  waitForExit: () => Promise<void>;
+  /**
+   * Convenience for early-return paths: `finalize` the supplied run, then
+   * `waitForExit` (blocks for SIGINT only when a helper server is up — i.e.
+   * tracing produced output in an interactive TTY), then `close` defensively.
+   * No-op for each step when tracing is disabled.
+   */
+  shutdown: (run: TraceRun) => Promise<void>;
+}
+
+/**
+ * Owns every concern of `--trace`: per-run event collection, file output,
+ * the Perfetto helper server lifecycle, and the post-run "wait for Ctrl+C"
+ * handoff. The orchestrator (e.g. `runTests`) only wires `onEvents` into
+ * the pool and calls `finalize`/`close`/`waitForExit` at the right
+ * lifecycle points.
+ */
+export const createTraceController = (options: {
+  enabled: boolean;
+  rootPath: string;
+}): TraceController => {
+  const { enabled, rootPath } = options;
+  let server: TraceServerHandle | undefined;
+  // Path of the trace file produced by the previous run in this session.
+  // In watch mode we replace it on each rerun so .rstest/ does not accumulate
+  // multi-MB JSONs; files from earlier sessions are left alone.
+  let lastTracePath: string | undefined;
+
+  const beginRun = (): TraceRun => {
+    if (!enabled) {
+      return { onEvents: undefined, finalize: async () => {} };
+    }
+    const events: TraceEvent[] = [];
+    return {
+      // Iterate instead of spreading: a single file with thousands of cases
+      // can hand `chunk` a very large array, and `push(...chunk)` would then
+      // exceed V8's argument-list limit and throw `RangeError: Maximum call
+      // stack size exceeded` before the trace is ever written.
+      onEvents: (chunk) => {
+        for (const ev of chunk) events.push(ev);
+      },
+      finalize: async () => {
+        if (!events.length) return;
+        const tracePath = getTraceOutputPath(rootPath);
+        await mkdir(dirname(tracePath), { recursive: true });
+        await writeFile(
+          tracePath,
+          JSON.stringify(buildTraceFile(events, rootPath)),
+        );
+        if (lastTracePath && lastTracePath !== tracePath) {
+          // Best-effort: ignore ENOENT if the user already removed it.
+          unlink(lastTracePath).catch(() => {});
+        }
+        lastTracePath = tracePath;
+        logger.log(
+          color.gray('  Perfetto trace file: '),
+          color.cyan(tracePath),
+        );
+        // The helper server keeps the event loop alive until SIGINT, which
+        // would hang `rstest run` in CI. Only start it in an interactive TTY,
+        // otherwise leave the file for the user to download from the CI
+        // artifact and open in Perfetto UI manually.
+        if (!isTTY('stdin')) {
+          logger.log(
+            color.gray(
+              '  Drag the file above into https://ui.perfetto.dev to view.',
+            ),
+          );
+          return;
+        }
+        if (!server) {
+          try {
+            server = await startTraceServer(tracePath);
+          } catch (err) {
+            logger.log(
+              color.yellow(
+                `  Could not start Perfetto helper server: ${(err as Error).message}`,
+              ),
+              color.gray(
+                '\n  Drag the file above into https://ui.perfetto.dev to view.',
+              ),
+            );
+            return;
+          }
+        } else {
+          server.setActiveTrace(tracePath);
+        }
+        logger.log(
+          color.gray('  Open in Perfetto UI: '),
+          color.cyan(server.url),
+        );
+      },
+    };
+  };
+
+  const controller: TraceController = {
+    beginRun,
+    close: async () => {
+      if (!server) return;
+      const s = server;
+      server = undefined;
+      await s.close();
+    },
+    waitForExit: async () => {
+      if (!server) return;
+      logger.log(
+        color.gray(
+          '  Press Ctrl+C to stop the Perfetto helper server and exit.',
+        ),
+      );
+      await server.waitForExit();
+    },
+    shutdown: async (run) => {
+      await run.finalize();
+      await controller.waitForExit();
+      await controller.close();
+    },
+  };
+  return controller;
+};

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -37,6 +37,7 @@ distpath
 docgen
 dogfooding
 dorny
+elifecycle
 endgroup
 envinfo
 estree


### PR DESCRIPTION
## Summary

<img width="949" height="176" alt="image" src="https://github.com/user-attachments/assets/740097b3-5d4c-4bb0-a945-dd77cfa90fbf" />

<img width="1629" height="973" alt="image" src="https://github.com/user-attachments/assets/28d7de15-3475-4f46-92d9-e9207834e378" />

<img width="1274" height="454" alt="image" src="https://github.com/user-attachments/assets/8d4546cc-f502-4645-a826-d6e9e1f1af3f" />

Adds a `--trace` CLI flag that dumps a Perfetto-compatible profile of a single rstest run.

### Background

Issue #1195. The single `Duration` number bundles worker startup, asset transfer, env setup, test evaluation, execution, coverage, and teardown — "tests feel slow" reports are un-triageable from a paste.

### Implementation

- **`--trace` CLI flag** (CLI-only, not a config option). Writes Perfetto JSON to `<rootPath>/.rstest/trace-<ts>.json`:
  - 8 per-phase slices per file: `prepare`, `envSetup`, `load`, `setupFiles`, `collect`, `tests`, `coverage`, `teardown`
  - Per-suite and per-case slices, annotated with `status` + `retryCount` (via runner lifecycle hooks — zero intrusion into `runner.ts`)
  - Heap counter (`heapUsedMB` / `heapTotalMB` / `rssMB`) sampled at each phase boundary
- **Per-file labels.** With `isolate: true`, the Perfetto row is labeled with the test file path directly; with `isolate: false` (shared worker), the row shows `worker <pid>` and each file shows up as a distinct thread track inside.
- **Helper server.** TTY runs lazily start `127.0.0.1:9001` (the only port Perfetto UI's CSP allows) so the printed link auto-loads; non-TTY (CI) runs write the file and exit cleanly.

### User Impact

Opt-in only; no behavior change without `--trace`. `Duration` output is unchanged.

## Related Links

- Issue: #1195

## Checklist

- [x] Tests pass; no test format change.
- [ ] Docs: follow-up PR (Profiling guide + CLI flag table).