### PR TITLE
fix(core): prevent pool.close() hang on forks pool

### DIFF
--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -1,6 +1,6 @@
 import { type BirpcReturn, createBirpc } from 'birpc';
 import type { RuntimeRPC, ServerRPC, TestFileResult } from '../types';
-import { logger, toError } from '../utils';
+import { toError } from '../utils';
 import type { PoolWorker } from './poolWorker';
 import {
   type CollectTaskResult,
@@ -13,7 +13,6 @@ import {
 import type { PoolTask } from './types';
 
 const WORKER_START_TIMEOUT_MS = 90_000;
-const WORKER_STOP_TIMEOUT_MS = 60_000;
 const MAX_STDERR_MESSAGE_BYTES = 64 * 1024;
 
 function formatCapturedStderr(text: string): string {
@@ -89,7 +88,6 @@ export class PoolRunner {
     | undefined;
   private startDeferred: Deferred | undefined;
   private stopDeferred: Deferred | undefined;
-  private stoppedAckDeferred: Deferred | undefined;
   private startTimer: NodeJS.Timeout | undefined;
   private lastFatalError: Error | undefined;
   /**
@@ -180,17 +178,12 @@ export class PoolRunner {
   }
 
   /**
-   * Stop the worker. The host owns termination via SIGTERM — relying on the
-   * worker's own `process.exit()` was the rstest#1275 hang. Idle workers
-   * skip the IPC handshake and SIGTERM directly; in-flight workers get
-   * WORKER_STOP_TIMEOUT_MS to ack `stopped`, with overrun surfaced as a
-   * `detectAsyncLeaks` hint.
-   *
-   * The idle path is intentionally silent. Native dependencies (rspack
-   * tokio runtime, etc.) keep worker event loops ref'd by design, so a
-   * "didn't exit naturally" warning here would fire on every healthy run.
-   * The in-flight warning is meaningful because a >60s task is a real
-   * anomaly worth surfacing.
+   * Stop the worker by SIGTERM (or SIGKILL if `force`). The host owns
+   * termination — there is no IPC `stop` handshake. Per-task teardown
+   * already runs inside `runInPool`'s own `finally` before the worker
+   * sends `runFinished`, so by the time `stop()` is called there is
+   * nothing process-level to drain. Relying on the worker's own
+   * `process.exit()` was the rstest#1275 hang.
    */
   stop(options?: { force?: boolean }): Promise<void> {
     return this.runOperation(async () => {
@@ -199,7 +192,6 @@ export class PoolRunner {
         case 'IDLE':
           return;
         case 'STOPPING': {
-          // Wait for the in-flight stop, then optionally force.
           if (this.stopDeferred) {
             await this.stopDeferred.promise;
           }
@@ -228,48 +220,8 @@ export class PoolRunner {
       this.state = 'STOPPING';
       this.stopDeferred = createDeferred();
 
-      if (options?.force) {
-        await this.worker.stop({ force: true });
-        await this.stopDeferred.promise;
-        return;
-      }
-
-      // Default to acked so the idle path (no in-flight task, no IPC) skips
-      // the warning. Only the in-flight branch can flip this to false.
-      let acked = true;
-
-      if (this.currentTask !== undefined) {
-        this.stoppedAckDeferred = createDeferred();
-        try {
-          this.worker.send({ type: 'stop' });
-        } catch {
-          // worker may already be down; fall through to SIGTERM
-        }
-
-        let ackTimer: NodeJS.Timeout | undefined;
-        acked = await Promise.race([
-          this.stoppedAckDeferred.promise.then(() => true),
-          new Promise<boolean>((resolve) => {
-            ackTimer = setTimeout(() => resolve(false), WORKER_STOP_TIMEOUT_MS);
-            ackTimer.unref();
-          }),
-        ]);
-        if (ackTimer) clearTimeout(ackTimer);
-      }
-
-      await this.worker.stop({ force: false });
+      await this.worker.stop({ force: options?.force ?? false });
       await this.stopDeferred.promise;
-
-      if (!acked) {
-        logger.warn(
-          `A worker process did not finish teardown within ${
-            WORKER_STOP_TIMEOUT_MS / 1000
-          }s of graceful stop and was force-killed. This usually means a ` +
-            'test left open handles — timers, sockets, file watchers, or ' +
-            'native module threads. Try setting `detectAsyncLeaks: true` ' +
-            'in your config to investigate.',
-        );
-      }
     });
   }
 
@@ -376,14 +328,6 @@ export class PoolRunner {
       case 'collectFinished':
         this.resolveTask('collect', response.taskId, response.result);
         return;
-      case 'stopped':
-        // Worker acknowledged graceful shutdown — teardown is drained.
-        // The host now sends SIGTERM via `worker.stop()` to terminate the
-        // process. The actual STOPPED state transition happens in
-        // `handleExit` when the child's `exit` event fires.
-        this.stoppedAckDeferred?.resolve();
-        this.stoppedAckDeferred = undefined;
-        return;
       case 'fatal_error': {
         const error = deserializeError(response.error);
         // Mark as crashed BEFORE rejecting. The host's dispatch unwinds via
@@ -429,13 +373,6 @@ export class PoolRunner {
     if (this.stopDeferred) {
       this.stopDeferred.resolve();
       this.stopDeferred = undefined;
-    }
-    // If the worker died before sending `stopped` (crash, host-driven
-    // SIGTERM after timeout), unblock any `Promise.race` waiting on the
-    // ack so `stop()` can proceed to its final SIGTERM/exit path.
-    if (this.stoppedAckDeferred) {
-      this.stoppedAckDeferred.resolve();
-      this.stoppedAckDeferred = undefined;
     }
 
     // Reject any in-flight task regardless of whether the exit was planned.

--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -1,6 +1,6 @@
 import { type BirpcReturn, createBirpc } from 'birpc';
 import type { RuntimeRPC, ServerRPC, TestFileResult } from '../types';
-import { toError } from '../utils';
+import { logger, toError } from '../utils';
 import type { PoolWorker } from './poolWorker';
 import {
   type CollectTaskResult,
@@ -89,9 +89,8 @@ export class PoolRunner {
     | undefined;
   private startDeferred: Deferred | undefined;
   private stopDeferred: Deferred | undefined;
+  private stoppedAckDeferred: Deferred | undefined;
   private startTimer: NodeJS.Timeout | undefined;
-  private stopTimer: NodeJS.Timeout | undefined;
-  private forceKillTimer: NodeJS.Timeout | undefined;
   private lastFatalError: Error | undefined;
   /**
    * Set when the worker reports `fatal_error` or a transport error. The
@@ -180,6 +179,19 @@ export class PoolRunner {
     return this.runTaskInternal('collect', task) as Promise<CollectTaskResult>;
   }
 
+  /**
+   * Stop the worker. The host owns termination via SIGTERM — relying on the
+   * worker's own `process.exit()` was the rstest#1275 hang. Idle workers
+   * skip the IPC handshake and SIGTERM directly; in-flight workers get
+   * WORKER_STOP_TIMEOUT_MS to ack `stopped`, with overrun surfaced as a
+   * `detectAsyncLeaks` hint.
+   *
+   * The idle path is intentionally silent. Native dependencies (rspack
+   * tokio runtime, etc.) keep worker event loops ref'd by design, so a
+   * "didn't exit naturally" warning here would fire on every healthy run.
+   * The in-flight warning is meaningful because a >60s task is a real
+   * anomaly worth surfacing.
+   */
   stop(options?: { force?: boolean }): Promise<void> {
     return this.runOperation(async () => {
       switch (this.state) {
@@ -216,35 +228,48 @@ export class PoolRunner {
       this.state = 'STOPPING';
       this.stopDeferred = createDeferred();
 
-      // Best-effort graceful stop. The worker defers its own exit until
-      // after any in-flight task completes teardown.
-      try {
-        this.worker.send({ type: 'stop' });
-      } catch {
-        // ignore: worker may already be down
-      }
-
-      // Escalate to SIGTERM after the budget expires, then SIGKILL shortly
-      // after. On Windows, SIGTERM is unconditionally fatal (the process
-      // cannot trap it), so sending it immediately would kill workers with
-      // in-flight tasks. Instead, rely on the IPC `stop` message for
-      // graceful shutdown and only signal when the worker fails to exit in
-      // time.
-      this.stopTimer = setTimeout(() => {
-        void this.worker.stop().catch(() => undefined);
-      }, WORKER_STOP_TIMEOUT_MS);
-      this.stopTimer.unref();
-      // Arm a hard SIGKILL fallback independently so it fires even if
-      // SIGTERM is trapped/ignored and `worker.stop()` never resolves.
-      this.forceKillTimer = setTimeout(() => {
-        void this.worker.stop({ force: true }).catch(() => undefined);
-      }, WORKER_STOP_TIMEOUT_MS + 5_000);
-      this.forceKillTimer.unref();
-
       if (options?.force) {
         await this.worker.stop({ force: true });
+        await this.stopDeferred.promise;
+        return;
       }
+
+      // Default to acked so the idle path (no in-flight task, no IPC) skips
+      // the warning. Only the in-flight branch can flip this to false.
+      let acked = true;
+
+      if (this.currentTask !== undefined) {
+        this.stoppedAckDeferred = createDeferred();
+        try {
+          this.worker.send({ type: 'stop' });
+        } catch {
+          // worker may already be down; fall through to SIGTERM
+        }
+
+        let ackTimer: NodeJS.Timeout | undefined;
+        acked = await Promise.race([
+          this.stoppedAckDeferred.promise.then(() => true),
+          new Promise<boolean>((resolve) => {
+            ackTimer = setTimeout(() => resolve(false), WORKER_STOP_TIMEOUT_MS);
+            ackTimer.unref();
+          }),
+        ]);
+        if (ackTimer) clearTimeout(ackTimer);
+      }
+
+      await this.worker.stop({ force: false });
       await this.stopDeferred.promise;
+
+      if (!acked) {
+        logger.warn(
+          `A worker process did not finish teardown within ${
+            WORKER_STOP_TIMEOUT_MS / 1000
+          }s of graceful stop and was force-killed. This usually means a ` +
+            'test left open handles — timers, sockets, file watchers, or ' +
+            'native module threads. Try setting `detectAsyncLeaks: true` ' +
+            'in your config to investigate.',
+        );
+      }
     });
   }
 
@@ -352,8 +377,12 @@ export class PoolRunner {
         this.resolveTask('collect', response.taskId, response.result);
         return;
       case 'stopped':
-        // Worker acknowledged graceful shutdown — actual transition happens
-        // in `handleExit`.
+        // Worker acknowledged graceful shutdown — teardown is drained.
+        // The host now sends SIGTERM via `worker.stop()` to terminate the
+        // process. The actual STOPPED state transition happens in
+        // `handleExit` when the child's `exit` event fires.
+        this.stoppedAckDeferred?.resolve();
+        this.stoppedAckDeferred = undefined;
         return;
       case 'fatal_error': {
         const error = deserializeError(response.error);
@@ -384,7 +413,6 @@ export class PoolRunner {
   }
 
   private handleExit(code: number | null, signal: NodeJS.Signals | null): void {
-    this.clearStopTimer();
     this.clearStartTimer();
 
     const wasStopping = this.state === 'STOPPING';
@@ -401,6 +429,13 @@ export class PoolRunner {
     if (this.stopDeferred) {
       this.stopDeferred.resolve();
       this.stopDeferred = undefined;
+    }
+    // If the worker died before sending `stopped` (crash, host-driven
+    // SIGTERM after timeout), unblock any `Promise.race` waiting on the
+    // ack so `stop()` can proceed to its final SIGTERM/exit path.
+    if (this.stoppedAckDeferred) {
+      this.stoppedAckDeferred.resolve();
+      this.stoppedAckDeferred = undefined;
     }
 
     // Reject any in-flight task regardless of whether the exit was planned.
@@ -469,16 +504,5 @@ export class PoolRunner {
     if (!this.startTimer) return;
     clearTimeout(this.startTimer);
     this.startTimer = undefined;
-  }
-
-  private clearStopTimer(): void {
-    if (this.stopTimer) {
-      clearTimeout(this.stopTimer);
-      this.stopTimer = undefined;
-    }
-    if (this.forceKillTimer) {
-      clearTimeout(this.forceKillTimer);
-      this.forceKillTimer = undefined;
-    }
   }
 }

--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -178,11 +178,9 @@ export class PoolRunner {
   }
 
   /**
-   * Stop the worker by SIGTERM (or SIGKILL if `force`). The host owns
-   * termination — there is no IPC `stop` handshake. Per-task teardown
-   * already runs inside `runInPool`'s own `finally` before the worker
-   * sends `runFinished`, so by the time `stop()` is called there is
-   * nothing process-level to drain. Relying on the worker's own
+   * Host owns termination — no IPC handshake. Per-task teardown runs in
+   * `runInPool`'s own `finally` before `runFinished`, so by `stop()` there
+   * is nothing process-level to drain. Relying on the worker's own
    * `process.exit()` was the rstest#1275 hang.
    */
   stop(options?: { force?: boolean }): Promise<void> {
@@ -192,6 +190,10 @@ export class PoolRunner {
         case 'IDLE':
           return;
         case 'STOPPING': {
+          // Wait for the in-flight stop to settle. If the caller asks for
+          // `force` and the prior stop was graceful, escalate to SIGKILL —
+          // the prior `await` may have resolved without actually killing
+          // the child (e.g. SIGTERM masked).
           if (this.stopDeferred) {
             await this.stopDeferred.promise;
           }

--- a/packages/core/src/pool/protocol.ts
+++ b/packages/core/src/pool/protocol.ts
@@ -20,8 +20,7 @@ export type WorkerRequest =
       type: 'collect';
       taskId: number;
       options: RunWorkerOptions['options'];
-    }
-  | { type: 'stop' };
+    };
 
 export type CollectTaskResult = {
   tests: Test[];
@@ -49,7 +48,6 @@ export type WorkerResponse =
       result: CollectTaskResult;
       memory?: WorkerMemoryReport;
     }
-  | { type: 'stopped' }
   | {
       type: 'fatal_error';
       error: SerializedError;

--- a/packages/core/src/pool/workers/forksPoolWorker.ts
+++ b/packages/core/src/pool/workers/forksPoolWorker.ts
@@ -12,7 +12,7 @@ const BENIGN_IPC_ERROR_CODES = new Set([
 
 /**
  * SIGKILL escalation budget after SIGTERM. Defensive guard for native
- * modules that mask SIGTERM. Matches Vitest and Jest.
+ * modules that mask SIGTERM.
  */
 const SIGKILL_FALLBACK_MS = 500;
 
@@ -99,8 +99,7 @@ export class ForksPoolWorker extends BasePoolWorker {
       // Use `exit`, not `close`. `close` waits for all processes holding
       // the stdio pipes to release them — if a test spawns a subprocess
       // that inherits the worker's stdout/stderr, `close` blocks until
-      // that grandchild exits too, stalling slot reclaim and potentially
-      // hanging the pool until WORKER_STOP_TIMEOUT_MS force-kills.
+      // that grandchild exits too, stalling slot reclaim.
       child.on('exit', (code, signal) => {
         this.exited = true;
         this.emitter.emit('exit', code, signal);

--- a/packages/core/src/pool/workers/forksPoolWorker.ts
+++ b/packages/core/src/pool/workers/forksPoolWorker.ts
@@ -11,6 +11,12 @@ const BENIGN_IPC_ERROR_CODES = new Set([
 ]);
 
 /**
+ * SIGKILL escalation budget after SIGTERM. Defensive guard for native
+ * modules that mask SIGTERM. Matches Vitest and Jest.
+ */
+const SIGKILL_FALLBACK_MS = 500;
+
+/**
  * IPC errors that surface during shutdown but reflect the channel already
  * going away, not a genuine failure. Windows additionally surfaces
  * `write UNKNOWN` when `child.send` races teardown — see rstest#1142.
@@ -113,10 +119,11 @@ export class ForksPoolWorker extends BasePoolWorker {
 
   async stop(options?: { force?: boolean }): Promise<void> {
     if (!this.hasLiveChild()) return;
-    await killAndWait(
-      this.childProcess!,
-      options?.force ? 'SIGKILL' : 'SIGTERM',
-    );
+    if (options?.force) {
+      await killAndWait(this.childProcess!, 'SIGKILL');
+      return;
+    }
+    await killAndWait(this.childProcess!, 'SIGTERM', SIGKILL_FALLBACK_MS);
   }
 
   sendRaw(envelope: Envelope): void {

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -36,9 +36,13 @@ const sendFatalError = (err: unknown): void => {
   });
 };
 
+/**
+ * Ack the graceful-stop request. Host owns termination via SIGTERM after the
+ * ack — we don't `process.exit()` because a wedged event loop can swallow
+ * `setImmediate`, which was the rstest#1275 hang.
+ */
 const finalizeStop = (): void => {
   send({ type: 'stopped' });
-  setImmediate(() => process.exit(0));
 };
 
 /**
@@ -117,23 +121,19 @@ const requestGracefulStop = (): void => {
   if (stopRequested) return;
   stopRequested = true;
   if (currentTaskId !== undefined) {
-    // Defer the ack + exit until the task's `finally { await teardown(); }`
-    // runs. PoolRunner's WORKER_STOP_TIMEOUT_MS escalates to SIGKILL if
-    // teardown truly hangs, so this deferral is bounded.
+    // Defer the ack until the task's `finally { await teardown(); }` runs.
+    // PoolRunner's WORKER_STOP_TIMEOUT_MS escalates to SIGTERM (then SIGKILL)
+    // if teardown truly hangs, so this deferral is bounded.
     exitOnTaskIdle = true;
     return;
   }
   finalizeStop();
 };
 
-// SIGTERM shares the same shutdown path under the forks pool. `PoolRunner.stop`
-// sends SIGTERM alongside the `stop` envelope; without this handler Node's
-// default SIGTERM behavior would terminate the process immediately and skip
-// teardown. Under the threads pool the host uses `worker.terminate()` instead
-// of signals, so this handler is a no-op there. `setup.ts` may install a
-// profiling-specific SIGTERM handler (`--cpu-prof` et al.) that runs first and
-// preempts ours, preserving existing profiling semantics.
-process.on('SIGTERM', requestGracefulStop);
+// No SIGTERM handler — host-driven SIGTERM must terminate even after
+// `stopRequested` is set; otherwise the listener would swallow the escalation
+// (rstest#1275). `setup.ts` may install a profiling-specific handler that
+// calls `process.exit()`, which is compatible with this contract.
 
 channel.on((message: unknown) => {
   if (!isWorkerRequestEnvelope(message)) {

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -14,14 +14,6 @@ const send = (response: WorkerResponse): void => {
 };
 
 let currentTaskId: number | undefined;
-let stopRequested = false;
-/**
- * Set when a stop arrived mid-task. The task handler drains teardown in its
- * own `finally` first; only then do we flush `stopped` and exit. Without the
- * deferral `process.exit(0)` would orphan env/coverage/mock cleanup and the
- * `process.exit` / `process.kill` restoration.
- */
-let exitOnTaskIdle = false;
 /**
  * Set when a task handler has reported `fatal_error` and is on its way to
  * exit. Suppresses the bottom-of-the-stack `fatalExit` from racing in with a
@@ -34,15 +26,6 @@ const sendFatalError = (err: unknown): void => {
     type: 'fatal_error',
     error: serializeError(err),
   });
-};
-
-/**
- * Ack the graceful-stop request. Host owns termination via SIGTERM after the
- * ack — we don't `process.exit()` because a wedged event loop can swallow
- * `setImmediate`, which was the rstest#1275 hang.
- */
-const finalizeStop = (): void => {
-  send({ type: 'stopped' });
 };
 
 /**
@@ -114,26 +97,12 @@ const runTask = async (
   }
 
   currentTaskId = undefined;
-  if (exitOnTaskIdle) finalizeStop();
 };
 
-const requestGracefulStop = (): void => {
-  if (stopRequested) return;
-  stopRequested = true;
-  if (currentTaskId !== undefined) {
-    // Defer the ack until the task's `finally { await teardown(); }` runs.
-    // PoolRunner's WORKER_STOP_TIMEOUT_MS escalates to SIGTERM (then SIGKILL)
-    // if teardown truly hangs, so this deferral is bounded.
-    exitOnTaskIdle = true;
-    return;
-  }
-  finalizeStop();
-};
-
-// No SIGTERM handler — host-driven SIGTERM must terminate even after
-// `stopRequested` is set; otherwise the listener would swallow the escalation
-// (rstest#1275). `setup.ts` may install a profiling-specific handler that
-// calls `process.exit()`, which is compatible with this contract.
+// No SIGTERM handler — the host owns termination and SIGTERM (default action:
+// exit) is what gets us out. Any handler that didn't unconditionally exit
+// would defeat that contract (rstest#1275). `setup.ts` may install a
+// profiling-specific handler that calls `process.exit()`, which is compatible.
 
 channel.on((message: unknown) => {
   if (!isWorkerRequestEnvelope(message)) {
@@ -151,9 +120,6 @@ channel.on((message: unknown) => {
       break;
     case 'collect':
       void runTask('collect', request);
-      break;
-    case 'stop':
-      requestGracefulStop();
       break;
   }
 });

--- a/packages/core/tests/pool/fixtures/testWorker.mjs
+++ b/packages/core/tests/pool/fixtures/testWorker.mjs
@@ -84,9 +84,9 @@ const makeRunResult = (request, extra) => ({
 let taskInFlight = false;
 let exitOnTaskIdle = false;
 
+// Mirrors the real worker — see worker/index.ts for rationale.
 const finalizeStop = () => {
   send({ type: 'stopped' });
-  setTimeout(() => process.exit(0), 10);
 };
 
 const handleRun = (request) => {
@@ -222,7 +222,4 @@ onHostMessage((message) => {
   }
 });
 
-// SIGTERM is meaningful only under the forks pool. In threads mode signals
-// are delivered to the parent process, not the worker thread, so this
-// handler is a harmless no-op there.
-process.on('SIGTERM', requestGracefulStop);
+// No SIGTERM handler — mirrors worker/index.ts.

--- a/packages/core/tests/pool/fixtures/testWorker.mjs
+++ b/packages/core/tests/pool/fixtures/testWorker.mjs
@@ -79,19 +79,8 @@ const makeRunResult = (request, extra) => ({
   ...extra,
 });
 
-// Mirrors the real worker: track whether a task is in-flight and defer
-// stop until the task completes.
-let taskInFlight = false;
-let exitOnTaskIdle = false;
-
-// Mirrors the real worker — see worker/index.ts for rationale.
-const finalizeStop = () => {
-  send({ type: 'stopped' });
-};
-
 const handleRun = (request) => {
   const mode = request.options?.__testMode;
-  taskInFlight = true;
 
   const finish = (extra) => {
     send({
@@ -99,12 +88,9 @@ const handleRun = (request) => {
       taskId: request.taskId,
       result: makeRunResult(request, extra),
     });
-    taskInFlight = false;
-    if (exitOnTaskIdle) finalizeStop();
   };
 
   if (mode === 'fatal') {
-    taskInFlight = false;
     send({
       type: 'fatal_error',
       error: {
@@ -189,18 +175,6 @@ const handleCollect = (request) => {
   });
 };
 
-let stopRequested = false;
-const requestGracefulStop = () => {
-  if (stopRequested) return;
-  stopRequested = true;
-  if (taskInFlight) {
-    // Defer until the in-flight task finishes, just like the real worker.
-    exitOnTaskIdle = true;
-    return;
-  }
-  finalizeStop();
-};
-
 onHostMessage((message) => {
   if (!message || message[REQ_TAG] !== true) return;
   const request = message.request;
@@ -215,9 +189,6 @@ onHostMessage((message) => {
       break;
     case 'collect':
       handleCollect(request);
-      break;
-    case 'stop':
-      requestGracefulStop();
       break;
   }
 });

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -312,42 +312,18 @@ describe('Pool - failure recovery', () => {
 // ── close() behavior ──────────────────────────────────────────────────────
 
 describe('Pool - close()', () => {
-  it('should not drop in-flight task result', async () => {
-    // Use isolate: false so the warm-up run establishes a reusable worker.
-    // The slow task then dispatches instantly on the existing process,
-    // eliminating the fork+handshake race that makes timer-based
-    // synchronization unreliable on slow CI.
-    const pool = new Pool(createPoolOptions({ isolate: false, minWorkers: 1 }));
-    // Warm up: ensure the worker is started and idle.
-    await pool.runTest(createTask());
-
-    const taskPromise = pool.runTest(
-      createTask('run', { __testMode: 'slow', __delayMs: 500 }),
-    );
-    // The reused worker receives the run request on an already-open IPC
-    // channel, so a short delay is enough for the message to arrive.
-    await new Promise((r) => setTimeout(r, 50));
-    const closePromise = pool.close();
-    // The task should still resolve (worker sends result before stopping).
-    const result = await taskPromise;
-    expect(result.status).toBe('pass');
-    await closePromise;
-  });
-
   it('should reject subsequent submissions after close()', async () => {
     const pool = new Pool(createPoolOptions());
     await pool.close();
     await expect(pool.runTest(createTask())).rejects.toThrow(/closed/);
   });
 
-  // Regression: rstest#1275. The worker no longer self-exits on `stop`; the
-  // host owns SIGTERM. If `close()` is called when all workers are idle (the
-  // common end-of-run case), the host must skip the IPC ack handshake and
-  // SIGTERM directly. Previously the host waited the full 60s graceful
-  // budget plus a 5s SIGKILL escalation, producing the 60–65s hang reported
-  // in the issue. This test asserts close completes in well under that
-  // budget.
-  it('should close promptly when workers are idle (rstest#1275)', async () => {
+  // Regression: rstest#1275. The host owns worker termination via SIGTERM
+  // and does not wait for any IPC ack. Previously the host waited the full
+  // 60s WORKER_STOP_TIMEOUT_MS plus a 5s SIGKILL escalation for workers
+  // that couldn't self-exit (e.g. rspack tokio threads ref'ing the loop),
+  // producing the 60–65s hang reported in the issue.
+  it('should close promptly under the forks pool (rstest#1275)', async () => {
     const pool = new Pool(createPoolOptions({ isolate: false, minWorkers: 1 }));
     await pool.runTest(createTask()); // warm up: worker is now alive and idle
 

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -339,6 +339,26 @@ describe('Pool - close()', () => {
     await pool.close();
     await expect(pool.runTest(createTask())).rejects.toThrow(/closed/);
   });
+
+  // Regression: rstest#1275. The worker no longer self-exits on `stop`; the
+  // host owns SIGTERM. If `close()` is called when all workers are idle (the
+  // common end-of-run case), the host must skip the IPC ack handshake and
+  // SIGTERM directly. Previously the host waited the full 60s graceful
+  // budget plus a 5s SIGKILL escalation, producing the 60–65s hang reported
+  // in the issue. This test asserts close completes in well under that
+  // budget.
+  it('should close promptly when workers are idle (rstest#1275)', async () => {
+    const pool = new Pool(createPoolOptions({ isolate: false, minWorkers: 1 }));
+    await pool.runTest(createTask()); // warm up: worker is now alive and idle
+
+    const start = Date.now();
+    await pool.close();
+    const elapsed = Date.now() - start;
+
+    // Idle close should be SIGTERM-fast (sub-second). Allow generous CI
+    // headroom but require it to be well below the 60s graceful budget.
+    expect(elapsed).toBeLessThan(5000);
+  });
 });
 
 // ── maxWorkers capacity ─────────────────────────────────────────────────────

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -244,7 +244,7 @@ describe('Pool - exit-based lifecycle (not close)', () => {
       // Task 1: worker spawns a 30s grandchild that inherits stdout/stderr,
       // then sends its result and exits. With a `close`-based lifecycle this
       // would block slot reclaim until the grandchild exits (30s), causing
-      // task 2 to hang until WORKER_STOP_TIMEOUT_MS.
+      // task 2 to hang.
       const start = Date.now();
       const r1 = await pool.runTest(
         createTask('run', { __testMode: 'spawn-orphan' }),

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,5 +1,6 @@
 # Custom Dictionary Words
 ACMRTUXB
+acked
 antd
 apng
 apos

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,6 +1,5 @@
 # Custom Dictionary Words
 ACMRTUXB
-acked
 antd
 apng
 apos


### PR DESCRIPTION
## Summary

Fixes a 60s `pool.close()` hang under `--pool forks` with multiple workers (reported in #1275, regression from 0.9.9). Common when native dependencies in user code keep a worker's event loop ref'd — e.g. the rspack tokio runtime, which doesn't release its worker threads until process termination.

The 0.10.0 forks pool relied on the worker self-exiting via `process.exit(0)` inside a `setImmediate` after acking IPC `stop`. When the event loop is wedged, that callback never fires and the host waits the full `WORKER_STOP_TIMEOUT_MS` (60s) before its SIGKILL fallback.

This PR drops the IPC `stop` handshake entirely. The host owns termination via SIGTERM (with 500ms SIGKILL fallback). Per-task teardown already runs inside `runInPool`'s own `finally` before `runFinished` is sent, so the worker has no process-level state to drain on close — the handshake was just adding latency. This restores the 0.9.9 / tinypool snappy-on-interrupt behavior.

- Worker no longer installs a SIGTERM handler or self-exits.
- `'stop'` / `'stopped'` envelope types and the `requestGracefulStop` / `exitOnTaskIdle` / `finalizeStop` machinery are gone.
- Host `stop()` is now: `await worker.stop({ force })` (SIGTERM + 500ms SIGKILL fallback, or SIGKILL on `force`).

No public API change.

## Related Links

- Closes #1275