### PR TITLE
refactor(core): use "Set up Rstest browser mode" as init header

### DIFF
--- a/packages/core/src/cli/init/browser/create.ts
+++ b/packages/core/src/cli/init/browser/create.ts
@@ -117,7 +117,7 @@ async function createNonInteractive(
   const provider: BrowserProvider = 'playwright';
 
   console.log();
-  console.log(color.cyan('◆'), color.bold('rstest init browser --yes'));
+  console.log(color.bold(color.magenta('Set up Rstest browser mode')));
   console.log();
 
   // Show detection results
@@ -169,7 +169,7 @@ async function createInteractive(
   const effectiveFramework: Framework =
     framework === 'react' ? 'react' : 'vanilla';
 
-  intro(color.bgCyan(color.black(' rstest init browser ')));
+  intro(color.bold(color.magenta('Set up Rstest browser mode')));
 
   // Step 1: Show detection results
   const detectionLines: string[] = [];

--- a/website/docs/en/guide/browser-testing/getting-started.mdx
+++ b/website/docs/en/guide/browser-testing/getting-started.mdx
@@ -30,7 +30,7 @@ When you run the command, Rstest automatically:
 Here's an example output for a React project:
 
 ```bash
-◆ @rstest/core init browser
+Set up Rstest browser mode
 
   Detecting project...
   ✓ Found React 19.0.0

--- a/website/docs/zh/guide/browser-testing/getting-started.mdx
+++ b/website/docs/zh/guide/browser-testing/getting-started.mdx
@@ -30,7 +30,7 @@ import { PackageManagerTabs } from '@theme';
 以下是 React 项目的初始化输出示例：
 
 ```bash
-◆ @rstest/core init browser
+Set up Rstest browser mode
 
   Detecting project...
   ✓ Found React 19.0.0


### PR DESCRIPTION
## Summary

Refine the `rstest init browser` console header in both interactive and non-interactive paths.

- Drop the `◆` prefix and the `bgCyan` chip background.
- Replace the command-echo style header (`rstest init browser` / `rstest init browser --yes`) with a short imperative label: **`Set up Rstest browser mode`**.
- Use **magenta + bold** for visual identity — magenta is already the established brand color (`color.magenta('rstest')` in `packages/core/src/utils/logger.ts`).
- Sync the en/zh `browser-testing/getting-started.mdx` example output to match the new header.

### Source changes

`packages/core/src/cli/init/browser/create.ts`:

```diff
-  console.log(color.cyan('◆'), color.bold('rstest init browser --yes'));
+  console.log(color.bold(color.magenta('Set up Rstest browser mode')));
...
-  intro(color.bgCyan(color.black(' rstest init browser ')));
+  intro(color.bold(color.magenta('Set up Rstest browser mode')));
```

### Docs

en + zh `getting-started.mdx`:

```diff
-◆ @rstest/core init browser
+Set up Rstest browser mode
```

(Previously the example showed `◆ @rstest/core init browser` after #894, which did not match the actual program output. This PR realigns docs with the new in-source header.)

## Test plan

- [x] Built `@rstest/core` and manually ran `init browser` (interactive + `--yes`) in a fresh React project; header renders as magenta-bold `Set up Rstest browser mode`.
- [x] Verified docs example output matches what the CLI now prints.