### PR TITLE
feat(core): isolate: 'soft' — reuse workers across files with env reset (RFC)

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -50,15 +50,21 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
         multipleProjects: context.projects.length > 1,
       });
 
+      // Mirrors the pattern in packages/browser/src/hostController.ts:
+      // only write `performance.buildCache` when the user has opted in.
+      // Writing `performance.buildCache: false` explicitly causes Rsbuild
+      // to set Rspack's `cache: false`, which disables Rspack's default
+      // in-memory module cache and makes every build start cold from disk
+      // (~4x slowdown on non-trivial test builds).
+      const buildCache = resolveProjectBuildCache({
+        context,
+        project,
+      });
+
       return mergeEnvironmentConfig(
         config,
         {
-          performance: {
-            buildCache: resolveProjectBuildCache({
-              context,
-              project,
-            }),
-          },
+          performance: buildCache ? { buildCache } : undefined,
           tools,
           resolve,
           source,

--- a/packages/core/src/core/plugins/moduleCacheControl.ts
+++ b/packages/core/src/core/plugins/moduleCacheControl.ts
@@ -23,7 +23,27 @@ function __rstest_clean_core_cache__() {
   });
 }
 
+/**
+ * Aggressive cache wipe for \`isolate: 'soft'\`. Removes every entry from the
+ * webpack module cache so the next file re-evaluates ALL modules — including
+ * user source, test code, and any module-mock proxies installed by the prior
+ * file (which otherwise leak across files because their state lives in the
+ * cached module instance).
+ *
+ * Vendors (\`node_modules/...\`) are also dropped here; in practice rspack
+ * caches their compilation, so re-evaluation is fast.
+ */
+function __rstest_clean_all_modules__() {
+  if (typeof __webpack_require__ === 'undefined') {
+    return;
+  }
+  for (const id of Object.keys(__webpack_module_cache__)) {
+    delete __webpack_module_cache__[id];
+  }
+}
+
 global.__rstest_clean_core_cache__ = __rstest_clean_core_cache__;
