### PR TITLE
docs(profiling): add profiler choice section

### DIFF
--- a/website/docs/en/guide/advanced/profiling.mdx
+++ b/website/docs/en/guide/advanced/profiling.mdx
@@ -115,10 +115,7 @@ With [verbose reporter](/guide/basic/reporters#verbose-reporter) enabled, you ca
 
 **2. Inspect detailed time distribution after narrowing the scope**
 
-Once the slow tests have been identified but the actual runtime cost is still unclear, use [samply](#using-samply) or [Node.js profiling](#nodejs-profiling) below for deeper analysis.
-
-- `samply` is useful for inspecting detailed time distribution across both the rstest main process and test processes.
-- `Node.js profiling` is useful for further analyzing CPU or memory overhead on the Node.js side.
+Once the slow tests have been identified but the actual runtime cost is still unclear, drop down to a profiler. See [Profiler](#profiler) for picking between [samply](#using-samply) and [Node.js profiling](#nodejs-profiling).
 
 ## Using Rsdoctor
 
@@ -163,13 +160,21 @@ After running the above commands, Rstest will automatically register the Rsdocto
 
 ![rsdoctor-rstest-outputs](https://assets.rspack.rs/rstest/assets/rsdoctor-rstest-outputs.png)
 
+## Profiler
+
+Choose a profiler based on what you need to analyze:
+
+- **CPU time distribution**: use [samply](#using-samply) (recommended). It profiles the rstest main process and worker forks together.
+- **Memory allocation**: use `--heap-prof`. See [Node.js profiling](#nodejs-profiling). samply does not collect memory data.
+- **Step-through debugging**: use `--inspect`. See [Node.js profiling](#nodejs-profiling).
+
 ## Using samply
 
 > Note: In order to be able to profiling the Node.js side code in macOS, Node.js v22.16+ is required.
 
 [Samply](https://github.com/mstange/samply) supports performance analysis for both Rstest main process and test process simultaneously. You can perform a complete performance analysis through the following steps:
 
-Run the following command to start performance analysis:：
+Run the following command to start performance analysis:
 
 ```bash
 samply record -- node --perf-prof --perf-basic-prof --interpreted-frames-native-stack {your_node_modules_folder}/@rstest/core/bin/rstest.js

--- a/website/docs/zh/guide/advanced/profiling.mdx
+++ b/website/docs/zh/guide/advanced/profiling.mdx
@@ -115,10 +115,7 @@ export default defineConfig({
 
 **2. 在范围缩小后查看更细的耗时分布**
 
-当已经知道慢点集中在哪些测试文件或测试用例上，但仍不清楚具体耗时来自哪一段运行时代码时，可以进一步使用下文的 [Samply](#使用-samply) 或 [Node.js profiling](#nodejs-profiling)。
-
-- `Samply` 适合查看 rstest 主进程与测试进程的详细耗时分布。
-- `Node.js profiling` 适合继续分析 Node.js 侧的 CPU 或内存开销。
+当已经知道慢点集中在哪些测试文件或测试用例上，但仍不清楚具体耗时来自哪一段运行时代码时，需要切换到 profiler。在 [Samply](#使用-samply) 和 [Node.js profiling](#nodejs-profiling) 之间如何选，参考下文 [Profiler](#profiler)。
 
 ## 使用 Rsdoctor
 
@@ -162,6 +159,14 @@ import { PackageManagerTabs } from '@theme';
 在项目内执行上述命令后，Rstest 会自动注册 Rsdoctor 的插件，并在构建完成后打开本次构建的分析页面，请参考 [Rsdoctor 文档](https://rsdoctor.rs/) 来了解完整功能。
 
 ![rsdoctor-rstest-outputs](https://assets.rspack.rs/rstest/assets/rsdoctor-rstest-outputs.png)
+
+## Profiler
+
+根据需要分析的目标选择合适的 profiler：
+
+- **CPU 耗时分布**：推荐使用 [Samply](#使用-samply)，可同时分析 rstest 主进程和 worker fork 进程。
+- **内存分配**：使用 `--heap-prof`，参见 [Node.js profiling](#nodejs-profiling)。Samply 不采集内存数据。
+- **断点 / 单步调试**：使用 `--inspect`，参见 [Node.js profiling](#nodejs-profiling)。
 
 ## 使用 Samply
 


### PR DESCRIPTION
## Summary

### Background

The profiling guide lists samply and Node.js profiling side by side but does not tell readers which one to pick for a given goal. The existing step-2 callout in the speed-up flow only repeats a vague description of each tool.

### Implementation

- Add a new `## Profiler` section that maps user goals to a profiler: CPU time → samply, memory allocation → `--heap-prof`, step-through debugging → `--inspect`.
- Rewrite step 2 of the "Speed up tests" flow to cross-reference the new section instead of duplicating the choice criteria inline.
- Mirror the change in the Chinese docs.

### User Impact

Readers landing on the profiling page can pick a profiler in one read instead of skimming both sections to compare them.

## Validation

Docs-only PR. Ran `pnpm format` and `pnpm run lint` (includes Prettier, CSpell, heading-case, rslint). Skipped `pnpm run test` and `cd e2e && pnpm test` per the docs-only path in the PR skill.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).