### PR TITLE
chore(deps): bump rstackjs/rstack-ecosystem-ci action to ca8d345

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -45,7 +45,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rstest' && github.event_name == 'workflow_dispatch'
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@4949c44494d7fd3503abd791f11534c798a2a1d0 # main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ca8d345a115158ea5ab3807378357f2162be7467 # main
         with:
           github-token: ${{ secrets.REPO_RSTEST_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev
@@ -61,7 +61,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rstest' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@4949c44494d7fd3503abd791f11534c798a2a1d0 # main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ca8d345a115158ea5ab3807378357f2162be7467 # main
         with:
           github-token: ${{ secrets.REPO_RSTEST_ECO_CI_GITHUB_TOKEN_NEXT }}
           ecosystem-owner: web-infra-dev


### PR DESCRIPTION
## Summary

The Ecosystem CI workflow currently fails with:

> The actions `rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem-ci-result@main` and `jamesives/github-pages-deploy-action@v4` are not allowed in `web-infra-dev/rstest` because all actions must be pinned to a full-length commit SHA.

The previously pinned SHA `4949c444` of `rstackjs/rstack-ecosystem-ci` references those two transitive actions by ref (`@main`, `@v4`) inside its composite actions, tripping the org policy. Upstream already pinned them in rstackjs/rstack-ecosystem-ci#41. This PR bumps both `ecosystem_ci_dispatch` and `ecosystem_ci_per_commit` usages to current `main` HEAD `ca8d345a`, which carries the fix. The composite action's `inputs`/`outputs` interface is unchanged between the two SHAs.

## Related Links

- Failing run: https://github.com/web-infra-dev/rstest/actions/runs/26085450016/job/76697301567
- Upstream fix: https://github.com/rstackjs/rstack-ecosystem-ci/pull/41
- New pinned commit: https://github.com/rstackjs/rstack-ecosystem-ci/commit/ca8d345a115158ea5ab3807378357f2162be7467