### PR TITLE
fix(core): guard interop has trap against primitive default export

### DIFF
--- a/packages/core/src/runtime/worker/interop.ts
+++ b/packages/core/src/runtime/worker/interop.ts
@@ -70,7 +70,9 @@ export function createInteropProxy(mod: any, defaultExport: any): any {
       if (prop === 'default') {
         return defaultExport !== undefined;
       }
-      return prop in mod || (defaultExport && prop in defaultExport);
+      return (
+        prop in mod || (!isPrimitive(defaultExport) && prop in defaultExport)
+      );
     },
     getOwnPropertyDescriptor(mod, prop): any {
       const descriptor = Reflect.getOwnPropertyDescriptor(mod, prop);

--- a/packages/core/tests/runner/interop.test.ts
+++ b/packages/core/tests/runner/interop.test.ts
@@ -117,6 +117,24 @@ describe('dynamic-import CJS interop pipeline', () => {
     });
   });
 
+  // Regression: `module.exports = <truthy primitive>` (e.g. a constant-export
+  // module). The `has` trap previously ran `prop in defaultExport` against the
+  // primitive and threw `TypeError: Cannot use 'in' operator to search for ...
+  // in 42`.
+  describe('primitive module.exports', () => {
+    const ns = interop({ default: 42 });
+
+    it('does not throw on `prop in ns` for non-default keys', () => {
+      expect(() => 'foo' in ns).not.toThrow();
+      expect('foo' in ns).toBe(false);
+    });
+
+    it('still resolves default via get and has', () => {
+      expect(ns.default).toBe(42);
+      expect('default' in ns).toBe(true);
+    });
+  });
+
   describe('plain CJS: no __esModule', () => {
     const cjsExports = { foo: 'foo', bar: 'bar' };
     const ns = interop(buildNamespace(cjsExports, ['foo', 'bar']));


### PR DESCRIPTION
## Summary

- Follow-up to #1210 (ultrareview finding `bug_004`).
- The `has` trap in `createInteropProxy` evaluated `prop in defaultExport` behind only a truthiness check. For CJS modules whose `module.exports` is a *truthy primitive* (`42`, `"str"`, `true`), `in` against a primitive throws `TypeError: Cannot use 'in' operator to search for ... in 42`.
- The `get` trap was already safe via `?.` optional chaining; the `has` path needed an explicit `!isPrimitive(defaultExport)` gate to match.

## Test plan

- [x] `pnpm --filter @rstest/core test -- tests/runner/interop.test.ts` (189/189 pass, including new `primitive module.exports` regression cases for `'foo' in ns` not throwing and `default` resolving via both `get` and `has`).