### PR TITLE
fix(core): improve related changed hints

### DIFF
--- a/e2e/browser-mode/related.test.ts
+++ b/e2e/browser-mode/related.test.ts
@@ -46,7 +46,9 @@ describe('browser mode - related', () => {
 
     await expectExecFailed();
 
-    expect(cli.stderr).toContain('No test files found, exiting with code 1.');
+    expect(cli.stderr).toContain(
+      'No test files found for related source files, exiting with code 1.',
+    );
     expect(cli.log).toContain('related:');
     expect(cli.log).toContain('tests/src/missing.ts');
     expect(cli.log).not.toContain('index.test.ts');

--- a/e2e/filter/changed.test.ts
+++ b/e2e/filter/changed.test.ts
@@ -235,6 +235,9 @@ describe('changed test filtering', () => {
     expect(cli.stdout).toContain(
       'Changed file(package.json) matched forceRerunTriggers, running all test files.',
     );
+    expect(cli.stdout).toContain(
+      'Changed file(package.json) matched forceRerunTriggers, running all test files.\n\n',
+    );
 
     const logs = collectRunTestFileLogs(cli.stdout);
 
@@ -285,6 +288,9 @@ describe('changed test filtering', () => {
 
     expect(cli.stdout).toContain(
       'Changed files(package.json and 2 files) matched forceRerunTriggers, running all test files.',
+    );
+    expect(cli.stdout).toContain(
+      'Changed files(package.json and 2 files) matched forceRerunTriggers, running all test files.\n\n',
     );
 
     const logs = collectRunTestFileLogs(cli.stdout);

--- a/e2e/filter/changed.test.ts
+++ b/e2e/filter/changed.test.ts
@@ -232,6 +232,10 @@ describe('changed test filtering', () => {
 
     await expectExecSuccess();
 
+    expect(cli.stdout).toContain(
+      'Changed files matched forceRerunTriggers, running all test files.',
+    );
+
     const logs = collectRunTestFileLogs(cli.stdout);
 
     expect(logs).toMatchInlineSnapshot(`
@@ -259,6 +263,8 @@ describe('changed test filtering', () => {
 
     await expectExecSuccess();
 
-    expect(cli.stdout).toContain('No test files found, exiting with code 0.');
+    expect(cli.stdout).toContain(
+      'No changed files found, exiting with code 0.',
+    );
   });
 });

--- a/e2e/filter/changed.test.ts
+++ b/e2e/filter/changed.test.ts
@@ -233,7 +233,7 @@ describe('changed test filtering', () => {
     await expectExecSuccess();
 
     expect(cli.stdout).toContain(
-      'Changed files matched forceRerunTriggers, running all test files.',
+      'Changed file(package.json) matched forceRerunTriggers, running all test files.',
     );
 
     const logs = collectRunTestFileLogs(cli.stdout);
@@ -242,6 +242,57 @@ describe('changed test filtering', () => {
       [
         " ✓ index.test.ts (1)",
         " ✓ other.test.ts (1)",
+      ]
+    `);
+  });
+
+  it('should list extra changed files when multiple force rerun triggers change', async () => {
+    const { fixturesTargetPath } = await prepareChangedFixture(
+      'changed-force-rerun-multiple',
+    );
+
+    await initGitFixture(fixturesTargetPath);
+
+    await writeFile(
+      join(fixturesTargetPath, 'package.json'),
+      `${JSON.stringify({ name: 'changed-force-rerun', version: '1.0.1' })}\n`,
+    );
+    await writeFile(
+      join(fixturesTargetPath, 'rstest.config.ts'),
+      [
+        'export default {',
+        "  forceRerunTriggers: ['package.json', 'rstest.config.ts', 'src/shared.ts'],",
+        '};',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      join(fixturesTargetPath, 'src/shared.ts'),
+      'export const greet = (name: string) => `Hi, ${name}!`;\n',
+    );
+
+    const { cli, expectExecFailed } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--changed'],
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecFailed();
+
+    expect(cli.stdout).toContain(
+      'Changed files(package.json and 2 files) matched forceRerunTriggers, running all test files.',
+    );
+
+    const logs = collectRunTestFileLogs(cli.stdout);
+
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        " ✗ index.test.ts (1)",
+        " ✗ other.test.ts (1)",
       ]
     `);
   });

--- a/e2e/filter/fixtures-changed/rstest.config.ts
+++ b/e2e/filter/fixtures-changed/rstest.config.ts
@@ -1,0 +1,3 @@
+export default {
+  forceRerunTriggers: ['package.json'],
+};

--- a/e2e/filter/related.test.ts
+++ b/e2e/filter/related.test.ts
@@ -120,7 +120,9 @@ describe('related test filtering', () => {
 
     await expectExecFailed();
 
-    expect(cli.stderr).toContain('No test files found, exiting with code 1.');
+    expect(cli.stderr).toContain(
+      'No test files found for related source files, exiting with code 1.',
+    );
     expect(cli.log).toContain('related:');
     expect(cli.log).toContain('404.ts');
     expect(cli.log).not.toContain('__rstest_related_no_match__');
@@ -139,7 +141,9 @@ describe('related test filtering', () => {
 
     await expectExecFailed();
 
-    expect(cli.stderr).toContain('No test files found, exiting with code 1.');
+    expect(cli.stderr).toContain(
+      'No test files found for related source files, exiting with code 1.',
+    );
     expect(cli.log).toContain('related:');
     expect(cli.log).toContain('src/fallback.ts');
     expect(cli.log).not.toContain('src/fallback.ts.test.ts');

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -12,6 +12,7 @@ import {
   color,
   createCoverageProvider,
   type FormattedError,
+  getNoTestFilesMessage,
   getSetupFiles,
   getTestEntries,
   isDebug,
@@ -1945,7 +1946,11 @@ export const runBrowserController = async (
     if (!skipOnTestRunEnd) {
       const message = shouldKeepWatchingWithEmptySet
         ? 'No test files found.'
-        : `No test files found, exiting with code ${code}.`;
+        : getNoTestFilesMessage({
+            context,
+            code,
+            defaultMessage: `No test files found, exiting with code ${code}.`,
+          });
       if (code === 0) {
         logger.log(color.yellow(message));
       } else {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -40,7 +40,13 @@ export type {
   WorkerState,
 } from './types';
 // Utils needed by browser package
-export { color, isDebug, logger, serializableConfig } from './utils';
+export {
+  color,
+  getNoTestFilesMessage,
+  isDebug,
+  logger,
+  serializableConfig,
+} from './utils';
 // Constants
 export {
   globalApis,

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -296,6 +296,30 @@ export const getForceRerunTriggers = ({
     ]),
   );
 
+export const getForceRerunTriggerFiles = ({
+  changedFiles,
+  triggers,
+  rootPath,
+}: {
+  changedFiles: string[];
+  triggers: string[];
+  rootPath: string;
+}): string[] => {
+  if (!triggers.length || !changedFiles.length) {
+    return [];
+  }
+
+  const matcher = picomatch(
+    triggers.map((trigger) => normalize(trigger)),
+    { windows: true },
+  );
+
+  return changedFiles.filter(
+    (file) =>
+      matcher(normalize(relative(rootPath, file))) || matcher(normalize(file)),
+  );
+};
+
 export const hasForceRerunTrigger = ({
   changedFiles,
   triggers,
@@ -304,21 +328,8 @@ export const hasForceRerunTrigger = ({
   changedFiles: string[];
   triggers: string[];
   rootPath: string;
-}): boolean => {
-  if (!triggers.length || !changedFiles.length) {
-    return false;
-  }
-
-  const matcher = picomatch(
-    triggers.map((trigger) => normalize(trigger)),
-    { windows: true },
-  );
-
-  return changedFiles.some(
-    (file) =>
-      matcher(normalize(relative(rootPath, file))) || matcher(normalize(file)),
-  );
-};
+}): boolean =>
+  getForceRerunTriggerFiles({ changedFiles, triggers, rootPath }).length > 0;
 
 export const resolveChangedFiles = async (
   cwd: string,
@@ -418,6 +429,7 @@ const resolveEffectiveCliFilters = async ({
   relatedMode?: 'related' | 'changed';
   relatedResolutionEmpty?: boolean;
   relatedRerunReason?: 'forceRerunTrigger';
+  relatedRerunFiles?: string[];
 }> => {
   const normalizedFilters = normalizeCliFilters(filters);
 
@@ -444,17 +456,19 @@ const resolveEffectiveCliFilters = async ({
         )
       : normalizedFilters;
 
-  if (
-    options.changed !== undefined &&
-    hasForceRerunTrigger({
-      changedFiles: sourceFilters,
-      triggers: getForceRerunTriggers({
-        rootTriggers: rstest.context.normalizedConfig.forceRerunTriggers,
-        projects: rstest.context.projects,
-      }),
-      rootPath: rstest.context.rootPath,
-    })
-  ) {
+  const forceRerunTriggerFiles =
+    options.changed !== undefined
+      ? getForceRerunTriggerFiles({
+          changedFiles: sourceFilters,
+          triggers: getForceRerunTriggers({
+            rootTriggers: rstest.context.normalizedConfig.forceRerunTriggers,
+            projects: rstest.context.projects,
+          }),
+          rootPath: rstest.context.rootPath,
+        })
+      : [];
+
+  if (forceRerunTriggerFiles.length) {
     return {
       effectiveFilters: [],
       fileFilterMode: 'fuzzy',
@@ -462,6 +476,9 @@ const resolveEffectiveCliFilters = async ({
       relatedMode: 'changed',
       relatedResolutionEmpty: false,
       relatedRerunReason: 'forceRerunTrigger',
+      relatedRerunFiles: forceRerunTriggerFiles.map((file) =>
+        normalize(relative(rstest.context.rootPath, file)),
+      ),
     };
   }
 
@@ -504,6 +521,7 @@ export const runRest = async ({
       relatedMode,
       relatedResolutionEmpty,
       relatedRerunReason,
+      relatedRerunFiles,
     } = await resolveEffectiveCliFilters({
       options,
       filters,
@@ -523,6 +541,7 @@ export const runRest = async ({
     rstest.context.relatedMode = relatedMode;
     rstest.context.relatedResolutionEmpty = relatedResolutionEmpty;
     rstest.context.relatedRerunReason = relatedRerunReason;
+    rstest.context.relatedRerunFiles = relatedRerunFiles;
 
     process.on('uncaughtException', unexpectedlyExitHandler);
 
@@ -633,6 +652,7 @@ export function createCli(): CAC {
           relatedMode,
           relatedResolutionEmpty,
           relatedRerunReason,
+          relatedRerunFiles,
         } = await resolveEffectiveCliFilters({
           options,
           filters,
@@ -652,6 +672,7 @@ export function createCli(): CAC {
         rstest.context.relatedMode = relatedMode;
         rstest.context.relatedResolutionEmpty = relatedResolutionEmpty;
         rstest.context.relatedRerunReason = relatedRerunReason;
+        rstest.context.relatedRerunFiles = relatedRerunFiles;
 
         await rstest.listTests({
           filesOnly: options.filesOnly,

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -415,7 +415,9 @@ const resolveEffectiveCliFilters = async ({
   effectiveFilters: string[];
   fileFilterMode: FileFilterMode;
   relatedFilters?: string[];
+  relatedMode?: 'related' | 'changed';
   relatedResolutionEmpty?: boolean;
+  relatedRerunReason?: 'forceRerunTrigger';
 }> => {
   const normalizedFilters = normalizeCliFilters(filters);
 
@@ -457,7 +459,9 @@ const resolveEffectiveCliFilters = async ({
       effectiveFilters: [],
       fileFilterMode: 'fuzzy',
       relatedFilters: sourceFilters,
+      relatedMode: 'changed',
       relatedResolutionEmpty: false,
+      relatedRerunReason: 'forceRerunTrigger',
     };
   }
 
@@ -471,6 +475,7 @@ const resolveEffectiveCliFilters = async ({
     effectiveFilters: relatedFiles,
     fileFilterMode: 'exact',
     relatedFilters: sourceFilters,
+    relatedMode: options.changed !== undefined ? 'changed' : 'related',
     relatedResolutionEmpty: relatedFiles.length === 0,
   };
 };
@@ -496,7 +501,9 @@ export const runRest = async ({
       effectiveFilters,
       fileFilterMode,
       relatedFilters,
+      relatedMode,
       relatedResolutionEmpty,
+      relatedRerunReason,
     } = await resolveEffectiveCliFilters({
       options,
       filters,
@@ -513,7 +520,9 @@ export const runRest = async ({
       fileFilterMode,
     );
     rstest.context.relatedFilters = relatedFilters;
+    rstest.context.relatedMode = relatedMode;
     rstest.context.relatedResolutionEmpty = relatedResolutionEmpty;
+    rstest.context.relatedRerunReason = relatedRerunReason;
 
     process.on('uncaughtException', unexpectedlyExitHandler);
 
@@ -621,7 +630,9 @@ export function createCli(): CAC {
           effectiveFilters,
           fileFilterMode,
           relatedFilters,
+          relatedMode,
           relatedResolutionEmpty,
+          relatedRerunReason,
         } = await resolveEffectiveCliFilters({
           options,
           filters,
@@ -638,7 +649,9 @@ export function createCli(): CAC {
           fileFilterMode,
         );
         rstest.context.relatedFilters = relatedFilters;
+        rstest.context.relatedMode = relatedMode;
         rstest.context.relatedResolutionEmpty = relatedResolutionEmpty;
+        rstest.context.relatedRerunReason = relatedRerunReason;
 
         await rstest.listTests({
           filesOnly: options.filesOnly,

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -58,7 +58,9 @@ export class Rstest implements RstestContext {
   public fileFilters?: string[];
   public fileFilterMode?: FileFilterMode;
   public relatedFilters?: string[];
+  public relatedMode?: 'related' | 'changed';
   public relatedResolutionEmpty?: boolean;
+  public relatedRerunReason?: 'forceRerunTrigger';
   public configFilePath?: string;
   public reporters: Reporter[];
   public snapshotManager: SnapshotManager;

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -61,6 +61,7 @@ export class Rstest implements RstestContext {
   public relatedMode?: 'related' | 'changed';
   public relatedResolutionEmpty?: boolean;
   public relatedRerunReason?: 'forceRerunTrigger';
+  public relatedRerunFiles?: string[];
   public configFilePath?: string;
   public reporters: Reporter[];
   public snapshotManager: SnapshotManager;

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -147,7 +147,7 @@ export async function runTests(context: Rstest): Promise<void> {
   cleanCoverageReports(context.normalizedConfig.coverage);
 
   if (context.relatedRerunReason === 'forceRerunTrigger') {
-    logger.log(color.yellow(getForceRerunTriggerMessage(context)));
+    logger.log(`${color.yellow(getForceRerunTriggerMessage(context))}\n`);
   }
 
   // Separate browser mode and node mode projects

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -14,6 +14,7 @@ import {
   color,
   createTraceController,
   getTestEntries,
+  getNoTestFilesMessage,
   logger,
   resolveShardedEntries,
   type TraceEvent,
@@ -65,7 +66,11 @@ const reportNoTestFiles = ({
     }
   } else {
     const code = context.normalizedConfig.passWithNoTests ? 0 : 1;
-    const message = `No test files found, exiting with code ${code}.`;
+    const message = getNoTestFilesMessage({
+      context,
+      code,
+      defaultMessage: `No test files found, exiting with code ${code}.`,
+    });
 
     if (code === 0) {
       logger.log(color.yellow(message));
@@ -139,6 +144,14 @@ const notifyReportersOnTestRunEnd = async ({
 
 export async function runTests(context: Rstest): Promise<void> {
   cleanCoverageReports(context.normalizedConfig.coverage);
+
+  if (context.relatedRerunReason === 'forceRerunTrigger') {
+    logger.log(
+      color.yellow(
+        'Changed files matched forceRerunTriggers, running all test files.',
+      ),
+    );
+  }
 
   // Separate browser mode and node mode projects
   const browserProjects = context.projects.filter(

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -14,6 +14,7 @@ import {
   color,
   createTraceController,
   getTestEntries,
+  getForceRerunTriggerMessage,
   getNoTestFilesMessage,
   logger,
   resolveShardedEntries,
@@ -146,11 +147,7 @@ export async function runTests(context: Rstest): Promise<void> {
   cleanCoverageReports(context.normalizedConfig.coverage);
 
   if (context.relatedRerunReason === 'forceRerunTrigger') {
-    logger.log(
-      color.yellow(
-        'Changed files matched forceRerunTriggers, running all test files.',
-      ),
-    );
+    logger.log(color.yellow(getForceRerunTriggerMessage(context)));
   }
 
   // Separate browser mode and node mode projects

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -66,8 +66,12 @@ export type RstestContext = {
   fileFilterMode?: FileFilterMode;
   /** Original source filters passed to `--related`, `--findRelatedTests`, or resolved from `--changed`. */
   relatedFilters?: string[];
+  /** CLI option that produced related source filters. */
+  relatedMode?: 'related' | 'changed';
   /** Related test resolution completed successfully but matched no test files. */
   relatedResolutionEmpty?: boolean;
+  /** Why a related run was expanded back to the full test suite. */
+  relatedRerunReason?: 'forceRerunTrigger';
   /** The config file path. */
   configFilePath?: string;
   /**

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -72,6 +72,8 @@ export type RstestContext = {
   relatedResolutionEmpty?: boolean;
   /** Why a related run was expanded back to the full test suite. */
   relatedRerunReason?: 'forceRerunTrigger';
+  /** Changed files that caused a related run to expand back to the full test suite. */
+  relatedRerunFiles?: string[];
   /** The config file path. */
   configFilePath?: string;
   /**

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './constants';
 export * from './helper';
 export * from './logger';
 export * from './process';
+export * from './relatedRun';
 export * from './shard';
 export * from './testFiles';
 export * from './trace';

--- a/packages/core/src/utils/relatedRun.ts
+++ b/packages/core/src/utils/relatedRun.ts
@@ -1,0 +1,31 @@
+import type { RstestContext } from '../types';
+
+type RelatedRunContext = Pick<
+  RstestContext,
+  'relatedFilters' | 'relatedMode' | 'relatedResolutionEmpty'
+>;
+
+export const getNoTestFilesMessage = ({
+  context,
+  code,
+  defaultMessage,
+}: {
+  context: RelatedRunContext;
+  code: number;
+  defaultMessage: string;
+}): string => {
+  if (!context.relatedResolutionEmpty) {
+    return defaultMessage;
+  }
+
+  if (context.relatedMode === 'changed' && !context.relatedFilters?.length) {
+    return `No changed files found, exiting with code ${code}.`;
+  }
+
+  const filterLabel =
+    context.relatedMode === 'changed'
+      ? 'changed files'
+      : 'related source files';
+
+  return `No test files found for ${filterLabel}, exiting with code ${code}.`;
+};

--- a/packages/core/src/utils/relatedRun.ts
+++ b/packages/core/src/utils/relatedRun.ts
@@ -2,7 +2,10 @@ import type { RstestContext } from '../types';
 
 type RelatedRunContext = Pick<
   RstestContext,
-  'relatedFilters' | 'relatedMode' | 'relatedResolutionEmpty'
+  | 'relatedFilters'
+  | 'relatedMode'
+  | 'relatedResolutionEmpty'
+  | 'relatedRerunFiles'
 >;
 
 export const getNoTestFilesMessage = ({
@@ -29,3 +32,26 @@ export const getNoTestFilesMessage = ({
 
   return `No test files found for ${filterLabel}, exiting with code ${code}.`;
 };
+
+export const formatForceRerunTriggerFiles = (files: string[]): string => {
+  const [firstFile, ...otherFiles] = files;
+
+  if (!firstFile) {
+    return 'files';
+  }
+
+  if (otherFiles.length === 0) {
+    return `file(${firstFile})`;
+  }
+
+  const suffix = otherFiles.length === 1 ? 'file' : 'files';
+
+  return `files(${firstFile} and ${otherFiles.length} ${suffix})`;
+};
+
+export const getForceRerunTriggerMessage = (
+  context: RelatedRunContext,
+): string =>
+  `Changed ${formatForceRerunTriggerFiles(
+    context.relatedRerunFiles ?? [],
+  )} matched forceRerunTriggers, running all test files.`;

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -5,6 +5,7 @@ import { normalize } from 'pathe';
 import { describe, expect, it, onTestFinished, rs } from '@rstest/core';
 import {
   createCli,
+  getForceRerunTriggerFiles,
   getForceRerunTriggers,
   hasForceRerunTrigger,
   normalizeCliFilters,
@@ -181,6 +182,26 @@ describe('hasForceRerunTrigger', () => {
         rootPath,
       }),
     ).toBe(true);
+  });
+});
+
+describe('getForceRerunTriggerFiles', () => {
+  it('returns only changed files that match force rerun triggers', () => {
+    const rootPath = normalize(join('workspace', 'project'));
+    const packageJson = normalize(join(rootPath, 'package.json'));
+    const configFile = normalize(join(rootPath, 'rstest.config.ts'));
+
+    expect(
+      getForceRerunTriggerFiles({
+        changedFiles: [
+          packageJson,
+          normalize(join(rootPath, 'src/index.ts')),
+          configFile,
+        ],
+        triggers: ['package.json', configFile],
+        rootPath,
+      }),
+    ).toEqual([packageJson, configFile]);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR improves CLI hints for related/changed filtering edge cases. `--changed` now reports when no changed files are found, related/changed no-match runs get more specific no-test messages, and force rerun trigger matches explicitly say that the full test suite is being run. Browser-mode no-test output reuses the same message helper for consistency.

<img width="532" height="172" alt="image" src="https://github.com/user-attachments/assets/b68535a6-55e1-4427-84e8-c0e3975fa4b7" />

<img width="576" height="175" alt="image" src="https://github.com/user-attachments/assets/c3933723-3fc1-414c-9700-33e0f30d781f" />

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).