### PR TITLE
fix(core): restore slot semantics for RSTEST_WORKER_ID

### DIFF
--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -4,8 +4,6 @@ import type { CollectTaskResult } from './protocol';
 import type { PoolOptions, PoolTask } from './types';
 import { createPoolWorker } from './workers';
 
-let nextWorkerId = 0;
-
 /**
  * Deliberately minimal scheduler — matches the prior tinypool behavior:
  *   - one task per worker at a time (concurrentTasksPerWorker=1)
@@ -26,6 +24,15 @@ export class Pool {
   private readonly stoppingRunners = new Set<PoolRunner>();
   private readonly stoppingPromises = new Set<Promise<void>>();
   private readonly slotWaiters: Array<() => void> = [];
+  /**
+   * Set of currently-assigned worker ids. Mirrors Jest's `JEST_WORKER_ID`
+   * and rstest 0.9.x's tinypool-backed semantics: ids are bounded by
+   * `[1, maxWorkers]` and reused after the previous worker fully exits, so
+   * consumers can use `RSTEST_WORKER_ID` to partition finite resources
+   * (e.g. database names). See rstest#1273 for the regression that
+   * motivated restoring this.
+   */
+  private readonly slotInUse = new Set<number>();
   private isClosing = false;
   private isClosed = false;
 
@@ -103,7 +110,7 @@ export class Pool {
 
       // Spawn a fresh runner. We claim the slot by inserting the runner into
       // activeRunners up-front; on start failure we drop it and wake a waiter.
-      const workerId = ++nextWorkerId;
+      const workerId = this.acquireWorkerId();
       const worker = createPoolWorker(task, this.options, workerId);
       gate?.attachWorker(worker);
       const runner = new PoolRunner(worker, { workerId });
@@ -143,6 +150,26 @@ export class Pool {
     }
     return true;
   };
