### PR TITLE
fix(core): include coverage config in build cache digest

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -276,6 +276,8 @@ export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {
       tsconfigPaths: merged.source?.tsconfigPath
         ? [merged.source.tsconfigPath]
         : [],
+      coverageEnabled: merged.coverage?.enabled,
+      coverageProvider: merged.coverage?.provider,
       outputDistPathRoot: merged.output.distPath.root,
     });
   }

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -189,6 +189,8 @@ export class Rstest implements RstestContext {
               outputDistPathRoot: rstestConfig.output.distPath.root,
               environmentName,
               browserEnabled: config.browser.enabled,
+              coverageEnabled: config.coverage?.enabled,
+              coverageProvider: config.coverage?.provider,
               assumeNormalized: true,
             });
           }

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -61,6 +61,8 @@ type BuildCacheInput = {
   command?: string;
   environmentName?: string;
   browserEnabled?: boolean;
+  coverageEnabled?: boolean;
+  coverageProvider?: string;
   outputDistPathRoot?: string;
   assumeNormalized?: boolean;
 };
@@ -83,6 +85,8 @@ export const normalizeBuildCache = ({
   command,
   environmentName,
   browserEnabled,
+  coverageEnabled,
+  coverageProvider,
   outputDistPathRoot,
   assumeNormalized = false,
 }: BuildCacheInput): false | RstestBuildCacheConfig => {
@@ -111,13 +115,17 @@ export const normalizeBuildCache = ({
 
   const userCacheDigest =
     assumeNormalized && userConfig.cacheDigest?.[0] === 'rstest'
-      ? userConfig.cacheDigest.slice(5)
+      ? userConfig.cacheDigest.slice(6)
       : userConfig.cacheDigest || [];
+  const coverageDigest = coverageEnabled
+    ? `coverage:${coverageProvider}`
+    : 'no-coverage';
   const cacheDigest = [
     'rstest',
     command,
     environmentName,
     browserEnabled ? 'browser' : 'node',
+    coverageDigest,
     outputDistPathRoot,
     ...userCacheDigest,
   ];
@@ -206,6 +214,8 @@ export const resolveProjectBuildCache = ({
     command: context.command,
     environmentName: project.environmentName,
     browserEnabled: project.normalizedConfig.browser.enabled,
+    coverageEnabled: project.normalizedConfig.coverage?.enabled,
+    coverageProvider: project.normalizedConfig.coverage?.provider,
     outputDistPathRoot: context.normalizedConfig.output.distPath.root,
     assumeNormalized: true,
   });

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe';
 import { mergeRstestConfig, withDefaultConfig } from '../src/config';
 import { Rstest } from '../src/core/rstest';
 import type { RstestConfig } from '../src/types';
-import { resolveProjectBuildCache } from '../src/utils';
+import { normalizeBuildCache, resolveProjectBuildCache } from '../src/utils';
 
 // Mock std-env to ensure consistent snapshot across environments
 rs.mock('std-env', () => ({
@@ -76,6 +76,7 @@ describe('mergeRstestConfig', () => {
         undefined,
         undefined,
         'node',
+        'no-coverage',
         'dist/.rstest-temp',
       ],
       buildDependencies: [resolve(__dirname, 'tsconfig.custom.json')],
@@ -104,10 +105,70 @@ describe('mergeRstestConfig', () => {
         undefined,
         undefined,
         'node',
+        'no-coverage',
         'custom/.rstest-temp',
         'user-digest',
       ],
       buildDependencies: [resolve(__dirname, 'a.config.ts')],
+    });
+  });
+
+  it('should include coverage state and provider in buildCache digest', () => {
+    const withoutCoverage = withDefaultConfig({
+      root: __dirname,
+      performance: {
+        buildCache: true,
+      },
+    });
+    const withCoverage = withDefaultConfig({
+      root: __dirname,
+      coverage: {
+        enabled: true,
+      },
+      performance: {
+        buildCache: true,
+      },
+    });
+
+    expect(withoutCoverage.performance?.buildCache).toMatchObject({
+      cacheDigest: [
+        'rstest',
+        undefined,
+        undefined,
+        'node',
+        'no-coverage',
+        'dist/.rstest-temp',
+      ],
+    });
+    expect(withCoverage.performance?.buildCache).toMatchObject({
+      cacheDigest: [
+        'rstest',
+        undefined,
+        undefined,
+        'node',
+        'coverage:istanbul',
+        'dist/.rstest-temp',
+      ],
+    });
+
+    const withCustomProvider = normalizeBuildCache({
+      buildCache: true,
+      root: __dirname,
+      browserEnabled: false,
+      coverageEnabled: true,
+      coverageProvider: 'custom',
+      outputDistPathRoot: 'dist/.rstest-temp',
+    });
+
+    expect(withCustomProvider).toMatchObject({
+      cacheDigest: [
+        'rstest',
+        undefined,
+        undefined,
+        'node',
+        'coverage:custom',
+        'dist/.rstest-temp',
+      ],
     });
   });
 
@@ -135,6 +196,7 @@ describe('mergeRstestConfig', () => {
         undefined,
         undefined,
         'node',
+        'no-coverage',
         'dist/.rstest-temp',
       ],
       buildDependencies: ['/repo/configs/cache-flags.ts'],
@@ -249,6 +311,7 @@ describe('mergeRstestConfig', () => {
         undefined,
         'browser',
         'node',
+        'no-coverage',
         'dist/.rstest-temp',
       ],
       buildDependencies: [],
@@ -257,7 +320,14 @@ describe('mergeRstestConfig', () => {
       rstest.projects[1]?.normalizedConfig.performance?.buildCache,
     ).toEqual({
       cacheDirectory: '/repo/projects/node/node_modules/.cache/rstest-node',
-      cacheDigest: ['rstest', undefined, 'node', 'node', 'dist/.rstest-temp'],
+      cacheDigest: [
+        'rstest',
+        undefined,
+        'node',
+        'node',
+        'no-coverage',
+        'dist/.rstest-temp',
+      ],
       buildDependencies: [],
     });
     expect(

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -715,6 +715,7 @@ describe('prepareRsbuild', () => {
         'run',
         'test',
         'node',
+        'no-coverage',
         TEMP_RSTEST_OUTPUT_DIR,
         'root-digest',
       ],


### PR DESCRIPTION
## Summary

### Background

Persistent build cache entries created without coverage instrumentation could be reused for coverage runs, causing empty coverage data.

### Implementation

- Add coverage state and provider to the Rstest build cache digest.
- Preserve user-provided cache digest values when normalized project cache config is re-normalized.
- Cover disabled coverage, default Istanbul, and custom provider digest cases.

### User Impact

Coverage runs with build cache enabled no longer reuse incompatible non-coverage or different-provider bundles.

## Related Links

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).