+global.__rstest_clean_all_modules__ = __rstest_clean_all_modules__;
 `;
       }
     }

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -11,7 +11,8 @@ let nextWorkerId = 0;
  *   - one task per worker at a time (concurrentTasksPerWorker=1)
  *   - parallel dispatch up to maxWorkers, slot-waiter blocks excess callers
  *   - isolate=true: fresh runner per task, stopped in the background
- *   - isolate=false: idle runners reused, lazy-spawned on demand
+ *   - isolate='soft': idle runners reused, worker resets DOM + module cache between tasks
+ *   - isolate=false: idle runners reused, no inter-task reset
  */
 export class Pool {
   private readonly options: PoolOptions;
@@ -148,12 +149,11 @@ export class Pool {
     this.activeRunners.delete(runner);
 
     // `isolate: true`, closing, or unusable — never reuse.
-    if (
-      this.options.isolate !== false ||
-      this.isClosing ||
-      this.isClosed ||
-      !runner.isUsable()
-    ) {
+    // `isolate: false` and `isolate: 'soft'` both reuse runners; only the
+    // worker-side reset semantics differ (see runInPool teardown for 'soft').
+    const reuse =
+      this.options.isolate === false || this.options.isolate === 'soft';
+    if (!reuse || this.isClosing || this.isClosed || !runner.isUsable()) {
       // Background dispose. The slot stays accounted for in `stoppingRunners`
       // until the child actually exits, so `isolate: true` cannot transiently
       // exceed `maxWorkers` and `close()` can drain in-flight stops.
@@ -161,7 +161,7 @@ export class Pool {
       return;
     }
 
-    // `isolate: false` reuse path.
+    // Reuse path (isolate: false or 'soft').
     //
     // `minWorkers` is a *floor for retained idle runners after demand drops*,
     // not a cap on reuse. Two cases keep this runner alive:

--- a/packages/core/src/pool/types.ts
+++ b/packages/core/src/pool/types.ts
@@ -10,11 +10,19 @@ export type PoolTask = {
   rpcMethods: RuntimeRPC;
 };
 
+/**
+ * Isolation strategy for the pool. See `RstestConfig.isolate` for full docs.
+ *   - `true`: fresh runner per task (process-per-file isolation)
+ *   - `'soft'`: reuse runner across tasks, signal worker to reset state per task
+ *   - `false`: reuse runner across tasks with no inter-task reset
+ */
+export type IsolateMode = boolean | 'soft';
+
 export type PoolOptions = {
   workerEntry: string;
   maxWorkers: number;
   minWorkers: number;
-  isolate: boolean;
+  isolate: IsolateMode;
   env?: Record<string, string>;
   execArgv?: string[];
   /**

--- a/packages/core/src/runtime/worker/env/happyDom.ts
+++ b/packages/core/src/runtime/worker/env/happyDom.ts
@@ -5,31 +5,68 @@ import { addDefaultErrorHandler, installGlobal } from './utils';
 
 type HappyDOMOptions = ConstructorParameters<typeof HappyDOMWindow>[0];
 
+// Per-worker cache — see env/jsdom.ts for full rationale.
+type Cached = {
+  win: HappyDOMWindow;
+  optionsKey: string;
+};
+let cached: Cached | undefined;
+
+const optionsKey = (options: HappyDOMOptions): string => {
+  try {
+    return JSON.stringify(options, (_k, v) => {
+      if (typeof v === 'function') return '__fn__';
+      if (
+        v &&
+        typeof v === 'object' &&
+        v.constructor &&
+        v.constructor.name !== 'Object' &&
+        !Array.isArray(v)
+      ) {
+        return '__opaque__';
+      }
+      return v;
+    });
+  } catch {
+    return Math.random().toString(36);
+  }
+};
+
 export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
   {
     name: 'happy-dom',
     setup: async (global, options = {}) => {
       checkPkgInstalled('happy-dom');
 
-      const { Window, GlobalWindow } = await import('happy-dom');
-      // Prefer GlobalWindow to run happy-dom in the global scope so globals like
-      // TextEncoder and Uint8Array are correctly exposed; fall back to Window for
-      // backward compatibility with older happy-dom versions that lack GlobalWindow.
-      const WindowClass = GlobalWindow || Window;
-      const win = new WindowClass({
-        ...options,
-        url: options.url || 'http://localhost:3000',
-        console: console && global.console ? global.console : undefined,
-      });
+      const key = optionsKey(options);
 
-      const cleanupGlobal = installGlobal(global, win, {
-        // jsdom doesn't support Request and Response, but happy-dom does
-        additionalKeys: ['Request', 'Response', 'MessagePort', 'fetch'],
-      });
+      let win: HappyDOMWindow;
+      if (cached && cached.optionsKey === key) {
+        win = cached.win;
+      } else {
+        const { Window, GlobalWindow } = await import('happy-dom');
+        const WindowClass = GlobalWindow || Window;
+        win = new WindowClass({
+          ...options,
+          url: options.url || 'http://localhost:3000',
+          console: console && global.console ? global.console : undefined,
+        });
+        cached = { win, optionsKey: key };
+      }
+
+      const { cleanup: cleanupGlobal, resetOverrides } = installGlobal(
+        global,
+        win,
+        {
+          additionalKeys: ['Request', 'Response', 'MessagePort', 'fetch'],
+        },
+      );
 
       const cleanupHandler = addDefaultErrorHandler(
         global as unknown as Window,
       );
+
+      const initialUrl = options.url || 'http://localhost:3000';
 
       return {
         async teardown() {
@@ -41,6 +78,30 @@ export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
             await win.happyDOM.cancelAsync();
           }
           cleanupGlobal();
+          cached = undefined;
+        },
+        async reset() {
+          resetOverrides();
+          const doc = win.document;
+          try {
+            doc.documentElement.innerHTML = '<head></head><body></body>';
+          } catch {
+            doc.open();
+            doc.write('<!DOCTYPE html><html><head></head><body></body></html>');
+            doc.close();
+          }
+          try {
+            win.history.replaceState(null, '', initialUrl);
+          } catch {
+            // location may be locked
+          }
+          if (typeof win.happyDOM?.cancelAsync === 'function') {
+            try {
+              await win.happyDOM.cancelAsync();
+            } catch {
+              // best-effort
+            }
+          }
         },
       };
     },

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -8,6 +8,47 @@ type JSDOMOptions = ConstructorOptions & {
   console?: boolean;
 };
 
+// Per-worker JSDOM cache. With `isolate: 'soft'`, the worker process is reused
+// across multiple test files. The expensive part of jsdom setup is the
+// `new JSDOM()` constructor (parses HTML, primes ~hundreds of WHATWG
+// prototypes); creating a fresh JSDOM per file costs ~300-1000 ms in cold
+// processes. By caching the JSDOM instance at module scope (each worker has
+// its own module copy), we pay that cost once.
+//
+// Between files, the `reset()` path:
+//   - uninstalls globals (so the previous file's setupFile mutations to
+//     `window.X = ...` / Object.defineProperty don't leak)
+//   - wipes the DOM tree
+//   - reinstalls globals on the same JSDOM window
+//
+// `installGlobal` defines ~270 getter/setter properties on `global`, which is
+// modestly priced (~5-15 ms) but dwarfed by the saved `new JSDOM()` cost.
+type Cached = {
+  dom: import('jsdom').JSDOM;
+  optionsKey: string;
+};
+let cached: Cached | undefined;
+
+const optionsKey = (options: JSDOMOptions): string => {
+  try {
+    return JSON.stringify(options, (_k, v) => {
+      if (typeof v === 'function') return '__fn__';
+      if (
+        v &&
+        typeof v === 'object' &&
+        v.constructor &&
+        v.constructor.name !== 'Object' &&
+        !Array.isArray(v)
+      ) {
+        return '__opaque__';
+      }
+      return v;
+    });
+  } catch {
+    return Math.random().toString(36);
+  }
+};
+
 export const environment: TestEnvironment<typeof globalThis> = {
   name: 'jsdom',
   setup: async (global, options) => {
@@ -28,33 +69,89 @@ export const environment: TestEnvironment<typeof globalThis> = {
       cookieJar = false,
       ...restOptions
     } = options as JSDOMOptions;
-    const dom = new JSDOM(html, {
-      pretendToBeVisual,
-      resources:
-        resources ??
-        (userAgent ? new ResourceLoader({ userAgent }) : undefined),
-      runScripts,
-      url,
-      virtualConsole:
-        console && global.console
-          ? new VirtualConsole().sendTo(global.console)
-          : undefined,
-      cookieJar: cookieJar ? new CookieJar() : undefined,
-      includeNodeLocations,
-      contentType,
-      userAgent,
-      ...restOptions,
-    });
 
-    const cleanupGlobal = installGlobal(global, dom.window);
+    const key = optionsKey(options as JSDOMOptions);
 
+    // Reuse the cached JSDOM if options match. The DOM has already been reset
+    // by the previous file's `reset()` (which uninstalled globals).
+    let dom: import('jsdom').JSDOM;
+    if (cached && cached.optionsKey === key) {
+      dom = cached.dom;
+    } else {
+      dom = new JSDOM(html as string, {
+        pretendToBeVisual,
+        resources:
+          resources ??
+          (userAgent ? new ResourceLoader({ userAgent }) : undefined),
+        runScripts,
+        url,
+        virtualConsole:
+          console && global.console
+            ? new VirtualConsole().sendTo(global.console)
+            : undefined,
+        cookieJar: cookieJar ? new CookieJar() : undefined,
+        includeNodeLocations,
+        contentType,
+        userAgent,
+        ...restOptions,
+      });
+      cached = { dom, optionsKey: key };
+    }
+
+    const { cleanup: cleanupGlobal, resetOverrides } = installGlobal(
+      global,
+      dom.window,
+    );
     const cleanupHandler = addDefaultErrorHandler(global as unknown as Window);
+
+    const initialUrl = url;
 
     return {
       teardown() {
         cleanupHandler();
-        dom.window.close();
+        try {
+          dom.window.close();
+        } catch {
+          // best-effort
+        }
         cleanupGlobal();
+        // Clear the cache so the next setup() rebuilds. Required for
+        // `isolate: true` to keep per-file fresh-env semantics.
+        cached = undefined;
+      },
+      // Soft reset for `isolate: 'soft'`. Wipes DOM tree, restores location,
+      // and clears every `global.X = ...` override made by the previous
+      // file's setupFile / tests — but KEEPS the JSDOM instance alive and
+      // KEEPS the global property descriptors in place (so `window` stays
+      // accessible until the next file's setup runs).
+      //
+      // What gets restored:
+      //   - DOM tree (`document.body`/`document.head` reset to empty)
+      //   - Window location (back to `initialUrl`)
+      //   - All overridden globals (`window.matchMedia = jest.fn()` etc.) →
+      //     defaults sourced from `dom.window` (the original JSDOM-backed
+      //     values).
+      //
+      // What does NOT get restored automatically:
+      //   - Mutations on prototype objects (`Element.prototype.X = ...`).
+      //     Use `restoreMocks: true` in your rstest config + `rstest.spyOn`
+      //     for those, or set them inside `beforeEach` instead of in a setup
+      //     file run-once.
+      reset() {
+        resetOverrides();
+        const doc = dom.window.document;
+        try {
+          doc.documentElement.innerHTML = '<head></head><body></body>';
+        } catch {
+          doc.open();
+          doc.write('<!DOCTYPE html><html><head></head><body></body></html>');
+          doc.close();
+        }
+        try {
+          dom.window.history.replaceState(null, '', initialUrl);
+        } catch {
+          // location may be locked
+        }
       },
     };
   },

--- a/packages/core/src/runtime/worker/env/utils.ts
+++ b/packages/core/src/runtime/worker/env/utils.ts
@@ -27,6 +27,20 @@ function isClassLike(name: string) {
   return name[0] && name.startsWith(name[0].toUpperCase());
 }
 
+export interface InstallGlobalHandle {
+  /** Uninstall: deletes the installed properties and restores originals. */
+  cleanup: () => void;
+  /**
+   * Reset all `global[key] = ...` overrides made since install (or last
+   * reset) back to the underlying window-backed defaults. The getter/setter
+   * descriptors themselves stay in place, so `global.window` etc. remain
+   * accessible. Used by `isolate: 'soft'` to discard per-file mutations
+   * without uninstalling globals (which would briefly leave the worker
+   * without `window` between test files).
+   */
+  resetOverrides: () => void;
+}
+
 export function installGlobal(
   global: any,
   win: any,
@@ -37,7 +51,7 @@ export function installGlobal(
     bindFunctions?: boolean;
     additionalKeys?: string[];
   } = {},
-): () => void {
+): InstallGlobalHandle {
   const { bindFunctions = true } = options || {};
   const keys = getWindowKeys(global, win, options.additionalKeys);
 
@@ -94,13 +108,18 @@ export function installGlobal(
     keys.add(k);
   }
 
-  return () => {
-    for (const key of keys) {
-      Reflect.deleteProperty(global, key);
-    }
-    originals.forEach((v, k) => {
-      global[k] = v;
-    });
+  return {
+    cleanup: () => {
+      for (const key of keys) {
+        Reflect.deleteProperty(global, key);
+      }
+      originals.forEach((v, k) => {
+        global[k] = v;
+      });
+    },
+    resetOverrides: () => {
+      overrides.clear();
+    },
   };
 }
 

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -153,6 +153,7 @@ const preparePool = async (
       testEnvironment,
       snapshotFormat,
       env,
+      isolate,
     },
   } = context;
 
@@ -243,25 +244,40 @@ const preparePool = async (
   });
 
   tracker?.transition('envSetup');
+  // For `isolate: 'soft'`, run the env's `reset()` between files (cheap DOM
+  // wipe) instead of `teardown()` (full close + reinstall). The env module
+  // caches the underlying JSDOM/HappyDOM instance so subsequent `setup()`
+  // calls in the same worker return the cached return object without
+  // creating a new window.
+  const useSoftReset =
+    (isolate as unknown as 'soft' | boolean | undefined) === 'soft';
   switch (testEnvironment.name) {
     case 'node':
       break;
     case 'jsdom': {
       const { environment } = await import('./env/jsdom');
-      const { teardown } = await environment.setup(
+      const envReturn = await environment.setup(
         global,
         testEnvironment.options || {},
       );
-      cleanupFns.push(() => teardown(global));
+      if (useSoftReset && envReturn.reset) {
+        cleanupFns.push(() => envReturn.reset!(global));
+      } else {
+        cleanupFns.push(() => envReturn.teardown(global));
+      }
       break;
     }
     case 'happy-dom': {
       const { environment } = await import('./env/happyDom');
-      const { teardown } = await environment.setup(
+      const envReturn = await environment.setup(
         global,
         testEnvironment.options || {},
       );
-      cleanupFns.push(async () => teardown(global));
+      if (useSoftReset && envReturn.reset) {
+        cleanupFns.push(async () => envReturn.reset!(global));
+      } else {
+        cleanupFns.push(async () => envReturn.teardown(global));
+      }
       break;
     }
     default:
@@ -316,7 +332,7 @@ const loadFiles = async ({
   runtimeDistPath?: string;
   testPath: string;
   interopDefault: boolean;
-  isolate: boolean;
+  isolate: boolean | 'soft';
   outputModule: boolean;
   tracker?: PhaseTracker;
 }): Promise<void> => {
@@ -324,8 +340,10 @@ const loadFiles = async ({
     ? await import('./loadEsModule')
     : await import('./loadModule');
 
-  // clean rstest core cache manually
-  if (!isolate) {
+  // For non-strict-isolate modes (`false` or `'soft'`), the rstest core module
+  // is kept alive across files in the same worker. Clear its internal caches
+  // so each file starts with fresh per-test state.
+  if (isolate !== true) {
     await loadModule({
       codeContent: `if (global && typeof global.__rstest_clean_core_cache__ === 'function') {
   global.__rstest_clean_core_cache__();
@@ -415,7 +433,10 @@ export const runInPool = async (
     // Run teardown
     await Promise.all(cleanups.map((fn) => fn()));
 
-    if (!isolate) {
+    // For non-strict-isolate modes (`false` or `'soft'`), the same worker
+    // process will handle the next test file. Wipe rstest's module cache
+    // so each file evaluates its imports fresh.
+    if (isolate !== true) {
       const { clearModuleCache } = options.context.outputModule
         ? await import('./loadEsModule')
         : await import('./loadModule');

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -343,11 +343,23 @@ const loadFiles = async ({
   // For non-strict-isolate modes (`false` or `'soft'`), the rstest core module
   // is kept alive across files in the same worker. Clear its internal caches
   // so each file starts with fresh per-test state.
+  //
+  // `isolate: 'soft'` additionally wipes the entire webpack module cache via
+  // `__rstest_clean_all_modules__()`. Without this, module-mock proxies from
+  // the prior file (e.g., `rstest.mock(...)` factories) stay attached to
+  // cached module instances, and the next file's tests trip on stale state
+  // (typically as `Proxy.set` failures on previously-mocked exports).
   if (isolate !== true) {
-    await loadModule({
-      codeContent: `if (global && typeof global.__rstest_clean_core_cache__ === 'function') {
+    const cleanCmd =
+      isolate === 'soft'
+        ? `if (global && typeof global.__rstest_clean_all_modules__ === 'function') {
+  global.__rstest_clean_all_modules__();
+}`
+        : `if (global && typeof global.__rstest_clean_core_cache__ === 'function') {
   global.__rstest_clean_core_cache__();
-  }`,
+}`;
+    await loadModule({
+      codeContent: cleanCmd,
       distPath: '',
       testPath,
       rstestContext,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -326,11 +326,25 @@ export interface RstestConfig {
    */
   pool?: RstestPoolType | RstestPoolOptions;
   /**
-   * Run tests in an isolated environment
+   * Isolation strategy between test files.
+   *
+   * - `true` (default): each test file runs in a fresh worker process. Strongest
+   *   isolation but pays the cost of process fork + bundle load + env setup
+   *   on every file.
+   * - `'soft'`: workers persist across files. Between files, rstest clears the
+   *   module cache (so test code re-evaluates fresh) and resets the test
+   *   environment (DOM wiped for `jsdom`/`happy-dom`). Globals installed by
+   *   setupFiles persist; `clearMocks: true` is recommended. Trades a small
+   *   amount of isolation strictness for a large drop in per-file overhead
+   *   (~300-1000 ms saved per file on libs that import jsdom or large
+   *   transitive deps).
+   * - `false`: workers persist across files with no isolation between them —
+   *   even module state leaks. Fast but use only when tests are designed for
+   *   it.
    *
    * @default true
    */
-  isolate?: boolean;
+  isolate?: boolean | 'soft';
   /**
    * Provide global APIs
    *

--- a/packages/core/src/types/environment.ts
+++ b/packages/core/src/types/environment.ts
@@ -1,7 +1,23 @@
 import type { MaybePromise } from './utils';
 
 export interface TestEnvironmentReturn {
+  /**
+   * Full teardown of the test environment. Called at the end of a test file's
+   * execution when `isolate: true` or `isolate: false`. Implementations should
+   * release every resource (e.g. close the JSDOM window, remove globals).
+   */
   teardown: (global: any) => MaybePromise<void>;
+  /**
+   * Soft reset between test files when the worker process is reused
+   * (`isolate: 'soft'`). The environment should clear per-file mutable state
+   * (DOM tree, location, transient event listeners) without releasing
+   * resources that are expensive to recreate. After `reset`, the environment
+   * must still be usable for the next file.
+   *
+   * Optional — when absent, rstest falls back to `teardown` + a fresh
+   * `setup`, which still works but defeats the perf benefit of soft isolate.
+   */
+  reset?: (global: any) => MaybePromise<void>;
 }
 export interface TestEnvironment<Global = any, Options = Record<string, any>> {
   name: string;


### PR DESCRIPTION
## Summary

Adds a third value for the `isolate` config: `'soft'`. With `isolate: 'soft'`, workers persist across test files (like `isolate: false`), but rstest does a per-file state reset:

- **DOM** wiped (`document.body`/`head` reset to empty, location restored)
- **globals overrides** cleared (any `window.X = ...` from the prior file)
- **module cache** wiped (so test code re-evaluates, including mock proxies)
- **`teardown()`** is replaced by `reset()` in the env (JSDOM stays alive)

Goal: trade a small amount of isolation strictness for a large drop in per-file overhead on libs with many test files and a heavy module graph. Specifically targets the per-file `~300-1000 ms` cost of `import('jsdom')` + JSDOM construction in cold worker processes.

## RFC — not ready to merge

Opening as a draft for **design discussion**. The architectural sketch works on simple libs but breaks on real-world ones where:

1. **Prototype mutations** in setupFiles (`Element.prototype.scrollIntoView = jest.fn()`) aren't restored between files → state leak.
2. **Module-mock proxies** initially leaked across files, fixed in [the second commit](https://github.com/web-infra-dev/rstest/pull/_/commits/6239ce0f) with a full module-cache wipe — but this is heavy-handed.
3. **No vm.Context-style isolation**, so shared global state (`HTMLElement.prototype.X`) survives any cache reset.

Real-world bench on a 74-jsdom-file lib (~3400 transitive modules, Lingui-heavy):

| Variant | Wall (median) | Tests pass? |
|---|---|---|
| `isolate: true` (default baseline) | ~90s | ✓ all |
| `isolate: 'soft'` (this PR) | ~28-30s on clean runs (≈ -67%) | ✗ ~20% pass before crash |

The perf upside is real (when it works). The correctness gap is real too. I'd love guidance on:

- Is `isolate: 'soft'` semantically reasonable for rstest's contract, or should this be expressed differently (e.g., per-env opt-in, or a new `vmContext` mode)?
- For the prototype-mutation leak: is the right path (a) user-side discipline ("setupFiles must be idempotent"), (b) rstest tracking `Object.defineProperty` + replay on reset, or (c) something else?
- Is wiping the full webpack module cache between files acceptable, or should rstest track a "mock-related modules" subset?

## What's in this PR

- `RstestConfig.isolate`: `boolean | 'soft'`
- `TestEnvironmentReturn.reset?`: new optional callback
- `env/jsdom.ts`, `env/happyDom.ts`: module-scope cache for the window; `reset()` wipes DOM + restores location without closing the window
- `env/utils.ts`: `installGlobal()` now returns `{ cleanup, resetOverrides }`; `resetOverrides()` clears the per-file override map without uninstalling getter/setter descriptors
- `pool.ts`: `releaseRunner()` reuses the runner for `false` and `'soft'`
- `moduleCacheControl.ts`: adds `__rstest_clean_all_modules__()` runtime helper
- `runInPool.ts`: plumbs `'soft'` through; teardown picks `reset()` over `teardown()`; cache-clear runs for any non-`true` isolate

Branch: https://github.com/pkasarda/rstest/tree/feat/isolate-soft

Context for what motivated this: web-infra-dev/rstest#1274 (CI perf regression), our investigation of the per-file fork + jsdom-load cost.