+
+  /**
+   * Allocates the lowest free id in `[1, maxWorkers]`. Capacity is
+   * guaranteed by the `slotWaiters` gate (callers park until
+   * `inFlightCount < maxWorkers`), so the loop always finds a slot —
+   * the throw guards against a future regression in slot accounting.
+   */
+  private acquireWorkerId(): number {
+    for (let i = 1; i <= this.options.maxWorkers; i++) {
+      if (!this.slotInUse.has(i)) {
+        this.slotInUse.add(i);
+        return i;
+      }
+    }
+    throw new Error('[rstest-pool]: no free worker id');
+  }
+
+  private releaseWorkerId(id: number): void {
+    this.slotInUse.delete(id);
+  }
 
   private releaseRunner(runner: PoolRunner): void {
     this.activeRunners.delete(runner);
@@ -203,6 +230,7 @@ export class Pool {
       .finally(() => {
         this.stoppingRunners.delete(runner);
         this.stoppingPromises.delete(stopPromise);
+        this.releaseWorkerId(runner.workerId);
         // Slot is now truly free — wake one waiter (unless we're closing,
         // in which case waiters were already drained).
         if (!this.isClosed) {

--- a/packages/core/tests/pool/fixtures/testWorker.mjs
+++ b/packages/core/tests/pool/fixtures/testWorker.mjs
@@ -58,6 +58,7 @@ const onHostMessage = (handler) => {
 // per spawned worker) as the per-worker id in threads mode. Forks each have
 // their own pid.
 const workerIdentity = isThreadWorker ? threadId : process.pid;
+let assignedWorkerId = null;
 
 let runCount = 0;
 
@@ -73,6 +74,7 @@ const makeRunResult = (request, extra) => ({
   // Test-only fields so the test can verify pool behavior. Under threads
   // mode this is `threadId`; under forks it is `process.pid`.
   _workerIdentity: workerIdentity,
+  _workerId: assignedWorkerId,
   _runCount: ++runCount,
   ...extra,
 });
@@ -205,6 +207,7 @@ onHostMessage((message) => {
 
   switch (request.type) {
     case 'start':
+      assignedWorkerId = request.workerId;
       send({ type: 'started', pid: workerIdentity });
       break;
     case 'run':

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -397,3 +397,84 @@ describe('Pool - capacity', () => {
     await pool.close();
   });
 });
+
+// ── worker-id slot semantics (rstest#1273) ──────────────────────────────────
+
+describe('Pool - worker-id slot', () => {
+  it('should keep RSTEST_WORKER_ID bounded by maxWorkers under isolate=true', async () => {
+    const maxWorkers = 2;
+    const taskCount = 6;
+    const pool = new Pool(createPoolOptions({ maxWorkers, isolate: true }));
+
+    try {
+      const ids: number[] = [];
+      for (let i = 0; i < taskCount; i++) {
+        const result = await pool.runTest(createTask());
+        ids.push((result as any)._workerId as number);
+      }
+
+      expect(ids).toHaveLength(taskCount);
+      for (const id of ids) {
+        expect(id).toBeGreaterThanOrEqual(1);
+        expect(id).toBeLessThanOrEqual(maxWorkers);
+      }
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('should assign distinct ids to concurrent workers within [1, maxWorkers]', async () => {
+    const maxWorkers = 3;
+    const pool = new Pool(createPoolOptions({ maxWorkers, isolate: true }));
+
+    try {
+      const results = await Promise.all(
+        Array.from({ length: maxWorkers }, () =>
+          pool.runTest(
+            createTask('run', { __testMode: 'slow', __delayMs: 100 }),
+          ),
+        ),
+      );
+      const ids = results.map((r) => (r as any)._workerId as number);
+      // All concurrent workers alive at the same time must have distinct ids.
+      expect(new Set(ids).size).toBe(maxWorkers);
+      // And those ids exactly fill [1, maxWorkers].
+      expect([...ids].sort()).toEqual([1, 2, 3]);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('should keep RSTEST_WORKER_ID stable across reuses under isolate=false', async () => {
+    const pool = new Pool(createPoolOptions({ isolate: false, minWorkers: 1 }));
+    try {
+      const r1 = await pool.runTest(createTask());
+      const r2 = await pool.runTest(createTask());
+      const r3 = await pool.runTest(createTask());
+      // Same process → same workerId across all reuses.
+      expect((r1 as any)._workerIdentity).toBe((r2 as any)._workerIdentity);
+      expect((r1 as any)._workerId).toBe((r2 as any)._workerId);
+      expect((r1 as any)._workerId).toBe((r3 as any)._workerId);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('should reset worker-id allocator per Pool instance', async () => {
+    const maxWorkers = 2;
+    const poolA = new Pool(createPoolOptions({ maxWorkers, isolate: true }));
+    const r1 = await poolA.runTest(createTask());
+    await poolA.close();
+
+    const poolB = new Pool(createPoolOptions({ maxWorkers, isolate: true }));
+    try {
+      const r2 = await poolB.runTest(createTask());
+      // A fresh Pool restarts the allocator at 1 — there is no cross-pool
+      // module-level counter (rstest#1273 regression).
+      expect((r1 as any)._workerId).toBe(1);
+      expect((r2 as any)._workerId).toBe(1);
+    } finally {
+      await poolB.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`process.env.RSTEST_WORKER_ID` used to be a slot in `[1, maxWorkers]` (matching Jest's `JEST_WORKER_ID` and rstest 0.9.x's tinypool-backed behavior), reused after the previous worker exited. After #1171 replaced tinypool with a self-owned pool, the value became a module-level monotonic counter — unbounded, never reused, and effectively useless for partitioning finite per-worker resources (e.g. database names). This PR restores the slot semantics.

The fix replaces the `let nextWorkerId = 0` counter with a per-`Pool` `Set<number>` of in-use ids. `acquireWorkerId()` picks the lowest free id in `[1, maxWorkers]` at spawn; `releaseWorkerId()` runs inside `disposeRunnerInBackground`'s `finally`, before the waiting spawn is woken, so the next spawn always sees a free slot. Capacity is still bounded by the existing slot-waiter gate, which guarantees `inFlightCount ≤ maxWorkers`.

## Related Links

- Closes #1273
- Regression introduced in #1171