### PR TITLE
perf(cli): remove process title startup overhead

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -5,8 +5,6 @@ import { prepareCli } from './prepare';
 export { initCli } from './init';
 
 export function runCLI(): void {
-  // make it easier to identify the process via activity monitor or other tools
-  process.title = 'rstest-node';
   prepareCli();
 
   try {


### PR DESCRIPTION
## Summary

This PR removes the Rstest CLI startup code that updates `process.title`. Updating the process title is a synchronous native operation and adds measurable overhead for short-lived CLI commands, while the title is not required for CLI correctness.

The equivalent Rsbuild change improved `rsbuild build` by `18.501 ms` mean time in a 30-run `react-1k` benchmark and by `10.018 ms` mean time in an 80-run benchmark.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7657
https://github.com/nodejs/node/issues/59678

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
