### PR TITLE
fix(core): split taskContext to remove node:async_hooks from browser bundle

### DIFF
--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -8,15 +8,15 @@ import {
 } from '@rstest/browser-manifest';
 import type {
   CoverageMapData,
+  CurrentTaskInfo,
   RunnerHooks,
   RuntimeConfig,
   WorkerState,
 } from '@rstest/core/browser-runtime';
 import {
+  createBrowserTaskContext,
   createRstestRuntime,
-  getCurrentTask,
   globalApis,
-  initTaskContext,
   setRealTimers,
 } from '@rstest/core/browser-runtime';
 import { normalize } from 'pathe';
@@ -152,14 +152,12 @@ const getFileTaskId = (testPath: string): string => {
   return `file:${testPath}`;
 };
 
-type CurrentTaskInfo = NonNullable<WorkerState['currentTask']>;
-
 /**
  * Intercept console methods and forward to host via send().
  * Returns a restore function to revert console to original.
  */
 const interceptConsole = (
-  getCurrentTaskFallback: () => CurrentTaskInfo | undefined,
+  getCurrentTask: () => CurrentTaskInfo | undefined,
   printConsoleTrace: boolean,
 ): (() => void) => {
   const originalConsole = {
@@ -186,7 +184,7 @@ const interceptConsole = (
 
       // Format message
       const content = args.map(formatArg).join(' ');
-      const currentTask = getCurrentTask() ?? getCurrentTaskFallback();
+      const currentTask = getCurrentTask();
 
       // Send to host
       send({
@@ -421,7 +419,6 @@ const run = async () => {
   send({ type: 'ready' });
 
   setRealTimers();
-  await initTaskContext();
 
   // Preload runner.js sourcemap for inline snapshot support.
   // The snapshot code runs in runner.js, so we need its sourcemap
@@ -529,7 +526,9 @@ const run = async () => {
         },
       };
 
-      const runtime = await createRstestRuntime(workerState);
+      const runtime = await createRstestRuntime(workerState, {
+        taskContext: createBrowserTaskContext(),
+      });
 
       // Register global APIs if globals config is enabled
       if (runtimeConfig.globals) {
@@ -587,6 +586,10 @@ const run = async () => {
       },
     ];
 
+    // Per-file TaskContext; taskStack supplies the concurrent attribution
+    // that the single-slot fallback can't.
+    const taskContext = createBrowserTaskContext();
+
     const shouldInterceptConsole =
       !runtimeConfig.disableConsoleIntercept ||
       runtimeConfig.silent === true ||
@@ -595,7 +598,7 @@ const run = async () => {
     // Intercept console methods to forward logs to host
     const restoreConsole = shouldInterceptConsole
       ? interceptConsole(
-          () => taskStack[taskStack.length - 1],
+          () => taskContext.getCurrent() ?? taskStack[taskStack.length - 1],
           runtimeConfig.disableConsoleIntercept
             ? false
             : (runtimeConfig.printConsoleTrace ?? false),
@@ -635,7 +638,7 @@ const run = async () => {
       syncCurrentTask();
     };
 
-    const runtime = await createRstestRuntime(workerState);
+    const runtime = await createRstestRuntime(workerState, { taskContext });
 
     // Register global APIs if globals config is enabled
     if (runtimeConfig.globals) {

--- a/packages/core/src/browserRuntime.ts
+++ b/packages/core/src/browserRuntime.ts
@@ -13,10 +13,12 @@ export { createRstestRuntime } from './runtime/api';
 // Public test APIs (describe, it, expect, etc.)
 export * from './runtime/api/public';
 export { setRealTimers } from './runtime/util';
-export { getCurrentTask, initTaskContext } from './runtime/worker/taskContext';
+export { createBrowserTaskContext } from './runtime/worker/taskContext.browser';
+export type { TaskContext } from './runtime/worker/taskContext';
 // Types for browser runtime
 export type {
   CoverageMapData,
+  CurrentTaskInfo,
   RunnerHooks,
   RuntimeConfig,
   Test,

--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -8,11 +8,13 @@ import type {
   WorkerState,
 } from '../../types';
 import { createRunner } from '../runner';
+import type { TaskContext } from '../worker/taskContext';
 import { assert, createExpect, GLOBAL_EXPECT, setupChaiConfig } from './expect';
 import { createRstestUtilities } from './utilities';
 
 export const createRstestRuntime = async (
   workerState: WorkerState,
+  { taskContext }: { taskContext: TaskContext },
 ): Promise<{
   runner: {
     runTests: (
@@ -26,7 +28,7 @@ export const createRstestRuntime = async (
   api: Rstest;
 }> => {
   const [{ runner, api: runnerAPI }, { SnapshotPlugin }] = await Promise.all([
-    Promise.resolve(createRunner({ workerState })),
+    Promise.resolve(createRunner({ workerState, taskContext })),
     import(/* webpackChunkName: "snapshot" */ './snapshot'),
   ]);
 

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -7,6 +7,7 @@ import type {
   TestInfo,
   WorkerState,
 } from '../../types';
+import type { TaskContext } from '../worker/taskContext';
 import { TestRunner } from './runner';
 import { createRuntimeAPI } from './runtime';
 import { traverseUpdateTest } from './task';
@@ -15,7 +16,13 @@ export const getFileTaskId = (testPath: string): string => {
   return `file:${testPath}`;
 };
 
-export function createRunner({ workerState }: { workerState: WorkerState }): {
+export function createRunner({
+  workerState,
+  taskContext,
+}: {
+  workerState: WorkerState;
+  taskContext: TaskContext;
+}): {
   api: RunnerAPI;
   runner: {
     runTests: (
@@ -37,7 +44,7 @@ export function createRunner({ workerState }: { workerState: WorkerState }): {
     testPath,
     runtimeConfig: workerState.runtimeConfig,
   });
-  const testRunner: TestRunner = new TestRunner();
+  const testRunner: TestRunner = new TestRunner(taskContext);
 
   return {
     api: {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -23,10 +23,7 @@ import type {
 import { getTaskNameWithPrefix } from '../../utils/helper';
 import { createExpect } from '../api/expect';
 import { formatTestError } from '../util';
-import {
-  runWithCurrentTask,
-  setFallbackCurrentTask,
-} from '../worker/taskContext';
+import type { TaskContext } from '../worker/taskContext';
 import { handleFixtures } from './fixtures';
 import { getFileTaskId } from './index';
 import {
@@ -42,6 +39,8 @@ export class TestRunner {
   /** current test case */
   private _test: TestCase | undefined;
   private workerState: WorkerState | undefined;
+
+  constructor(private readonly taskContext: TaskContext) {}
 
   async runTests({
     tests,
@@ -297,7 +296,7 @@ export class TestRunner {
       }
 
       if (test.type === 'suite') {
-        result = await runWithCurrentTask(
+        result = await this.taskContext.run(
           {
             taskId: test.testId,
             taskName: test.name,
@@ -399,7 +398,7 @@ export class TestRunner {
 
         errors.push(...(result.errors || []));
       } else {
-        result = await runWithCurrentTask(
+        result = await this.taskContext.run(
           {
             taskId: test.testId,
             taskName: test.name,
@@ -501,7 +500,7 @@ export class TestRunner {
     // saves files and returns SnapshotResult
     const snapshotResult = await snapshotClient.finish(testPath);
 
-    setFallbackCurrentTask({
+    this.taskContext.setFallback({
       taskId: getFileTaskId(testPath),
       taskType: 'file',
       testPath,
@@ -523,7 +522,7 @@ export class TestRunner {
         duration: RealDate.now() - start,
       };
     } finally {
-      setFallbackCurrentTask(undefined);
+      this.taskContext.setFallback(undefined);
     }
   }
 

--- a/packages/core/src/runtime/worker/console.ts
+++ b/packages/core/src/runtime/worker/console.ts
@@ -22,10 +22,9 @@ import {
   type InspectOptions,
   inspect,
 } from 'node:util';
-import type { UserConsoleLog } from '../../types';
+import type { CurrentTaskInfo, UserConsoleLog } from '../../types';
 import { prettyTime } from '../../utils/helper';
 import { color } from '../../utils/logger';
-import { getCurrentTask } from './taskContext';
 
 const RealDate = Date;
 
@@ -49,10 +48,12 @@ export function createCustomConsole({
   onConsoleLog,
   testPath,
   printConsoleTrace,
+  getCurrentTask,
 }: {
   onConsoleLog: (log: UserConsoleLog) => void;
   testPath: string;
   printConsoleTrace: boolean;
+  getCurrentTask: () => CurrentTaskInfo | undefined;
 }): Console {
   const getConsoleTrace = () => {
     const limit = Error.stackTraceLimit;

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -14,7 +14,8 @@ import { formatTestError, getRealTimers, setRealTimers } from '../util';
 import { createForksRpcOptions, createRuntimeRpc } from './rpc';
 import { createSilentConsoleController } from './silentConsole';
 import { RstestSnapshotEnvironment } from './snapshot';
-import { initTaskContext, setFallbackCurrentTask } from './taskContext';
+import { createNodeTaskContext } from './taskContext.node';
+import type { TaskContext } from './taskContext';
 
 let sourceMaps: Record<string, string> = {};
 
@@ -113,7 +114,7 @@ const preparePool = async ({
   });
   globalCleanups.length = 0;
 
-  await initTaskContext();
+  const taskContext = createNodeTaskContext();
   setRealTimers();
 
   const cleanupFns: (() => MaybePromise<void>)[] = [];
@@ -172,6 +173,7 @@ const preparePool = async ({
       },
       testPath,
       printConsoleTrace: !disableConsoleIntercept && printConsoleTrace,
+      getCurrentTask: () => taskContext.getCurrent(),
     });
   }
 
@@ -223,7 +225,9 @@ const preparePool = async ({
     process.off('unhandledRejection', unhandledRejection);
   });
 
-  const { api, runner } = await createRstestRuntime(workerState);
+  const { api, runner } = await createRstestRuntime(workerState, {
+    taskContext,
+  });
 
   switch (testEnvironment.name) {
     case 'node':
@@ -270,6 +274,7 @@ const preparePool = async ({
     rpc,
     silentConsoleController,
     api,
+    taskContext,
     unhandledErrors,
     cleanup: async () => {
       await Promise.all(cleanupFns.map((fn) => fn()));
@@ -447,6 +452,7 @@ export const runInPool = async (
     }
   }
 
+  let taskContext: TaskContext | undefined;
   try {
     const {
       rstestContext,
@@ -457,7 +463,9 @@ export const runInPool = async (
       cleanup,
       unhandledErrors,
       interopDefault,
+      taskContext: preparedTaskContext,
     } = await preparePool(options);
+    taskContext = preparedTaskContext;
 
     if (bail && (await rpc.getCountOfFailedTests()) >= bail) {
       return {
@@ -499,7 +507,7 @@ export const runInPool = async (
     // Keep file-level context only while evaluating top-level module code.
     // Once the runner starts, suite/case tasks should own subsequent logs so
     // passed suite buffers are not replayed by the final file-level flush.
-    setFallbackCurrentTask({
+    taskContext.setFallback({
       taskId: getFileTaskId(testPath),
       taskType: 'file',
       testPath,
@@ -518,7 +526,7 @@ export const runInPool = async (
         outputModule: options.context.outputModule,
       });
     } finally {
-      setFallbackCurrentTask(undefined);
+      taskContext.setFallback(undefined);
     }
 
     const results = await runner.runTests(
@@ -603,7 +611,7 @@ export const runInPool = async (
       errors: await formatTestError(err),
     };
   } finally {
-    setFallbackCurrentTask(undefined);
+    taskContext?.setFallback(undefined);
     await teardown();
   }
 };

--- a/packages/core/src/runtime/worker/taskContext.browser.ts
+++ b/packages/core/src/runtime/worker/taskContext.browser.ts
@@ -1,0 +1,24 @@
+import type { CurrentTaskInfo } from '../../types';
+import type { TaskContext } from './taskContext';
+
+// Browser fallback: single slot. Browsers lack AsyncLocalStorage, so concurrent
+// tasks may mis-attribute — callers must layer a hook-driven mechanism for that.
+export const createBrowserTaskContext = (): TaskContext => {
+  let fallback: CurrentTaskInfo | undefined;
+
+  return {
+    getCurrent: () => fallback,
+    run: async (task, fn) => {
+      const previous = fallback;
+      fallback = task;
+      try {
+        return await fn();
+      } finally {
+        fallback = previous;
+      }
+    },
+    setFallback: (task) => {
+      fallback = task;
+    },
+  };
+};

--- a/packages/core/src/runtime/worker/taskContext.node.ts
+++ b/packages/core/src/runtime/worker/taskContext.node.ts
@@ -1,0 +1,16 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { CurrentTaskInfo } from '../../types';
+import type { TaskContext } from './taskContext';
+
+export const createNodeTaskContext = (): TaskContext => {
+  const storage = new AsyncLocalStorage<CurrentTaskInfo>();
+  let fallback: CurrentTaskInfo | undefined;
+
+  return {
+    getCurrent: () => storage.getStore() ?? fallback,
+    run: (task, fn) => storage.run(task, fn),
+    setFallback: (task) => {
+      fallback = task;
+    },
+  };
+};

--- a/packages/core/src/runtime/worker/taskContext.ts
+++ b/packages/core/src/runtime/worker/taskContext.ts
@@ -1,60 +1,8 @@
 import type { CurrentTaskInfo } from '../../types';
 
-type TaskStorage = {
-  getStore(): CurrentTaskInfo | undefined;
-  run<T>(task: CurrentTaskInfo, fn: () => Promise<T> | T): Promise<T> | T;
-};
-
-type AsyncHooksModule = {
-  AsyncLocalStorage?: new () => TaskStorage;
-};
-
-let taskStorage: TaskStorage | undefined;
-let fallbackTask: CurrentTaskInfo | undefined;
-let taskStorageReady = false;
-
-export const initTaskContext = async (): Promise<void> => {
-  if (taskStorageReady) {
-    return;
-  }
-
-  taskStorageReady = true;
-
-  try {
-    const asyncHooksSpecifier = 'node:async_hooks';
-    const { AsyncLocalStorage } = (await import(
-      /* webpackIgnore: true */ asyncHooksSpecifier
-    )) as AsyncHooksModule;
-    taskStorage = AsyncLocalStorage ? new AsyncLocalStorage() : undefined;
-  } catch {
-    taskStorage = undefined;
-  }
-};
-
-export const getCurrentTask = (): CurrentTaskInfo | undefined => {
-  return taskStorage?.getStore() ?? fallbackTask;
-};
-
-export const runWithCurrentTask = async <T>(
-  task: CurrentTaskInfo,
-  fn: () => Promise<T> | T,
-): Promise<T> => {
-  const previousFallbackTask = fallbackTask;
-  fallbackTask = task;
-
-  try {
-    if (taskStorage) {
-      return await taskStorage.run(task, fn);
-    }
-
-    return await fn();
-  } finally {
-    fallbackTask = previousFallbackTask;
-  }
-};
-
-export const setFallbackCurrentTask = (
-  task: CurrentTaskInfo | undefined,
-): void => {
-  fallbackTask = task;
-};
+/** Per-platform task attribution primitive used by the shared runner. */
+export interface TaskContext {
+  getCurrent(): CurrentTaskInfo | undefined;
+  run<T>(task: CurrentTaskInfo, fn: () => T | Promise<T>): T | Promise<T>;
+  setFallback(task: CurrentTaskInfo | undefined): void;
+}


### PR DESCRIPTION
## Summary

### Background

CI refined at https://github.com/web-infra-dev/rstest/pull/1242.

`@rstest/core/browser-runtime` re-exported a shared `taskContext` module that used `await import(asyncHooksSpecifier)` with a `/* webpackIgnore: true */` magic comment to lazy-load `node:async_hooks`. The variable specifier defeats Rspack's static analysis (the magic comment only applies to literal arguments), so `node:async_hooks` ended up in the browser bundle and any downstream consumer rebundling that chunk hits `Critical dependency: the request of a dependency is an expression`.

<img width="810" height="417" alt="image" src="https://github.com/user-attachments/assets/fd168899-2a79-4415-b2f8-9ca3b1e18eea" />

### Implementation

- Split `taskContext.ts` into a type-only contract (`TaskContext`) plus per-platform implementations: `taskContext.node.ts` with static `import { AsyncLocalStorage } from 'node:async_hooks'` and `taskContext.browser.ts` with a closure-only fallback.
- Inject the impl via `createRstestRuntime(workerState, { taskContext })` so `runner.ts` and `console.ts` no longer import any platform-specific module.
- Construct the Node impl once in `runInPool.ts`; construct the Browser impl per test file in `@rstest/browser/client/entry.ts`.

### User Impact

Removes the `Critical dependency` warning when `@rstest/core/browser-runtime` is bundled by a downstream consumer (reproducible via `examples/browser-react`).

```
@rstest/browser/client/entry.ts          packages/core/.../runInPool.ts
        │                                          │
        ▼                                          ▼
createBrowserTaskContext()              createNodeTaskContext()
        │                                          │
        └──────────── { taskContext } ─────────────┘
                              │
                              ▼
              createRstestRuntime(workerState, { taskContext })
                              │
                              ▼
                       TestRunner / console
                   (no platform-specific import)
```

## Test plan

- [x] `pnpm run lint` — pass
- [x] `pnpm run typecheck` — pass
- [x] `pnpm run build` — pass
- [x] `pnpm run test` — 370/370 pass
- [x] `examples/browser-react` `pnpm test` — 6/6 pass, zero `Critical dependency` warnings (previously emitted 3 times per run)
- [x] silent reporter e2e — 6/6 pass (incl. concurrent attribution)
- [x] browser-mode console e2e — 5/5 pass (incl. `silent=passed-only` + `disableConsoleIntercept` combinations)
- [x] Full e2e — 605/607 pass; 2 pre-existing flakes (`build/index.test.ts > should write output to customized distPath.root` and `browser-mode/snapshot.test.ts > should create snapshot files on first run`) that pass in isolation and are unrelated to this change