### PR TITLE
feat(browser-react): add React 17 entry via `@rstest/browser-react/react17`

### DIFF
--- a/e2e/browser-mode/browserReact17.test.ts
+++ b/e2e/browser-mode/browserReact17.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@rstest/core';
+import { runBrowserCli } from './utils';
+
+describe('browser mode - @rstest/browser-react (React 17)', () => {
+  it('should work with legacy ReactDOM.render path under React 17', async () => {
+    const { expectExecSuccess, cli } = await runBrowserCli('browser-react-17');
+    await expectExecSuccess();
+
+    expect(cli.stdout).toContain('render.test.tsx');
+    expect(cli.stdout).toContain('renderHook.test.tsx');
+    expect(cli.stdout).toContain('cleanup.test.tsx');
+
+    expect(cli.stdout).toMatch(/Tests.*passed/);
+  });
+});

--- a/e2e/browser-mode/fixtures/browser-react-17/package.json
+++ b/e2e/browser-mode/fixtures/browser-react-17/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@rstest/test-browser-react-17",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "@rsbuild/plugin-react": "^2.0.0",
+    "@rstest/browser": "workspace:*",
+    "@rstest/browser-react": "workspace:*",
+    "@rstest/core": "workspace:*",
+    "@types/react": "^17.0.83",
+    "@types/react-dom": "^17.0.26",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/e2e/browser-mode/fixtures/browser-react-17/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-react-17/rstest.config.mts
@@ -1,0 +1,32 @@
+import { createRequire } from 'node:module';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS } from '../ports';
+
+const require = createRequire(import.meta.url);
+
+// Workspace-only plumbing: pnpm symlinks `@rstest/browser-react` into this
+// fixture, so the bundler walks the realpath and resolves `react` / `react-dom`
+// from `packages/browser-react/node_modules` (devDep React 19) instead of the
+// fixture's pinned React 17. These exact-match aliases pin resolution to the
+// fixture's own copies. End users installing from npm don't need this.
+export default defineConfig({
+  plugins: [pluginReact()],
+  resolve: {
+    alias: {
+      react$: require.resolve('react'),
+      'react-dom$': require.resolve('react-dom'),
+      'react-dom/test-utils': require.resolve('react-dom/test-utils'),
+      'react/jsx-runtime$': require.resolve('react/jsx-runtime'),
+      'react/jsx-dev-runtime$': require.resolve('react/jsx-dev-runtime'),
+    },
+  },
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS['browser-react-17'],
+  },
+  include: ['tests/**/*.test.tsx'],
+  testTimeout: 30000,
+});

--- a/e2e/browser-mode/fixtures/browser-react-17/src/App.tsx
+++ b/e2e/browser-mode/fixtures/browser-react-17/src/App.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode, useState } from 'react';
+
+interface ButtonProps {
+  onClick?: () => void;
+  children: ReactNode;
+}
+
+export const Button = ({ onClick, children }: ButtonProps): JSX.Element => {
+  return (
+    <button type="button" className="btn" onClick={onClick}>
+      {children}
+    </button>
+  );
+};
+
+interface CounterProps {
+  initialCount?: number;
+  title?: string;
+}
+
+export const Counter = ({
+  initialCount = 0,
+  title,
+}: CounterProps): JSX.Element => {
+  const [count, setCount] = useState(initialCount);
+
+  return (
+    <div className="counter">
+      {title && <h2 data-testid="counter-title">{title}</h2>}
+      <span data-testid="count">{count}</span>
+      <Button onClick={() => setCount((c) => c + 1)}>Increment</Button>
+      <Button onClick={() => setCount((c) => c - 1)}>Decrement</Button>
+    </div>
+  );
+};
+
+export const App = (): JSX.Element => {
+  return (
+    <div className="app">
+      <h1>React Browser Test</h1>
+      <p data-testid="description">Testing @rstest/browser-react on React 17</p>
+      <Counter />
+    </div>
+  );
+};

