### PR TITLE
test(e2e): assert no framework warnings in browser-mode CLI output

### DIFF
--- a/e2e/browser-mode/utils.ts
+++ b/e2e/browser-mode/utils.ts
@@ -33,6 +33,35 @@ export const shouldRunHeadedBrowserTests =
   Boolean(process.env.CI || process.env.RSTEST_E2E_RUN_HEADED);
 
 /**
+ * Framework-level warnings that the build pipeline must not emit. Browser-mode
+ * tests launch rstest as a subprocess, so any Rsbuild/Rspack build warning or
+ * Node deprecation notice lands in `cli.stdout`/`cli.stderr` and is otherwise
+ * swallowed by the parent test runner. Asserting against this pattern turns
+ * silent regressions (e.g. a dynamic import losing its `webpackIgnore` magic
+ * comment) into explicit test failures.
+ */
+const FRAMEWORK_WARNING_PATTERN =
+  /Build warning:|Critical dependency:|DeprecationWarning:|\[MODULE_TYPELESS_PACKAGE_JSON\]/;
+
+export const expectNoFrameworkWarnings = (cli: {
+  stdout: string;
+  stderr: string;
+}): void => {
+  if (
+    !FRAMEWORK_WARNING_PATTERN.test(cli.stdout) &&
+    !FRAMEWORK_WARNING_PATTERN.test(cli.stderr)
+  ) {
+    return;
+  }
+  const offending = `${cli.stdout}\n${cli.stderr}`
+    .split('\n')
+    .filter((line) => FRAMEWORK_WARNING_PATTERN.test(line));
+  throw new Error(
+    `Expected no framework warnings in CLI output, found:\n${offending.join('\n')}`,
+  );
+};
+
+/**
  * Run browser mode CLI with specified fixture
  */
 export const runBrowserCli = async (
@@ -44,7 +73,7 @@ export const runBrowserCli = async (
 ) => {
   const args = extra?.args || [];
 
-  return await runRstestCli({
+  const result = await runRstestCli({
     command: 'rstest',
     args: ['run', ...args],
     options: {
@@ -54,6 +83,13 @@ export const runBrowserCli = async (
       },
     },
   });
+  return {
+    ...result,
+    expectExecSuccess: async () => {
+      await result.expectExecSuccess();
+      expectNoFrameworkWarnings(result.cli);
+    },
+  };
 };
 
 /**
@@ -66,7 +102,7 @@ export const runBrowserWatchCli = async (
     env?: Record<string, string>;
   },
 ) => {
-  return await runRstestCli({
+  const result = await runRstestCli({
     command: 'rstest',
     args: ['watch', '--disableConsoleIntercept', ...(extra?.args || [])],
     options: {
@@ -76,6 +112,13 @@ export const runBrowserWatchCli = async (
       },
     },
   });
+  return {
+    ...result,
+    expectExecSuccess: async () => {
+      await result.expectExecSuccess();
+      expectNoFrameworkWarnings(result.cli);
+    },
+  };
 };
 
 /**
@@ -88,7 +131,7 @@ export const runBrowserCliWithCwd = async (
     env?: Record<string, string>;
   },
 ) => {
-  return await runRstestCli({
+  const result = await runRstestCli({
     command: 'rstest',
     args: ['run', ...(extra?.args || [])],
     options: {
@@ -98,4 +141,11 @@ export const runBrowserCliWithCwd = async (
       },
     },
   });
+  return {
+    ...result,
+    expectExecSuccess: async () => {
+      await result.expectExecSuccess();
+      expectNoFrameworkWarnings(result.cli);
+    },
+  };
 };


### PR DESCRIPTION
## Summary

Browser-mode e2e tests run rstest as a subprocess via `runBrowserCli` and siblings, so any Rsbuild/Rspack **build warning** or Node deprecation lands inside `cli.stdout` / `cli.stderr` and is otherwise silently swallowed by the parent test runner — the e2e CI log on `main` shows zero `Critical dependency` lines today even though every browser-mode test actually emits it.

This PR decorates `expectExecSuccess` returned by the three browser-mode helpers (`runBrowserCli`, `runBrowserWatchCli`, `runBrowserCliWithCwd`) so that on success it additionally scans the captured CLI output for framework-warning markers:

- `Build warning:` (Rsbuild)
- `Critical dependency:` (rspack / webpack)
- `DeprecationWarning:` (Node)
- `[MODULE_TYPELESS_PACKAGE_JSON]` (Node ESM loader)

Any hit fails the test with the offending lines included in the error message. The helper `expectNoFrameworkWarnings(cli)` is also exported so watch-mode and other custom flows can call it explicitly.

This turns silent regressions like an `await import(<var>)` dynamic specifier losing its `webpackIgnore` magic comment into explicit, debuggable test failures.

## Expectation

CI is **expected to fail** on this PR — the regression that #1244 fixes is still present on `main`, so every browser-mode test currently produces three `Build warning: Critical dependency` lines per build. After #1244 lands and the dist is rebuilt, this assertion turns green and protects against future recurrence.

Refs: #1244

## Test plan

- [ ] CI fails as expected on this branch (pre-merge of #1244)
- [ ] After rebasing on `main` post-#1244, all browser-mode e2e jobs pass
- [ ] Locally verified: `e2e/browser-mode/basic.test.ts` raises \`Expected no framework warnings in CLI output, found: ...\` with the three `Critical dependency` lines surfaced