### PR TITLE
feat(core): support changed coverage

### DIFF
--- a/e2e/filter/changed.test.ts
+++ b/e2e/filter/changed.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -9,6 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const changedFixturePath = join(__dirname, 'fixtures-changed');
+const coverageFixturePath = join(__dirname, '../test-coverage/fixtures');
 
 const collectRunTestFileLogs = (stdout: string) =>
   stdout
@@ -32,8 +33,23 @@ const prepareChangedFixture = async (name: string) => {
     fixturesPath: changedFixturePath,
     fixturesTargetPath,
   });
+  await symlink(
+    join(coverageFixturePath, 'node_modules'),
+    join(fixturesTargetPath, 'node_modules'),
+    'dir',
+  );
 
   return { fixturesTargetPath, fs };
+};
+
+const readCoverageFiles = async (cwd: string): Promise<string[]> => {
+  const coverage = JSON.parse(
+    await readFile(join(cwd, 'coverage/coverage-final.json'), 'utf8'),
+  ) as Record<string, unknown>;
+
+  return Object.keys(coverage)
+    .map((file) => file.replaceAll('\\', '/'))
+    .sort();
 };
 
 const runGit = async (cwd: string, args: string[]) => {
@@ -206,6 +222,284 @@ describe('changed test filtering', () => {
         " ✗ other.test.ts (1)",
       ]
     `);
+  });
+
+  it('should only report coverage for changed source files', async () => {
+    const { fixturesTargetPath, fs } =
+      await prepareChangedFixture('changed-coverage');
+
+    await writeFile(
+      join(fixturesTargetPath, 'rstest.config.ts'),
+      `import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    include: ['src/**/*.ts'],
+    reporters: ['json'],
+  },
+});
+`,
+    );
+    await initGitFixture(fixturesTargetPath);
+
+    fs.update(
+      join(fixturesTargetPath, 'src/index.ts'),
+      (content) => `${content}\nexport const changed = true;\n`,
+    );
+
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--changed'],
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const coverageFiles = await readCoverageFiles(fixturesTargetPath);
+
+    expect(coverageFiles.some((file) => file.endsWith('/src/index.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/other.ts'))).toBe(
+      false,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/shared.ts'))).toBe(
+      false,
+    );
+  });
+
+  it('should only report coverage for files from coverage.changed without filtering tests', async () => {
+    const { fixturesTargetPath, fs } =
+      await prepareChangedFixture('coverage-changed');
+
+    await writeFile(
+      join(fixturesTargetPath, 'rstest.config.ts'),
+      `import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    include: ['src/**/*.ts'],
+    reporters: ['json'],
+  },
+});
+`,
+    );
+    await initGitFixture(fixturesTargetPath);
+
+    fs.update(
+      join(fixturesTargetPath, 'src/index.ts'),
+      (content) => `${content}\nexport const changed = true;\n`,
+    );
+
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--coverage.changed'],
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const logs = collectRunTestFileLogs(cli.stdout);
+    expect(logs).toEqual([' ✓ index.test.ts (1)', ' ✓ other.test.ts (1)']);
+
+    const coverageFiles = await readCoverageFiles(fixturesTargetPath);
+
+    expect(coverageFiles.some((file) => file.endsWith('/src/index.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/other.ts'))).toBe(
+      false,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/shared.ts'))).toBe(
+      false,
+    );
+  });
+
+  it('should let coverage.changed override changed coverage filters', async () => {
+    const { fixturesTargetPath, fs } = await prepareChangedFixture(
+      'coverage-changed-override',
+    );
+
+    await writeFile(
+      join(fixturesTargetPath, 'rstest.config.ts'),
+      `import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    include: ['src/**/*.ts'],
+    reporters: ['json'],
+  },
+});
+`,
+    );
+    await initGitFixture(fixturesTargetPath);
+
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+      cwd: fixturesTargetPath,
+      encoding: 'utf8',
+    });
+    const baseCommit = stdout.trim();
+
+    fs.update(
+      join(fixturesTargetPath, 'src/other.ts'),
+      (content) => `${content}\nexport const otherChanged = true;\n`,
+    );
+    await runGit(fixturesTargetPath, ['add', '.']);
+    await runGit(fixturesTargetPath, [
+      '-c',
+      'user.name=rstest',
+      '-c',
+      'user.email=rstest@example.com',
+      'commit',
+      '-m',
+      'change other',
+    ]);
+    fs.update(
+      join(fixturesTargetPath, 'src/index.ts'),
+      (content) => `${content}\nexport const indexChanged = true;\n`,
+    );
+
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', `--changed=${baseCommit}`, '--coverage.changed=HEAD'],
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const coverageFiles = await readCoverageFiles(fixturesTargetPath);
+
+    expect(coverageFiles.some((file) => file.endsWith('/src/index.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/other.ts'))).toBe(
+      false,
+    );
+  });
+
+  it('should let explicit coverage.changed limit coverage for force reruns', async () => {
+    const { fixturesTargetPath, fs } = await prepareChangedFixture(
+      'coverage-changed-force-rerun',
+    );
+
+    await writeFile(
+      join(fixturesTargetPath, 'rstest.config.ts'),
+      `import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    include: ['src/**/*.ts'],
+    reporters: ['json'],
+  },
+});
+`,
+    );
+    await initGitFixture(fixturesTargetPath);
+
+    fs.update(
+      join(fixturesTargetPath, 'src/index.ts'),
+      (content) => `${content}\nexport const changed = true;\n`,
+    );
+    await writeFile(
+      join(fixturesTargetPath, 'package.json'),
+      `${JSON.stringify({ name: 'coverage-changed-force-rerun', version: '1.0.1' })}\n`,
+    );
+
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--changed', '--coverage.changed'],
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const logs = collectRunTestFileLogs(cli.stdout);
+    expect(logs).toEqual([' ✓ index.test.ts (1)', ' ✓ other.test.ts (1)']);
+
+    const coverageFiles = await readCoverageFiles(fixturesTargetPath);
+
+    expect(coverageFiles.some((file) => file.endsWith('/src/index.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/other.ts'))).toBe(
+      false,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/shared.ts'))).toBe(
+      false,
+    );
+  });
+
+  it('should report full coverage when a force rerun trigger changes', async () => {
+    const { fixturesTargetPath } = await prepareChangedFixture(
+      'changed-coverage-force-rerun',
+    );
+
+    await writeFile(
+      join(fixturesTargetPath, 'rstest.config.ts'),
+      `import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    include: ['src/**/*.ts'],
+    reporters: ['json'],
+  },
+});
+`,
+    );
+    await initGitFixture(fixturesTargetPath);
+
+    await writeFile(
+      join(fixturesTargetPath, 'package.json'),
+      `${JSON.stringify({ name: 'changed-coverage-force-rerun', version: '1.0.1' })}\n`,
+    );
+
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--changed'],
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const coverageFiles = await readCoverageFiles(fixturesTargetPath);
+
+    expect(coverageFiles.some((file) => file.endsWith('/src/index.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/other.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/shared.ts'))).toBe(
+      true,
+    );
   });
 
   it('should run all tests when a force rerun trigger changes', async () => {

--- a/e2e/filter/changed.test.ts
+++ b/e2e/filter/changed.test.ts
@@ -273,6 +273,57 @@ export default defineConfig({
     );
   });
 
+  it('should report full coverage when coverage.changed is false with changed test filtering', async () => {
+    const { fixturesTargetPath, fs } = await prepareChangedFixture(
+      'changed-coverage-disabled',
+    );
+
+    await writeFile(
+      join(fixturesTargetPath, 'rstest.config.ts'),
+      `import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    changed: false,
+    include: ['src/**/*.ts'],
+    reporters: ['json'],
+  },
+});
+`,
+    );
+    await initGitFixture(fixturesTargetPath);
+
+    fs.update(
+      join(fixturesTargetPath, 'src/index.ts'),
+      (content) => `${content}\nexport const changed = true;\n`,
+    );
+
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--changed'],
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const coverageFiles = await readCoverageFiles(fixturesTargetPath);
+
+    expect(coverageFiles.some((file) => file.endsWith('/src/index.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/other.ts'))).toBe(
+      true,
+    );
+    expect(coverageFiles.some((file) => file.endsWith('/src/shared.ts'))).toBe(
+      true,
+    );
+  });
+
   it('should only report coverage for files from coverage.changed without filtering tests', async () => {
     const { fixturesTargetPath, fs } =
       await prepareChangedFixture('coverage-changed');

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -55,6 +55,10 @@ const runtimeOptionDefinitions: OptionDefinition[] = [
   ['-u, --update', 'Update snapshot files'],
   ['--coverage', 'Enable code coverage collection'],
   [
+    '--coverage.changed [commit]',
+    'Collect coverage only for changed files, optionally since a commit',
+  ],
+  [
     '--project <name>',
     'Run only projects that match the name, can be a full name or wildcards pattern',
   ],
@@ -189,6 +193,40 @@ const applyOptions = (
 const applyRuntimeCommandOptions = (command: Command): void => {
   applyOptions(command, runtimeOptionDefinitions);
   applyOptions(command, poolOptionDefinitions);
+};
+
+const normalizeCoverageCliArgs = (argv: string[]): string[] => {
+  const hasCoverageNestedOption = argv.some((arg) =>
+    arg.startsWith('--coverage.'),
+  );
+
+  if (!hasCoverageNestedOption) {
+    return argv;
+  }
+
+  return argv.map((arg) => {
+    if (arg === '--coverage') {
+      return '--coverage.enabled';
+    }
+    if (arg.startsWith('--coverage=')) {
+      return `--coverage.enabled=${arg.slice('--coverage='.length)}`;
+    }
+    if (arg === '--no-coverage') {
+      return '--coverage.enabled=false';
+    }
+
+    return arg;
+  });
+};
+
+const allowMixedCoverageCliOptions = (cli: CAC): void => {
+  const originalParse = cli.parse.bind(cli);
+
+  cli.parse = ((argv, options) =>
+    originalParse(
+      normalizeCoverageCliArgs(argv ?? process.argv),
+      options,
+    )) as CAC['parse'];
 };
 
 const filterHelpOptions = (
@@ -389,6 +427,14 @@ export const resolveChangedFiles = async (
   }
 };
 
+const getCoverageChangedOption = (options: CommonOptions) => {
+  if (options.coverage === undefined || typeof options.coverage === 'boolean') {
+    return undefined;
+  }
+
+  return options.coverage.changed;
+};
+
 const resolveEffectiveCliFilters = async ({
   options,
   filters,
@@ -416,6 +462,7 @@ const resolveEffectiveCliFilters = async ({
   fileFilterMode: FileFilterMode;
   relatedFilters?: string[];
   relatedResolutionEmpty?: boolean;
+  changedCoverageFilters?: string[];
 }> => {
   const normalizedFilters = normalizeCliFilters(filters);
 
@@ -466,13 +513,41 @@ const resolveEffectiveCliFilters = async ({
     filterLabel: options.changed !== undefined ? '--changed' : '--related',
     allowEmpty: options.changed !== undefined,
   });
+  const coverageChanged = getCoverageChangedOption(options);
 
   return {
     effectiveFilters: relatedFiles,
     fileFilterMode: 'exact',
     relatedFilters: sourceFilters,
     relatedResolutionEmpty: relatedFiles.length === 0,
+    changedCoverageFilters:
+      options.changed !== undefined && coverageChanged === undefined
+        ? sourceFilters
+        : undefined,
   };
+};
+
+const resolveCoverageChangedFilters = async (
+  rstest: RstestInstance,
+): Promise<string[] | undefined> => {
+  const { changed } = rstest.context.normalizedConfig.coverage;
+
+  if (changed === undefined || changed === false) {
+    return rstest.context.changedCoverageFilters;
+  }
+
+  try {
+    return await resolveChangedFiles(
+      rstest.context.rootPath,
+      typeof changed === 'string' ? changed : undefined,
+    );
+  } catch (error) {
+    const reason = formatGitError(error);
+    logger.warn(
+      `Failed to resolve changed files for \`coverage.changed\`, falling back to full coverage.${reason ? ` Git error: ${reason}` : ''}`,
+    );
+    return undefined;
+  }
 };
 
 export const runRest = async ({
@@ -497,6 +572,7 @@ export const runRest = async ({
       fileFilterMode,
       relatedFilters,
       relatedResolutionEmpty,
+      changedCoverageFilters,
     } = await resolveEffectiveCliFilters({
       options,
       filters,
@@ -514,6 +590,9 @@ export const runRest = async ({
     );
     rstest.context.relatedFilters = relatedFilters;
     rstest.context.relatedResolutionEmpty = relatedResolutionEmpty;
+    rstest.context.changedCoverageFilters = changedCoverageFilters;
+    rstest.context.changedCoverageFilters =
+      await resolveCoverageChangedFilters(rstest);
 
     process.on('uncaughtException', unexpectedlyExitHandler);
 
@@ -622,6 +701,7 @@ export function createCli(): CAC {
           fileFilterMode,
           relatedFilters,
           relatedResolutionEmpty,
+          changedCoverageFilters,
         } = await resolveEffectiveCliFilters({
           options,
           filters,
@@ -639,6 +719,9 @@ export function createCli(): CAC {
         );
         rstest.context.relatedFilters = relatedFilters;
         rstest.context.relatedResolutionEmpty = relatedResolutionEmpty;
+        rstest.context.changedCoverageFilters = changedCoverageFilters;
+        rstest.context.changedCoverageFilters =
+          await resolveCoverageChangedFilters(rstest);
 
         await rstest.listTests({
           filesOnly: options.filesOnly,
@@ -735,6 +818,8 @@ export function createCli(): CAC {
         process.exit(1);
       }
     });
+
+  allowMixedCoverageCliOptions(cli);
 
   return cli;
 }

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -532,8 +532,11 @@ const resolveCoverageChangedFilters = async (
 ): Promise<string[] | undefined> => {
   const { changed } = rstest.context.normalizedConfig.coverage;
 
-  if (changed === undefined || changed === false) {
+  if (changed === undefined) {
     return rstest.context.changedCoverageFilters;
+  }
+  if (changed === false) {
+    return undefined;
   }
 
   try {

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -61,8 +61,9 @@ export type CommonOptions = {
   coverage?:
     | boolean
     | {
-        enabled?: boolean;
+        enabled?: boolean | string;
         allowExternal?: boolean;
+        changed?: boolean | string;
       };
   passWithNoTests?: boolean;
   silent?: boolean | 'passed-only';
@@ -87,6 +88,20 @@ export type CommonOptions = {
   hideSkippedTestFiles?: boolean;
   bail?: number | boolean;
   shard?: string;
+};
+
+const normalizeBooleanLikeCliValue = (
+  value: boolean | string,
+): boolean | string => {
+  if (value === 'false') {
+    return false;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  return value;
 };
 
 function mergeWithCLIOptions(
@@ -165,10 +180,20 @@ function mergeWithCLIOptions(
       config.coverage.enabled = options.coverage;
     } else {
       if (options.coverage.enabled !== undefined) {
-        config.coverage.enabled = options.coverage.enabled;
+        config.coverage.enabled = Boolean(
+          normalizeBooleanLikeCliValue(options.coverage.enabled),
+        );
       }
       if (options.coverage.allowExternal !== undefined) {
         config.coverage.allowExternal = options.coverage.allowExternal;
+      }
+      if (options.coverage.changed !== undefined) {
+        const changed = normalizeBooleanLikeCliValue(options.coverage.changed);
+        config.coverage.changed = changed;
+
+        if (options.coverage.enabled === undefined && changed !== false) {
+          config.coverage.enabled = true;
+        }
       }
     }
   }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -271,6 +271,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
       '**/*.{test,spec}.[cm][jt]sx',
     ],
     enabled: false,
+    changed: undefined,
     provider: 'istanbul',
     reporters: ['text', 'html', 'clover', 'json'],
     reportsDirectory: './coverage',

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -59,6 +59,7 @@ export class Rstest implements RstestContext {
   public fileFilterMode?: FileFilterMode;
   public relatedFilters?: string[];
   public relatedResolutionEmpty?: boolean;
+  public changedCoverageFilters?: string[];
   public configFilePath?: string;
   public reporters: Reporter[];
   public snapshotManager: SnapshotManager;

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -1,5 +1,5 @@
 import type FS from 'node:fs';
-import { normalize } from 'pathe';
+import { normalize, relative } from 'pathe';
 import { glob, isDynamicPattern } from 'tinyglobby';
 import type { RstestContext } from '../types';
 import type {
@@ -46,6 +46,30 @@ export const getIncludedFiles = async (
   return allFiles;
 };
 
+export const filterChangedFiles = (
+  files: string[],
+  changedCoverageFilters: string[] | undefined,
+  rootPath: string,
+): string[] => {
+  if (!changedCoverageFilters?.length) {
+    return files;
+  }
+
+  const changedFilesSet = new Set<string>();
+  for (const file of changedCoverageFilters) {
+    changedFilesSet.add(normalize(file));
+    changedFilesSet.add(normalize(relative(rootPath, file)));
+  }
+
+  return files.filter((file) => {
+    const normalizedFile = normalize(file);
+    return (
+      changedFilesSet.has(normalizedFile) ||
+      changedFilesSet.has(normalize(relative(rootPath, file)))
+    );
+  });
+};
+
 export async function generateCoverage(
   context: RstestContext,
   coverageMap: CoverageMap,
@@ -82,7 +106,11 @@ export async function generateCoverage(
       // intermediate data be GC'd before the next one starts.
       const allFiles: string[] = [];
       for (const p of projects) {
-        const includedFiles = await getIncludedFiles(coverage, p.rootPath);
+        const includedFiles = filterChangedFiles(
+          await getIncludedFiles(coverage, p.rootPath),
+          context.changedCoverageFilters,
+          p.rootPath,
+        );
         allFiles.push(...includedFiles);
 
         const uncoveredFiles = includedFiles.filter(
@@ -108,6 +136,12 @@ export async function generateCoverage(
       // should be better to filter files before swc coverage is processed
       const allFilesSet = new Set(allFiles.map(normalize));
       finalCoverageMap.filter((file) => allFilesSet.has(normalize(file)));
+    } else if (context.changedCoverageFilters?.length) {
+      finalCoverageMap.filter(
+        (file) =>
+          filterChangedFiles([file], context.changedCoverageFilters, rootPath)
+            .length > 0,
+      );
     }
 
     // Generate coverage reports

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -68,6 +68,8 @@ export type RstestContext = {
   relatedFilters?: string[];
   /** Related test resolution completed successfully but matched no test files. */
   relatedResolutionEmpty?: boolean;
+  /** Changed source files used to limit coverage reports for `--changed`. */
+  changedCoverageFilters?: string[];
   /** The config file path. */
   configFilePath?: string;
   /**

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -70,6 +70,14 @@ export type CoverageOptions = {
   include?: string[];
 
   /**
+   * Collect coverage only for files changed since a specified commit or branch.
+   * When enabled from `--changed`, it inherits the changed files collected by `--changed`.
+   *
+   * @default undefined
+   */
+  changed?: boolean | string;
+
+  /**
    * A list of glob patterns that should be excluded from coverage collection.
    *
    * This option accepts an array of wax(https://crates.io/crates/wax)-compatible glob patterns
@@ -143,10 +151,11 @@ export type CoverageOptions = {
 };
 
 export type NormalizedCoverageOptions = Required<
-  Omit<CoverageOptions, 'thresholds' | 'include'>
+  Omit<CoverageOptions, 'thresholds' | 'include' | 'changed'>
 > & {
   thresholds?: CoverageThresholds;
   include?: string[];
+  changed?: boolean | string;
 };
 
 export declare class CoverageProvider {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -16,6 +16,7 @@ exports[`mergeRstestConfig > should merge config correctly with default config 1
   "clearMocks": false,
   "coverage": {
     "allowExternal": false,
+    "changed": undefined,
     "clean": true,
     "enabled": false,
     "exclude": [

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -35,6 +35,7 @@ describe('CLI help output', () => {
     expect(help).toContain('--summary');
     expect(help).toContain('--filesOnly');
     expect(help).toContain('--changed');
+    expect(help).toContain('--coverage.changed');
     expect(help).not.toContain('--cleanup');
   });
 
@@ -65,6 +66,18 @@ describe('CLI help output', () => {
     expect(() =>
       cli.parse(['node', 'rstest', 'init', '--coverage'], { run: true }),
     ).toThrow('Unknown option `--coverage`');
+  });
+
+  it('allows --coverage to be mixed with nested coverage options', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--coverage', '--coverage.changed=HEAD'],
+      { run: false },
+    );
+
+    expect(parsed.options.coverage).toEqual({
+      enabled: true,
+      changed: 'HEAD',
+    });
   });
 });
 

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -427,6 +427,81 @@ describe('resolveProjects', () => {
     });
   });
 
+  describe('coverage CLI options', () => {
+    it('should apply coverage.changed from CLI', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [
+            {
+              name: 'test-project',
+              coverage: {
+                enabled: true,
+              },
+            },
+          ],
+        },
+        root: rootPath,
+        options: {
+          coverage: {
+            changed: 'HEAD',
+          },
+        },
+      });
+
+      expect(projects[0]!.config.coverage).toMatchObject({
+        enabled: true,
+        changed: 'HEAD',
+      });
+    });
+
+    it('should normalize boolean-like coverage CLI values', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [
+            {
+              name: 'test-project',
+            },
+          ],
+        },
+        root: rootPath,
+        options: {
+          coverage: {
+            enabled: 'true',
+            changed: 'false',
+          },
+        },
+      });
+
+      expect(projects[0]!.config.coverage).toMatchObject({
+        enabled: true,
+        changed: false,
+      });
+    });
+
+    it('should enable coverage when coverage.changed is enabled from CLI', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [
+            {
+              name: 'test-project',
+            },
+          ],
+        },
+        root: rootPath,
+        options: {
+          coverage: {
+            changed: true,
+          },
+        },
+      });
+
+      expect(projects[0]!.config.coverage).toMatchObject({
+        enabled: true,
+        changed: true,
+      });
+    });
+  });
+
   describe('pool CLI options', () => {
     it('should apply --pool shorthand (string) and preserve other pool fields', async () => {
       const projects = await resolveProjects({

--- a/packages/core/tests/core/__snapshots__/rstest.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rstest.test.ts.snap
@@ -16,6 +16,7 @@ exports[`rstest context > should generate rstest context correctly 1`] = `
   "clearMocks": false,
   "coverage": {
     "allowExternal": false,
+    "changed": undefined,
     "clean": true,
     "enabled": false,
     "exclude": [
@@ -115,6 +116,7 @@ exports[`rstest context > should generate rstest context correctly with multiple
   "clearMocks": false,
   "coverage": {
     "allowExternal": false,
+    "changed": undefined,
     "clean": true,
     "enabled": false,
     "exclude": [
@@ -217,6 +219,7 @@ exports[`rstest context > should generate rstest context correctly with multiple
   "clearMocks": false,
   "coverage": {
     "allowExternal": false,
+    "changed": undefined,
     "clean": true,
     "enabled": false,
     "exclude": [

--- a/packages/core/tests/coverage/generate.test.ts
+++ b/packages/core/tests/coverage/generate.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { FileCoverageData } from 'istanbul-lib-coverage';
 import { withDefaultConfig } from '../../src/config';
-import { generateCoverage } from '../../src/coverage/generate';
+import {
+  filterChangedFiles,
+  generateCoverage,
+} from '../../src/coverage/generate';
 import type { RstestContext } from '../../src/types';
 import type { CoverageMap, CoverageProvider } from '../../src/types/coverage';
 
@@ -91,5 +94,106 @@ describe('generateCoverage', () => {
     } finally {
       rmSync(rootPath, { recursive: true, force: true });
     }
+  });
+
+  it('limits included coverage files to changed coverage filters', async () => {
+    const rootPath = mkdtempSync(path.join(tmpdir(), 'rstest-coverage-'));
+    const srcDir = path.join(rootPath, 'src');
+    mkdirSync(srcDir, { recursive: true });
+
+    const changedFile = path.join(srcDir, 'changed.ts');
+    writeFileSync(changedFile, 'export const changed = true;\n');
+    writeFileSync(
+      path.join(srcDir, 'unchanged.ts'),
+      'export const unchanged = true;\n',
+    );
+
+    const defaultCoverage = withDefaultConfig({}).coverage;
+    const coveredFiles = new Map<string, FileCoverageData>();
+
+    const createCoverageMap = (): CoverageMap =>
+      ({
+        addFileCoverage(coverage: { path: string }) {
+          coveredFiles.set(coverage.path, coverage);
+        },
+        files() {
+          return Array.from(coveredFiles.keys());
+        },
+        filter(predicate: (filePath: string) => boolean) {
+          for (const filePath of Array.from(coveredFiles.keys())) {
+            if (!predicate(filePath)) {
+              coveredFiles.delete(filePath);
+            }
+          }
+        },
+        merge(coverage: Record<string, FileCoverageData>) {
+          Object.entries(coverage).forEach(([filePath, fileCoverage]) => {
+            coveredFiles.set(filePath, fileCoverage);
+          });
+        },
+      }) as CoverageMap;
+
+    const provider = {
+      init: () => {},
+      collect: () => null,
+      cleanup: () => {},
+      createCoverageMap: () => createCoverageMap(),
+      async generateCoverageForUntestedFiles({ files }) {
+        return files.map((file) => ({
+          path: file,
+          statementMap: {},
+          fnMap: {},
+          branchMap: {},
+          s: {},
+          f: {},
+          b: {},
+          all: false,
+          _coverageSchema: 'test',
+          hash: file,
+        }));
+      },
+      async generateReports(coverageMap) {
+        expect(coverageMap.files().map(path.normalize)).toEqual([
+          path.normalize(changedFile),
+        ]);
+      },
+    } satisfies CoverageProvider;
+
+    const context = {
+      rootPath,
+      normalizedConfig: {
+        coverage: {
+          ...defaultCoverage,
+          include: ['src/**/*.ts'],
+        },
+      },
+      changedCoverageFilters: [changedFile],
+      projects: [
+        {
+          rootPath,
+          environmentName: 'node',
+        },
+      ],
+    } as RstestContext;
+
+    try {
+      await generateCoverage(context, createCoverageMap(), provider);
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it('matches relative changed coverage filters', () => {
+    const rootPath = path.join(tmpdir(), 'rstest-coverage-relative');
+    const changedFile = path.join(rootPath, 'src/changed.ts');
+    const unchangedFile = path.join(rootPath, 'src/unchanged.ts');
+
+    expect(
+      filterChangedFiles(
+        [changedFile, unchangedFile],
+        ['src/changed.ts'],
+        rootPath,
+      ),
+    ).toEqual([changedFile]);
   });
 });

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -187,10 +187,12 @@ export default defineConfig({
 npx rstest run --changed --coverage
 npx rstest run --coverage.changed
 npx rstest run --coverage.changed=HEAD~1
+npx rstest run --coverage.changed=origin/main
 ```
 
 - `npx rstest run --changed --coverage` runs changed-related tests and, by default, also limits coverage to the same changed file set.
 - `npx rstest run --coverage.changed=HEAD~1` runs the normal test suite but only reports coverage for files changed since `HEAD~1`.
+- `npx rstest run --coverage.changed=origin/main` is useful when your branch is based on `main`: it still runs the normal test suite, but the coverage report only includes files changed compared with `origin/main`.
 
 ### exclude
 

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -15,6 +15,7 @@ type CoverageOptions = {
   enabled?: boolean;
   provider?: 'istanbul';
   include?: string[];
+  changed?: boolean | string;
   exclude?: string[];
   reporters?: (keyof ReportOptions | ReportWithOptions)[];
   reportsDirectory?: string;
@@ -121,6 +122,32 @@ export default defineConfig({
     include: ['src/**/*.{js,jsx,ts,tsx}'],
   },
 });
+```
+
+### changed
+
+- **Type:** `boolean | string`
+- **Default:** `undefined`
+- **CLI:** `--coverage.changed`, `--coverage.changed=<commit>`
+
+Collect coverage only for files changed in the current Git repository. Pass a commit or branch to collect coverage for files changed since that ref.
+
+`coverage.changed` only controls the coverage report scope. It does not change which tests are executed. When `--changed` is used and `coverage.changed` is not configured, coverage reports inherit the changed files collected by `--changed`.
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    changed: 'HEAD~1',
+  },
+});
+```
+
+```bash
+npx rstest run --coverage.changed
+npx rstest run --coverage.changed=HEAD~1
 ```
 
 ### exclude

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -134,7 +134,43 @@ export default defineConfig({
 
 Collect coverage only for files changed in the current Git repository. Pass a commit or branch to collect coverage for files changed since that ref.
 
-`coverage.changed` only controls the coverage report scope. It does not change which tests are executed. When [`--changed`](/guide/basic/cli#run-changed-tests) is used and `coverage.changed` is not configured, coverage reports inherit the changed files collected by `--changed`.
+This option is available in both config and CLI:
+
+- Use `coverage.changed` in `rstest.config.ts` when you want a persistent default, for example in CI.
+- Use `--coverage.changed` for one-off local or CI runs.
+
+`coverage.changed` only limits the coverage report scope. It does not change which tests are executed.
+
+That means these two commands do different things:
+
+```bash
+npx rstest run --changed
+npx rstest run --coverage.changed
+```
+
+- `--changed` changes the test selection and runs tests related to changed files.
+- `--coverage.changed` keeps the normal test selection, but only reports coverage for changed source files.
+
+#### Interaction with `--changed`
+
+- When [`--changed`](/guide/basic/cli#run-changed-tests) is used and `coverage.changed` is not configured, coverage reports inherit the changed files collected by `--changed`.
+- If `--changed` hits [`forceRerunTriggers`](/config/test/force-rerun-triggers), Rstest reruns the full test suite. Coverage stays full in that case unless `coverage.changed` is explicitly enabled.
+- If you want to use `--changed` for test selection but still keep full coverage reports, set `coverage.changed` to `false` in config.
+
+Common setups:
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    changed: 'origin/main',
+  },
+});
+```
+
+The example above still runs the normal test suite, but the coverage report only includes files changed since `origin/main`.
 
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
@@ -148,9 +184,13 @@ export default defineConfig({
 ```
 
 ```bash
+npx rstest run --changed --coverage
 npx rstest run --coverage.changed
 npx rstest run --coverage.changed=HEAD~1
 ```
+
+- `npx rstest run --changed --coverage` runs changed-related tests and, by default, also limits coverage to the same changed file set.
+- `npx rstest run --coverage.changed=HEAD~1` runs the normal test suite but only reports coverage for files changed since `HEAD~1`.
 
 ### exclude
 

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -126,6 +126,8 @@ export default defineConfig({
 
 ### changed
 
+<ApiMeta addedVersion="0.10.0" />
+
 - **Type:** `boolean | string`
 - **Default:** `undefined`
 - **CLI:** `--coverage.changed`, `--coverage.changed=<commit>`

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -134,7 +134,7 @@ export default defineConfig({
 
 Collect coverage only for files changed in the current Git repository. Pass a commit or branch to collect coverage for files changed since that ref.
 
-`coverage.changed` only controls the coverage report scope. It does not change which tests are executed. When `--changed` is used and `coverage.changed` is not configured, coverage reports inherit the changed files collected by `--changed`.
+`coverage.changed` only controls the coverage report scope. It does not change which tests are executed. When [`--changed`](/guide/basic/cli#run-changed-tests) is used and `coverage.changed` is not configured, coverage reports inherit the changed files collected by `--changed`.
 
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -104,6 +104,8 @@ npx rstest run --changed=origin/main
 
 When a changed file matches [`forceRerunTriggers`](/config/test/force-rerun-triggers), Rstest runs the whole test suite instead of only related tests.
 
+When coverage is enabled and [`coverage.changed`](/config/test/coverage#changed) is not configured, `--changed` also limits coverage reports to changed source files. If a changed file matches [`forceRerunTriggers`](/config/test/force-rerun-triggers), Rstest runs the whole test suite and reports full coverage unless `coverage.changed` is explicitly enabled.
+
 Use `rstest list` to preview which tests would run without executing them:
 
 ```bash
@@ -292,6 +294,7 @@ Rstest CLI options are registered per command instead of being shared by every c
 | `--exclude <exclude>`           | Exclude files from test, see [exclude](/config/test/exclude)                                                                                                          |
 | `-u, --update`                  | Update snapshot files, see [update](/config/test/update)                                                                                                              |
 | `--coverage`                    | Enable code coverage collection, see [coverage](/config/test/coverage)                                                                                                |
+| `--coverage.changed [commit]`   | Collect coverage only for changed files in the current Git repository, optionally since a commit                                                                      |
 | `--passWithNoTests`             | Allows the test suite to pass when no files are found, see [passWithNoTests](/config/test/pass-with-no-tests)                                                         |
 | `--silent [value]`              | Silence intercepted test console output, or keep logs only for failed tasks with `passed-only`, see [silent](/config/test/silent)                                     |
 | `--printConsoleTrace`           | Print console traces when calling any console method, see [printConsoleTrace](/config/test/print-console-trace)                                                       |

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -187,10 +187,12 @@ export default defineConfig({
 npx rstest run --changed --coverage
 npx rstest run --coverage.changed
 npx rstest run --coverage.changed=HEAD~1
+npx rstest run --coverage.changed=origin/main
 ```
 
 - `npx rstest run --changed --coverage` 会运行变更相关测试，并且默认把覆盖率也限制到同一批变更文件。
 - `npx rstest run --coverage.changed=HEAD~1` 会执行正常测试集，但只报告相对 `HEAD~1` 以来变更文件的覆盖率。
+- `npx rstest run --coverage.changed=origin/main` 适合在功能分支上使用：它仍然会执行正常测试集，但覆盖率报告只包含相对 `origin/main` 变更过的文件。
 
 ### exclude
 

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -15,6 +15,7 @@ type CoverageOptions = {
   enabled?: boolean;
   provider?: 'istanbul';
   include?: string[];
+  changed?: boolean | string;
   exclude?: string[];
   reporters?: (keyof ReportOptions | ReportWithOptions)[];
   reportsDirectory?: string;
@@ -121,6 +122,32 @@ export default defineConfig({
     include: ['src/**/*.{js,jsx,ts,tsx}'],
   },
 });
+```
+
+### changed
+
+- **类型：** `boolean | string`
+- **默认值：** `undefined`
+- **CLI：** `--coverage.changed`, `--coverage.changed=<commit>`
+
+只收集当前 Git 仓库中变更文件的覆盖率。你也可以传入 commit 或 branch，收集从该 ref 以来变更文件的覆盖率。
+
+`coverage.changed` 只控制覆盖率报告范围，不会改变要运行的测试。当使用 `--changed` 且没有配置 `coverage.changed` 时，覆盖率报告会继承 `--changed` 收集到的变更文件。
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    changed: 'HEAD~1',
+  },
+});
+```
+
+```bash
+npx rstest run --coverage.changed
+npx rstest run --coverage.changed=HEAD~1
 ```
 
 ### exclude

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -134,7 +134,7 @@ export default defineConfig({
 
 只收集当前 Git 仓库中变更文件的覆盖率。你也可以传入 commit 或 branch，收集从该 ref 以来变更文件的覆盖率。
 
-`coverage.changed` 只控制覆盖率报告范围，不会改变要运行的测试。当使用 `--changed` 且没有配置 `coverage.changed` 时，覆盖率报告会继承 `--changed` 收集到的变更文件。
+`coverage.changed` 只控制覆盖率报告范围，不会改变要运行的测试。当使用 [`--changed`](/guide/basic/cli#运行变更相关测试) 且没有配置 `coverage.changed` 时，覆盖率报告会继承 `--changed` 收集到的变更文件。
 
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -134,7 +134,43 @@ export default defineConfig({
 
 只收集当前 Git 仓库中变更文件的覆盖率。你也可以传入 commit 或 branch，收集从该 ref 以来变更文件的覆盖率。
 
-`coverage.changed` 只控制覆盖率报告范围，不会改变要运行的测试。当使用 [`--changed`](/guide/basic/cli#运行变更相关测试) 且没有配置 `coverage.changed` 时，覆盖率报告会继承 `--changed` 收集到的变更文件。
+这个选项既可以写在配置里，也可以通过 CLI 使用：
+
+- 当你希望在项目里长期保持一个默认行为时，使用 `rstest.config.ts` 中的 `coverage.changed`，例如在 CI 中。
+- 当你只想临时跑一次时，使用 `--coverage.changed`。
+
+`coverage.changed` 只控制覆盖率报告范围，不会改变要运行的测试。
+
+也就是说，下面两个命令的效果并不一样：
+
+```bash
+npx rstest run --changed
+npx rstest run --coverage.changed
+```
+
+- `--changed` 会改变测试选择范围，只运行与变更文件相关的测试。
+- `--coverage.changed` 会保持正常的测试选择范围，只把覆盖率报告限制在变更的源码文件上。
+
+#### 与 `--changed` 的关系
+
+- 当使用 [`--changed`](/guide/basic/cli#运行变更相关测试) 且没有配置 `coverage.changed` 时，覆盖率报告会继承 `--changed` 收集到的变更文件。
+- 如果 `--changed` 命中了 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，Rstest 会回退为运行完整测试套件。此时覆盖率默认也会回到完整范围，除非显式启用了 `coverage.changed`。
+- 如果你想用 `--changed` 缩小测试执行范围，但仍然保留完整覆盖率报告，可以在配置中将 `coverage.changed` 设为 `false`。
+
+常见用法如下：
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    changed: 'origin/main',
+  },
+});
+```
+
+上面的配置不会改变测试执行范围，但会让覆盖率报告只包含相对 `origin/main` 有变更的文件。
 
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
@@ -148,9 +184,13 @@ export default defineConfig({
 ```
 
 ```bash
+npx rstest run --changed --coverage
 npx rstest run --coverage.changed
 npx rstest run --coverage.changed=HEAD~1
 ```
+
+- `npx rstest run --changed --coverage` 会运行变更相关测试，并且默认把覆盖率也限制到同一批变更文件。
+- `npx rstest run --coverage.changed=HEAD~1` 会执行正常测试集，但只报告相对 `HEAD~1` 以来变更文件的覆盖率。
 
 ### exclude
 

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -126,6 +126,8 @@ export default defineConfig({
 
 ### changed
 
+<ApiMeta addedVersion="0.10.0" />
+
 - **类型：** `boolean | string`
 - **默认值：** `undefined`
 - **CLI：** `--coverage.changed`, `--coverage.changed=<commit>`

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -104,6 +104,8 @@ npx rstest run --changed=origin/main
 
 当变更文件命中 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 时，Rstest 会运行完整测试套件，而不是只运行相关测试。
 
+开启覆盖率且未配置 [`coverage.changed`](/config/test/coverage#changed) 时，`--changed` 也会将覆盖率报告限制在变更的源文件范围内。如果变更文件命中 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，Rstest 会运行完整测试套件，并生成完整覆盖率报告，除非显式启用了 `coverage.changed`。
+
 如果只想预览将要执行哪些测试，可以配合 `rstest list` 使用：
 
 ```bash
@@ -291,6 +293,7 @@ Rstest CLI 参数是按命令注册的，并不是所有命令共享同一套参
 | `--exclude <exclude>`           | 排除指定文件，详见 [exclude](/config/test/exclude)                                                                                                   |
 | `-u, --update`                  | 更新快照文件，详见 [update](/config/test/update)                                                                                                     |
 | `--coverage`                    | 启用代码覆盖率收集，详见 [coverage](/config/test/coverage)                                                                                           |
+| `--coverage.changed [commit]`   | 只收集当前 Git 仓库中变更文件的覆盖率，也可以指定从某个 commit 以来的变更                                                                            |
 | `--passWithNoTests`             | 当未找到测试文件时允许测试通过，详见 [passWithNoTests](/config/test/pass-with-no-tests)                                                              |
 | `--silent [value]`              | 静默被拦截的测试 console 输出，或用 `passed-only` 仅保留失败任务日志，详见 [silent](/config/test/silent)                                             |
 | `--printConsoleTrace`           | 调用 console 方法时打印调用栈，详见 [printConsoleTrace](/config/test/print-console-trace)                                                            |


### PR DESCRIPTION
## Summary

This PR adds changed-file scoped coverage so users can collect coverage only for files changed in the current Git repository, either through `coverage.changed` config or `--coverage.changed [commit]`. It also makes `--changed` reuse its changed source file set for coverage when coverage is enabled and `coverage.changed` is not explicitly configured, while preserving full coverage for force reruns unless changed coverage is explicitly requested.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).