### PR TITLE
test(e2e): isolate build/ rstest spawns to per-fixture cwd

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -79,15 +79,15 @@ Important:
 - Keep fixtures minimal and representative of the behavior under test
 - Don't create near-duplicate fixtures just to add one extra test case
 
-## E2E rstest spawns that write to disk
+## E2E rstest spawns with persistent `dist/.rstest-temp/`
 
-A spawned rstest run only writes `<cwd>/dist/.rstest-temp/` when something forces it — `performance.buildCache`, `dev.writeToDisk: true`, `DEBUG=rstest`, coverage. Sibling test files run in parallel under the worker pool, so two such writers under the same `cwd` race on that path. Pure in-memory runs (just stdout/exit checks) don't race — sharing `cwd: __dirname` is fine and is how most e2e tests are written.
+A fixture that enables `performance.buildCache` (or `dev.writeToDisk: true`) forces rstest to persist the built bundle under `<cwd>/dist/.rstest-temp/`. If sibling test files share that `cwd`, those persistent writes race against any test asserting on the default path. Other disk writers like coverage or blob reporters land in `<cwd>/coverage/` or `<cwd>/.rstest-reports/` — different surfaces, not covered by this rule.
 
-When your test or its fixture config writes to disk:
+When your fixture enables persistent build output:
 
