### PR TITLE
fix(types): export missing public types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,7 @@ export type {
   RstestExpect as Expect,
   RstestUtilities,
   TestCaseInfo,
+  TestContext,
   TestFileInfo,
   TestFileResult,
   TestInfo,

--- a/packages/core/src/runtime/api/public.ts
+++ b/packages/core/src/runtime/api/public.ts
@@ -1,7 +1,7 @@
 import type { Rstest, RstestUtilities } from '../../types';
 
 export type { Assertion } from '../../types/expect';
-export type { Mock, Mocked } from '../../types/mock';
+export type { Mock, Mocked, MockInstance } from '../../types/mock';
 
 declare global {
   var RSTEST_API: Rstest | undefined;

--- a/website/docs/en/api/javascript-api/_meta.json
+++ b/website/docs/en/api/javascript-api/_meta.json
@@ -1,1 +1,1 @@
-["reporter", "rstest-core"]
+["rstest-core", "types", "reporter"]

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -50,6 +50,10 @@ import type {
 } from '@rstest/core';
 ```
 
+<ApiMeta addedVersion="0.10.1" />
+
+`TestContext` is available as a public type export starting in Rstest 0.10.1.
+
 - `Rstest`: The full runtime API shape, including `test`, `describe`, `expect`, hooks, and `rstest` utilities.
 - `RstestUtilities`: The type of the `rstest` and `rs` utility objects.
 - `TestContext`: The context object passed to test callbacks and lifecycle hooks.

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -1,0 +1,156 @@
+---
+title: Rstest types
+description: Import public TypeScript types from @rstest/core for configuration, runtime APIs, reporters, and mock helpers.
+---
+
+import { ApiMeta } from '@components/ApiMeta';
+
+# Rstest types
+
+Rstest exports its public TypeScript types from `@rstest/core`. Use `import type` so these imports are erased from runtime output.
+
+```ts
+import type { Mock, Mocked, RstestConfig } from '@rstest/core';
+```
+
+## Configuration types
+
+Use these types when you need to type a config object, a config factory, or shared config utilities outside `defineConfig`.
+
+```ts
+import type {
+  ProjectConfig,
+  RstestConfig,
+  RstestConfigAsyncFn,
+  RstestConfigExport,
+  RstestConfigSyncFn,
+} from '@rstest/core';
+```
+
+- `RstestConfig`: The top-level Rstest configuration type.
+- `RstestConfigSyncFn`: A synchronous function that returns `RstestConfig`.
+- `RstestConfigAsyncFn`: An asynchronous function that returns `RstestConfig`.
+- `RstestConfigExport`: The union accepted by a Rstest config file.
+- `ProjectConfig`: The type for a standalone [Rstest Project](/guide/basic/projects) config.
+
+For most config files, prefer [`defineConfig`](/api/javascript-api/rstest-core#defineconfig), [`defineProject`](/api/javascript-api/rstest-core#defineproject), and [`defineInlineProject`](/api/javascript-api/rstest-core#defineinlineproject) because they preserve autocomplete without requiring explicit annotations.
+
+## Test API types
+
+Use these types when extending test APIs, defining reusable helpers, or typing custom fixtures.
+
+```ts
+import type {
+  Describe,
+  Expect,
+  ExpectStatic,
+  Rstest,
+  RstestUtilities,
+  TestContext,
+} from '@rstest/core';
+```
+
+- `Rstest`: The full runtime API shape, including `test`, `describe`, `expect`, hooks, and `rstest` utilities.
+- `RstestUtilities`: The type of the `rstest` and `rs` utility objects.
+- `TestContext`: The context object passed to test callbacks and lifecycle hooks.
+- `Describe`: The type of the `describe` API.
+- `Expect`: The assertion type returned by `expect(value)`.
+- `ExpectStatic`: The callable `expect` API type.
+
+## Mock types
+
+Use mock types when a helper accepts mock functions, spies, or mocked modules.
+
+```ts
+import type { Mock, Mocked, MockInstance } from '@rstest/core';
+```
+
+### Mock
+
+`Mock<T>` represents a callable mock function created by [`rstest.fn`](/api/runtime-api/rstest/mock-functions#rstestfn). It preserves the parameters and return type of `T` while adding mock control APIs.
+
+```ts
+import { rstest } from '@rstest/core';
+import type { Mock } from '@rstest/core';
+
+type LoadUser = (id: string) => Promise<{ name: string }>;
+
+const loadUser: Mock<LoadUser> = rstest.fn<LoadUser>();
+loadUser.mockResolvedValue({ name: 'Jack' });
+```
+
+### MockInstance
+
+<ApiMeta addedVersion="0.10.1" />
+
+`MockInstance<T>` represents the shared mock control API on both `rstest.fn()` mocks and `rstest.spyOn()` spies. Use it when a helper only needs mock methods such as `mockClear`, `mockReset`, or `mockRestore` and does not need to call the mock function directly.
+
+```ts
+import type { MockInstance } from '@rstest/core';
+
+function resetTrackedMock(mock: MockInstance) {
+  mock.mockReset();
+}
+```
+
+When you create a mock or spy inline, you usually do not need to annotate it because TypeScript can infer the type.
+
+```ts
+const spy = rstest.spyOn(service, 'loadUser');
+spy.mockResolvedValue({ name: 'Jack' });
+```
+
+### Mocked
+
+`Mocked<T>` wraps an object or module type so its methods are typed as mocks. This is useful after [`rstest.mock`](/api/runtime-api/rstest/mock-modules#rsmock), [`rstest.mockObject`](/api/runtime-api/rstest/mock-functions#rstestmockobject), or [`rstest.mocked`](/api/runtime-api/rstest/mock-functions#rstestmocked).
+
+```ts
+import { rstest } from '@rstest/core';
+import type { Mocked } from '@rstest/core';
+import * as userApi from './userApi';
+
+rstest.mock('./userApi');
+
+const mockedUserApi: Mocked<typeof userApi> = rstest.mocked(userApi);
+mockedUserApi.loadUser.mockResolvedValue({ name: 'Jack' });
+```
+
+## Reporter and result types
+
+Use these types when creating custom reporters or external tools that consume Rstest results.
+
+```ts
+import type {
+  Reporter,
+  TestCaseInfo,
+  TestFileInfo,
+  TestFileResult,
+  TestResult,
+  TestSuiteInfo,
+} from '@rstest/core';
+```
+
+For reporter implementation details, see [Reporter](/api/javascript-api/reporter).
+
+## Assertion types
+
+Use `Assertion` or `ExpectStatic` when typing custom assertion helpers.
+
+```ts
+import type { Assertion, ExpectStatic } from '@rstest/core';
+
+function expectVisible(
+  expect: ExpectStatic,
+  value: HTMLElement,
+): Assertion<HTMLElement> {
+  return expect(value);
+}
+```
+
+## Rsbuild type
+
+Rstest re-exports `Rspack` from `@rsbuild/core` for integrations that need to type Rsbuild or Rspack hooks while staying on the same dependency graph as Rstest.
+
+```ts
+import type { Rspack } from '@rstest/core';
+```

--- a/website/docs/zh/api/javascript-api/_meta.json
+++ b/website/docs/zh/api/javascript-api/_meta.json
@@ -1,1 +1,1 @@
-["reporter", "rstest-core"]
+["rstest-core", "types", "reporter"]

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -1,0 +1,156 @@
+---
+title: Rstest types
+description: 从 @rstest/core 导入公开的 TypeScript 类型，用于配置、运行时 API、Reporter 和 mock 工具。
+---
+
+import { ApiMeta } from '@components/ApiMeta';
+
+# Rstest types
+
+Rstest 会从 `@rstest/core` 导出公开的 TypeScript 类型。请使用 `import type`，这样这些导入会在运行时代码中被擦除。
+
+```ts
+import type { Mock, Mocked, RstestConfig } from '@rstest/core';
+```
+
+## 配置类型
+
+当你需要在 `defineConfig` 外部为配置对象、配置工厂或共享配置工具标注类型时，可以使用这些类型。
+
+```ts
+import type {
+  ProjectConfig,
+  RstestConfig,
+  RstestConfigAsyncFn,
+  RstestConfigExport,
+  RstestConfigSyncFn,
+} from '@rstest/core';
+```
+
+- `RstestConfig`：顶层 Rstest 配置类型。
+- `RstestConfigSyncFn`：返回 `RstestConfig` 的同步函数。
+- `RstestConfigAsyncFn`：返回 `RstestConfig` 的异步函数。
+- `RstestConfigExport`：Rstest 配置文件可接受的导出类型联合。
+- `ProjectConfig`：独立 [Rstest Project](/guide/basic/projects) 配置的类型。
+
+对于大多数配置文件，建议优先使用 [`defineConfig`](/api/javascript-api/rstest-core#defineconfig)、[`defineProject`](/api/javascript-api/rstest-core#defineproject) 和 [`defineInlineProject`](/api/javascript-api/rstest-core#defineinlineproject)，它们可以提供自动补全，而不需要显式类型标注。
+
+## Test API 类型
+
+当你扩展 Test API、定义可复用 helper 或为自定义 fixture 标注类型时，可以使用这些类型。
+
+```ts
+import type {
+  Describe,
+  Expect,
+  ExpectStatic,
+  Rstest,
+  RstestUtilities,
+  TestContext,
+} from '@rstest/core';
+```
+
+- `Rstest`：完整的运行时 API 形状，包括 `test`、`describe`、`expect`、hooks 和 `rstest` 工具。
+- `RstestUtilities`：`rstest` 和 `rs` 工具对象的类型。
+- `TestContext`：传递给测试回调和生命周期 hooks 的 context 对象。
+- `Describe`：`describe` API 的类型。
+- `Expect`：`expect(value)` 返回的 assertion 类型。
+- `ExpectStatic`：可调用的 `expect` API 类型。
+
+## Mock 类型
+
+当 helper 接收 mock function、spy 或 mocked module 时，可以使用 mock 类型。
+
+```ts
+import type { Mock, Mocked, MockInstance } from '@rstest/core';
+```
+
+### Mock
+
+`Mock<T>` 表示由 [`rstest.fn`](/api/runtime-api/rstest/mock-functions#rstestfn) 创建的可调用 mock function。它会保留 `T` 的参数和返回值类型，同时增加 mock 控制 API。
+
+```ts
+import { rstest } from '@rstest/core';
+import type { Mock } from '@rstest/core';
+
+type LoadUser = (id: string) => Promise<{ name: string }>;
+
+const loadUser: Mock<LoadUser> = rstest.fn<LoadUser>();
+loadUser.mockResolvedValue({ name: 'Jack' });
+```
+
+### MockInstance
+
+<ApiMeta addedVersion="0.10.1" />
+
+`MockInstance<T>` 表示 `rstest.fn()` mock 和 `rstest.spyOn()` spy 共享的 mock 控制 API。当一个 helper 只需要 `mockClear`、`mockReset` 或 `mockRestore` 等 mock 方法，而不需要直接调用 mock function 时，可以使用它。
+
+```ts
+import type { MockInstance } from '@rstest/core';
+
+function resetTrackedMock(mock: MockInstance) {
+  mock.mockReset();
+}
+```
+
+当你直接创建 mock 或 spy 时，通常不需要手动标注类型，TypeScript 可以自动推导。
+
+```ts
+const spy = rstest.spyOn(service, 'loadUser');
+spy.mockResolvedValue({ name: 'Jack' });
+```
+
+### Mocked
+
+`Mocked<T>` 会包装对象或模块类型，使其中的方法按 mock 类型处理。它适合配合 [`rstest.mock`](/api/runtime-api/rstest/mock-modules#rsmock)、[`rstest.mockObject`](/api/runtime-api/rstest/mock-functions#rstestmockobject) 或 [`rstest.mocked`](/api/runtime-api/rstest/mock-functions#rstestmocked) 使用。
+
+```ts
+import { rstest } from '@rstest/core';
+import type { Mocked } from '@rstest/core';
+import * as userApi from './userApi';
+
+rstest.mock('./userApi');
+
+const mockedUserApi: Mocked<typeof userApi> = rstest.mocked(userApi);
+mockedUserApi.loadUser.mockResolvedValue({ name: 'Jack' });
+```
+
+## Reporter 和结果类型
+
+当你创建自定义 Reporter，或编写消费 Rstest 结果的外部工具时，可以使用这些类型。
+
+```ts
+import type {
+  Reporter,
+  TestCaseInfo,
+  TestFileInfo,
+  TestFileResult,
+  TestResult,
+  TestSuiteInfo,
+} from '@rstest/core';
+```
+
+Reporter 实现细节见 [Reporter](/api/javascript-api/reporter)。
+
+## Assertion 类型
+
+当你为自定义 assertion helper 标注类型时，可以使用 `Assertion` 或 `ExpectStatic`。
+
+```ts
+import type { Assertion, ExpectStatic } from '@rstest/core';
+
+function expectVisible(
+  expect: ExpectStatic,
+  value: HTMLElement,
+): Assertion<HTMLElement> {
+  return expect(value);
+}
+```
+
+## Rsbuild 类型
+
+Rstest 会从 `@rsbuild/core` 重新导出 `Rspack`，用于需要标注 Rsbuild 或 Rspack hooks 的集成场景，同时保持与 Rstest 相同的依赖图。
+
+```ts
+import type { Rspack } from '@rstest/core';
+```

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -50,6 +50,10 @@ import type {
 } from '@rstest/core';
 ```
 
+<ApiMeta addedVersion="0.10.1" />
+
+`TestContext` 从 Rstest 0.10.1 开始作为公开类型导出。
+
 - `Rstest`：完整的运行时 API 形状，包括 `test`、`describe`、`expect`、hooks 和 `rstest` 工具。
 - `RstestUtilities`：`rstest` 和 `rs` 工具对象的类型。
 - `TestContext`：传递给测试回调和生命周期 hooks 的 context 对象。


### PR DESCRIPTION
## Summary

This PR exports missing public TypeScript types from `@rstest/core`, including `MockInstance` for mock/spy helpers and `TestContext` for test callbacks and hooks. It also adds a `Rstest types` JavaScript API page in English and Chinese so users can find stable type imports instead of relying on internal paths.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
