### PR TITLE
feat(core): add memory-aware worker spawn gate

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -26,6 +26,7 @@ import {
   needFlagExperimentalDetectModule,
 } from '../utils';
 import { isMemorySufficient } from '../utils/memory';
+import { createDefaultMemoryGate } from './memoryGate';
 import { Pool } from './pool';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -371,6 +372,7 @@ export const createPool = async ({
       ...getForceColorEnv(),
       ...process.env,
     } as Record<string, string>,
+    memoryGate: createDefaultMemoryGate(),
   });
 
   const createRpcMethods = ({

--- a/packages/core/src/pool/memoryGate.ts
+++ b/packages/core/src/pool/memoryGate.ts
@@ -59,7 +59,6 @@ export class MemoryGate {
   private readonly heapDeltaSamples: number[] = [];
   private readonly freememFn: () => number;
   private readonly readMeminfoFn: () => string | null;
-  private heapBeforeDispatch: number | undefined;
   private heapTrackingEnabled = false;
   private freememCache: Cached | undefined;
   private memInfoCache: Cached | undefined;
@@ -94,19 +93,16 @@ export class MemoryGate {
     this.rssP90Cache = undefined;
   }
 
-  recordDispatch(): void {
-    if (!this.heapTrackingEnabled) return;
-    this.heapBeforeDispatch = process.memoryUsage().heapUsed;
+  /** Token returned to the caller so concurrent dispatches don't clobber each other's baselines. */
+  recordDispatch(): number | undefined {
+    if (!this.heapTrackingEnabled) return undefined;
+    return process.memoryUsage().heapUsed;
   }
 
-  recordResolve(): void {
+  recordResolve(baseline: number | undefined): void {
     if (!this.heapTrackingEnabled) return;
-    if (this.heapBeforeDispatch === undefined) return;
-    const delta = Math.max(
-      0,
-      process.memoryUsage().heapUsed - this.heapBeforeDispatch,
-    );
-    this.heapBeforeDispatch = undefined;
+    if (baseline === undefined) return;
+    const delta = Math.max(0, process.memoryUsage().heapUsed - baseline);
     this.pushSample(this.heapDeltaSamples, delta);
     this.heapDeltaP90Cache = undefined;
   }

--- a/packages/core/src/pool/memoryGate.ts
+++ b/packages/core/src/pool/memoryGate.ts
@@ -1,0 +1,247 @@
+import { readFileSync } from 'node:fs';
+import os from 'node:os';
+import v8 from 'node:v8';
+import { isDebug, logger } from '../utils/logger';
+import { isWorkerResponseEnvelope } from './protocol';
+
+// Hard-coded internal tuning. Intentionally not exposed as config or env var
+// — see plan #1160. WHY values where non-obvious:
+const RSS_QUANTILE = 0.9;
+const WINDOW_SIZE = 32;
+// ×3 leaves headroom for tail samples + system memory drift; ×2 caused
+// fast/slow lane flapping in fixture tests, ×5 downgraded too late.
+const FAST_LANE_FACTOR = 3;
+// 1.5× empirical margin for GC nondeterminism in the host heap.
+const HEAP_SAFETY_FACTOR = 1.5;
+// Slow-lane cache is tighter (250 ms) than fast-lane (1 s) because slow-lane
+// decisions are clustered and 1 s drift would block re-spawns too long.
+const FREEMEM_CACHE_MS = 1000;
+const MEMINFO_CACHE_MS = 250;
+const POLL_INTERVAL_MS = 500;
+// 0 = engage the gate the instant the first sample lands. Higher values
+// trade cold-start defense for sample-stability — kept at 0 by design.
+const WARMUP_SAMPLES = 0;
+
+type Cached = { value: number; expiresAt: number };
+
+/**
+ * Structural subset of PoolWorker — kept narrow so MemoryGate doesn't need
+ * to import the PoolWorker type, which keeps unit tests simple.
+ */
+export interface MemoryReportSource {
+  on(event: 'message', listener: (msg: unknown) => void): void;
+}
+
+const p90 = (samples: number[]): number => {
+  if (samples.length === 0) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.floor(RSS_QUANTILE * sorted.length),
+  );
+  return sorted[idx]!;
+};
+
+/** @internal — test seam for deterministic freemem/meminfo reads. */
+export type MemoryGateDeps = {
+  freemem?: () => number;
+  readMeminfo?: () => string | null;
+};
+
+/**
+ * Memory-aware spawn gate. `recordDispatch`/`recordResolve` stay no-ops
+ * until the slow lane first triggers, so the dispatch hot path is one
+ * boolean read when memory is plentiful. Owns its own poll timer so the
+ * Pool only sees a single `attachPoll(wake)` / `dispose()` surface.
+ */
+export class MemoryGate {
+  private readonly rssSamples: number[] = [];
+  private readonly heapDeltaSamples: number[] = [];
+  private readonly freememFn: () => number;
+  private readonly readMeminfoFn: () => string | null;
+  private heapBeforeDispatch: number | undefined;
+  private heapTrackingEnabled = false;
+  private freememCache: Cached | undefined;
+  private memInfoCache: Cached | undefined;
+  /**
+   * Cached p90 values for the two sample windows. Invalidated to `undefined`
+   * on every `pushSample`. `canSpawnNewWorker` can fire dozens of times per
+   * worker turnover while the sample set doesn't move, so this avoids
+   * re-sorting a 32-element array per call.
+   */
+  private rssP90Cache: number | undefined;
+  private heapDeltaP90Cache: number | undefined;
+  private heapHeadroomCache: Cached | undefined;
+  private pollTimer: NodeJS.Timeout | undefined;
+
+  constructor(deps: MemoryGateDeps = {}) {
+    this.freememFn = deps.freemem ?? os.freemem;
+    this.readMeminfoFn =
+      deps.readMeminfo ??
+      (() => {
+        try {
+          return readFileSync('/proc/meminfo', 'utf-8');
+        } catch {
+          // /proc/meminfo missing (containers, exotic kernels) — fall back.
+          return null;
+        }
+      });
+  }
+
+  recordWorkerRss(rss: number): void {
+    if (rss <= 0) return;
+    this.pushSample(this.rssSamples, rss);
+    this.rssP90Cache = undefined;
+  }
+
+  recordDispatch(): void {
+    if (!this.heapTrackingEnabled) return;
+    this.heapBeforeDispatch = process.memoryUsage().heapUsed;
+  }
+
+  recordResolve(): void {
+    if (!this.heapTrackingEnabled) return;
+    if (this.heapBeforeDispatch === undefined) return;
+    const delta = Math.max(
+      0,
+      process.memoryUsage().heapUsed - this.heapBeforeDispatch,
+    );
+    this.heapBeforeDispatch = undefined;
+    this.pushSample(this.heapDeltaSamples, delta);
+    this.heapDeltaP90Cache = undefined;
+  }
+
+  canSpawnNewWorker(activeCount: number): boolean {
+    // Deadlock guard: at least one worker must always be allowed.
+    if (activeCount === 0) return true;
+
+    // Cold-start bypass: don't defend until the first sample lands.
+    if (this.rssSamples.length <= WARMUP_SAMPLES) return true;
+
+    const estRss = (this.rssP90Cache ??= p90(this.rssSamples));
+
+    // Fast lane uses os.freemem() (= MemFree on Linux). It excludes
+    // reclaimable page cache, so it errs pessimistic — at worst we drop
+    // into the slow lane earlier than strictly necessary; never a wrong
+    // fast-pass.
+    const freemem = this.cachedFreemem();
+    if (freemem >= estRss * FAST_LANE_FACTOR) return true;
+
+    // Slow lane enables lazy heap tracking — see recordDispatch/recordResolve.
+    this.heapTrackingEnabled = true;
+
+    const available = this.accurateAvailableMemory();
+    if (available < estRss) {
+      this.logDeferred('system memory', { estRss, available });
+      return false;
+    }
+
+    if (this.heapDeltaSamples.length > 0) {
+      const heapHeadroom = this.cachedHeapHeadroom();
+      const estHeapDelta = (this.heapDeltaP90Cache ??= p90(
+        this.heapDeltaSamples,
+      ));
+      if (heapHeadroom < estHeapDelta * HEAP_SAFETY_FACTOR) {
+        this.logDeferred('main heap', { heapHeadroom, estHeapDelta });
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /** Subscribes off-band so PoolRunner stays free of gate-specific plumbing. */
+  attachWorker(source: MemoryReportSource): void {
+    source.on('message', (msg) => {
+      if (!isWorkerResponseEnvelope(msg)) return;
+      const r = msg.response;
+      if (r.type !== 'runFinished' && r.type !== 'collectFinished') return;
+      if (r.memory) this.recordWorkerRss(r.memory.rss);
+    });
+  }
+
+  /**
+   * Idempotent. `wake` returns `false` to stop the loop (queue drained /
+   * pool closing). `.unref()` so the timer never holds the process open.
+   */
+  attachPoll(wake: () => boolean): void {
+    if (this.pollTimer) return;
+    this.pollTimer = setInterval(() => {
+      if (!wake()) this.dispose();
+    }, POLL_INTERVAL_MS);
+    this.pollTimer.unref();
+  }
+
+  dispose(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = undefined;
+    }
+  }
+
+  private pushSample(arr: number[], value: number): void {
+    arr.push(value);
+    if (arr.length > WINDOW_SIZE) arr.shift();
+  }
+
+  private cachedFreemem(): number {
+    const now = Date.now();
+    if (this.freememCache && this.freememCache.expiresAt > now) {
+      return this.freememCache.value;
+    }
+    const value = this.freememFn();
+    this.freememCache = { value, expiresAt: now + FREEMEM_CACHE_MS };
+    return value;
+  }
+
+  /**
+   * `v8.getHeapStatistics()` allocates a fresh object each call. The poll
+   * loop can re-enter the slow lane every 500 ms, so cap re-reads at the
+   * meminfo TTL (same clustering rationale).
+   */
+  private cachedHeapHeadroom(): number {
+    const now = Date.now();
+    if (this.heapHeadroomCache && this.heapHeadroomCache.expiresAt > now) {
+      return this.heapHeadroomCache.value;
+    }
+    const stats = v8.getHeapStatistics();
+    const value = stats.heap_size_limit - stats.used_heap_size;
+    this.heapHeadroomCache = { value, expiresAt: now + MEMINFO_CACHE_MS };
+    return value;
+  }
+
+  /**
+   * On Linux, `MemAvailable` from /proc/meminfo accounts for reclaimable
+   * page cache, which `os.freemem()` (= MemFree) does not. Slow lane only.
+   */
+  private accurateAvailableMemory(): number {
+    const now = Date.now();
+    if (this.memInfoCache && this.memInfoCache.expiresAt > now) {
+      return this.memInfoCache.value;
+    }
+    let value = this.freememFn();
+    const meminfo = this.readMeminfoFn();
+    if (meminfo) {
+      const match = meminfo.match(/^MemAvailable:\s+(\d+)\s+kB/m);
+      if (match) value = Number(match[1]) * 1024;
+    }
+    this.memInfoCache = { value, expiresAt: now + MEMINFO_CACHE_MS };
+    return value;
+  }
+
+  private logDeferred(reason: string, details: Record<string, number>): void {
+    if (!isDebug()) return;
+    const parts = Object.entries(details).map(
+      ([k, v]) => `${k}=${(v / 1024 / 1024).toFixed(0)}MB`,
+    );
+    logger.debug(
+      `[pool] deferred worker spawn (${reason}): ${parts.join(', ')}`,
+    );
+  }
+}
+
+/** Honors `RSTEST_MEMORY_AWARE=0` (emergency kill switch). */
+export const createDefaultMemoryGate = (): MemoryGate | undefined => {
+  if (process.env.RSTEST_MEMORY_AWARE === '0') return undefined;
+  return new MemoryGate();
+};

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -50,14 +50,14 @@ export class Pool {
     }
 
     const runner = await this.acquireRunner(task);
-    this.options.memoryGate?.recordDispatch();
+    const heapBaseline = this.options.memoryGate?.recordDispatch();
     try {
       if (op === 'run') {
         return await runner.runTest(task);
       }
       return await runner.collectTests(task);
     } finally {
-      this.options.memoryGate?.recordResolve();
+      this.options.memoryGate?.recordResolve(heapBaseline);
       this.releaseRunner(runner);
     }
   }

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -50,12 +50,14 @@ export class Pool {
     }
 
     const runner = await this.acquireRunner(task);
+    this.options.memoryGate?.recordDispatch();
     try {
       if (op === 'run') {
         return await runner.runTest(task);
       }
       return await runner.collectTests(task);
     } finally {
+      this.options.memoryGate?.recordResolve();
       this.releaseRunner(runner);
     }
   }
@@ -76,11 +78,20 @@ export class Pool {
         continue;
       }
 
-      const inFlight =
-        this.activeRunners.size +
-        this.idleRunners.length +
-        this.stoppingRunners.size;
+      const inFlight = this.inFlightCount;
       if (inFlight >= this.options.maxWorkers) {
+        await new Promise<void>((resolve) => {
+          this.slotWaiters.push(resolve);
+        });
+        if (this.isClosing || this.isClosed) {
+          throw new Error('[rstest-pool]: pool is closed');
+        }
+        continue;
+      }
+
+      const gate = this.options.memoryGate;
+      if (gate && !gate.canSpawnNewWorker(inFlight)) {
+        gate.attachPoll(this.tryWakeGateWaiter);
         await new Promise<void>((resolve) => {
           this.slotWaiters.push(resolve);
         });
@@ -94,6 +105,7 @@ export class Pool {
       // activeRunners up-front; on start failure we drop it and wake a waiter.
       const workerId = ++nextWorkerId;
       const worker = createPoolWorker(task, this.options, workerId);
+      gate?.attachWorker(worker);
       const runner = new PoolRunner(worker, { workerId });
       this.activeRunners.add(runner);
       try {
@@ -108,6 +120,29 @@ export class Pool {
       return runner;
     }
   }
+
+  private get inFlightCount(): number {
+    return (
+      this.activeRunners.size +
+      this.idleRunners.length +
+      this.stoppingRunners.size
+    );
+  }
+
+  /**
+   * Returned to MemoryGate's wake-loop. Returning `false` tells the gate
+   * to stop polling. Only shifts a waiter when the gate would actually let
+   * one through — preserves FIFO and avoids park/re-park churn.
+   */
+  private readonly tryWakeGateWaiter = (): boolean => {
+    if (this.slotWaiters.length === 0 || this.isClosing || this.isClosed) {
+      return false;
+    }
+    if (this.options.memoryGate?.canSpawnNewWorker(this.inFlightCount)) {
+      this.slotWaiters.shift()?.();
+    }
+    return true;
+  };
 
   private releaseRunner(runner: PoolRunner): void {
     this.activeRunners.delete(runner);
@@ -180,6 +215,7 @@ export class Pool {
   async close(): Promise<void> {
     if (this.isClosed) return;
     this.isClosing = true;
+    this.options.memoryGate?.dispose();
     // Wake waiters so any caller blocked on capacity throws on `isClosing`
     // before we await the stop promises below.
     while (this.slotWaiters.length > 0) {

--- a/packages/core/src/pool/protocol.ts
+++ b/packages/core/src/pool/protocol.ts
@@ -30,17 +30,24 @@ export type CollectTaskResult = {
   errors?: FormattedError[];
 };
 
+export type WorkerMemoryReport = {
+  /** Resident set size (bytes) sampled just before the worker sent the response. */
+  rss: number;
+};
+
 export type WorkerResponse =
   | { type: 'started'; pid: number }
   | {
       type: 'runFinished';
       taskId: number;
       result: TestFileResult;
+      memory?: WorkerMemoryReport;
     }
   | {
       type: 'collectFinished';
       taskId: number;
       result: CollectTaskResult;
+      memory?: WorkerMemoryReport;
     }
   | { type: 'stopped' }
   | {

--- a/packages/core/src/pool/types.ts
+++ b/packages/core/src/pool/types.ts
@@ -1,4 +1,5 @@
 import type { RuntimeRPC, RunWorkerOptions } from '../types';
+import type { MemoryGate } from './memoryGate';
 
 export type PoolWorkerKind = 'forks';
 
@@ -23,4 +24,10 @@ export type PoolOptions = {
    * stderr so the simulated noise doesn't leak into the host log.
    */
   forwardStdio?: boolean;
+  /**
+   * Memory-aware spawn gate. Omit or pass `undefined` to disable (used by
+   * unit tests that need deterministic spawn timing). `createPool` injects
+   * a fresh `MemoryGate` by default.
+   */
+  memoryGate?: MemoryGate;
 };

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -80,6 +80,10 @@ const RESPONSE_TYPE: Record<TaskKind, 'runFinished' | 'collectFinished'> = {
   collect: 'collectFinished',
 };
 
+// Read once at worker bootstrap — toggling `RSTEST_MEMORY_AWARE` mid-run is
+// not supported (host samples it at pool construction too).
+const MEMORY_REPORTING_ENABLED = process.env.RSTEST_MEMORY_AWARE !== '0';
+
 const runTask = async (
   kind: TaskKind,
   request: Extract<WorkerRequest, { type: 'run' | 'collect' }>,
@@ -92,6 +96,9 @@ const runTask = async (
       type: RESPONSE_TYPE[kind],
       taskId: request.taskId,
       result: result as any,
+      memory: MEMORY_REPORTING_ENABLED
+        ? { rss: process.memoryUsage().rss }
+        : undefined,
     });
   } catch (err) {
     // runInPool's own uncaughtException handler funnels per-test errors into

--- a/packages/core/tests/pool/memoryGate.test.ts
+++ b/packages/core/tests/pool/memoryGate.test.ts
@@ -1,3 +1,4 @@
+import v8 from 'node:v8';
 import { MemoryGate, createDefaultMemoryGate } from '../../src/pool/memoryGate';
 
 const MB = 1024 * 1024;
@@ -78,8 +79,9 @@ describe('MemoryGate - heap tracking lazily activates', () => {
 
     // Spy heapUsed reads: a no-op recordDispatch must not call memoryUsage.
     const memSpy = rs.spyOn(process, 'memoryUsage');
-    gate.recordDispatch();
-    gate.recordResolve();
+    const baseline = gate.recordDispatch();
+    gate.recordResolve(baseline);
+    expect(baseline).toBeUndefined();
     expect(memSpy).not.toHaveBeenCalled();
   });
 
@@ -106,9 +108,52 @@ describe('MemoryGate - heap tracking lazily activates', () => {
         arrayBuffers: 0,
       } as NodeJS.MemoryUsage);
 
-    gate.recordDispatch();
-    gate.recordResolve();
+    const baseline = gate.recordDispatch();
+    gate.recordResolve(baseline);
     expect(memSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should keep concurrent dispatch baselines independent', () => {
+    const gate = new MemoryGate({
+      freemem: () => 100 * MB,
+      // 1 GB MemAvailable: passes the slow-lane `available < estRss` guard so
+      // execution reaches the heap-headroom branch.
+      readMeminfo: () => 'MemTotal: 4096000 kB\nMemAvailable: 1024000 kB\n',
+    });
+    for (const v of [200, 200, 200]) gate.recordWorkerRss(v * MB);
+    // Flips heapTrackingEnabled. heapDeltaSamples still empty → returns true.
+    expect(gate.canSpawnNewWorker(4)).toBe(true);
+
+    const heapReadings = [100, 120, 180, 200];
+    let idx = 0;
+    rs.spyOn(process, 'memoryUsage').mockImplementation(
+      () =>
+        ({
+          rss: 0,
+          heapTotal: 0,
+          heapUsed: heapReadings[idx++]! * MB,
+          external: 0,
+          arrayBuffers: 0,
+        }) as NodeJS.MemoryUsage,
+    );
+
+    const baselineA = gate.recordDispatch();
+    const baselineB = gate.recordDispatch();
+    // Resolve order is reversed: under the prior shared-field bug, B's resolve
+    // would land its 60 MB delta, then A's resolve would see a cleared field
+    // and skip — only one sample would land. Per-dispatch tokens force both.
+    gate.recordResolve(baselineB);
+    gate.recordResolve(baselineA);
+
+    // Tighten heap headroom to 120 MB. With both samples [60, 100], p90 = 100
+    // → threshold 150 MB > 120 → return false. If only one sample landed
+    // (the old bug), p90 = 60 → threshold 90 MB ≤ 120 → would return true.
+    rs.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+      heap_size_limit: 1000 * MB,
+      used_heap_size: 880 * MB,
+    } as v8.HeapInfo);
+
+    expect(gate.canSpawnNewWorker(4)).toBe(false);
   });
 });
 

--- a/packages/core/tests/pool/memoryGate.test.ts
+++ b/packages/core/tests/pool/memoryGate.test.ts
@@ -1,0 +1,147 @@
+import { MemoryGate, createDefaultMemoryGate } from '../../src/pool/memoryGate';
+
+const MB = 1024 * 1024;
+
+/**
+ * Build a MemoryGate with deterministic deps. By default reports an
+ * impossibly-tight 1 MB of free memory so the only way `canSpawnNewWorker`
+ * passes is via the deadlock or cold-start bypasses.
+ */
+const makeGate = (
+  opts: {
+    freemem?: number;
+    /** Bytes reported as MemAvailable; falsy → no /proc/meminfo. */
+    memAvailable?: number;
+  } = {},
+) => {
+  return new MemoryGate({
+    freemem: () => opts.freemem ?? 1 * MB,
+    readMeminfo: () =>
+      opts.memAvailable
+        ? `MemTotal: ${(opts.memAvailable * 4) / 1024} kB\nMemAvailable: ${opts.memAvailable / 1024} kB\n`
+        : null,
+  });
+};
+
+describe('MemoryGate - cold-start & deadlock guards', () => {
+  it('should always allow the first worker (activeCount === 0)', () => {
+    const gate = makeGate({ freemem: 1 * MB }); // pathologically tight
+    expect(gate.canSpawnNewWorker(0)).toBe(true);
+  });
+
+  it('should bypass entirely until the first RSS sample arrives', () => {
+    const gate = makeGate({ freemem: 1 * MB });
+    expect(gate.canSpawnNewWorker(4)).toBe(true);
+  });
+
+  it('should engage the gate once a sample has been recorded', () => {
+    const gate = makeGate({ freemem: 100 * MB, memAvailable: 100 * MB });
+    gate.recordWorkerRss(500 * MB);
+    // 100 MB free < 500 MB P90 → fast lane fails → slow lane 100 MB < 500 MB → false.
+    expect(gate.canSpawnNewWorker(4)).toBe(false);
+  });
+});
+
+describe('MemoryGate - fast lane short-circuit', () => {
+  it('should fast-pass when freemem ≥ P90(rss) × 3', () => {
+    // P90 ≈ 500 MB → threshold 1.5 GB. 2 GB free clearly above.
+    const memSpy = rs.fn(() => 2048 * MB);
+    const meminfoSpy = rs.fn(() => null);
+    const gate = new MemoryGate({ freemem: memSpy, readMeminfo: meminfoSpy });
+    for (const v of [400, 450, 500, 500, 500]) gate.recordWorkerRss(v * MB);
+
+    expect(gate.canSpawnNewWorker(4)).toBe(true);
+    // Fast lane proven: meminfo (only read in slow lane) was never touched.
+    expect(meminfoSpy).not.toHaveBeenCalled();
+  });
+
+  it('should engage slow lane only when fast lane fails', () => {
+    const meminfoSpy = rs.fn(
+      () => 'MemTotal: 2048000 kB\nMemAvailable: 500000 kB\n',
+    );
+    const gate = new MemoryGate({
+      freemem: () => 500 * MB,
+      readMeminfo: meminfoSpy,
+    });
+    for (const v of [600, 700, 800, 800, 800]) gate.recordWorkerRss(v * MB);
+    // P90 ≈ 800 MB → fast lane threshold 2.4 GB. 500 MB free trips slow lane.
+    expect(gate.canSpawnNewWorker(4)).toBe(false);
+    expect(meminfoSpy).toHaveBeenCalled();
+  });
+});
+
+describe('MemoryGate - heap tracking lazily activates', () => {
+  it('should keep recordDispatch as a no-op until slow lane triggers', () => {
+    const gate = makeGate();
+    // Bypass branch is taken (no samples) — heapTrackingEnabled stays false.
+    expect(gate.canSpawnNewWorker(0)).toBe(true);
+
+    // Spy heapUsed reads: a no-op recordDispatch must not call memoryUsage.
+    const memSpy = rs.spyOn(process, 'memoryUsage');
+    gate.recordDispatch();
+    gate.recordResolve();
+    expect(memSpy).not.toHaveBeenCalled();
+  });
+
+  it('should start sampling heap delta once slow lane fires', () => {
+    const gate = makeGate({ freemem: 100 * MB, memAvailable: 100 * MB });
+    for (const v of [600, 700, 800]) gate.recordWorkerRss(v * MB);
+    // First slow-lane invocation flips `heapTrackingEnabled`.
+    gate.canSpawnNewWorker(4);
+
+    const memSpy = rs
+      .spyOn(process, 'memoryUsage')
+      .mockReturnValueOnce({
+        rss: 0,
+        heapTotal: 0,
+        heapUsed: 100 * MB,
+        external: 0,
+        arrayBuffers: 0,
+      } as NodeJS.MemoryUsage)
+      .mockReturnValueOnce({
+        rss: 0,
+        heapTotal: 0,
+        heapUsed: 150 * MB,
+        external: 0,
+        arrayBuffers: 0,
+      } as NodeJS.MemoryUsage);
+
+    gate.recordDispatch();
+    gate.recordResolve();
+    expect(memSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('MemoryGate - RSS sample sanity', () => {
+  it('should ignore zero or negative RSS reports', () => {
+    const gate = makeGate({ freemem: 1 });
+    gate.recordWorkerRss(0);
+    gate.recordWorkerRss(-100);
+    // Treated as no samples → cold-start bypass still in effect.
+    expect(gate.canSpawnNewWorker(4)).toBe(true);
+  });
+});
+
+describe('createDefaultMemoryGate', () => {
+  it('should return undefined when RSTEST_MEMORY_AWARE=0', () => {
+    const prev = process.env.RSTEST_MEMORY_AWARE;
+    try {
+      process.env.RSTEST_MEMORY_AWARE = '0';
+      expect(createDefaultMemoryGate()).toBeUndefined();
+    } finally {
+      if (prev === undefined) delete process.env.RSTEST_MEMORY_AWARE;
+      else process.env.RSTEST_MEMORY_AWARE = prev;
+    }
+  });
+
+  it('should return a MemoryGate instance otherwise', () => {
+    const prev = process.env.RSTEST_MEMORY_AWARE;
+    try {
+      delete process.env.RSTEST_MEMORY_AWARE;
+      const gate = createDefaultMemoryGate();
+      expect(gate).toBeInstanceOf(MemoryGate);
+    } finally {
+      if (prev !== undefined) process.env.RSTEST_MEMORY_AWARE = prev;
+    }
+  });
+});

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'pathe';
+import { MemoryGate } from '../../src/pool/memoryGate';
 import { Pool } from '../../src/pool/pool';
 import type { PoolOptions, PoolTask } from '../../src/pool/types';
 
@@ -14,6 +15,9 @@ const createPoolOptions = (overrides?: Partial<PoolOptions>): PoolOptions => ({
   // truncation. Suppress host forwarding so this simulated noise doesn't
   // leak into the parent rstest log on CI.
   forwardStdio: false,
+  // Leave `memoryGate` unset so existing assertions around spawn
+  // timing/order stay deterministic — the integration case below opts in
+  // with its own fake.
   ...overrides,
 });
 
@@ -187,6 +191,43 @@ describe('Pool - isolate', () => {
       // runner, this would hang or throw an IPC error.
       const result = await pool.runTest(createTask());
       expect(result.status).toBe('pass');
+    } finally {
+      await pool.close();
+    }
+  });
+});
+
+// ── memory gate integration ────────────────────────────────────────────────
+
+describe('Pool - memory gate', () => {
+  it('should park spawns when the gate blocks and resume when it unblocks', async () => {
+    let allowSpawn = false;
+    const gate = new MemoryGate();
+    // Fake: first worker always allowed (deadlock guard); subsequent
+    // fresh spawns only when `allowSpawn` flips true.
+    const spy = rs
+      .spyOn(gate, 'canSpawnNewWorker')
+      .mockImplementation((active: number) =>
+        active === 0 ? true : allowSpawn,
+      );
+
+    const pool = new Pool(
+      createPoolOptions({ maxWorkers: 4, isolate: true, memoryGate: gate }),
+    );
+
+    try {
+      const r1 = pool.runTest(createTask());
+      const r2 = pool.runTest(createTask());
+
+      // Wait until the gate has rejected at least once (proves r2 parked).
+      while (!spy.mock.calls.some(([n]) => (n as number) > 0)) {
+        await new Promise((r) => setImmediate(r));
+      }
+      allowSpawn = true;
+
+      const [res1, res2] = await Promise.all([r1, r2]);
+      expect(res1.status).toBe('pass');
+      expect(res2.status).toBe('pass');
     } finally {
       await pool.close();
     }


### PR DESCRIPTION
### Background

`@rstest/core`'s worker pool scaled purely by CPU count, so low-RAM hosts (CI containers, smaller dev machines) could OOM the device when worker RSS piled up, or trip a V8 heap-limit crash in the host when many in-flight IPC payloads landed at once. Closes #1160.

### Implementation

- New `MemoryGate` consulted in `Pool.acquireRunner` before each fresh spawn; defers when system memory or main-process heap headroom can't safely host another worker.
- Hot path stays free: cached `os.freemem()` fast lane (`>= P90(rss) × 3`) short-circuits; heap-delta tracking is lazily enabled only after the slow lane first fires.
- Cold-start window is intentionally undefended — first workers spawn at full speed, their RSS reports back-feed the gate. Emergency kill switch via `RSTEST_MEMORY_AWARE=0`.
- Gate owns its own poll timer + worker-message subscription so `PoolRunner` is untouched.

```
acquireRunner ─► maxWorkers cap ─► MemoryGate.canSpawnNewWorker ─► spawn
                                          │
                                          ├─ deadlock guard (activeCount == 0)
                                          ├─ cold-start bypass (no samples)
                                          ├─ fast lane: freemem ≥ P90(rss) × 3
                                          └─ slow lane:
                                                ├─ MemAvailable ≥ P90(rss)
                                                └─ heap_headroom ≥ P90(heapΔ) × 1.5
```

### User Impact

Tests now defer worker spawns under memory pressure instead of OOM-ing. No public API or default-behavior changes when memory is plentiful.

## Related Links

Closes #1160