### PR TITLE
docs(core): clarify buildCache comment

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -52,10 +52,8 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
 
       // Mirrors the pattern in packages/browser/src/hostController.ts:
       // only write `performance.buildCache` when the user has opted in.
-      // Writing `performance.buildCache: false` explicitly causes Rsbuild
-      // to set Rspack's `cache: false`, which disables Rspack's default
-      // in-memory module cache and makes every build start cold from disk
-      // (~4x slowdown on non-trivial test builds).
+      // Leaving it undefined keeps the generated Rsbuild config aligned with
+      // the user's original intent instead of materializing the default value.
       const buildCache = resolveProjectBuildCache({
         context,
         project,


### PR DESCRIPTION
## Summary

This PR clarifies the comment added around `performance.buildCache` in `pluginBasic`. The previous wording incorrectly suggested that `performance.buildCache: false` causes Rsbuild to set Rspack's `cache: false`; the updated comment only explains why Rstest avoids materializing the default value in the generated Rsbuild config.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1276

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).