-- Set `cwd` to the fixture subdirectory (`join(__dirname, 'fixtures', <name>)`), not `__dirname`.
+- Set `cwd` to the fixture subdirectory, not the parent test directory.
 - In that fixture's config, drop any `include` referencing paths outside the fixture (e.g. `'./fixtures/<name>/index.test.ts'`). Fixture-local globs like `'./*.test.ts'` are fine.
-- Read `dist/.rstest-temp/...` assertions from that isolated fixture dir, not from a shared parent.
+- Read `dist/.rstest-temp/` assertions from that isolated fixture dir, not from a shared parent.
 
 ## Snapshot policy
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -79,6 +79,15 @@ Important:
 - Keep fixtures minimal and representative of the behavior under test
 - Don't create near-duplicate fixtures just to add one extra test case
 
+## Spawning rstest via `runRstestCli` in e2e tests
+
+Sibling test files run in parallel under the worker pool. The moment any of them triggers disk writes — `performance.buildCache`, `dev.writeToDisk: true`, `DEBUG=rstest`, coverage — they race on the shared default output path `<cwd>/dist/.rstest-temp/`. Plain in-memory runs don't race today, but a future config flip can turn any fixture into a writer.
+
+- **Set `cwd` to a dedicated fixture subdirectory**, not `__dirname` of the test file.
+- **Never share `cwd: __dirname`** across test files in the same directory.
+- **Drop `include` patterns that reference paths outside the fixture directory** (e.g. `'./fixtures/<name>/index.test.ts'`). Fixture-local globs like `'./*.test.ts'` are fine.
+- **Keep `dist/.rstest-temp/...` assertions inside an isolated fixture directory**, never a shared one.
+
 ## Snapshot policy
 
 - Only update snapshots when the behavioral change is **intentional**

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -79,14 +79,15 @@ Important:
 - Keep fixtures minimal and representative of the behavior under test
 - Don't create near-duplicate fixtures just to add one extra test case
 
-## Spawning rstest via `runRstestCli` in e2e tests
+## E2E rstest spawns that write to disk
 
-Sibling test files run in parallel under the worker pool. The moment any of them triggers disk writes — `performance.buildCache`, `dev.writeToDisk: true`, `DEBUG=rstest`, coverage — they race on the shared default output path `<cwd>/dist/.rstest-temp/`. Plain in-memory runs don't race today, but a future config flip can turn any fixture into a writer.
+A spawned rstest run only writes `<cwd>/dist/.rstest-temp/` when something forces it — `performance.buildCache`, `dev.writeToDisk: true`, `DEBUG=rstest`, coverage. Sibling test files run in parallel under the worker pool, so two such writers under the same `cwd` race on that path. Pure in-memory runs (just stdout/exit checks) don't race — sharing `cwd: __dirname` is fine and is how most e2e tests are written.
 
-- **Set `cwd` to a dedicated fixture subdirectory**, not `__dirname` of the test file.
-- **Never share `cwd: __dirname`** across test files in the same directory.
-- **Drop `include` patterns that reference paths outside the fixture directory** (e.g. `'./fixtures/<name>/index.test.ts'`). Fixture-local globs like `'./*.test.ts'` are fine.
-- **Keep `dist/.rstest-temp/...` assertions inside an isolated fixture directory**, never a shared one.
+When your test or its fixture config writes to disk:
+
+- Set `cwd` to the fixture subdirectory (`join(__dirname, 'fixtures', <name>)`), not `__dirname`.
+- In that fixture's config, drop any `include` referencing paths outside the fixture (e.g. `'./fixtures/<name>/index.test.ts'`). Fixture-local globs like `'./*.test.ts'` are fine.
+- Read `dist/.rstest-temp/...` assertions from that isolated fixture dir, not from a shared parent.
 
 ## Snapshot policy
 

--- a/e2e/build/buildCache.test.ts
+++ b/e2e/build/buildCache.test.ts
@@ -11,9 +11,9 @@ describe('test build cache config', () => {
   it('should enable build cache with rstest-aware dependencies and keep warm runs measurable', async ({
     onTestFinished,
   }) => {
-    const fixtureName = 'buildCache';
-    const cacheDir = join(__dirname, '.cache/build-cache-fixture');
-    const outputDir = join(__dirname, 'dist/.rstest-temp');
+    const fixtureDir = join(__dirname, 'fixtures/buildCache');
+    const cacheDir = join(fixtureDir, '.cache/build-cache-fixture');
+    const outputDir = join(fixtureDir, 'dist/.rstest-temp');
     const inspectDir = join(outputDir, '.rsbuild');
 
     fs.rmSync(cacheDir, { recursive: true, force: true });
@@ -23,16 +23,11 @@ describe('test build cache config', () => {
       const start = Date.now();
       const result = await runRstestCli({
         command: 'rstest',
-        args: [
-          'run',
-          `fixtures/${fixtureName}`,
-          '-c',
-          `fixtures/${fixtureName}/rstest.config.mts`,
-        ],
+        args: ['run'],
         onTestFinished,
         options: {
           nodeOptions: {
-            cwd: __dirname,
+            cwd: fixtureDir,
             env: {
               DEBUG: 'rstest',
             },
@@ -75,8 +70,8 @@ describe('test build cache config', () => {
   it('should collect happy-dom build cache timing data on a non-trivial fixture', async ({
     onTestFinished,
   }) => {
-    const fixtureName = 'happyDomBuildCache';
-    const cacheDir = join(__dirname, '.cache/happy-dom-build-cache');
+    const fixtureDir = join(__dirname, 'fixtures/happyDomBuildCache');
+    const cacheDir = join(fixtureDir, '.cache/happy-dom-build-cache');
 
     fs.rmSync(cacheDir, { recursive: true, force: true });
 
@@ -84,16 +79,11 @@ describe('test build cache config', () => {
       const start = Date.now();
       const result = await runRstestCli({
         command: 'rstest',
-        args: [
-          'run',
-          `fixtures/${fixtureName}`,
-          '-c',
-          `fixtures/${fixtureName}/rstest.config.mts`,
-        ],
+        args: ['run'],
         onTestFinished,
         options: {
           nodeOptions: {
-            cwd: __dirname,
+            cwd: fixtureDir,
           },
         },
       });
@@ -118,24 +108,19 @@ describe('test build cache config', () => {
   it('should keep virtual module mocks stable across cold and warm build cache runs', async ({
     onTestFinished,
   }) => {
-    const fixtureName = 'mockBuildCache';
-    const cacheDir = join(__dirname, '.cache/mock-build-cache');
+    const fixtureDir = join(__dirname, 'fixtures/mockBuildCache');
+    const cacheDir = join(fixtureDir, '.cache/mock-build-cache');
 
     fs.rmSync(cacheDir, { recursive: true, force: true });
 
     const runFixture = async () => {
       const result = await runRstestCli({
         command: 'rstest',
-        args: [
-          'run',
-          `fixtures/${fixtureName}`,
-          '-c',
-          `fixtures/${fixtureName}/rstest.config.mts`,
-        ],
+        args: ['run'],
         onTestFinished,
         options: {
           nodeOptions: {
-            cwd: __dirname,
+            cwd: fixtureDir,
           },
         },
       });

--- a/e2e/build/fixtures/buildCache/rstest.config.mts
+++ b/e2e/build/fixtures/buildCache/rstest.config.mts
@@ -1,7 +1,6 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  include: ['./fixtures/buildCache/index.test.ts'],
   performance: {
     buildCache: {
       cacheDirectory: '.cache/build-cache-fixture',

--- a/e2e/build/fixtures/happyDomBuildCache/rstest.config.mts
+++ b/e2e/build/fixtures/happyDomBuildCache/rstest.config.mts
@@ -1,13 +1,11 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  include: ['./fixtures/happyDomBuildCache/index.test.ts'],
   testEnvironment: 'happy-dom',
   performance: {
     buildCache: {
       cacheDirectory: '.cache/happy-dom-build-cache',
       cacheDigest: ['happy-dom-fixture'],
-      buildDependencies: ['./fixtures/happyDomBuildCache/rstest.config.mts'],
     },
   },
 });

--- a/e2e/build/index.test.ts
+++ b/e2e/build/index.test.ts
@@ -17,18 +17,16 @@ describe('test build config', () => {
   ])(
     '$name config should work correctly',
     async ({ name }, { onTestFinished }) => {
+      // Run each fixture inside its own directory so the default output path
+      // (dist/.rstest-temp) is scoped to that fixture and never collides with
+      // sibling test files that also spawn rstest under e2e/build/.
       const { expectExecSuccess } = await runRstestCli({
         command: 'rstest',
-        args: [
-          'run',
-          `fixtures/${name}`,
-          '-c',
-          `fixtures/${name}/rstest.config.mts`,
-        ],
+        args: ['run'],
         onTestFinished,
         options: {
           nodeOptions: {
-            cwd: __dirname,
+            cwd: join(__dirname, 'fixtures', name),
           },
         },
       });
@@ -40,28 +38,23 @@ describe('test build config', () => {
   it('should write output to customized distPath.root', async ({
     onTestFinished,
   }) => {
-    const defaultOutputPath = join(__dirname, 'dist/.rstest-temp');
-    const customOutputPath = join(__dirname, 'custom/.rstest-temp');
+    const fixtureDir = join(__dirname, 'fixtures/customOutput');
+    const defaultOutputPath = join(fixtureDir, 'dist/.rstest-temp');
+    const customOutputPath = join(fixtureDir, 'custom/.rstest-temp');
 
     fs.rmSync(defaultOutputPath, { recursive: true, force: true });
-    fs.rmSync(join(__dirname, 'custom'), {
+    fs.rmSync(join(fixtureDir, 'custom'), {
       recursive: true,
       force: true,
     });
-    fs.rmSync(join(defaultOutputPath, 'rstest-manifest.json'), { force: true });
 
     const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',
-      args: [
-        'run',
-        'fixtures/customOutput',
-        '-c',
-        'fixtures/customOutput/rstest.config.mts',
-      ],
+      args: ['run'],
       onTestFinished,
       options: {
         nodeOptions: {
-          cwd: __dirname,
+          cwd: fixtureDir,
         },
       },
     });


### PR DESCRIPTION
## Summary

### Background

`e2e/build/buildCache.test.ts` and `e2e/build/index.test.ts` both spawned rstest subprocesses with `cwd: __dirname`. When any sibling test triggered disk writes — `performance.buildCache` (enabled by the three buildCache fixtures), `DEBUG=rstest`, etc. — they raced on the shared default output path `e2e/build/dist/.rstest-temp/`, intermittently flipping the `should write output to customized distPath.root` assertion in `build/index.test.ts`. CI hid this via `retry: 2` + low CPU concurrency; locally it failed ~85% of the time.

### Implementation

- Move every `runRstestCli` spawn under `e2e/build/` into the fixture's own subdirectory as `cwd`, so each invocation owns its `dist/.rstest-temp/` tree.
- Drop `include`/`buildDependencies` entries from `buildCache` and `happyDomBuildCache` fixture configs that anchored to the outer cwd; rstest auto-discovers the fixture's `index.test.ts` once `cwd` is the fixture itself.
- Document the convention in `.agents/skills/testing/SKILL.md` so future tests don't reintroduce the pattern.

### User Impact

None — internal e2e test refactor.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- \`pnpm format\` — clean
- \`pnpm run lint\` — pass
- \`pnpm run typecheck\` — fails on \`watch/fixtures-test-build-fail-module/index.test.ts\` (pre-existing on main, unrelated to this PR)
- \`pnpm run build\` — pass
- \`pnpm run test\` — pass
- \`cd e2e && pnpm test\` — 205/205 testFiles pass
- Stress: \`pnpm exec rstest run build\` 30/30 pass (baseline on main: 3/20 pass)