### PR TITLE
build: enable tsgo in CI

### DIFF
--- a/packages/browser/rslib.config.ts
+++ b/packages/browser/rslib.config.ts
@@ -16,8 +16,7 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2023',
       dts: {
-        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
-        tsgo: !process.env.CI,
+        tsgo: true,
         bundle: false,
       },
       output: {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -18,8 +18,7 @@ export default defineConfig({
         advancedEsm: true,
       },
       dts: {
-        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
-        tsgo: !process.env.CI,
+        tsgo: true,
         bundle: process.env.SOURCEMAP
           ? false
           : {
@@ -138,8 +137,7 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2023',
       dts: {
-        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
-        tsgo: !process.env.CI,
+        tsgo: true,
         bundle: true,
       },
       source: {


### PR DESCRIPTION
## Background

TypeScript 7.0 Beta is now available, and Microsoft describes `tsgo` as ready to try in daily workflows and CI pipelines.

## Implementation

- Enable `tsgo` unconditionally for declaration generation in `@rstest/core` and `@rstest/browser` package builds.
- Remove the stale CI guard that limited `tsgo` to local development.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/
