### PR TITLE
docs: add silent version metadata

### DIFF
--- a/website/docs/en/config/test/silent.mdx
+++ b/website/docs/en/config/test/silent.mdx
@@ -2,7 +2,11 @@
 description: Silence intercepted console output from tests, or only keep logs for failed tasks.
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # silent
+
+<ApiMeta addedVersion="0.10.0" />
 
 - **Type:** `boolean | 'passed-only'`
 - **Default:** `false`

--- a/website/docs/zh/config/test/silent.mdx
+++ b/website/docs/zh/config/test/silent.mdx
@@ -2,7 +2,11 @@
 description: 控制是否输出测试中的 console 日志，或只保留失败任务的日志。
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # silent
+
+<ApiMeta addedVersion="0.10.0" />
 
 - **类型：** `boolean | 'passed-only'`
 - **默认值：** `false`


### PR DESCRIPTION
## Summary

### Background

The `silent` config page documents behavior introduced for the v0.10.0 release, but it did not show the version metadata badge used by other config pages.

### Implementation

- Imported `ApiMeta` on the English and Chinese `silent` config pages.
- Added the `0.10.0` added-version marker below the page title.

### User Impact

Docs readers can see when the `silent` config became available.

## Related Links


https://github.com/web-infra-dev/rstest/pull/1224


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation: `pnpm prettier --write website/docs/en/config/test/silent.mdx website/docs/zh/config/test/silent.mdx`; `pnpm prettier --check website/docs/en/config/test/silent.mdx website/docs/zh/config/test/silent.mdx`; `git diff --check`.