--- a/e2e/browser-mode/fixtures/browser-react-17/src/useCounter.ts
+++ b/e2e/browser-mode/fixtures/browser-react-17/src/useCounter.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+export function useCounter(initialValue = 0): {
+  count: number;
+  increment: () => void;
+  decrement: () => void;
+  reset: () => void;
+} {
+  const [count, setCount] = useState(initialValue);
+
+  return {
+    count,
+    increment: () => setCount((c) => c + 1),
+    decrement: () => setCount((c) => c - 1),
+    reset: () => setCount(initialValue),
+  };
+}

--- a/e2e/browser-mode/fixtures/browser-react-17/tests/cleanup.test.tsx
+++ b/e2e/browser-mode/fixtures/browser-react-17/tests/cleanup.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render } from '@rstest/browser-react/react17/pure';
+import { describe, expect, it } from '@rstest/core';
+import { Counter } from '../src/App';
+
+describe('@rstest/browser-react cleanup (React 17)', () => {
+  it('should cleanup all mounted components', async () => {
+    await render(<Counter initialCount={1} />);
+    await render(<Counter initialCount={2} />);
+    await render(<Counter initialCount={3} />);
+
+    const counters = document.querySelectorAll('.counter');
+    expect(counters.length).toBe(3);
+
+    await cleanup();
+
+    const countersAfter = document.querySelectorAll('.counter');
+    expect(countersAfter.length).toBe(0);
+  });
+
+  it('should allow rendering after cleanup', async () => {
+    const { container } = await render(<Counter initialCount={10} />);
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe(
+      '10',
+    );
+
+    await cleanup();
+
+    const { container: container2 } = await render(
+      <Counter initialCount={20} />,
+    );
+    expect(container2.querySelector('[data-testid="count"]')?.textContent).toBe(
+      '20',
+    );
+
+    await cleanup();
+  });
+});

--- a/e2e/browser-mode/fixtures/browser-react-17/tests/render.test.tsx
+++ b/e2e/browser-mode/fixtures/browser-react-17/tests/render.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@rstest/browser-react/react17';
+import { describe, expect, it } from '@rstest/core';
+import { App, Button, Counter } from '../src/App';
+
+describe('@rstest/browser-react render (React 17)', () => {
+  it('should render App component correctly', async () => {
+    const { container } = await render(<App />);
+
+    expect(container.querySelector('h1')?.textContent).toBe(
+      'React Browser Test',
+    );
+  });
+
+  it('should render Button with children', async () => {
+    const { container } = await render(<Button>Click me</Button>);
+
+    const button = container.querySelector('button');
+    expect(button).toBeTruthy();
+    expect(button?.textContent).toBe('Click me');
+    expect(button?.className).toBe('btn');
+  });
+
+  it('should render Counter with initial value', async () => {
+    const { container } = await render(<Counter initialCount={5} />);
+
+    const countDisplay = container.querySelector('[data-testid="count"]');
+    expect(countDisplay?.textContent).toBe('5');
+  });
+
+  it('should handle unmount correctly', async () => {
+    const { container, unmount } = await render(<App />);
+
+    expect(container.querySelector('h1')).toBeTruthy();
+
+    await unmount();
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should handle rerender correctly', async () => {
+    const { container, rerender } = await render(
+      <Counter initialCount={0} title="First" />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="counter-title"]')?.textContent,
+    ).toBe('First');
+
+    await rerender(<Counter initialCount={10} title="Second" />);
+
+    expect(
+      container.querySelector('[data-testid="counter-title"]')?.textContent,
+    ).toBe('Second');
+  });
+});

