### PR TITLE
test(e2e): loosen github-actions Duration regex to avoid Windows flakes

### DIFF
--- a/e2e/reporter/githubActions.test.ts
+++ b/e2e/reporter/githubActions.test.ts
@@ -55,7 +55,7 @@ it.skipIf(!process.env.CI)('github-actions', async () => {
   expect(stepSummary).toContain('| **Test Files** | ❌ 1 failed |');
   expect(stepSummary).toContain('| **Tests** | ❌ 2 failed |');
   expect(stepSummary).toMatch(
-    /\| \*\*Duration\*\* \| \d+ms \(build \d+ms, tests \d+ms\) \|/,
+    /\| \*\*Duration\*\* \| .+ \(build .+, tests .+\) \|/,
   );
   expect(stepSummary).toContain('## Failures');
   expect(stepSummary).toContain(
@@ -174,7 +174,7 @@ it.skipIf(!process.env.CI)('github-actions summary on pass', async () => {
     '| **Tests** | ✅ 13 passed \\| 1 skipped (14) |',
   );
   expect(stepSummary).toMatch(
-    /\| \*\*Duration\*\* \| \d+ms \(build \d+ms, tests \d+ms\) \|/,
+    /\| \*\*Duration\*\* \| .+ \(build .+, tests .+\) \|/,
   );
   expect(stepSummary).not.toContain('## Failures');
 


### PR DESCRIPTION
## Summary

The `github-actions` reporter e2e tests assert the Duration row with `/\| \*\*Duration\*\* \| \d+ms \(build \d+ms, tests \d+ms\) \|/`, which only matches values formatted as milliseconds. However, `prettyTime` switches to `X.YZs` once the value crosses 1000ms, and on slower Windows runners the total occasionally exceeds 1s — producing output like `| **Duration** | 1.53s (build 772ms, tests 757ms) |` and failing the assertion. This caused intermittent failures on a single Windows matrix job (e.g. [run 25915348435](https://github.com/web-infra-dev/rstest/actions/runs/25915348435/job/76170926433)) while peer jobs passed.

Loosen the regex to match the row structure (`(build …, tests …)`) instead of pinning the time unit, since the unit choice isn't part of what the test is verifying.

## Related Links

- Failing job: https://github.com/web-infra-dev/rstest/actions/runs/25915348435/job/76170926433

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).