### PR TITLE
chore: enable Renovate security preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    'github>rstackjs/renovate:security',
     'schedule:weekly',
     'helpers:pinGitHubActionDigests',
   ],


### PR DESCRIPTION
## Summary

### Background

Renovate should use the shared security preset so its minimal release age behavior stays aligned with the pnpm setting documented by the Rstack preset.

### Implementation

- Extend `.github/renovate.json5` with `github>rstackjs/renovate:security`.

### User Impact

None — internal dependency automation configuration only.

## Related Links

- https://github.com/rstackjs/renovate#security-preset

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation: `pnpm run lint`.