### PR TITLE
ci: split PR baseline and cron supplemental e2e coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,8 +160,10 @@ jobs:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
-        node_version: ${{ fromJson(github.event_name == 'schedule' && '["20","22","24"]' || '["20","24"]') }}
-        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test:commonjs","test:no-isolate"]' || '["test"]') }}
+        node_version: ${{ fromJson((github.event_name == 'schedule' || startsWith(github.event.pull_request.title, 'release:')) && '["20","22","24"]' || '["20","24"]') }}
+        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test:commonjs","test:no-isolate"]' || (startsWith(github.event.pull_request.title, 'release:') && '["test","test:commonjs","test:no-isolate"]' || '["test"]')) }}
+        # On release PRs the baseline `test` only covers Node 20/24 (matching the PR matrix), so exclude `test` × Node 22.
+        exclude: ${{ fromJson(startsWith(github.event.pull_request.title, 'release:') && '[{"node_version":"22","test_script":"test"}]' || '[]') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,11 +161,7 @@ jobs:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
         node_version: ${{ fromJson(github.event_name == 'schedule' && '["20","22","24"]' || '["20","24"]') }}
-        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test","test:commonjs","test:no-isolate"]' || '["test"]') }}
-        exclude:
-          # Node 20 is flaky here because reused no-isolate workers can hit upstream vm native crashes.
-          - node_version: '20'
-            test_script: 'test:no-isolate'
+        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test:commonjs","test:no-isolate"]' || '["test"]') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
-      is_release_pr: ${{ startsWith(github.event.pull_request.title, 'release:') }}
+      # Full e2e sweep: push to main (post-merge gate) or release PR (pre-publish gate)
       is_full_run: ${{ github.event_name == 'push' || startsWith(github.event.pull_request.title, 'release:') }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,7 @@ jobs:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
         node_version: ${{ fromJson(github.event_name == 'schedule' && '["20","22","24"]' || '["20","24"]') }}
-        test_script: ['test', 'test:commonjs', 'test:no-isolate']
+        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test","test:commonjs","test:no-isolate"]' || '["test"]') }}
         exclude:
           # Node 20 is flaky here because reused no-isolate workers can hit upstream vm native crashes.
           - node_version: '20'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,10 +161,33 @@ jobs:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
-        node_version: ${{ fromJson((github.event_name == 'schedule' || needs.prepare.outputs.is_release_pr == 'true') && '["20","22","24"]' || '["20","24"]') }}
-        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test:commonjs","test:no-isolate"]' || (needs.prepare.outputs.is_release_pr == 'true' && '["test","test:commonjs","test:no-isolate"]' || '["test"]')) }}
-        # On release PRs the baseline `test` only covers Node 20/24 (matching the PR matrix), so exclude `test` × Node 22.
-        exclude: ${{ fromJson(needs.prepare.outputs.is_release_pr == 'true' && '[{"node_version":"22","test_script":"test"}]' || '[]') }}
+        # Trigger-dependent axes:
+        #
+        #   trigger      | node_version | test_script                  | exclude
+        #   -------------+--------------+------------------------------+-----------
+        #   PR / push    | [20, 24]     | [test]                       | -
+        #   schedule     | [20, 22, 24] | [commonjs, no-isolate]       | -
+        #   release PR   | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
+        node_version: >-
+          ${{ fromJson(
+            (github.event_name == 'schedule' || needs.prepare.outputs.is_release_pr == 'true')
+            && '["20","22","24"]'
+            || '["20","24"]'
+          ) }}
+        test_script: >-
+          ${{ fromJson(
+            github.event_name == 'schedule'
+              && '["test:commonjs","test:no-isolate"]'
+            || needs.prepare.outputs.is_release_pr == 'true'
+              && '["test","test:commonjs","test:no-isolate"]'
+            || '["test"]'
+          ) }}
+        exclude: >-
+          ${{ fromJson(
+            needs.prepare.outputs.is_release_pr == 'true'
+              && '[{"node_version":"22","test_script":"test"}]'
+            || '[]'
+          ) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
+      is_release_pr: ${{ startsWith(github.event.pull_request.title, 'release:') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -160,10 +161,10 @@ jobs:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
-        node_version: ${{ fromJson((github.event_name == 'schedule' || startsWith(github.event.pull_request.title, 'release:')) && '["20","22","24"]' || '["20","24"]') }}
-        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test:commonjs","test:no-isolate"]' || (startsWith(github.event.pull_request.title, 'release:') && '["test","test:commonjs","test:no-isolate"]' || '["test"]')) }}
+        node_version: ${{ fromJson((github.event_name == 'schedule' || needs.prepare.outputs.is_release_pr == 'true') && '["20","22","24"]' || '["20","24"]') }}
+        test_script: ${{ fromJson(github.event_name == 'schedule' && '["test:commonjs","test:no-isolate"]' || (needs.prepare.outputs.is_release_pr == 'true' && '["test","test:commonjs","test:no-isolate"]' || '["test"]')) }}
         # On release PRs the baseline `test` only covers Node 20/24 (matching the PR matrix), so exclude `test` × Node 22.
-        exclude: ${{ fromJson(startsWith(github.event.pull_request.title, 'release:') && '[{"node_version":"22","test_script":"test"}]' || '[]') }}
+        exclude: ${{ fromJson(needs.prepare.outputs.is_release_pr == 'true' && '[{"node_version":"22","test_script":"test"}]' || '[]') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches: [main]
 
-  schedule:
-    - cron: '0 16 * * *'
-
   workflow_dispatch:
 
 concurrency:
@@ -48,7 +45,6 @@ jobs:
 
   # ======== lint ========
   lint:
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
 
     steps:
@@ -89,7 +85,7 @@ jobs:
   # ======== ut ========
   ut:
     needs: prepare
-    if: needs.prepare.outputs.changed == 'true' || github.event_name == 'schedule'
+    if: needs.prepare.outputs.changed == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -151,9 +147,9 @@ jobs:
     needs: [prepare, lint, ut]
     if: |
       always() &&
-      (needs.prepare.outputs.changed == 'true' || github.event_name == 'schedule') &&
+      needs.prepare.outputs.changed == 'true' &&
       needs.ut.result == 'success' &&
-      (github.event_name == 'schedule' || needs.lint.result == 'success')
+      needs.lint.result == 'success'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -163,31 +159,33 @@ jobs:
         os: [macos-14, windows-latest]
         # Trigger-dependent axes:
         #
-        #   trigger      | node_version | test_script                  | exclude
-        #   -------------+--------------+------------------------------+-----------
-        #   PR / push    | [20, 24]     | [test]                       | -
-        #   schedule     | [20, 22, 24] | [commonjs, no-isolate]       | -
-        #   release PR   | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
+        #   trigger             | node_version | test_script                  | exclude
+        #   --------------------+--------------+------------------------------+-----------
+        #   PR (regular)        | [20, 24]     | [test]                       | -
+        #   push to main        | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
+        #   release PR          | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
+        #
+        # Notification timeliness: push to main carries the same supplemental sweep that
+        # used to live on the nightly cron, so any regression that slips past PR baseline
+        # surfaces immediately on merge instead of on the next scheduled run.
         #
         # Note: Node 20 + test:no-isolate can hit upstream vm native crashes under worker
-        # reuse; tolerated on schedule / release PR runs in exchange for coverage.
+        # reuse; tolerated on push / release PR runs in exchange for coverage.
         node_version: >-
           ${{ fromJson(
-            (github.event_name == 'schedule' || needs.prepare.outputs.is_release_pr == 'true')
+            (github.event_name == 'push' || needs.prepare.outputs.is_release_pr == 'true')
             && '["20","22","24"]'
             || '["20","24"]'
           ) }}
         test_script: >-
           ${{ fromJson(
-            github.event_name == 'schedule'
-              && '["test:commonjs","test:no-isolate"]'
-            || needs.prepare.outputs.is_release_pr == 'true'
+            (github.event_name == 'push' || needs.prepare.outputs.is_release_pr == 'true')
               && '["test","test:commonjs","test:no-isolate"]'
             || '["test"]'
           ) }}
         exclude: >-
           ${{ fromJson(
-            needs.prepare.outputs.is_release_pr == 'true'
+            (github.event_name == 'push' || needs.prepare.outputs.is_release_pr == 'true')
               && '[{"node_version":"22","test_script":"test"}]'
             || '[]'
           ) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,9 @@ jobs:
         #   PR / push    | [20, 24]     | [test]                       | -
         #   schedule     | [20, 22, 24] | [commonjs, no-isolate]       | -
         #   release PR   | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
+        #
+        # Note: Node 20 + test:no-isolate can hit upstream vm native crashes under worker
+        # reuse; tolerated on schedule / release PR runs in exchange for coverage.
         node_version: >-
           ${{ fromJson(
             (github.event_name == 'schedule' || needs.prepare.outputs.is_release_pr == 'true')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
       is_release_pr: ${{ startsWith(github.event.pull_request.title, 'release:') }}
+      is_full_run: ${{ github.event_name == 'push' || startsWith(github.event.pull_request.title, 'release:') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -145,11 +146,7 @@ jobs:
   # ======== e2e ========
   e2e:
     needs: [prepare, lint, ut]
-    if: |
-      always() &&
-      needs.prepare.outputs.changed == 'true' &&
-      needs.ut.result == 'success' &&
-      needs.lint.result == 'success'
+    if: needs.prepare.outputs.changed == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -157,35 +154,31 @@ jobs:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
         os: [macos-14, windows-latest]
-        # Trigger-dependent axes:
+        # Trigger-dependent axes (gated by prepare.outputs.is_full_run):
         #
-        #   trigger             | node_version | test_script                  | exclude
-        #   --------------------+--------------+------------------------------+-----------
-        #   PR (regular)        | [20, 24]     | [test]                       | -
-        #   push to main        | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
-        #   release PR          | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
+        #   trigger      | node_version | test_script                  | exclude
+        #   -------------+--------------+------------------------------+-----------
+        #   PR (regular) | [20, 24]     | [test]                       | -
+        #   push to main | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
+        #   release PR   | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
         #
-        # Notification timeliness: push to main carries the same supplemental sweep that
-        # used to live on the nightly cron, so any regression that slips past PR baseline
-        # surfaces immediately on merge instead of on the next scheduled run.
-        #
-        # Note: Node 20 + test:no-isolate can hit upstream vm native crashes under worker
-        # reuse; tolerated on push / release PR runs in exchange for coverage.
+        # Node 20 + test:no-isolate can hit upstream vm native crashes under worker
+        # reuse; tolerated on full runs in exchange for coverage.
         node_version: >-
           ${{ fromJson(
-            (github.event_name == 'push' || needs.prepare.outputs.is_release_pr == 'true')
-            && '["20","22","24"]'
+            needs.prepare.outputs.is_full_run == 'true'
+              && '["20","22","24"]'
             || '["20","24"]'
           ) }}
         test_script: >-
           ${{ fromJson(
-            (github.event_name == 'push' || needs.prepare.outputs.is_release_pr == 'true')
+            needs.prepare.outputs.is_full_run == 'true'
               && '["test","test:commonjs","test:no-isolate"]'
             || '["test"]'
           ) }}
         exclude: >-
           ${{ fromJson(
-            (github.event_name == 'push' || needs.prepare.outputs.is_release_pr == 'true')
+            needs.prepare.outputs.is_full_run == 'true'
               && '[{"node_version":"22","test_script":"test"}]'
             || '[]'
           ) }}


### PR DESCRIPTION
## Summary

### Background

The e2e matrix currently fires too many jobs on every PR — all three scripts (`test`, `test:commonjs`, `test:no-isolate`) run across every PR node combination, costing 10 jobs even for trivial changes. The intended shape is a fast baseline on every PR, the full supplemental sweep on every merge to `main`, and the same full sweep as a final gate on release PRs.

Per @9aoy's feedback: a nightly cron's failure surfaces too late. Folding the supplemental sweep into the push-to-`main` trigger keeps the PR matrix tight while still catching any regression the baseline misses, with timely notification on merge.

### Implementation

Drive all three axes off `github.event_name` and a new `prepare.outputs.is_release_pr` (matched via `startsWith(github.event.pull_request.title, 'release:')`):

```plaintext
trigger      | node_version | test_script                  | exclude
-------------+--------------+------------------------------+-----------
PR (regular) | [20, 24]     | [test]                       | -
push to main | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
release PR   | [20, 22, 24] | [test, commonjs, no-isolate] | test × 22
```

- PR (regular): 4 jobs (baseline `test` only) — down from 10.
- push to main: 16 jobs (union — `test` × Node 22 excluded so the baseline footprint matches the PR matrix).
- release PR: same matrix as push, runs as a pre-merge gate.
- The `schedule:` trigger and its conditional branches in `lint` / `ut` / `e2e` are removed; push-to-`main` is now the single supplemental trigger.
- Note inlined near the matrix: Node 20 + `test:no-isolate` can hit upstream vm native crashes under worker reuse; tolerated on push / release-PR runs.

### User Impact

None — internal CI cost reduction and notification-latency improvement. PR e2e job count: 10 → 4. Supplemental regression coverage moves from "next nightly cron" to "immediately on merge to main".

## Validation

Scoped to the workflow YAML file — no runtime/test source touched. Full build/test/e2e suites skipped as not applicable. `prettier --check` passes on the file.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).