### PR TITLE
chore(deps): update pnpm workspace settings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,8 +61,6 @@
     },
   ],
   ignoreDeps: [
-    // manually update some packages
-    'pnpm',
     // align Node.js version minimum requirements
     '@types/node',
     'node',

--- a/package.json
+++ b/package.json
@@ -37,24 +37,9 @@
     "prettier-plugin-packagejson": "^3.0.2",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@10.12.4",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": "^20.19.0 || >=22.12.0",
     "pnpm": ">=10.12.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "core-js",
-      "lefthook"
-    ],
-    "packageExtensions": {
-      "@vue/test-utils": {
-        "peerDependencies": {
-          "@vue/compiler-dom": "3.5.17",
-          "@vue/server-renderer": "3.5.17",
-          "vue": "^3.5.17"
-        }
-      }
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,39 @@ packages:
   - 'examples/**'
   - 'e2e/**'
 
-strictPeerDependencies: false
+allowBuilds:
+  '@parcel/watcher': false
+  '@swc/core': false
+  '@vscode/vsce-sign': false
+  core-js-pure: false
+  keytar: false
+  lefthook: true
+  svelte-preprocess: false
+
 autoInstallPeers: false
+
 # for vsce
 hoistPattern: ['@secretlint/*']
+
+# Reduce the risk of installing compromised packages
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'
+
+packageExtensions:
+  '@vue/test-utils':
+    peerDependencies:
+      '@vue/compiler-dom': 3.5.17
+      '@vue/server-renderer': 3.5.17
+      vue: ^3.5.17
+
+# Prevent un-reviewed build scripts
+strictDepBuilds: true
+
+strictPeerDependencies: false


### PR DESCRIPTION
## Summary

### Background

pnpm 10.33.4 supports workspace-level build-script and release-age controls, which keeps dependency manager policy out of the root package manifest and lets Renovate manage pnpm updates.

### Implementation

- Pins the project package manager to pnpm 10.33.4 and removes `pnpm` from Renovate's ignored dependencies.
- Moves existing package extensions into `pnpm-workspace.yaml` and adds explicit `allowBuilds`, `strictDepBuilds`, and `minimumReleaseAge` settings.

### User Impact

None - dependency installation policy is tightened without changing Rstest runtime APIs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
