### PR TITLE
docs: update agent migrate skill

### DIFF
--- a/website/docs/en/shared/agent-migrate.md
+++ b/website/docs/en/shared/agent-migrate.md
@@ -11,36 +11,32 @@ Migrate Jest- or Vitest-based tests and configuration to Rstest with minimal beh
 3. **Do not change user source behavior**: avoid modifying production/business source files unless user explicitly requests it.
 4. **Avoid bulk test rewrites**: do not refactor entire test suites when a local compatibility patch can solve it.
 5. **Preserve test intent**: keep assertions and scenario coverage unchanged unless clearly broken by framework differences.
-6. **Defer legacy runner removal**: keep Jest/Vitest dependency and legacy config during migration; remove only after Rstest tests pass.
+6. **Two-phase legacy-runner lifecycle (per migrated scope)**: (a) While the scope being migrated is not green on Rstest, keep every Jest/Vitest dep + config/setup/workspace file untouched — they are your rollback path. (b) Once that scope is green, delete its scope-local legacy config/setup files in the same commit. Drop the shared legacy devDeps (`jest`, `vitest`, adapters, environments) only when no other scope still relies on them — in a partial / mixed-mode monorepo migration that means the final scope, not the first. Leaving files behind "for reference" creates two source-of-truth configs. Framework-specific file enumeration: see the deltas reference.
+7. **Literal API substitution, no shims**: rewrite every `vi.` / `jest.` / `vitest.` call site — no global aliasing, no local rebinding, no aliased imports. Full forbidden-form list and reasoning in `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`.
+8. **Replace on call sites, not strings**: match only identifiers preceding `(`; after every batch edit, grep `describe\(|it\(|test\(` to confirm no test name string was mutated. Regex template and rationale in `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`.
+9. **Coverage thresholds are not negotiable**: never lower `coverage.thresholds` (lines/functions/branches/statements) to make a migrated suite pass. If thresholds fail under Rstest, investigate `coverage.include` / `exclude` / provider wiring before touching the numbers.
 
 ## Workflow
 
 1. Detect current test framework (`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md`)
-2. Open the official migration guide(s):
-   - Jest: https://rstest.rs/guide/migration/jest.md
-   - Vitest: https://rstest.rs/guide/migration/vitest.md
-   - Prefer the `.md` URL form when available; Rstest pages provide Markdown variants that are more AI-friendly.
-3. Dependency install gate (blocker check, see `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`)
-4. Apply framework-specific migration deltas:
+2. Dependency install gate (blocker check, see `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`)
+3. Open the framework-specific deltas file and the official migration guide it points to. Prefer the `.md` URL form when fetching — Rstest pages provide Markdown variants that are more AI-friendly.
    - Jest: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/jest-migration-deltas.md`
    - Vitest: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/vitest-migration-deltas.md`
    - Global API replacement rules: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`
-   - Known compatibility pitfalls: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/rstest-compat-pitfalls.md`
+4. Apply the mapping from the official guide + the skill-side enforcement rules from the deltas file
 5. Check type errors
 6. Run tests and fix deltas
-7. Remove legacy test runner dependency/config only after Rstest is green
+7. Apply cleanup phase of principle 6 once the migrated scope is green (delete scope-local legacy config/setup in the same commit; drop shared legacy devDeps only when no other scope still relies on them; framework-specific file list is in the deltas file)
 8. Summarize changes
 
-## 1. Detect current test framework
+## Detect current test framework
 
-Use `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md`.
-If both Jest and Vitest are present, migrate one scope at a time (package/suite), keeping mixed mode until each scope is green on Rstest.
+See `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md` for detection signals and the mixed-mode scope policy.
 
-## 3. Dependency install gate (blocker check)
+## Dependency install gate (blocker check)
 
-Before large-scale edits, verify dependencies can be installed and test runner binaries are available.
-Detailed checks, blocked-mode output format, and `ni` policy are in:
-`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`
+Before large-scale edits, verify dependencies can be installed and test runner binaries are available. Detailed checks, blocked-mode output format, and `ni` policy are in `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`.
 
 ## Patch scope policy (strict)
 
@@ -56,11 +52,12 @@ Detailed checks, blocked-mode output format, and `ni` policy are in:
 
 ### Red lines
 
+Principles 6–9 above are themselves red lines — the bullets below cover the scope / intent red lines not captured there:
+
 - Do not rewrite many tests in one sweep without first proving config-level fixes are insufficient.
 - Do not alter business/runtime behavior to satisfy tests.
 - Do not change assertion semantics just to make tests pass.
-- Do not broaden migration to unrelated packages in monorepo.
-- Do not delete legacy runner dependency/config before confirming Rstest tests pass.
+- Do not broaden migration to unrelated packages in a monorepo.
 
 ### Escalation rule for large edits
 
@@ -76,15 +73,13 @@ stop and provide:
 3. expected impact/risk per option,
 4. recommended option.
 
-## 6. Run tests and fix deltas
+## Run tests and fix deltas
 
 - Run the test suite and fix failures iteratively.
 - Fix configuration and resolver errors first, then address mocks/timers/snapshots, and touch test logic last.
-- If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3`.
-- Before broad test rewrites, check known pitfalls in:
-  `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/rstest-compat-pitfalls.md`
+- If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3` (fixed in 0.9.3 — upgrade before debugging mock behavior further).
 
-## 8. Summarize changes
+## Summarize changes
 
 - Provide a concise change summary and list files touched.
 - Call out any remaining manual steps or TODOs.


### PR DESCRIPTION
## Summary

Updates the generated agent migration guidance used by the documentation site so it matches the latest `migrate-to-rstest` skill content. The refreshed guidance tightens legacy runner cleanup rules, API replacement constraints, and coverage threshold expectations for Jest/Vitest migrations.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