--- a/e2e/browser-mode/fixtures/browser-react-17/tests/renderHook.test.tsx
+++ b/e2e/browser-mode/fixtures/browser-react-17/tests/renderHook.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook } from '@rstest/browser-react/react17';
+import { describe, expect, it } from '@rstest/core';
+import { useCounter } from '../src/useCounter';
+
+describe('@rstest/browser-react renderHook (React 17)', () => {
+  it('should render hook with initial value', async () => {
+    const { result } = await renderHook(() => useCounter(5));
+
+    expect(result.current.count).toBe(5);
+  });
+
+  it('should handle hook state updates with act', async () => {
+    const { result, act } = await renderHook(() => useCounter(0));
+
+    expect(result.current.count).toBe(0);
+
+    await act(() => {
+      result.current.increment();
+    });
+
+    expect(result.current.count).toBe(1);
+
+    await act(() => {
+      result.current.increment();
+      result.current.increment();
+    });
+
+    expect(result.current.count).toBe(3);
+  });
+
+  it('should handle unmount', async () => {
+    const { result, unmount } = await renderHook(() => useCounter(0));
+
+    expect(result.current.count).toBe(0);
+
+    await unmount();
+
+    expect(result.current.count).toBe(0);
+  });
+});

--- a/e2e/browser-mode/fixtures/ports.ts
+++ b/e2e/browser-mode/fixtures/ports.ts
@@ -7,6 +7,7 @@
 export const BROWSER_PORTS = {
   basic: 5180,
   'browser-react': 5202,
+  'browser-react-17': 5234,
   'locator-api': 5226,
   list: 5204,
   'no-tests': 5206,

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -14,6 +14,7 @@
     "projects/fixtures/",
     "projects/fixtures-shard/",
     "globals/fixtures/",
-    "browser-mode/fixtures/react/"
+    "browser-mode/fixtures/react/",
+    "browser-mode/fixtures/browser-react-17/"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bench:memory": "pnpm --filter @rstest/benchmarks bench:memory",
     "build": "pnpm --filter \"./packages/*\" run build",
     "bump": "node --experimental-strip-types scripts/version.mts",
-    "check-dependency-version": "pnpx check-dependency-version-consistency --ignore-package @rstest/test-mock-re-exports . && echo",
+    "check-dependency-version": "pnpx check-dependency-version-consistency --ignore-package @rstest/test-mock-re-exports --ignore-package @rstest/test-browser-react-17 . && echo",
     "check-spell": "pnpx cspell && heading-case",
     "check-unused": "knip",
     "e2e": "cd e2e && pnpm test && pnpm test:commonjs && pnpm test:no-isolate",

--- a/packages/browser-react/README.md
+++ b/packages/browser-react/README.md
@@ -233,7 +233,7 @@ Wraps state updates in React's `act()` for proper batching. Automatically manage
 function act(callback: () => unknown): Promise<void>;
 ```
 
-> **Note:** For React 17 (which doesn't export `act`), this function falls back to simple async execution.
+> **Note:** This is the React 18+ `act`. React 17 users should import from `@rstest/browser-react/react17`, which uses `act` from `react-dom/test-utils`.
 
 ### `cleanup()`
 
@@ -263,6 +263,23 @@ interface RenderConfiguration {
 - React 17, 18, and 19
 - Rstest browser mode (experimental)
 - Node.js >= 20.19.0
+
+### React 17
+
+The default entry (`@rstest/browser-react`) targets React 18+ and statically imports `react-dom/client`, which does not exist under React 17. React 17 users should import from the dedicated entry instead:
+
+```ts
+import {
+  render,
+  renderHook,
+  cleanup,
+  act,
+} from '@rstest/browser-react/react17';
+// or, without auto-cleanup:
+import { render, cleanup } from '@rstest/browser-react/react17/pure';
+```
+
+The `/react17` entry uses `ReactDOM.render` / `unmountComponentAtNode` and pulls `act` from `react-dom/test-utils`. No bundler configuration is required.
 
 ## License
 

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -28,6 +28,14 @@
       "types": "./dist/pure.d.ts",
       "default": "./dist/pure.js"
     },
+    "./react17": {
+      "types": "./dist/index.react17.d.ts",
+      "default": "./dist/index.react17.js"
+    },
+    "./react17/pure": {
+      "types": "./dist/pure.react17.d.ts",
+      "default": "./dist/pure.react17.js"
+    },
     "./package.json": {
       "default": "./package.json"
     }

--- a/packages/browser-react/rslib.config.ts
+++ b/packages/browser-react/rslib.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
           react: 'react',
           'react-dom': 'react-dom',
           'react-dom/client': 'react-dom/client',
+          // React 17 entry uses legacy ReactDOMTestUtils.act.
+          'react-dom/test-utils': 'react-dom/test-utils',
           'react/jsx-runtime': 'react/jsx-runtime',
           'react/jsx-dev-runtime': 'react/jsx-dev-runtime',
           // Keep @rstest/core as external
@@ -27,6 +29,8 @@ export default defineConfig({
     entry: {
       index: './src/index.ts',
       pure: './src/pure.tsx',
+      'index.react17': './src/index.react17.ts',
+      'pure.react17': './src/pure.react17.tsx',
     },
   },
   tools: {

--- a/packages/browser-react/src/act.ts
+++ b/packages/browser-react/src/act.ts
@@ -10,8 +10,9 @@ function updateActEnvironment(): void {
   setActEnvironment(activeActs > 0);
 }
 
-// React 18+ exports act, React 17 has unstable_act
-const _act = (React as Record<string, unknown>).act as
+// React 18.3+: React.act. React 18.0–18.2: React.unstable_act.
+const _act = ((React as Record<string, unknown>).act ??
+  (React as Record<string, unknown>).unstable_act) as
   | ((callback: () => unknown) => Promise<void>)
   | undefined;
 

--- a/packages/browser-react/src/createRenderApi.tsx
+++ b/packages/browser-react/src/createRenderApi.tsx
@@ -1,0 +1,175 @@
+import type { JSXElementConstructor, ReactNode } from 'react';
+import React from 'react';
+
+export interface RenderResult {
+  /** The container element the component is rendered into */
+  container: HTMLElement;
+  /** The base element for queries, defaults to document.body */
+  baseElement: HTMLElement;
+  unmount: () => Promise<void>;
+  /** Re-render the component with new props/element */
+  rerender: (ui: ReactNode) => Promise<void>;
+  /** Returns the rendered UI as a DocumentFragment (useful for snapshots) */
+  asFragment: () => DocumentFragment;
+}
+
+export interface RenderOptions {
+  /** Custom container element to render into */
+  container?: HTMLElement;
+  /** Base element for queries, defaults to document.body */
+  baseElement?: HTMLElement;
+  /** Wrapper component (e.g., for providers/context) */
+  wrapper?: JSXElementConstructor<{ children: ReactNode }>;
+}
+
+export interface RenderHookOptions<Props> extends RenderOptions {
+  /** Initial props passed to the hook */
+  initialProps?: Props;
+}
+
+export interface RenderHookResult<Result, Props> {
+  /** Reference to the latest hook return value */
+  result: { current: Result };
+  /** Re-render the hook with new props */
+  rerender: (props?: Props) => Promise<void>;
+  unmount: () => Promise<void>;
+  /** Access to act for manual state updates */
+  act: (callback: () => unknown) => Promise<void>;
+}
+
+export interface RenderConfiguration {
+  /** Enable React StrictMode wrapper */
+  reactStrictMode: boolean;
+}
+
+/** @internal */
+export interface ReactRoot {
+  render: (element: ReactNode) => void;
+  unmount: () => void;
+}
+
+/** @internal */
+export type ActFunction = (callback: () => unknown) => Promise<void>;
+
+/** @internal */
+export interface RenderApiDeps {
+  createRoot: (container: HTMLElement) => ReactRoot;
+  act: ActFunction;
+}
+
+/** @internal */
+export interface RenderApi {
+  render: (ui: ReactNode, options?: RenderOptions) => Promise<RenderResult>;
+  renderHook: <Props, Result>(
+    callback: (props?: Props) => Result,
+    options?: RenderHookOptions<Props>,
+  ) => Promise<RenderHookResult<Result, Props>>;
+  cleanup: () => Promise<void>;
+  configure: (customConfig: Partial<RenderConfiguration>) => void;
+  act: ActFunction;
+}
+
+/** @internal */
+export function createRenderApi(deps: RenderApiDeps): RenderApi {
+  const { createRoot, act } = deps;
+
+  const roots = new Map<HTMLElement, ReactRoot>();
+  const config: RenderConfiguration = {
+    reactStrictMode: false,
+  };
+
+  function strictModeIfNeeded(ui: ReactNode): ReactNode {
+    return config.reactStrictMode
+      ? React.createElement(React.StrictMode, null, ui)
+      : ui;
+  }
+
+  function wrapUiIfNeeded(
+    ui: ReactNode,
+    wrapper?: JSXElementConstructor<{ children: ReactNode }>,
+  ): ReactNode {
+    return wrapper ? React.createElement(wrapper, null, ui) : ui;
+  }
+
+  async function render(
+    ui: ReactNode,
+    options: RenderOptions = {},
+  ): Promise<RenderResult> {
+    const { wrapper } = options;
+    const baseElement = options.baseElement ?? document.body;
+    const container =
+      options.container ??
+      baseElement.appendChild(document.createElement('div'));
+
+    let root = roots.get(container);
+    if (!root) {
+      root = createRoot(container);
+      roots.set(container, root);
+    }
+
+    const wrappedUi = wrapUiIfNeeded(strictModeIfNeeded(ui), wrapper);
+    await act(() => root.render(wrappedUi));
+
+    return {
+      container,
+      baseElement,
+      unmount: async () => {
+        await act(() => root.unmount());
+      },
+      rerender: async (newUi: ReactNode) => {
+        const wrapped = wrapUiIfNeeded(strictModeIfNeeded(newUi), wrapper);
+        await act(() => root.render(wrapped));
+      },
+      asFragment: () =>
+        document.createRange().createContextualFragment(container.innerHTML),
+    };
+  }
+
+  async function renderHook<Props, Result>(
+    renderCallback: (props?: Props) => Result,
+    options: RenderHookOptions<Props> = {},
+  ): Promise<RenderHookResult<Result, Props>> {
+    const { initialProps, ...renderOptions } = options;
+    const result = { current: undefined as Result };
+
+    function TestComponent({ hookProps }: { hookProps?: Props }): null {
+      const value = renderCallback(hookProps);
+      React.useEffect(() => {
+        result.current = value;
+      });
+      return null;
+    }
+
+    const { rerender: baseRerender, unmount } = await render(
+      React.createElement(TestComponent, { hookProps: initialProps }),
+      renderOptions,
+    );
+
+    return {
+      result,
+      rerender: async (props?: Props) => {
+        await baseRerender(
+          React.createElement(TestComponent, { hookProps: props }),
+        );
+      },
+      unmount,
+      act,
+    };
+  }
+
+  async function cleanup(): Promise<void> {
+    for (const [container, root] of roots) {
+      await act(() => root.unmount());
+      if (container.parentNode === document.body) {
+        document.body.removeChild(container);
+      }
+    }
+    roots.clear();
+  }
+
+  function configure(customConfig: Partial<RenderConfiguration>): void {
+    Object.assign(config, customConfig);
+  }
+
+  return { render, renderHook, cleanup, configure, act };
+}

--- a/packages/browser-react/src/index.react17.ts
+++ b/packages/browser-react/src/index.react17.ts
@@ -1,0 +1,8 @@
+import { beforeEach } from '@rstest/core';
+import { cleanup } from './pure.react17';
+
+beforeEach(async () => {
+  await cleanup();
+});
+
+export * from './pure.react17';

--- a/packages/browser-react/src/pure.react17.tsx
+++ b/packages/browser-react/src/pure.react17.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import * as ReactDOMLib from 'react-dom';
+import * as TestUtilsLib from 'react-dom/test-utils';
+import type { RenderApi } from './createRenderApi';
+import { createRenderApi } from './createRenderApi';
+
+// `@types/react-dom@19` removed these exports; redeclare for the React 17 path.
+interface LegacyReactDOM {
+  render: (element: ReactNode, container: Element) => void;
+  unmountComponentAtNode: (container: Element) => boolean;
+}
+
+interface LegacyTestUtils {
+  act: (callback: () => unknown) => Promise<void>;
+}
+
+function interopDefault<T>(mod: unknown): T {
+  return ((mod as { default?: T }).default ?? mod) as T;
+}
+
+const ReactDOM = interopDefault<LegacyReactDOM>(ReactDOMLib);
+const TestUtils = interopDefault<LegacyTestUtils>(TestUtilsLib);
+const act: LegacyTestUtils['act'] = TestUtils.act;
+
+const api: RenderApi = createRenderApi({
+  createRoot: (container) => ({
+    render: (element) => {
+      ReactDOM.render(element, container);
+    },
+    unmount: () => {
+      ReactDOM.unmountComponentAtNode(container);
+    },
+  }),
+  act,
+});
+
+export type {
+  RenderConfiguration,
+  RenderHookOptions,
+  RenderHookResult,
+  RenderOptions,
+  RenderResult,
+} from './createRenderApi';
+
+export const render: RenderApi['render'] = api.render;
+export const renderHook: RenderApi['renderHook'] = api.renderHook;
+export const cleanup: RenderApi['cleanup'] = api.cleanup;
+export const configure: RenderApi['configure'] = api.configure;
+export { act };

--- a/packages/browser-react/src/pure.tsx
+++ b/packages/browser-react/src/pure.tsx
@@ -1,206 +1,29 @@
-import type { JSXElementConstructor, ReactNode } from 'react';
-import React from 'react';
 import { createRoot as createReactRoot } from 'react-dom/client';
 import { act } from './act';
+import type { RenderApi } from './createRenderApi';
+import { createRenderApi } from './createRenderApi';
 
-// ===== Types =====
+const api: RenderApi = createRenderApi({
+  createRoot: (container) => {
+    const root = createReactRoot(container);
+    return {
+      render: (element) => root.render(element),
+      unmount: () => root.unmount(),
+    };
+  },
+  act,
+});
 
-export interface RenderResult {
-  /** The container element the component is rendered into */
-  container: HTMLElement;
-  /** The base element for queries, defaults to document.body */
-  baseElement: HTMLElement;
-  /** Unmount the rendered component */
-  unmount: () => Promise<void>;
-  /** Re-render the component with new props/element */
-  rerender: (ui: ReactNode) => Promise<void>;
-  /** Returns the rendered UI as a DocumentFragment (useful for snapshots) */
-  asFragment: () => DocumentFragment;
-}
+export type {
+  RenderConfiguration,
+  RenderHookOptions,
+  RenderHookResult,
+  RenderOptions,
+  RenderResult,
+} from './createRenderApi';
 
-export interface RenderOptions {
-  /** Custom container element to render into */
-  container?: HTMLElement;
-  /** Base element for queries, defaults to document.body */
-  baseElement?: HTMLElement;
-  /** Wrapper component (e.g., for providers/context) */
-  wrapper?: JSXElementConstructor<{ children: ReactNode }>;
-}
-
-export interface RenderHookOptions<Props> extends RenderOptions {
-  /** Initial props passed to the hook */
-  initialProps?: Props;
-}
-
-export interface RenderHookResult<Result, Props> {
-  /** Reference to the latest hook return value */
-  result: { current: Result };
-  /** Re-render the hook with new props */
-  rerender: (props?: Props) => Promise<void>;
-  /** Unmount the hook */
-  unmount: () => Promise<void>;
-  /** Access to act for manual state updates */
-  act: (callback: () => unknown) => Promise<void>;
-}
-
-export interface RenderConfiguration {
-  /** Enable React StrictMode wrapper */
-  reactStrictMode: boolean;
-}
-
-// ===== Internal State =====
-
-interface ReactRoot {
-  render: (element: ReactNode) => void;
-  unmount: () => void;
-}
-
-interface MountedRootEntry {
-  container: HTMLElement;
-  root: ReactRoot;
-}
-
-const mountedContainers = new Set<HTMLElement>();
-const mountedRootEntries: MountedRootEntry[] = [];
-
-const config: RenderConfiguration = {
-  reactStrictMode: false,
-};
-
-// ===== Internal Helpers =====
-
-function createRoot(container: HTMLElement): ReactRoot {
-  const root = createReactRoot(container);
-  return {
-    render: (element: ReactNode) => root.render(element),
-    unmount: () => root.unmount(),
-  };
-}
-
-function strictModeIfNeeded(ui: ReactNode): ReactNode {
-  return config.reactStrictMode
-    ? React.createElement(React.StrictMode, null, ui)
-    : ui;
-}
-
-function wrapUiIfNeeded(
-  ui: ReactNode,
-  wrapper?: JSXElementConstructor<{ children: ReactNode }>,
-): ReactNode {
-  return wrapper ? React.createElement(wrapper, null, ui) : ui;
-}
-
-// ===== Public API =====
-
-/**
- * Render a React element into the DOM.
- */
-export async function render(
-  ui: ReactNode,
-  options: RenderOptions = {},
-): Promise<RenderResult> {
-  const { wrapper } = options;
-  let { container, baseElement } = options;
-
-  if (!baseElement) {
-    baseElement = document.body;
-  }
-
-  if (!container) {
-    container = baseElement.appendChild(document.createElement('div'));
-  }
-
-  let root: ReactRoot;
-
-  if (!mountedContainers.has(container)) {
-    root = createRoot(container);
-
-    mountedRootEntries.push({ container, root });
-    mountedContainers.add(container);
-  } else {
-    const entry = mountedRootEntries.find((e) => e.container === container);
-    if (!entry) {
-      throw new Error('Container is tracked but root entry not found');
-    }
-    root = entry.root;
-  }
-
-  const wrappedUi = wrapUiIfNeeded(strictModeIfNeeded(ui), wrapper);
-  await act(() => root.render(wrappedUi));
-
-  return {
-    container,
-    baseElement,
-    unmount: async () => {
-      await act(() => root.unmount());
-    },
-    rerender: async (newUi: ReactNode) => {
-      const wrapped = wrapUiIfNeeded(strictModeIfNeeded(newUi), wrapper);
-      await act(() => root.render(wrapped));
-    },
-    asFragment: () => {
-      return document
-        .createRange()
-        .createContextualFragment(container.innerHTML);
-    },
-  };
-}
-
-/**
- * Render a custom React hook for testing.
- */
-export async function renderHook<Props, Result>(
-  renderCallback: (props?: Props) => Result,
-  options: RenderHookOptions<Props> = {},
-): Promise<RenderHookResult<Result, Props>> {
-  const { initialProps, ...renderOptions } = options;
-  const result = { current: undefined as Result };
-
-  function TestComponent({ hookProps }: { hookProps?: Props }): null {
-    const value = renderCallback(hookProps);
-    React.useEffect(() => {
-      result.current = value;
-    });
-    return null;
-  }
-
-  const { rerender: baseRerender, unmount } = await render(
-    React.createElement(TestComponent, { hookProps: initialProps }),
-    renderOptions,
-  );
-
-  return {
-    result,
-    rerender: async (props?: Props) => {
-      await baseRerender(
-        React.createElement(TestComponent, { hookProps: props }),
-      );
-    },
-    unmount,
-    act,
-  };
-}
-
-/**
- * Cleanup all mounted components.
- * Call this in beforeEach or afterEach to prevent test pollution.
- */
-export async function cleanup(): Promise<void> {
-  for (const { root, container } of mountedRootEntries) {
-    await act(() => root.unmount());
-    if (container.parentNode === document.body) {
-      document.body.removeChild(container);
-    }
-  }
-  mountedRootEntries.length = 0;
-  mountedContainers.clear();
-}
-
-/**
- * Configure render behavior.
- */
-export function configure(customConfig: Partial<RenderConfiguration>): void {
-  Object.assign(config, customConfig);
-}
-
+export const render: RenderApi['render'] = api.render;
+export const renderHook: RenderApi['renderHook'] = api.renderHook;
+export const cleanup: RenderApi['cleanup'] = api.cleanup;
+export const configure: RenderApi['configure'] = api.configure;
 export { act };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,33 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/coverage-istanbul
 
+  e2e/browser-mode/fixtures/browser-react-17:
+    devDependencies:
+      '@rsbuild/plugin-react':
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2(@swc/helpers@0.5.21))
+      '@rstest/browser':
+        specifier: workspace:*
+        version: link:../../../../packages/browser
+      '@rstest/browser-react':
+        specifier: workspace:*
+        version: link:../../../../packages/browser-react
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
+      '@types/react':
+        specifier: ^17.0.83
+        version: 17.0.91
+      '@types/react-dom':
+        specifier: ^17.0.26
+        version: 17.0.26(@types/react@17.0.91)
+      react:
+        specifier: ^17.0.2
+        version: 17.0.2
+      react-dom:
+        specifier: ^17.0.2
+        version: 17.0.2(react@17.0.2)
+
   e2e/build/fixtures/runtimeRequire: {}
 
   e2e/build/runtimeImport: {}
@@ -3618,6 +3645,11 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/react-dom@17.0.26':
+    resolution: {integrity: sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==}
+    peerDependencies:
+      '@types/react': ^17.0.0
+
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -3628,6 +3660,9 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react@17.0.91':
+    resolution: {integrity: sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==}
+
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
@@ -3636,6 +3671,9 @@ packages:
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
+  '@types/scheduler@0.16.8':
+    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -6557,6 +6595,11 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@17.0.2:
+    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
+    peerDependencies:
+      react: 17.0.2
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -6620,6 +6663,10 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react@17.0.2:
+    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -6971,6 +7018,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.20.2:
+    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -10442,6 +10492,10 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/react-dom@17.0.26(@types/react@17.0.91)':
+    dependencies:
+      '@types/react': 17.0.91
+
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -10449,6 +10503,12 @@ snapshots:
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
+
+  '@types/react@17.0.91':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      '@types/scheduler': 0.16.8
+      csstype: 3.2.3
 
   '@types/react@18.3.28':
     dependencies:
@@ -10460,6 +10520,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/sarif@2.1.7': {}
+
+  '@types/scheduler@0.16.8': {}
 
   '@types/semver@7.7.1': {}
 
@@ -14024,6 +14086,13 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
+  react-dom@17.0.2(react@17.0.2):
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react: 17.0.2
+      scheduler: 0.20.2
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -14078,6 +14147,11 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.5(react@19.2.5)
+
+  react@17.0.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
 
   react@18.3.1:
     dependencies:
@@ -14446,6 +14520,11 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.20.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
 
   scheduler@0.23.2:
     dependencies:


### PR DESCRIPTION
## Summary

### Background

`@rstest/browser-react` statically imports `react-dom/client`, which does not exist under React 17. React 17 users hit a hard resolution error today and have no workable entry point.

### Implementation

- Extract a shared `createRenderApi` factory so `render` / `renderHook` / `cleanup` are reused across React majors.
- Add new entries `@rstest/browser-react/react17` (auto-cleanup) and `@rstest/browser-react/react17/pure`, mounting via `ReactDOM.render` / `unmountComponentAtNode` and pulling `act` from `react-dom/test-utils`.
- Detect `React.unstable_act` so the default entry also keeps working under React 18.0–18.2.

### User Impact

React 17 projects can now use `@rstest/browser-react/react17` without bundler configuration. React 18+ users are unaffected (default entry is unchanged).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).