### PR TITLE
fix(adapter-rslib): use `mergeRslibConfig` instead of `mergeRsbuildConfig`

### DIFF
--- a/packages/adapter-rslib/src/index.ts
+++ b/packages/adapter-rslib/src/index.ts
@@ -1,5 +1,5 @@
 import { dirname, isAbsolute, resolve } from 'node:path';
-import { loadConfig, type RslibConfig, rsbuild } from '@rslib/core';
+import { loadConfig, type RslibConfig, mergeRslibConfig } from '@rslib/core';
 import type { ExtendConfig, ExtendConfigFn } from '@rstest/core';
 
 export interface WithRslibConfigOptions {
@@ -127,10 +127,10 @@ export function withRslibConfig(
     };
 
     const rslibConfig = Array.isArray(lib)
-      ? rsbuild.mergeRsbuildConfig<RslibConfig>(
+      ? (mergeRslibConfig(
           rawLibConfig as RslibConfig,
           libTestConfig as RslibConfig,
-        )
+        ) as RslibConfig)
       : (rawLibConfig as RslibConfig);
 
     let libDecoratorsVersion = rslibConfig.source?.decorators?.version;


### PR DESCRIPTION
## Summary

 use `mergeRslibConfig` instead of `mergeRsbuildConfig`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
