### PR TITLE
fix(core): only merge performance.buildCache when user opts in

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -50,15 +50,21 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
         multipleProjects: context.projects.length > 1,
       });
 
+      // Mirrors the pattern in packages/browser/src/hostController.ts:
+      // only write `performance.buildCache` when the user has opted in.
+      // Writing `performance.buildCache: false` explicitly causes Rsbuild
+      // to set Rspack's `cache: false`, which disables Rspack's default
+      // in-memory module cache and makes every build start cold from disk
+      // (~4x slowdown on non-trivial test builds).
+      const buildCache = resolveProjectBuildCache({
+        context,
+        project,
+      });
+
       return mergeEnvironmentConfig(
         config,
         {
-          performance: {
-            buildCache: resolveProjectBuildCache({
-              context,
-              project,
-            }),
-          },
+          performance: buildCache ? { buildCache } : undefined,
           tools,
           resolve,
           source,


### PR DESCRIPTION
## Summary

`pluginBasic` writes `performance.buildCache` into the merged Rsbuild environment config on every run. When the user has **not** configured `performance.buildCache`, `resolveProjectBuildCache` returns `false`, so `performance.buildCache: false` is written explicitly. Rsbuild propagates that to Rspack as `cache: false`, which disables Rspack's default in-memory module cache (`cache: { type: 'memory' }`). Every build then starts cold from disk — roughly a **4× build-phase slowdown** on non-trivial test setups.

This PR guards the merge so `performance.buildCache` is only set when the resolved value is truthy. When the user opts in (`performance.buildCache: true | { ... }`), behaviour is unchanged.

Refs #1274.

## Bisect

Cold runs against a real-world Rsbuild + SWC + jsdom test config (191 jsdom tests, React/Lingui/Babel-macro pipeline). Build-phase only, median of N cold runs per commit:

| Commit | Build phase | Δ |
|---|---|---|
| `ff3d9a35` (parent of #1196) | **0.94s** | baseline |
| `c9907eb0` feat(core): support build cache (#1196) | **4.95s** | **+426%** |
| `2690a8bb` v0.10.0 | 5.32s | + small drift |

PR #1196 is the single cause. The other commits between v0.9.10 and v0.10.0 do not contribute.

## Hyperfine results

`hyperfine --warmup 1 --runs 10 --prepare 'rm -rf node_modules/.cache .rstest tmp/rstest'`, total wall time per run:

| Version | Mean ± σ | Min | Max | Relative |
|---|---|---|---|---|
| 0.9.10 | 7.55s ± 2.04s | 5.72s | 12.61s | 1.04× |
| 0.10.0 | 13.73s ± 3.07s | 10.60s | 18.76s | **1.89× slower** |
| 0.10.0 + this patch | **7.27s ± 0.92s** | 6.27s | 8.74s | **1.00×** |

Patched 0.10.0 is **1.89× faster than unpatched 0.10.0**, ties 0.9.10 within noise, with tighter variance (σ 0.92s vs 3.07s).

## Root cause

[`packages/core/src/core/plugins/basic.ts`](https://github.com/web-infra-dev/rstest/blob/main/packages/core/src/core/plugins/basic.ts) before:

```ts
return mergeEnvironmentConfig(
  config,
  {
    performance: {
      buildCache: resolveProjectBuildCache({ context, project }),
    },
    tools, resolve, source, output, dev,
  },
  // ...
);
```

`resolveProjectBuildCache` returns `false | RstestBuildCacheConfig`. When the user has not configured `performance.buildCache`, it returns `false`, and the literal above sets `performance.buildCache: false`. Rsbuild forwards `performance.buildCache: false` to Rspack as `cache: false`, disabling Rspack's default `cache: { type: 'memory' }`.

After this patch, `performance.buildCache` is only set in the merged config when truthy, so Rspack's in-memory cache default is preserved on opt-out users.

## Test plan

- [x] `pnpm --filter @rstest/core test` — passes
- [x] Manual bench above shows v0.10.0 + patch ties v0.9.10
- [ ] Existing `e2e/build/buildCache.test.ts` should continue to pass (it explicitly sets `performance.buildCache`, so this PR doesn't change its code path)
- [ ] If maintainers want, happy to add a regression test asserting the merged env config doesn't include `performance.buildCache` when the user has not opted in

Marked **draft** — let me know if you'd like the regression test before promoting it.

cc @9aoy @fi3ework