### PR TITLE
feat(core): experimental softMode — reuse workers with per-file env reset

### DIFF
--- a/e2e/soft-mode-happy-dom/fixtures/rstest.config.mts
+++ b/e2e/soft-mode-happy-dom/fixtures/rstest.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  experiments: {
+    softMode: true,
+  },
+  testEnvironment: 'happy-dom',
+  // Force single worker so file-a always precedes file-b — assertions
+  // about cross-file state reset are deterministic.
+  pool: {
+    maxWorkers: 1,
+  },
+  setupFiles: ['./test/setup.ts'],
+});

--- a/e2e/soft-mode-happy-dom/fixtures/test/a-init.test.ts
+++ b/e2e/soft-mode-happy-dom/fixtures/test/a-init.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@rstest/core';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __soft_worker_pid__: number | undefined;
+}
+
+globalThis.__soft_worker_pid__ ??= process.pid;
+
+describe('soft mode happy-dom — file A', () => {
+  it('owns a fresh DOM body', () => {
+    expect(document.body.innerHTML).toBe('');
+    document.body.innerHTML = '<div id="from-a">x</div>';
+  });
+
+  it('mutates storage', () => {
+    expect(localStorage.length).toBe(0);
+    localStorage.setItem('from-a', 'leaked-if-soft-reset-broken');
+  });
+});

--- a/e2e/soft-mode-happy-dom/fixtures/test/b-verify.test.ts
+++ b/e2e/soft-mode-happy-dom/fixtures/test/b-verify.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@rstest/core';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __soft_worker_pid__: number | undefined;
+}
+
+describe('soft mode happy-dom — file B', () => {
+  it('runs in the same worker as file A', () => {
+    expect(globalThis.__soft_worker_pid__).toBe(process.pid);
+  });
+
+  it('starts with a clean DOM body', () => {
+    expect(document.body.innerHTML).toBe('');
+    expect(document.querySelector('#from-a')).toBeNull();
+  });
+
+  it('starts with clean storage', () => {
+    expect(localStorage.length).toBe(0);
+    expect(localStorage.getItem('from-a')).toBeNull();
+  });
+
+  it('HTMLElement.prototype.focus descriptor restored across files', () => {
+    // setup.ts records the descriptor SHAPE on each module re-eval BEFORE
+    // re-patching. With softMode handling happy-dom, file-a saw 'value'
+    // (fresh DOM) and file-b also saw 'value' because softResetEnv's
+    // protoSnapshot restore wiped file-a's getter-only patch.
+    const history = (
+      globalThis as { __soft_focus_descriptor_history__?: Array<string> }
+    ).__soft_focus_descriptor_history__;
+    expect(history).toEqual(['value', 'value']);
+  });
+});

--- a/e2e/soft-mode-happy-dom/fixtures/test/setup.ts
+++ b/e2e/soft-mode-happy-dom/fixtures/test/setup.ts
@@ -1,0 +1,38 @@
+/**
+ * Mirrors the jsdom fixture's setup-spy.ts but for happy-dom. happy-dom
+ * exposes the same Element/HTMLElement/Node globals jsdom does, so the
+ * vendor-style focus monkey-patch + descriptor-history recording is
+ * portable. softResetEnv's protoSnapshot path handles both env names.
+ */
+if (typeof HTMLElement !== 'undefined') {
+  const preDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'focus',
+  );
+  (
+    globalThis as { __soft_focus_descriptor_history__?: Array<string> }
+  ).__soft_focus_descriptor_history__ ??= [];
+  (
+    globalThis as { __soft_focus_descriptor_history__?: Array<string> }
+  ).__soft_focus_descriptor_history__!.push(
+    !preDescriptor
+      ? 'missing'
+      : 'value' in preDescriptor && typeof preDescriptor.value === 'function'
+        ? 'value'
+        : preDescriptor.get && !preDescriptor.set
+          ? 'get-only'
+          : 'other',
+  );
+
+  const originalFocus = HTMLElement.prototype.focus;
+  Object.defineProperty(HTMLElement.prototype, 'focus', {
+    configurable: true,
+    get: () =>
+      function patchedFocus(this: HTMLElement, options?: FocusOptions) {
+        (globalThis as { __soft_focus_calls__?: number }).__soft_focus_calls__ =
+          ((globalThis as { __soft_focus_calls__?: number })
+            .__soft_focus_calls__ ?? 0) + 1;
+        return originalFocus.call(this, options);
+      },
+  });
+}

--- a/e2e/soft-mode-happy-dom/index.test.ts
+++ b/e2e/soft-mode-happy-dom/index.test.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('experiments.softMode — happy-dom', () => {
+  it('resets DOM/storage/prototype state between files (happy-dom env)', async ({
+    onTestFinished,
+  }) => {
+    // Mirrors the jsdom soft-mode fixture for happy-dom. Verifies that
+    // `softResetEnv` and the prototype-snapshot path handle the
+    // `happy-dom` env-name branch the same way they handle `jsdom`.
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, './fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+});

--- a/e2e/soft-mode-recycle/fixtures/rstest.config.mts
+++ b/e2e/soft-mode-recycle/fixtures/rstest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  // maxFilesPerWorker: 1 disposes the runner after every task, so each
+  // file gets a fresh worker process. With pool.maxWorkers: 2 and 4 files,
+  // every file's `process.pid` must be unique — the driver asserts that
+  // pidcount === filecount. Default soft-mode reuse would yield fewer
+  // pids than files (covered by e2e/soft-mode-reuse).
+  experiments: {
+    softMode: { maxFilesPerWorker: 1 },
+  },
+  pool: {
+    maxWorkers: 2,
+  },
+});

--- a/e2e/soft-mode-recycle/fixtures/test/f1.test.ts
+++ b/e2e/soft-mode-recycle/fixtures/test/f1.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f1');
+
+describe('soft mode recycle — file 1', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-recycle/fixtures/test/f2.test.ts
+++ b/e2e/soft-mode-recycle/fixtures/test/f2.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f2');
+
+describe('soft mode recycle — file 2', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-recycle/fixtures/test/f3.test.ts
+++ b/e2e/soft-mode-recycle/fixtures/test/f3.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f3');
+
+describe('soft mode recycle — file 3', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-recycle/fixtures/test/f4.test.ts
+++ b/e2e/soft-mode-recycle/fixtures/test/f4.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f4');
+
+describe('soft mode recycle — file 4', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-recycle/fixtures/test/record-pid.ts
+++ b/e2e/soft-mode-recycle/fixtures/test/record-pid.ts
@@ -1,0 +1,17 @@
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/**
+ * Record this file's `process.pid` + the file's tag into a shared log.
+ * The driver reads this back after the fixture run and asserts the pid
+ * count matches the file count — proving the runner was disposed after
+ * each task (the configured `maxFilesPerWorker: 1` cap).
+ */
+export const PID_LOG_PATH =
+  process.env.RSTEST_SOFT_RECYCLE_LOG ??
+  join(tmpdir(), 'rstest-soft-mode-recycle.log');
+
+export const recordPid = (fileTag: string): void => {
+  appendFileSync(PID_LOG_PATH, `${process.pid}\t${fileTag}\n`);
+};

--- a/e2e/soft-mode-recycle/index.test.ts
+++ b/e2e/soft-mode-recycle/index.test.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('experiments.softMode — maxFilesPerWorker recycle', () => {
+  it('disposes the runner after each task when maxFilesPerWorker=1', async ({
+    onTestFinished,
+  }) => {
+    const logPath = join(
+      tmpdir(),
+      `rstest-soft-mode-recycle-${process.pid}-${Date.now()}.log`,
+    );
+    onTestFinished(() => {
+      if (existsSync(logPath)) unlinkSync(logPath);
+    });
+
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, './fixtures'),
+          env: {
+            RSTEST_SOFT_RECYCLE_LOG: logPath,
+          },
+        },
+      },
+    });
+    await expectExecSuccess();
+
+    // 4 fixture files × maxFilesPerWorker=1 → every runner is disposed
+    // after a single task, so every file MUST observe a unique pid. If
+    // recycling were broken (cap ignored or off-by-one), some pair of
+    // files would share a pid and this assertion would catch it.
+    const lines = readFileSync(logPath, 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(lines.length).toBe(4);
+
+    const pids = new Set(lines.map((line) => line.split('\t')[0]));
+    expect(pids.size).toBe(4);
+  });
+});

--- a/e2e/soft-mode-reuse/fixtures/rstest.config.mts
+++ b/e2e/soft-mode-reuse/fixtures/rstest.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  experiments: {
+    softMode: true,
+  },
+  // 4 test files + 2 workers → at least one worker handles ≥2 files,
+  // so at least one pair of files must share `process.pid`. The driver
+  // (e2e/soft-mode-reuse/index.test.ts) asserts the worker-reuse
+  // invariant after the fixture run by reading the recorded pids back.
+  pool: {
+    maxWorkers: 2,
+  },
+});

--- a/e2e/soft-mode-reuse/fixtures/test/f1.test.ts
+++ b/e2e/soft-mode-reuse/fixtures/test/f1.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f1');
+
+describe('soft mode reuse — file 1', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-reuse/fixtures/test/f2.test.ts
+++ b/e2e/soft-mode-reuse/fixtures/test/f2.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f2');
+
+describe('soft mode reuse — file 2', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-reuse/fixtures/test/f3.test.ts
+++ b/e2e/soft-mode-reuse/fixtures/test/f3.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f3');
+
+describe('soft mode reuse — file 3', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-reuse/fixtures/test/f4.test.ts
+++ b/e2e/soft-mode-reuse/fixtures/test/f4.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@rstest/core';
+import { recordPid } from './record-pid';
+
+recordPid('f4');
+
+describe('soft mode reuse — file 4', () => {
+  it('runs and records its pid', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode-reuse/fixtures/test/record-pid.ts
+++ b/e2e/soft-mode-reuse/fixtures/test/record-pid.ts
@@ -1,0 +1,20 @@
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/**
+ * Record this file's process.pid + the file's name into a shared log
+ * file. The driver test reads the log after the fixture finishes and
+ * asserts that fewer unique pids exist than files — proving the worker
+ * pool reused workers across files.
+ *
+ * Cannot use `globalThis` because each worker process has its own
+ * global, so a counter there is per-worker not workspace-wide.
+ */
+export const PID_LOG_PATH =
+  process.env.RSTEST_SOFT_REUSE_LOG ??
+  join(tmpdir(), 'rstest-soft-mode-reuse.log');
+
+export const recordPid = (fileTag: string): void => {
+  appendFileSync(PID_LOG_PATH, `${process.pid}\t${fileTag}\n`);
+};

--- a/e2e/soft-mode-reuse/index.test.ts
+++ b/e2e/soft-mode-reuse/index.test.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('experiments.softMode — multi-worker reuse', () => {
+  it('reuses workers across files when files > workers', async ({
+    onTestFinished,
+  }) => {
+    const logPath = join(
+      tmpdir(),
+      `rstest-soft-mode-reuse-${process.pid}-${Date.now()}.log`,
+    );
+    onTestFinished(() => {
+      if (existsSync(logPath)) unlinkSync(logPath);
+    });
+
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, './fixtures'),
+          env: {
+            RSTEST_SOFT_REUSE_LOG: logPath,
+          },
+        },
+      },
+    });
+    await expectExecSuccess();
+
+    // 4 fixture files × pool.maxWorkers=2 → by pigeon-hole, at least
+    // one pid must appear on ≥2 lines. If softMode silently fell back
+    // to `isolate: true`, every file would have its own pid and the
+    // unique-pid set would have 4 elements — the assertion below
+    // catches that regression.
+    const lines = readFileSync(logPath, 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    expect(lines.length).toBe(4);
+
+    const pids = new Set(lines.map((line) => line.split('\t')[0]));
+    expect(pids.size).toBeLessThan(4);
+    // And at least one worker really was reused (not just one worker
+    // for all 4 — that would be a single-worker fallback regression).
+    expect(pids.size).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/e2e/soft-mode/fixtures/rstest.config.mts
+++ b/e2e/soft-mode/fixtures/rstest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  experiments: {
+    softMode: true,
+  },
+  testEnvironment: 'jsdom',
+  // Force a single worker so file-a runs before file-b deterministically.
+  // The fixture asserts cross-file state-reset semantics that only
+  // exercise the soft-mode code path when both files share one worker.
+  pool: {
+    maxWorkers: 1,
+  },
+  setupFiles: ['./test/setup-spy.ts'],
+});

--- a/e2e/soft-mode/fixtures/test/a-init.test.ts
+++ b/e2e/soft-mode/fixtures/test/a-init.test.ts
@@ -37,8 +37,9 @@ describe('soft mode — file A (state setter)', () => {
     rstest.setSystemTime(new Date('2020-01-01T00:00:00Z'));
     expect(new Date().toISOString()).toBe('2020-01-01T00:00:00.000Z');
     // Deliberately DO NOT call useRealTimers() — soft mode must restore
-    // real timers between files, otherwise file-b's useFakeTimers() throws
-    // "Can't install fake timers twice on the same global object".
+    // real timers between files, otherwise a downstream file's
+    // useFakeTimers() throws "Can't install fake timers twice on the
+    // same global object".
   });
 
   it('exercises HTMLElement.prototype.focus patch', () => {

--- a/e2e/soft-mode/fixtures/test/b-leak.test.ts
+++ b/e2e/soft-mode/fixtures/test/b-leak.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @rstest-environment jsdom
+ *
+ * Deliberately leaks unawaited async work so the next file's
+ * `preparePool` exercises the `drainPendingAsyncFromPriorFile` absorber.
+ *
+ * If the absorber regresses (removed, drain count too low, listener
+ * install/remove order wrong), this file's leak surfaces as an
+ * `unhandledRejection` attributed to file-b or file-c → suite fails.
+ * With the absorber working, the leak is silently absorbed and
+ * subsequent files run cleanly.
+ */
+import { describe, expect, it } from '@rstest/core';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __soft_file_seq__: string[] | undefined;
+}
+
+globalThis.__soft_file_seq__ ??= [];
+globalThis.__soft_file_seq__.push('file-leaker');
+
+describe('soft mode — leaker (exercises the absorber)', () => {
+  it('finishes without awaiting a deferred rejection', () => {
+    // Schedule a rejection that will fire AFTER this test's microtask
+    // queue has drained — i.e. after the file's slot has closed. The
+    // worker survives because soft mode drains + absorbs before
+    // installing the next file's per-file `unhandledRejection` handler.
+    setTimeout(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      Promise.reject(
+        new Error('intentional leak — should be absorbed by drain'),
+      );
+    }, 0);
+
+    // Also schedule a deferred uncaughtException-style throw. Same idea:
+    // it must not surface in the next file's slot.
+    setTimeout(() => {
+      throw new Error('intentional leak — should be absorbed by drain');
+    }, 0);
+
+    // Assert something trivial so this counts as a passing test.
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/soft-mode/fixtures/test/c-verify.test.ts
+++ b/e2e/soft-mode/fixtures/test/c-verify.test.ts
@@ -1,8 +1,8 @@
 /**
  * @rstest-environment jsdom
  *
- * Runs after file-a in the same worker. Asserts every kind of state
- * soft mode is supposed to reset.
+ * Runs after `a-init` and `b-leak` in the same worker. Asserts every
+ * kind of state soft mode is supposed to reset.
  */
 import { describe, expect, it, rstest } from '@rstest/core';
 
@@ -17,11 +17,21 @@ globalThis.__soft_file_seq__ ??= [];
 globalThis.__soft_file_seq__.push('file-b');
 
 describe('soft mode — file B (state asserter)', () => {
-  it('runs in the same worker as file-a', () => {
+  it('runs in the same worker as a-init and b-leak', () => {
     expect(globalThis.__soft_worker_pid__).toBe(process.pid);
-    // file-a wrote to this array; we appended above. Length >= 2 proves the
-    // global state survived (it's a global, not env-reset state).
-    expect(globalThis.__soft_file_seq__?.length).toBeGreaterThanOrEqual(2);
+    // Each file pushed its tag; exact sequence pins file ordering AND
+    // proves the global survived softReset (which only clears env-side
+    // state, not arbitrary globals). `file-leaker` being present here
+    // also proves the leaker file completed successfully — its deferred
+    // unhandled rejection + throw were absorbed by
+    // `drainPendingAsyncFromPriorFile` before this file's `preparePool`
+    // installed per-file handlers. If the absorber regresses, those
+    // leaks would bubble into this file's slot and fail the suite.
+    expect(globalThis.__soft_file_seq__).toEqual([
+      'file-a',
+      'file-leaker',
+      'file-b',
+    ]);
   });
 
   it('starts with a clean DOM body (file-a leaks reset)', () => {
@@ -51,35 +61,36 @@ describe('soft mode — file B (state asserter)', () => {
 
   it('HTMLElement.prototype.focus was restored to value-descriptor between files', () => {
     // setup-spy.ts snapshots the descriptor shape on every module
-    // re-evaluation BEFORE re-patching. With soft mode working:
-    //   file-a setup: sees 'value' (fresh JSDOM)
-    //   file-b setup: sees 'value' AGAIN because softReset restored it
-    // Without soft mode (or with a broken restore):
-    //   file-b setup would see 'get-only' — file-a's patch lingers
+    // re-evaluation BEFORE re-patching. With soft mode working, every
+    // file's setupFile sees a freshly-restored `value` descriptor (the
+    // prior file's getter-only patch was wiped by softResetEnv's
+    // protoSnapshot restore). Without soft mode, file 2+ would see
+    // `'get-only'` — the prior file's patch lingers.
+    //
+    // 3 files in this fixture (a-init, b-leak, c-verify) → 3 captures,
+    // all should be `'value'`.
     const history = (
       globalThis as { __soft_focus_descriptor_history__?: Array<string> }
     ).__soft_focus_descriptor_history__;
     expect(history).toBeDefined();
-    expect(history).toEqual(['value', 'value']);
+    expect(history).toEqual(['value', 'value', 'value']);
   });
 
   it('Element.prototype.getBoundingClientRect spy is fresh', () => {
     // setup-spy.ts re-installed the spy for this file. If file-a's spy
-    // wasn't restored, the new spy would wrap the OLD spy and call counts
-    // would be inflated. We can't directly inspect the inner chain, but we
-    // can check the spy responds to mockClear and starts at zero calls.
+    // wasn't restored across the file boundary, the new spy would wrap
+    // the OLD spy and `.mock.calls` would already be non-empty.
     const div = document.createElement('div');
-    const before = (
+    const mock = (
       div.getBoundingClientRect as unknown as {
         mock?: { calls: unknown[] };
       }
     ).mock;
-    if (before) {
-      // It IS a mock — check it starts with zero recorded calls for this file.
-      // (rstest's `clearMocks: true` plus tinyspy.restoreAll between files
-      //  yields a fresh spy.)
-      expect(before.calls.length).toBe(0);
-    }
+    // Assert it IS a mock — proves setup-spy.ts re-ran for file-b.
+    // Without this assertion the spy-restored check would silently pass
+    // when the spy didn't install at all (regression in setupFile re-eval).
+    expect(mock).toBeDefined();
+    expect(mock!.calls.length).toBe(0);
     div.getBoundingClientRect();
     expect(div.getBoundingClientRect().width).toBe(100);
   });

--- a/e2e/soft-mode/fixtures/test/file-a.test.ts
+++ b/e2e/soft-mode/fixtures/test/file-a.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @rstest-environment jsdom
+ *
+ * First file in a soft-mode worker. Establishes state (mutates DOM, sets
+ * storage, installs fake timers, exercises the focus patch). The next
+ * files assert all of this is reset between them.
+ */
+import { describe, expect, it, rstest } from '@rstest/core';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __soft_worker_pid__: number | undefined;
+  // eslint-disable-next-line no-var
+  var __soft_file_seq__: string[] | undefined;
+}
+
+// Capture the worker's pid; later files assert the same pid (worker reuse).
+globalThis.__soft_worker_pid__ ??= process.pid;
+globalThis.__soft_file_seq__ ??= [];
+globalThis.__soft_file_seq__.push('file-a');
+
+describe('soft mode — file A (state setter)', () => {
+  it('owns a fresh DOM body', () => {
+    expect(document.body.innerHTML).toBe('');
+    document.body.innerHTML = '<div id="from-file-a">x</div>';
+    expect(document.querySelector('#from-file-a')).not.toBeNull();
+  });
+
+  it('owns fresh storage', () => {
+    expect(localStorage.length).toBe(0);
+    localStorage.setItem('from-file-a', 'leaked-if-soft-reset-broken');
+    sessionStorage.setItem('from-file-a-s', 'leaked-if-soft-reset-broken');
+  });
+
+  it('installs fake timers without throwing', () => {
+    rstest.useFakeTimers();
+    rstest.setSystemTime(new Date('2020-01-01T00:00:00Z'));
+    expect(new Date().toISOString()).toBe('2020-01-01T00:00:00.000Z');
+    // Deliberately DO NOT call useRealTimers() — soft mode must restore
+    // real timers between files, otherwise file-b's useFakeTimers() throws
+    // "Can't install fake timers twice on the same global object".
+  });
+
+  it('exercises HTMLElement.prototype.focus patch', () => {
+    const el = document.createElement('button');
+    document.body.appendChild(el);
+    el.focus();
+    expect(
+      (globalThis as { __soft_focus_calls__?: number }).__soft_focus_calls__,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/e2e/soft-mode/fixtures/test/file-b.test.ts
+++ b/e2e/soft-mode/fixtures/test/file-b.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @rstest-environment jsdom
+ *
+ * Runs after file-a in the same worker. Asserts every kind of state
+ * soft mode is supposed to reset.
+ */
+import { describe, expect, it, rstest } from '@rstest/core';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __soft_worker_pid__: number | undefined;
+  // eslint-disable-next-line no-var
+  var __soft_file_seq__: string[] | undefined;
+}
+
+globalThis.__soft_file_seq__ ??= [];
+globalThis.__soft_file_seq__.push('file-b');
+
+describe('soft mode — file B (state asserter)', () => {
+  it('runs in the same worker as file-a', () => {
+    expect(globalThis.__soft_worker_pid__).toBe(process.pid);
+    // file-a wrote to this array; we appended above. Length >= 2 proves the
+    // global state survived (it's a global, not env-reset state).
+    expect(globalThis.__soft_file_seq__?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('starts with a clean DOM body (file-a leaks reset)', () => {
+    expect(document.body.innerHTML).toBe('');
+    expect(document.querySelector('#from-file-a')).toBeNull();
+  });
+
+  it('starts with clean storage', () => {
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+    expect(localStorage.getItem('from-file-a')).toBeNull();
+    expect(sessionStorage.getItem('from-file-a-s')).toBeNull();
+  });
+
+  it('useFakeTimers() does NOT throw after file-a installed them', () => {
+    // file-a installed fake timers and intentionally never uninstalled.
+    // Soft mode's between-file teardown should have called useRealTimers()
+    // via the captured api. If not, sinon's `install()` throws
+    // "Can't install fake timers twice on the same global object".
+    expect(() => {
+      rstest.useFakeTimers();
+      rstest.setSystemTime(new Date('2030-06-15T00:00:00Z'));
+    }).not.toThrow();
+    expect(new Date().toISOString()).toBe('2030-06-15T00:00:00.000Z');
+    rstest.useRealTimers();
+  });
+
+  it('HTMLElement.prototype.focus was restored to value-descriptor between files', () => {
+    // setup-spy.ts snapshots the descriptor shape on every module
+    // re-evaluation BEFORE re-patching. With soft mode working:
+    //   file-a setup: sees 'value' (fresh JSDOM)
+    //   file-b setup: sees 'value' AGAIN because softReset restored it
+    // Without soft mode (or with a broken restore):
+    //   file-b setup would see 'get-only' — file-a's patch lingers
+    const history = (
+      globalThis as { __soft_focus_descriptor_history__?: Array<string> }
+    ).__soft_focus_descriptor_history__;
+    expect(history).toBeDefined();
+    expect(history).toEqual(['value', 'value']);
+  });
+
+  it('Element.prototype.getBoundingClientRect spy is fresh', () => {
+    // setup-spy.ts re-installed the spy for this file. If file-a's spy
+    // wasn't restored, the new spy would wrap the OLD spy and call counts
+    // would be inflated. We can't directly inspect the inner chain, but we
+    // can check the spy responds to mockClear and starts at zero calls.
+    const div = document.createElement('div');
+    const before = (
+      div.getBoundingClientRect as unknown as {
+        mock?: { calls: unknown[] };
+      }
+    ).mock;
+    if (before) {
+      // It IS a mock — check it starts with zero recorded calls for this file.
+      // (rstest's `clearMocks: true` plus tinyspy.restoreAll between files
+      //  yields a fresh spy.)
+      expect(before.calls.length).toBe(0);
+    }
+    div.getBoundingClientRect();
+    expect(div.getBoundingClientRect().width).toBe(100);
+  });
+});

--- a/e2e/soft-mode/fixtures/test/setup-spy.ts
+++ b/e2e/soft-mode/fixtures/test/setup-spy.ts
@@ -1,0 +1,71 @@
+// Shared setupFile: every test file in this fixture re-evaluates this
+// module (rstest re-runs setupFiles per file). The spy and the
+// HTMLElement.prototype.focus assignment are deliberate cross-file leaks
+// that soft mode must clean up between files.
+import { rstest } from '@rstest/core';
+
+// Spy on Element.prototype.getBoundingClientRect — registered with
+// tinyspy's worker-scope `spies` Set; soft mode's `restoreAll()` between
+// files restores the original method so file N+1's setupFile creates a
+// fresh spy on the original (not a spy-of-a-spy).
+if (typeof Element !== 'undefined') {
+  rstest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+    () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 100,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  );
+}
+
+// Vendor-style monkey-patch on HTMLElement.prototype.focus — mirrors what
+// `@testing-library/user-event`'s `patchFocus` does (replaces the value
+// descriptor with a getter-only one). Without soft mode's prototype
+// snapshot+restore, file N+1's plain `prototype.focus = fn` would throw.
+//
+// Before re-patching, capture the current descriptor's *shape* so tests
+// can assert that soft mode reset it back to the original `value+writable`
+// form between files. After re-patching, the descriptor is getter-only
+// again, so we can't observe the reset by inspecting the descriptor at
+// test time — we have to look BEFORE the patch runs.
+if (typeof HTMLElement !== 'undefined') {
+  const preDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'focus',
+  );
+  (
+    globalThis as { __soft_focus_descriptor_history__?: Array<string> }
+  ).__soft_focus_descriptor_history__ ??= [];
+  // 'value' = original / restored; 'get-only' = a prior file's patch is
+  // still in place; 'missing' = something destroyed the property.
+  (
+    globalThis as { __soft_focus_descriptor_history__?: Array<string> }
+  ).__soft_focus_descriptor_history__!.push(
+    !preDescriptor
+      ? 'missing'
+      : 'value' in preDescriptor && typeof preDescriptor.value === 'function'
+        ? 'value'
+        : preDescriptor.get && !preDescriptor.set
+          ? 'get-only'
+          : 'other',
+  );
+
+  const originalFocus = HTMLElement.prototype.focus;
+  Object.defineProperty(HTMLElement.prototype, 'focus', {
+    configurable: true,
+    get: () =>
+      function patchedFocus(this: HTMLElement, options?: FocusOptions) {
+        (globalThis as { __soft_focus_calls__?: number }).__soft_focus_calls__ =
+          ((globalThis as { __soft_focus_calls__?: number })
+            .__soft_focus_calls__ ?? 0) + 1;
+        return originalFocus.call(this, options);
+      },
+  });
+}

--- a/e2e/soft-mode/fixtures/test/setup-spy.ts
+++ b/e2e/soft-mode/fixtures/test/setup-spy.ts
@@ -27,8 +27,9 @@ if (typeof Element !== 'undefined') {
 
 // Vendor-style monkey-patch on HTMLElement.prototype.focus — mirrors what
 // `@testing-library/user-event`'s `patchFocus` does (replaces the value
-// descriptor with a getter-only one). Without soft mode's prototype
-// snapshot+restore, file N+1's plain `prototype.focus = fn` would throw.
+// descriptor with a getter-only one via `Object.defineProperty`). Without
+// soft mode's prototype snapshot+restore, file N+1's vendor code that
+// re-assigns via `prototype.focus = fn` would throw "has only a getter".
 //
 // Before re-patching, capture the current descriptor's *shape* so tests
 // can assert that soft mode reset it back to the original `value+writable`

--- a/e2e/soft-mode/index.test.ts
+++ b/e2e/soft-mode/index.test.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('experiments.softMode', () => {
+  it('reuses workers across files while resetting per-file env state', async ({
+    onTestFinished,
+  }) => {
+    // The fixture asserts:
+    //   - same worker pid for file-a and file-b (worker reuse)
+    //   - DOM body, localStorage, sessionStorage cleared between files
+    //   - HTMLElement.prototype mutations from file-a are reverted
+    //   - `useFakeTimers()` in file-b doesn't throw "twice on the same
+    //     global" after file-a installed them and never uninstalled
+    //   - tinyspy-registered spies restored between files
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, './fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -302,15 +302,18 @@ export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {
   // axis. The public surface stays `boolean | undefined` for `isolate` and
   // gates soft on the experiments flag so the contract is clear: this
   // mode is experimental and may change shape before stabilising.
-  if (merged.experiments?.softMode === true) {
+  //
+  // `softMode` accepts `true` or an options object (`{ maxFilesPerWorker }`);
+  // any truthy value enables the mode.
+  if (merged.experiments?.softMode) {
     // Surface the conflict when a user has BOTH `isolate: false` (explicit
-    // reuse-without-reset) and `experiments.softMode: true` (reuse-WITH-
+    // reuse-without-reset) and `experiments.softMode` enabled (reuse-WITH-
     // reset). softMode wins because it's the strictly-stronger semantic,
     // but silent override is surprising; one warning per config-load is
     // cheap and self-documenting.
     if (merged.isolate === false) {
       logger.warn(
-        '[rstest] `experiments.softMode: true` overrides `isolate: false`. ' +
+        '[rstest] `experiments.softMode` overrides `isolate: false`. ' +
           'Soft mode reuses workers AND resets per-file env state; ' +
           '`isolate: false` is reuse without reset. Remove one to silence ' +
           'this warning.',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -284,12 +284,27 @@ const createDefaultConfig = (): NormalizedConfig => ({
 
 export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {
   const merged = mergeRstestConfig(
-    createDefaultConfig(),
+    // `createDefaultConfig()` returns `NormalizedConfig`, whose internal
+    // `isolate` is wider (`boolean | 'soft'`) than the public
+    // `RstestConfig.isolate`. The cast narrows it for the merge step;
+    // the `as NormalizedConfig` below re-widens to internal.
+    createDefaultConfig() as unknown as RstestConfig,
     config,
   ) as NormalizedConfig;
 
   merged.setupFiles = castArray(merged.setupFiles);
   merged.globalSetup = castArray(merged.globalSetup);
+
+  // Normalize `experiments.softMode` to the internal `isolate: 'soft'`
+  // representation. The internal `IsolateMode` (`pool/types.ts`) keeps the
+  // three-way distinction (`true | false | 'soft'`) so the pool and worker
+  // can encode strict / reuse / reuse-with-reset without adding a fourth
+  // axis. The public surface stays `boolean | undefined` for `isolate` and
+  // gates soft on the experiments flag so the contract is clear: this
+  // mode is experimental and may change shape before stabilising.
+  if (merged.experiments?.softMode === true) {
+    (merged as unknown as { isolate: 'soft' }).isolate = 'soft';
+  }
 
   const outputDistPathRoot = getOutputDistPathRoot(merged.output?.distPath);
   merged.output.distPath = {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -303,6 +303,19 @@ export const withDefaultConfig = (config: RstestConfig): NormalizedConfig => {
   // gates soft on the experiments flag so the contract is clear: this
   // mode is experimental and may change shape before stabilising.
   if (merged.experiments?.softMode === true) {
+    // Surface the conflict when a user has BOTH `isolate: false` (explicit
+    // reuse-without-reset) and `experiments.softMode: true` (reuse-WITH-
+    // reset). softMode wins because it's the strictly-stronger semantic,
+    // but silent override is surprising; one warning per config-load is
+    // cheap and self-documenting.
+    if (merged.isolate === false) {
+      logger.warn(
+        '[rstest] `experiments.softMode: true` overrides `isolate: false`. ' +
+          'Soft mode reuses workers AND resets per-file env state; ' +
+          '`isolate: false` is reuse without reset. Remove one to silence ' +
+          'this warning.',
+      );
+    }
     (merged as unknown as { isolate: 'soft' }).isolate = 'soft';
   }
 

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -338,9 +338,16 @@ export const createPool = async ({
   const numCpus = getNumCpus();
 
   const {
-    normalizedConfig: { pool: poolOptions, isolate },
+    normalizedConfig: { pool: poolOptions, isolate, experiments },
     reporters,
   } = context;
+
+  // `softMode` accepts `true` or `{ maxFilesPerWorker }`. The truthy check
+  // is mirrored in `withDefaultConfig` where the public flag is collapsed
+  // into the internal `isolate: 'soft'`; here we only need the tuning value.
+  const softModeOptions =
+    typeof experiments?.softMode === 'object' ? experiments.softMode : null;
+  const softModeMaxFilesPerWorker = softModeOptions?.maxFilesPerWorker;
 
   const workerKind: PoolWorkerKind = poolOptions.type ?? 'forks';
 
@@ -374,6 +381,7 @@ export const createPool = async ({
     isolate,
     maxWorkers,
     minWorkers,
+    softModeMaxFilesPerWorker,
     execArgv: [
       ...(poolOptions?.execArgv ?? []),
       ...execArgv,

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -12,6 +12,16 @@ import { createPoolWorker } from './workers';
  *   - isolate='soft': idle runners reused; worker resets test env per task
  *   - isolate=false: idle runners reused, no per-task reset
  */
+/**
+ * Default cap for tasks handled by a single worker in `experiments.softMode`
+ * (or `isolate: false`). Empirically chosen from a 74-file jsdom-heavy lib
+ * where heap grew from 71MB at file 1 to 4GB at file 65 in a single
+ * worker; recycling at 20 keeps the peak heap under ~1GB and prevents the
+ * 2-3× per-test slowdown that GC pressure inflicted at the top of that
+ * range. Strict isolate runners are single-use so this doesn't apply.
+ */
+const DEFAULT_SOFT_MODE_MAX_TASKS = 20;
+
 export class Pool {
   private readonly options: PoolOptions;
   private readonly idleRunners: PoolRunner[] = [];
@@ -66,6 +76,10 @@ export class Pool {
       return await runner.collectTests(task);
     } finally {
       this.options.memoryGate?.recordResolve(heapBaseline);
+      // Increment the runner's task counter BEFORE release so `isUsable()`
+      // can flip false when the cap is reached. `releaseRunner` then
+      // disposes instead of returning to the idle pool.
+      runner.recordTaskCompleted();
       this.releaseRunner(runner);
     }
   }
@@ -114,7 +128,18 @@ export class Pool {
       const workerId = this.acquireWorkerId();
       const worker = createPoolWorker(task, this.options, workerId);
       gate?.attachWorker(worker);
-      const runner = new PoolRunner(worker, { workerId });
+      const runner = new PoolRunner(worker, {
+        workerId,
+        // Cap soft-mode reuse — heap accumulates monotonically across
+        // file evaluations (vendor modules + React fiber trees + JSDOM
+        // nodes), and by ~50 files on a jsdom-heavy lib the worker is
+        // GC-thrashing at multi-GB heap, slowing each test 2-3×. Default
+        // applies only to soft mode; strict-isolate runners are
+        // single-use anyway. `isolate: false` (reuse without reset) also
+        // benefits because the same heap pressure applies.
+        maxTasks:
+          this.options.isolate === true ? 0 : DEFAULT_SOFT_MODE_MAX_TASKS,
+      });
       this.activeRunners.add(runner);
       try {
         await runner.start();

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -19,6 +19,8 @@ import { createPoolWorker } from './workers';
  * worker; recycling at 20 keeps the peak heap under ~1GB and prevents the
  * 2-3× per-test slowdown that GC pressure inflicted at the top of that
  * range. Strict isolate runners are single-use so this doesn't apply.
+ *
+ * Override via `experiments.softMode.maxFilesPerWorker`.
  */
 const DEFAULT_SOFT_MODE_MAX_TASKS = 20;
 
@@ -138,7 +140,10 @@ export class Pool {
         // single-use anyway. `isolate: false` (reuse without reset) also
         // benefits because the same heap pressure applies.
         maxTasks:
-          this.options.isolate === true ? 0 : DEFAULT_SOFT_MODE_MAX_TASKS,
+          this.options.isolate === true
+            ? 0
+            : (this.options.softModeMaxFilesPerWorker ??
+              DEFAULT_SOFT_MODE_MAX_TASKS),
       });
       this.activeRunners.add(runner);
       try {

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -9,7 +9,8 @@ import { createPoolWorker } from './workers';
  *   - one task per worker at a time (concurrentTasksPerWorker=1)
  *   - parallel dispatch up to maxWorkers, slot-waiter blocks excess callers
  *   - isolate=true: fresh runner per task, stopped in the background
- *   - isolate=false: idle runners reused, lazy-spawned on demand
+ *   - isolate='soft': idle runners reused; worker resets test env per task
+ *   - isolate=false: idle runners reused, no per-task reset
  */
 export class Pool {
   private readonly options: PoolOptions;
@@ -175,12 +176,11 @@ export class Pool {
     this.activeRunners.delete(runner);
 
     // `isolate: true`, closing, or unusable — never reuse.
-    if (
-      this.options.isolate !== false ||
-      this.isClosing ||
-      this.isClosed ||
-      !runner.isUsable()
-    ) {
+    // `isolate: false` and `isolate: 'soft'` both reuse runners; only the
+    // worker-side per-file reset semantics differ.
+    const canReuse =
+      this.options.isolate === false || this.options.isolate === 'soft';
+    if (!canReuse || this.isClosing || this.isClosed || !runner.isUsable()) {
       // Background dispose. The slot stays accounted for in `stoppingRunners`
       // until the child actually exits, so `isolate: true` cannot transiently
       // exceed `maxWorkers` and `close()` can drain in-flight stops.

--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -64,6 +64,20 @@ let nextTaskSeq = 0;
 
 type PoolRunnerOptions = {
   workerId: number;
+  /**
+   * For `experiments.softMode` (or `isolate: false`) where the worker is
+   * reused across tasks, this caps how many tasks a single worker handles
+   * before `isUsable()` reports false and the pool disposes it for a
+   * fresh one. Unbounded reuse leaks heap (vendor modules, React fiber
+   * trees, JSDOM nodes, accumulated closures) — by file 50+ on a
+   * jsdom-heavy lib we observed 4GB+ heap and 2-3× per-test slowdown
+   * from GC pressure.
+   *
+   * Default `0` = unbounded (legacy behavior). Recommended for soft
+   * mode: 20-30. Strict isolate (`isolate: true`) never reuses runners
+   * so this cap is irrelevant there.
+   */
+  maxTasks?: number;
 };
 
 /**
@@ -99,8 +113,18 @@ export class PoolRunner {
    */
   private crashed = false;
 
+  /**
+   * Tasks completed on this runner. When `maxTasks > 0`, `isUsable()`
+   * starts returning false once the count reaches the cap, prompting the
+   * pool to dispose this runner and spawn a fresh one. See
+   * `PoolRunnerOptions.maxTasks` for rationale.
+   */
+  private tasksRun = 0;
+  private readonly maxTasks: number;
+
   constructor(worker: PoolWorker, options: PoolRunnerOptions) {
     this.workerId = options.workerId;
+    this.maxTasks = Math.max(0, options.maxTasks ?? 0);
     this.worker = worker;
 
     this.handleMessage = this.handleMessage.bind(this);
@@ -113,7 +137,19 @@ export class PoolRunner {
   }
 
   isUsable(): boolean {
-    return this.state === 'STARTED' && !this.crashed;
+    if (this.state !== 'STARTED' || this.crashed) return false;
+    if (this.maxTasks > 0 && this.tasksRun >= this.maxTasks) return false;
+    return true;
+  }
+
+  /**
+   * Called by the pool after each completed task. Drives the soft-mode
+   * heap-pressure relief: once `tasksRun >= maxTasks`, `isUsable()` flips
+   * to false and the pool's `releaseRunner` path disposes us instead of
+   * returning us to the idle pool.
+   */
+  recordTaskCompleted(): void {
+    this.tasksRun++;
   }
 
   start(): Promise<void> {

--- a/packages/core/src/pool/types.ts
+++ b/packages/core/src/pool/types.ts
@@ -10,11 +10,19 @@ export type PoolTask = {
   rpcMethods: RuntimeRPC;
 };
 
+/**
+ * Isolation strategy for the pool. See `RstestConfig.isolate` for full docs.
+ *   - `true`: fresh runner per task (process-per-file isolation)
+ *   - `'soft'`: reuse runner across tasks; worker resets test env per task
+ *   - `false`: reuse runner across tasks with no per-task reset
+ */
+export type IsolateMode = boolean | 'soft';
+
 export type PoolOptions = {
   workerEntry: string;
   maxWorkers: number;
   minWorkers: number;
-  isolate: boolean;
+  isolate: IsolateMode;
   env?: Record<string, string>;
   execArgv?: string[];
   /**

--- a/packages/core/src/pool/types.ts
+++ b/packages/core/src/pool/types.ts
@@ -23,6 +23,13 @@ export type PoolOptions = {
   maxWorkers: number;
   minWorkers: number;
   isolate: IsolateMode;
+  /**
+   * Cap on tasks dispatched to a single runner before it is disposed and
+   * a fresh one spawns. Only consulted when `isolate === 'soft'` (or
+   * `false`, where reuse also accrues heap). `0` or omitted means
+   * unbounded reuse.
+   */
+  softModeMaxFilesPerWorker?: number;
   env?: Record<string, string>;
   execArgv?: string[];
   /**

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -67,19 +67,119 @@ let isTeardown = false;
  *
  * The cached entry is reset between files via `softResetEnv` (clear DOM,
  * reset URL) so leaked DOM state from file N doesn't contaminate file N+1.
+ *
+ * `protoSnapshot` captures the original property descriptors of well-known
+ * DOM prototypes so we can revert in-place mutations vendor packages make
+ * during a file run (e.g. `@testing-library/user-event`'s `patchFocus`
+ * which replaces `HTMLElement.prototype.focus` with a getter-only
+ * descriptor; the next file's bundle re-evaluation does
+ * `prototype.focus = newFn` and dies on "has only a getter").
  */
 let cachedEnv:
   | {
       name: string;
       teardown: (global: any) => MaybePromise<void>;
+      protoSnapshot: Array<{
+        proto: any;
+        descriptors: Record<string, PropertyDescriptor>;
+      }>;
     }
   | undefined;
 
-const softResetEnv = (envName: string): void => {
+/**
+ * Set of property names whose descriptors we capture for restore. Limited
+ * to the keys vendor packages are known to mutate (user-event patches
+ * focus/blur; react-aria patches focus; testing libraries occasionally
+ * patch click, scrollIntoView, getBoundingClientRect). Snapshotting every
+ * property would be both slow and surprising — most properties don't need
+ * restoration.
+ */
+const TRACKED_PROTO_KEYS = [
+  'focus',
+  'blur',
+  'click',
+  'scrollIntoView',
+  'getBoundingClientRect',
+] as const;
+
+const captureProtoSnapshot = (
+  win: any,
+): Array<{ proto: any; descriptors: Record<string, PropertyDescriptor> }> => {
+  const snapshot: Array<{
+    proto: any;
+    descriptors: Record<string, PropertyDescriptor>;
+  }> = [];
+  const protos = [
+    win.HTMLElement?.prototype,
+    win.Element?.prototype,
+    win.Node?.prototype,
+  ].filter(Boolean);
+  for (const proto of protos) {
+    const descriptors: Record<string, PropertyDescriptor> = {};
+    for (const key of TRACKED_PROTO_KEYS) {
+      const d = Object.getOwnPropertyDescriptor(proto, key);
+      if (d) descriptors[key] = d;
+    }
+    if (Object.keys(descriptors).length > 0) {
+      snapshot.push({ proto, descriptors });
+    }
+  }
+  return snapshot;
+};
+
+const restoreProtoSnapshot = (
+  snapshot: Array<{
+    proto: any;
+    descriptors: Record<string, PropertyDescriptor>;
+  }>,
+): void => {
+  for (const { proto, descriptors } of snapshot) {
+    for (const key of Object.keys(descriptors)) {
+      const current = Object.getOwnPropertyDescriptor(proto, key);
+      const original = descriptors[key]!;
+      // Skip if unchanged — avoid wasted defineProperty calls.
+      if (
+        current &&
+        current.value === original.value &&
+        current.get === original.get &&
+        current.set === original.set &&
+        current.writable === original.writable &&
+        current.enumerable === original.enumerable &&
+        current.configurable === original.configurable
+      ) {
+        continue;
+      }
+      try {
+        Object.defineProperty(proto, key, original);
+      } catch {
+        // best-effort — if the property is locked or original was a non-
+        // configurable accessor we may not be able to revert.
+      }
+    }
+  }
+};
+
+const softResetEnv = (
+  envName: string,
+  protoSnapshot?: Array<{
+    proto: any;
+    descriptors: Record<string, PropertyDescriptor>;
+  }>,
+): void => {
   if (envName !== 'jsdom' && envName !== 'happy-dom') return;
   const g = global as unknown as {
-    document?: { body?: { innerHTML: string }; head?: { innerHTML: string } };
-    window?: { history?: { replaceState?: Function }; scrollTo?: Function };
+    document?: {
+      body?: { innerHTML: string };
+      head?: { innerHTML: string };
+      cookie?: string;
+    };
+    window?: {
+      history?: { replaceState?: Function };
+      scrollTo?: Function;
+      localStorage?: { clear?: () => void };
+      sessionStorage?: { clear?: () => void };
+      _resetActiveElement?: () => void;
+    };
     location?: { href?: string };
   };
   try {
@@ -87,9 +187,30 @@ const softResetEnv = (envName: string): void => {
     if (g.document?.head) g.document.head.innerHTML = '';
     g.window?.history?.replaceState?.(null, '', '/');
     g.window?.scrollTo?.(0, 0);
+    g.window?.localStorage?.clear?.();
+    g.window?.sessionStorage?.clear?.();
+    // Also clear via globalThis in case test code references the global
+    // shortcut rather than `window.localStorage`.
+    (globalThis as any).localStorage?.clear?.();
+    (globalThis as any).sessionStorage?.clear?.();
+    // Clear all cookies for the current document. Setting `cookie` to an
+    // expired version of each existing pair drops it. This is best-effort;
+    // jsdom respects max-age=0 / past expires dates.
+    if (g.document && typeof g.document.cookie === 'string') {
+      const cookies = g.document.cookie.split(';');
+      for (const c of cookies) {
+        const eqIx = c.indexOf('=');
+        const name = (eqIx > -1 ? c.slice(0, eqIx) : c).trim();
+        if (name)
+          g.document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+      }
+    }
   } catch {
     // best-effort — env may be in a weird state, the next preparePool
     // call will surface a real error if it's actually broken.
+  }
+  if (protoSnapshot) {
+    restoreProtoSnapshot(protoSnapshot);
   }
 };
 
@@ -293,8 +414,9 @@ const preparePool = async (
 
   if (canReuseEnv) {
     // Worker is being reused for another file; soft-reset the env in place
-    // instead of paying the full setup cost again.
-    softResetEnv(cachedEnv!.name);
+    // (clear DOM + restore mutated DOM prototype descriptors) instead of
+    // paying the full setup cost again.
+    softResetEnv(cachedEnv!.name, cachedEnv!.protoSnapshot);
   } else {
     // Tear down any prior env of the wrong type before installing a fresh one.
     if (cachedEnv) {
@@ -314,7 +436,11 @@ const preparePool = async (
           global,
           testEnvironment.options || {},
         );
-        cachedEnv = { name: 'jsdom', teardown };
+        cachedEnv = {
+          name: 'jsdom',
+          teardown,
+          protoSnapshot: captureProtoSnapshot(global as any),
+        };
         break;
       }
       case 'happy-dom': {
@@ -323,7 +449,11 @@ const preparePool = async (
           global,
           testEnvironment.options || {},
         );
-        cachedEnv = { name: 'happy-dom', teardown };
+        cachedEnv = {
+          name: 'happy-dom',
+          teardown,
+          protoSnapshot: captureProtoSnapshot(global as any),
+        };
         break;
       }
       default:

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -58,6 +58,41 @@ const registerGlobalApi = (api: Rstest) => {
 const globalCleanups: (() => void)[] = [];
 let isTeardown = false;
 
+/**
+ * Worker-scope test-environment cache. In `isolate: 'soft' | false` the
+ * worker is reused across files, so paying the jsdom/happyDom setup cost
+ * per file is wasteful — and tearing the env down between files races with
+ * any async work the previous file scheduled (e.g. React commit phase
+ * accessing `window` after `dom.window.close()` already ran).
+ *
+ * The cached entry is reset between files via `softResetEnv` (clear DOM,
+ * reset URL) so leaked DOM state from file N doesn't contaminate file N+1.
+ */
+let cachedEnv:
+  | {
+      name: string;
+      teardown: (global: any) => MaybePromise<void>;
+    }
+  | undefined;
+
+const softResetEnv = (envName: string): void => {
+  if (envName !== 'jsdom' && envName !== 'happy-dom') return;
+  const g = global as unknown as {
+    document?: { body?: { innerHTML: string }; head?: { innerHTML: string } };
+    window?: { history?: { replaceState?: Function }; scrollTo?: Function };
+    location?: { href?: string };
+  };
+  try {
+    if (g.document?.body) g.document.body.innerHTML = '';
+    if (g.document?.head) g.document.head.innerHTML = '';
+    g.window?.history?.replaceState?.(null, '', '/');
+    g.window?.scrollTo?.(0, 0);
+  } catch {
+    // best-effort — env may be in a weird state, the next preparePool
+    // call will surface a real error if it's actually broken.
+  }
+};
+
 const setErrorName = (error: Error, type: string): Error => {
   try {
     error.name = type;
@@ -168,7 +203,13 @@ const preparePool = async (
       silent,
     },
     emitInterceptedLog: async (log) => {
-      await rpc.onConsoleLog(log);
+      try {
+        await rpc.onConsoleLog(log);
+      } catch {
+        // RPC may already be closed if a pending async log (e.g. React
+        // commit or microtask) fires after teardown. Drop it; the log is
+        // best-effort and we don't want to spam unhandled rejections.
+      }
     },
     writeOriginalLog: createOriginalLogWriter(),
   });
@@ -244,30 +285,63 @@ const preparePool = async (
   });
 
   tracker?.transition('envSetup');
-  switch (testEnvironment.name) {
-    case 'node':
-      break;
-    case 'jsdom': {
-      const { environment } = await import('./env/jsdom');
-      const { teardown } = await environment.setup(
-        global,
-        testEnvironment.options || {},
-      );
-      cleanupFns.push(() => teardown(global));
-      break;
+  const isolateMode = context.runtimeConfig.isolate;
+  const canReuseEnv =
+    isolateMode !== true &&
+    cachedEnv !== undefined &&
+    cachedEnv.name === testEnvironment.name;
+
+  if (canReuseEnv) {
+    // Worker is being reused for another file; soft-reset the env in place
+    // instead of paying the full setup cost again.
+    softResetEnv(cachedEnv!.name);
+  } else {
+    // Tear down any prior env of the wrong type before installing a fresh one.
+    if (cachedEnv) {
+      try {
+        await cachedEnv.teardown(global);
+      } catch {
+        // ignore — installing the new env will overwrite globals anyway.
+      }
+      cachedEnv = undefined;
     }
-    case 'happy-dom': {
-      const { environment } = await import('./env/happyDom');
-      const { teardown } = await environment.setup(
-        global,
-        testEnvironment.options || {},
-      );
-      cleanupFns.push(async () => teardown(global));
-      break;
+    switch (testEnvironment.name) {
+      case 'node':
+        break;
+      case 'jsdom': {
+        const { environment } = await import('./env/jsdom');
+        const { teardown } = await environment.setup(
+          global,
+          testEnvironment.options || {},
+        );
+        cachedEnv = { name: 'jsdom', teardown };
+        break;
+      }
+      case 'happy-dom': {
+        const { environment } = await import('./env/happyDom');
+        const { teardown } = await environment.setup(
+          global,
+          testEnvironment.options || {},
+        );
+        cachedEnv = { name: 'happy-dom', teardown };
+        break;
+      }
+      default:
+        throw new Error(`Unknown test environment: ${testEnvironment.name}`);
     }
-    default:
-      throw new Error(`Unknown test environment: ${testEnvironment.name}`);
   }
+
+  // In strict isolation, the env is torn down after the file via `cleanupFns`.
+  // In soft mode, the cached env persists; teardown only fires when the
+  // worker exits (handled by the pool, not this function).
+  if (isolateMode === true && cachedEnv) {
+    const env = cachedEnv;
+    cleanupFns.push(async () => {
+      await env.teardown(global);
+      cachedEnv = undefined;
+    });
+  }
+
   tracker?.transition('prepare');
 
   if (globals) {
@@ -413,8 +487,45 @@ export const runInPool = async (
     process.exit = exit;
   });
 
+  // Captured by preparePool — used by teardown to perform per-file resets
+  // when the worker is reused (`isolate !== true`).
+  let perFileApi: Rstest | undefined;
+
   const teardown = async () => {
     await new Promise((resolve) => getRealTimers().setTimeout!(resolve));
+
+    // Soft/non-strict isolate: process is reused for the next file, so we
+    // must reset per-file global state that would otherwise leak.
+    //
+    // Per-api rstest.restoreAllMocks() only reaches spies registered to the
+    // CURRENT file's `mocks` Set — spies from prior files are orphaned when
+    // their api is GC'd, leaving the property descriptors patched. Use
+    // tinyspy's worker-scope `restoreAll()` instead: it walks the same
+    // module-level `spies` Set that `internalSpyOn` registers into, so it
+    // restores every spy in the worker regardless of which api created it.
+    //
+    // The fake-timers reset is also critical: sinon's `install()` rejects a
+    // second install on the same global, so the next file's
+    // `useFakeTimers()` would throw "Can't install fake timers twice on the
+    // same global object" without this.
+    if (isolate !== true) {
+      if (perFileApi) {
+        try {
+          if (perFileApi.rstest.isFakeTimers()) {
+            perFileApi.rstest.useRealTimers();
+          }
+        } catch {
+          // api may already be in a torn-down state; the next file's
+          // preparePool will create a fresh one.
+        }
+      }
+      try {
+        const { restoreAll } = await import('tinyspy');
+        restoreAll();
+      } catch {
+        // tinyspy not available or registry already empty — nothing to do.
+      }
+    }
 
     // Run teardown
     await Promise.all(cleanups.map((fn) => fn()));
@@ -438,7 +549,9 @@ export const runInPool = async (
         cleanup,
         unhandledErrors,
         interopDefault,
+        api,
       } = await preparePool(options);
+      perFileApi = api;
       const { assetFiles, sourceMaps: sourceMapsFromAssets } =
         assets || (await rpc.getAssetsByEntry());
       sourceMaps = sourceMapsFromAssets;
@@ -503,6 +616,7 @@ export const runInPool = async (
       interopDefault,
       taskContext: preparedTaskContext,
     } = await preparePool(options, tracker);
+    perFileApi = api;
     taskContext = preparedTaskContext;
     if (detectAsyncLeaks) {
       asyncLeakDetector = createAsyncLeakDetector(taskContext);

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -317,7 +317,7 @@ const loadFiles = async ({
   runtimeDistPath?: string;
   testPath: string;
   interopDefault: boolean;
-  isolate: boolean;
+  isolate: boolean | 'soft';
   outputModule: boolean;
   tracker?: PhaseTracker;
 }): Promise<void> => {
@@ -326,7 +326,10 @@ const loadFiles = async ({
     : await import('./loadModule');
 
   // clean rstest core cache manually
-  if (!isolate) {
+  // Runs for any non-strict isolate (`false` or `'soft'`): the worker
+  // process is reused across files, so rstest's internal state needs to
+  // start clean for each new file.
+  if (isolate !== true) {
     await loadModule({
       codeContent: `if (global && typeof global.__rstest_clean_core_cache__ === 'function') {
   global.__rstest_clean_core_cache__();
@@ -416,7 +419,7 @@ export const runInPool = async (
     // Run teardown
     await Promise.all(cleanups.map((fn) => fn()));
 
-    if (!isolate) {
+    if (isolate !== true) {
       const { clearModuleCache } = options.context.outputModule
         ? await import('./loadEsModule')
         : await import('./loadModule');

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -1,3 +1,4 @@
+import { appendFileSync } from 'node:fs';
 import type { FileCoverageData } from 'istanbul-lib-coverage';
 import { isMainThread, threadId } from 'node:worker_threads';
 import { install } from 'source-map-support';
@@ -435,6 +436,28 @@ const preparePool = async (
   // equivalent of the per-file vm.Context teardown Jest gets for free.
   if (cachedEnv && context.runtimeConfig.isolate !== true) {
     await drainPendingAsyncFromPriorFile();
+  }
+
+  // DIAGNOSTIC: heap usage at file boundary, gated on env var so it doesn't
+  // pollute normal runs. Tracks across the worker's file sequence so we can
+  // see heap growth + GC behaviour.
+  // Optional diagnostic: heap usage at file boundary. Set
+  // `RSTEST_HEAP_TRACE=1` and read the per-pid log files under /private/tmp
+  // to observe heap growth across a worker's file sequence — useful when
+  // tuning soft-mode worker recycle cap.
+  if (process.env.RSTEST_HEAP_TRACE === '1') {
+    try {
+      const m = process.memoryUsage();
+      const g = globalThis as { __rstest_file_seq__?: number };
+      g.__rstest_file_seq__ = (g.__rstest_file_seq__ ?? 0) + 1;
+      const seq = g.__rstest_file_seq__;
+      appendFileSync(
+        `/private/tmp/rstest-heap-${process.pid}.log`,
+        `${seq}\t${context.runtimeConfig.isolate}\t${(m.heapUsed / 1024 / 1024).toFixed(1)}\t${(m.heapTotal / 1024 / 1024).toFixed(1)}\t${(m.rss / 1024 / 1024).toFixed(1)}\t${(m.external / 1024 / 1024).toFixed(1)}\t${testPath.split('/').slice(-2).join('/')}\n`,
+      );
+    } catch {
+      // best-effort diagnostic; don't fail the file
+    }
   }
 
   const taskContext = createNodeTaskContext();

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -176,11 +176,13 @@ const descriptorEquals = (
 
 const restoreProtoSnapshot = (snapshot: ProtoEntry[]): void => {
   for (const { proto, descriptors } of snapshot) {
-    const keys: PropertyKey[] = [
+    const snapshotKeys: PropertyKey[] = [
       ...Object.getOwnPropertyNames(descriptors),
       ...Object.getOwnPropertySymbols(descriptors),
     ];
-    for (const key of keys) {
+
+    // Step 1: restore mutated descriptors to their original shape.
+    for (const key of snapshotKeys) {
       const original = (descriptors as any)[key] as PropertyDescriptor;
       const current = Object.getOwnPropertyDescriptor(proto, key);
       if (current && descriptorEquals(current, original)) continue;
@@ -190,6 +192,27 @@ const restoreProtoSnapshot = (snapshot: ProtoEntry[]): void => {
         // Property is non-configurable (some Web IDL bindings) and was
         // mutated in-place — we can't undo. Falls through; the caller
         // accepts that some leaks may persist.
+      }
+    }
+
+    // Step 2: drop own-keys that didn't exist at snapshot time. A prior
+    // file could have added a brand-new method to the prototype (e.g.
+    // `HTMLElement.prototype.myCustomHelper = fn`); without symmetric
+    // removal it would persist into the next file. Symbols are included
+    // — vendor packages occasionally stash markers behind Symbols (e.g.
+    // user-event's `Symbol('patched...')` marker) that we want to clear.
+    const snapshotKeySet = new Set<PropertyKey>(snapshotKeys);
+    const currentKeys: PropertyKey[] = [
+      ...Object.getOwnPropertyNames(proto),
+      ...Object.getOwnPropertySymbols(proto),
+    ];
+    for (const key of currentKeys) {
+      if (SKIP_PROTO_KEYS.has(key)) continue;
+      if (snapshotKeySet.has(key)) continue;
+      try {
+        delete (proto as any)[key];
+      } catch {
+        // Same reason as above — non-configurable. Best-effort.
       }
     }
   }
@@ -523,13 +546,18 @@ const preparePool = async (
   const uncaughtException = (e: Error) => handleError(e, 'uncaughtException');
   const unhandledRejection = (e: Error) => handleError(e, 'unhandledRejection');
 
-  process.on('uncaughtException', uncaughtException);
-  process.on('unhandledRejection', unhandledRejection);
-
+  // Register the cleanup BEFORE the listener install. Without this order
+  // an early throw between `process.on(...)` and the matching
+  // `globalCleanups.push(...)` would leak the listener — across many such
+  // throws in soft mode the worker accumulates duplicate handlers and any
+  // `unhandledRejection` fires N times, attributing the same error to N
+  // earlier file slots.
   globalCleanups.push(() => {
     process.off('uncaughtException', uncaughtException);
     process.off('unhandledRejection', unhandledRejection);
   });
+  process.on('uncaughtException', uncaughtException);
+  process.on('unhandledRejection', unhandledRejection);
 
   const { api, runner } = await createRstestRuntime(workerState, {
     taskContext,

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -218,6 +218,62 @@ const softResetStep = (label: string, fn: () => void): void => {
   }
 };
 
+/**
+ * Drain pending microtasks and a few macrotask cycles, absorbing any
+ * `unhandledRejection` / `uncaughtException` that fires during the drain.
+ *
+ * Why: under `experiments.softMode` (or `isolate: false`), a worker
+ * survives across files. If the previous file's tests started an XHR
+ * (e.g. via a `useEffect` that wasn't awaited in the test body), the
+ * XHR is still in flight when the file ends. Once the previous file's
+ * mock-server handlers have been reset and the file slot has closed, the
+ * XHR resolves — its `onUnhandledRequest` error bubbles up as an
+ * unhandled rejection and lands in the NEXT file's slot, wrongly
+ * attributing the failure.
+ *
+ * In `isolate: true`, the worker process dies between files, so the
+ * pending XHR dies with it. In Jest, the per-file `vm.Context` is torn
+ * down — same effect. Worker-reuse modes don't get that for free, so
+ * we recreate the moral equivalent: give pending async ~5 macrotask
+ * cycles to finish and absorb any errors that surface during the drain.
+ *
+ * Errors absorbed here are NOT attributable to the next file in any
+ * useful way — they originate in the previous file and only manifest
+ * now. Surfacing them as the next file's failure is worse than dropping
+ * them (the previous file already passed its assertions; if it had a
+ * latent leak, that's a test-code hygiene issue users should address
+ * separately). Set `DEBUG=rstest:soft-mode` to log the absorbed count.
+ */
+const drainPendingAsyncFromPriorFile = async (): Promise<void> => {
+  const absorbed: unknown[] = [];
+  const swallow = (e: unknown) => {
+    absorbed.push(e);
+  };
+  process.on('unhandledRejection', swallow);
+  process.on('uncaughtException', swallow);
+  try {
+    // Each iteration awaits one `setImmediate` cycle: that drains all
+    // currently-queued microtasks (Promise jobs run before the next macro)
+    // plus one macrotask batch. 5 cycles is enough to settle typical
+    // fetch → response → React commit chains; more is wasted budget.
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((resolve) =>
+        getRealTimers().setImmediate
+          ? getRealTimers().setImmediate!(resolve)
+          : getRealTimers().setTimeout!(resolve, 0),
+      );
+    }
+  } finally {
+    process.removeListener('unhandledRejection', swallow);
+    process.removeListener('uncaughtException', swallow);
+  }
+  if (absorbed.length > 0 && process.env.DEBUG?.includes('rstest:soft-mode')) {
+    process.stderr.write(
+      `[rstest:soft-mode] absorbed ${absorbed.length} async error(s) from prior file\n`,
+    );
+  }
+};
+
 const softResetEnv = (envName: string, protoSnapshot?: ProtoEntry[]): void => {
   if (envName !== 'jsdom' && envName !== 'happy-dom') return;
   const g = global as unknown as {
@@ -347,6 +403,16 @@ const preparePool = async (
     fn();
   });
   globalCleanups.length = 0;
+
+  // If a cachedEnv exists, the worker is being reused for another file.
+  // Drain any pending async work scheduled by the previous file BEFORE we
+  // install this file's `unhandledRejection` listener — otherwise leftover
+  // XHRs / promise chains from the previous file would resolve into this
+  // file's slot and surface as misattributed errors. This is the moral
+  // equivalent of the per-file vm.Context teardown Jest gets for free.
+  if (cachedEnv && context.runtimeConfig.isolate !== true) {
+    await drainPendingAsyncFromPriorFile();
+  }
 
   const taskContext = createNodeTaskContext();
   setRealTimers();
@@ -479,7 +545,8 @@ const preparePool = async (
   if (canReuseEnv) {
     // Worker is being reused for another file; soft-reset the env in place
     // (clear DOM + restore mutated DOM prototype descriptors) instead of
-    // paying the full setup cost again.
+    // paying the full setup cost again. Pending-async drain already ran
+    // at the top of preparePool (before per-file listeners installed).
     softResetEnv(cachedEnv!.name, cachedEnv!.protoSnapshot);
   } else {
     // Tear down any prior env of the wrong type before installing a fresh one.

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -79,93 +79,146 @@ let cachedEnv:
   | {
       name: string;
       teardown: (global: any) => MaybePromise<void>;
-      protoSnapshot: Array<{
-        proto: any;
-        descriptors: Record<string, PropertyDescriptor>;
-      }>;
+      protoSnapshot: ProtoEntry[];
     }
   | undefined;
 
-/**
- * Set of property names whose descriptors we capture for restore. Limited
- * to the keys vendor packages are known to mutate (user-event patches
- * focus/blur; react-aria patches focus; testing libraries occasionally
- * patch click, scrollIntoView, getBoundingClientRect). Snapshotting every
- * property would be both slow and surprising — most properties don't need
- * restoration.
- */
-const TRACKED_PROTO_KEYS = [
-  'focus',
-  'blur',
-  'click',
-  'scrollIntoView',
-  'getBoundingClientRect',
-] as const;
+// In soft mode the per-file `cleanupFns` does NOT include the env teardown
+// (the env persists across files). Without this hook, a worker that exits
+// cleanly (no fatal error, pool drained) leaks the JSDOM window — virtual
+// console handlers, scheduled timers, the cookie jar, the global Proxy.
+// On `beforeExit` we still have a chance to flush; on `exit` (synchronous)
+// we just attempt the call and ignore.
+//
+// `process.exit` short-circuits `beforeExit`, but rstest's pool sends
+// graceful shutdown messages and the worker returns from the message loop,
+// so beforeExit fires in the common case.
+const teardownCachedEnvOnExit = (): void => {
+  if (!cachedEnv) return;
+  try {
+    // Fire-and-forget; the event loop is already winding down so awaiting
+    // a promise here is best-effort. JSDOM's teardown is synchronous as of
+    // jsdom 26.x — this stays meaningful even without await.
+    void cachedEnv.teardown(global);
+  } catch {
+    // best-effort
+  } finally {
+    cachedEnv = undefined;
+  }
+};
+process.on('beforeExit', teardownCachedEnvOnExit);
+process.on('exit', teardownCachedEnvOnExit);
 
-const captureProtoSnapshot = (
-  win: any,
-): Array<{ proto: any; descriptors: Record<string, PropertyDescriptor> }> => {
-  const snapshot: Array<{
-    proto: any;
-    descriptors: Record<string, PropertyDescriptor>;
-  }> = [];
+/**
+ * Snapshot every own-property descriptor on the well-known DOM prototypes
+ * the worker exposes via globals. This is the "all-keys" form: we capture
+ * each descriptor at env-setup time and re-apply it between files when its
+ * shape has drifted (e.g. `@testing-library/user-event`'s `patchFocus`
+ * replaces `HTMLElement.prototype.focus` with a getter-only descriptor on
+ * the first `userEvent.click()`; without restore, file N+1's vendor code
+ * that re-assigns via `prototype.focus = fn` throws "has only a getter").
+ *
+ * Why "all keys" and not a curated allow-list: vendor monkey-patching
+ * targets are open-ended (focus, blur, addEventListener, dispatchEvent,
+ * scrollIntoView, getBoundingClientRect, animate, matches, closest, …).
+ * A curated list misses one and you get confusing failures only on
+ * specific libs. The cost is small — ~3 prototypes × ~50-100 own keys
+ * each, descriptor lookups are O(1).
+ *
+ * `constructor` is excluded: rewriting it can break `instanceof` checks
+ * in any code that has a stale constructor reference.
+ */
+type ProtoEntry = {
+  proto: object;
+  descriptors: Record<PropertyKey, PropertyDescriptor>;
+};
+
+const SKIP_PROTO_KEYS = new Set<PropertyKey>(['constructor']);
+
+const captureProtoDescriptors = (
+  proto: object,
+): Record<PropertyKey, PropertyDescriptor> => {
+  const descriptors: Record<PropertyKey, PropertyDescriptor> = {};
+  const keys: PropertyKey[] = [
+    ...Object.getOwnPropertyNames(proto),
+    ...Object.getOwnPropertySymbols(proto),
+  ];
+  for (const key of keys) {
+    if (SKIP_PROTO_KEYS.has(key)) continue;
+    const d = Object.getOwnPropertyDescriptor(proto, key);
+    if (d) descriptors[key as string] = d;
+  }
+  return descriptors;
+};
+
+const captureProtoSnapshot = (win: any): ProtoEntry[] => {
   const protos = [
     win.HTMLElement?.prototype,
     win.Element?.prototype,
     win.Node?.prototype,
-  ].filter(Boolean);
-  for (const proto of protos) {
-    const descriptors: Record<string, PropertyDescriptor> = {};
-    for (const key of TRACKED_PROTO_KEYS) {
-      const d = Object.getOwnPropertyDescriptor(proto, key);
-      if (d) descriptors[key] = d;
-    }
-    if (Object.keys(descriptors).length > 0) {
-      snapshot.push({ proto, descriptors });
-    }
-  }
-  return snapshot;
+  ].filter(Boolean) as object[];
+  return protos.map((proto) => ({
+    proto,
+    descriptors: captureProtoDescriptors(proto),
+  }));
 };
 
-const restoreProtoSnapshot = (
-  snapshot: Array<{
-    proto: any;
-    descriptors: Record<string, PropertyDescriptor>;
-  }>,
-): void => {
+const descriptorEquals = (
+  a: PropertyDescriptor,
+  b: PropertyDescriptor,
+): boolean =>
+  a.value === b.value &&
+  a.get === b.get &&
+  a.set === b.set &&
+  a.writable === b.writable &&
+  a.enumerable === b.enumerable &&
+  a.configurable === b.configurable;
+
+const restoreProtoSnapshot = (snapshot: ProtoEntry[]): void => {
   for (const { proto, descriptors } of snapshot) {
-    for (const key of Object.keys(descriptors)) {
+    const keys: PropertyKey[] = [
+      ...Object.getOwnPropertyNames(descriptors),
+      ...Object.getOwnPropertySymbols(descriptors),
+    ];
+    for (const key of keys) {
+      const original = (descriptors as any)[key] as PropertyDescriptor;
       const current = Object.getOwnPropertyDescriptor(proto, key);
-      const original = descriptors[key]!;
-      // Skip if unchanged — avoid wasted defineProperty calls.
-      if (
-        current &&
-        current.value === original.value &&
-        current.get === original.get &&
-        current.set === original.set &&
-        current.writable === original.writable &&
-        current.enumerable === original.enumerable &&
-        current.configurable === original.configurable
-      ) {
-        continue;
-      }
+      if (current && descriptorEquals(current, original)) continue;
       try {
         Object.defineProperty(proto, key, original);
       } catch {
-        // best-effort — if the property is locked or original was a non-
-        // configurable accessor we may not be able to revert.
+        // Property is non-configurable (some Web IDL bindings) and was
+        // mutated in-place — we can't undo. Falls through; the caller
+        // accepts that some leaks may persist.
       }
     }
   }
 };
 
-const softResetEnv = (
-  envName: string,
-  protoSnapshot?: Array<{
-    proto: any;
-    descriptors: Record<string, PropertyDescriptor>;
-  }>,
-): void => {
+/**
+ * Per-step reset wrapper. Each step is independent — if one throws the
+ * others should still run. We log to stderr in `DEBUG=rstest:soft-mode`
+ * so silent failures can surface without forcing every consumer to opt
+ * into noisy logs.
+ *
+ * Returning `void` keeps the call sites readable; the caller doesn't
+ * need to know which step failed, just that the env wound up as clean
+ * as best-effort can make it.
+ */
+const softResetStep = (label: string, fn: () => void): void => {
+  try {
+    fn();
+  } catch (e) {
+    if (process.env.DEBUG?.includes('rstest:soft-mode')) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(
+        `[rstest:soft-mode] reset step "${label}" failed: ${msg}\n`,
+      );
+    }
+  }
+};
+
+const softResetEnv = (envName: string, protoSnapshot?: ProtoEntry[]): void => {
   if (envName !== 'jsdom' && envName !== 'happy-dom') return;
   const g = global as unknown as {
     document?: {
@@ -178,39 +231,50 @@ const softResetEnv = (
       scrollTo?: Function;
       localStorage?: { clear?: () => void };
       sessionStorage?: { clear?: () => void };
-      _resetActiveElement?: () => void;
     };
-    location?: { href?: string };
   };
-  try {
+
+  softResetStep('body.innerHTML', () => {
     if (g.document?.body) g.document.body.innerHTML = '';
+  });
+  softResetStep('head.innerHTML', () => {
     if (g.document?.head) g.document.head.innerHTML = '';
+  });
+  softResetStep('history.replaceState', () => {
     g.window?.history?.replaceState?.(null, '', '/');
+  });
+  softResetStep('scrollTo', () => {
     g.window?.scrollTo?.(0, 0);
+  });
+  softResetStep('localStorage.clear', () => {
     g.window?.localStorage?.clear?.();
-    g.window?.sessionStorage?.clear?.();
     // Also clear via globalThis in case test code references the global
-    // shortcut rather than `window.localStorage`.
+    // shortcut rather than `window.localStorage` (some helpers do).
     (globalThis as any).localStorage?.clear?.();
+  });
+  softResetStep('sessionStorage.clear', () => {
+    g.window?.sessionStorage?.clear?.();
     (globalThis as any).sessionStorage?.clear?.();
-    // Clear all cookies for the current document. Setting `cookie` to an
-    // expired version of each existing pair drops it. This is best-effort;
-    // jsdom respects max-age=0 / past expires dates.
+  });
+  softResetStep('cookies', () => {
+    // Setting `cookie` to an expired version of each existing pair drops
+    // it. Note: cookies set with a non-root `path` won't be wiped by this
+    // — tests that set such cookies need to clear them in afterEach.
     if (g.document && typeof g.document.cookie === 'string') {
       const cookies = g.document.cookie.split(';');
       for (const c of cookies) {
         const eqIx = c.indexOf('=');
         const name = (eqIx > -1 ? c.slice(0, eqIx) : c).trim();
-        if (name)
+        if (name) {
           g.document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+        }
       }
     }
-  } catch {
-    // best-effort — env may be in a weird state, the next preparePool
-    // call will surface a real error if it's actually broken.
-  }
+  });
   if (protoSnapshot) {
-    restoreProtoSnapshot(protoSnapshot);
+    softResetStep('protoSnapshot.restore', () => {
+      restoreProtoSnapshot(protoSnapshot);
+    });
   }
 };
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -326,11 +326,26 @@ export interface RstestConfig {
    */
   pool?: RstestPoolType | RstestPoolOptions;
   /**
-   * Run tests in an isolated environment
+   * Isolation strategy between test files.
+   *
+   * - `true` (default): each test file runs in a fresh worker process. Strongest
+   *   isolation but pays the cost of process fork + bundle load + env setup
+   *   on every file.
+   * - `'soft'`: workers persist across files. Each file still gets a fresh
+   *   test environment (`new JSDOM()`, fresh setupFiles, fresh test module
+   *   cache), but the worker process — and Node's module cache for vendor
+   *   deps like `jsdom` — stays warm. This skips the ~300-1000 ms cold load
+   *   of `jsdom` and its transitives on every file.
+   *
+   *   Trade-off: works for tests whose setup is idempotent. Doesn't work for
+   *   suites that rely on `rstest.mock(...)` module factories needing to be
+   *   re-applied per file — those still need `isolate: true`.
+   * - `false`: workers persist with no per-file env reset. Fastest but
+   *   leaks every kind of state between files.
    *
    * @default true
    */
-  isolate?: boolean;
+  isolate?: boolean | 'soft';
   /**
    * Provide global APIs
    *

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -331,21 +331,54 @@ export interface RstestConfig {
    * - `true` (default): each test file runs in a fresh worker process. Strongest
    *   isolation but pays the cost of process fork + bundle load + env setup
    *   on every file.
-   * - `'soft'`: workers persist across files. Each file still gets a fresh
-   *   test environment (`new JSDOM()`, fresh setupFiles, fresh test module
-   *   cache), but the worker process — and Node's module cache for vendor
-   *   deps like `jsdom` — stays warm. This skips the ~300-1000 ms cold load
-   *   of `jsdom` and its transitives on every file.
-   *
-   *   Trade-off: works for tests whose setup is idempotent. Doesn't work for
-   *   suites that rely on `rstest.mock(...)` module factories needing to be
-   *   re-applied per file — those still need `isolate: true`.
    * - `false`: workers persist with no per-file env reset. Fastest but
    *   leaks every kind of state between files.
    *
+   * For an in-between option that reuses workers but resets per-file env
+   * state (DOM, timers, spies, storage, prototype mutations), opt into
+   * the experimental `experiments.softMode` flag instead — most tests are
+   * idempotent enough to benefit without the per-file fork cost.
+   *
    * @default true
    */
-  isolate?: boolean | 'soft';
+  isolate?: boolean;
+  /**
+   * Experimental features. Shape may change before stabilising; opt in
+   * deliberately and pin your `@rstest/core` version if you depend on
+   * the exact semantics.
+   */
+  experiments?: {
+    /**
+     * Reuse worker processes across test files while still resetting
+     * per-file env state between them.
+     *
+     * What's reset between files:
+     * - DOM contents (`document.body/head` innerHTML, URL, scroll)
+     * - Web storage (`localStorage`, `sessionStorage`, document cookies)
+     * - DOM prototype descriptors mutated by vendor packages (e.g.
+     *   `HTMLElement.prototype.focus` patched by
+     *   `@testing-library/user-event`)
+     * - Sinon fake timers (`useRealTimers()` on the prior file's api)
+     * - Tinyspy spies via the worker-scope `restoreAll()`
+     *
+     * What survives across files (this is the speedup):
+     * - The worker process itself (no fork cost)
+     * - Node's module cache for vendor deps (no `import('jsdom')` cold load)
+     * - JSDOM window instance (no `new JSDOM()` per file)
+     *
+     * Trade-offs vs `isolate: true`:
+     * - Tests that depend on per-file `rstest.mock(...)` module factory
+     *   re-application may need to stay on `isolate: true`. The module
+     *   mock registry is per-bundle (one bundle per file in rstest), but
+     *   tests that interact with module-level singletons inside vendors
+     *   (final-form's `keysCache`, msw's interceptor state) can leak.
+     * - Has precedence over `isolate`: if both are set, soft semantics win.
+     *
+     * @default false
+     * @experimental
+     */
+    softMode?: boolean;
+  };
   /**
    * Provide global APIs
    *
@@ -586,7 +619,8 @@ type OptionalKeys =
   | 'hideSkippedTestFiles'
   | 'resolveSnapshotPath'
   | 'extends'
-  | 'shard';
+  | 'shard'
+  | 'experiments';
 
 export type NormalizedBrowserModeConfig = {
   enabled: boolean;
@@ -612,6 +646,7 @@ export type NormalizedConfig = Required<
     | 'testEnvironment'
     | 'browser'
     | 'output'
+    | 'isolate'
   >
 > &
   Partial<Pick<RstestConfig, OptionalKeys>> & {
@@ -626,6 +661,13 @@ export type NormalizedConfig = Required<
       override?: boolean;
     };
     output: NormalizedOutputConfig;
+    /**
+     * Internal three-way isolation mode. The public `RstestConfig.isolate`
+     * is `boolean`; `'soft'` is set internally when
+     * `experiments.softMode === true`. Pool/worker code switches on this
+     * to encode strict / reuse / reuse-with-reset behavior.
+     */
+    isolate: boolean | 'soft';
   };
 
 export type NormalizedProjectConfig = Required<

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -242,6 +242,26 @@ export type EnvironmentWithOptions = {
   options?: Record<string, any>;
 };
 
+/**
+ * Tuning knobs for `experiments.softMode`. Reserved for soft-mode-specific
+ * concerns; keep general pool options on `RstestPoolOptions`.
+ */
+export interface SoftModeOptions {
+  /**
+   * Cap on the number of test files a single worker handles before it is
+   * disposed and a fresh one spawns. Bounds the heap growth that accumulates
+   * from per-file module state (vendor caches, React fiber trees, JSDOM
+   * nodes) across a reused worker.
+   *
+   * Set higher for libs with light tests, lower for heavy React/JSDOM
+   * workloads where heap pressure dominates wall time. Has no effect when
+   * `softMode` is disabled.
+   *
+   * @default 20
+   */
+  maxFilesPerWorker?: number;
+}
+
 export interface RstestConfig {
   /**
    * Extend configuration from adapters
@@ -372,12 +392,21 @@ export interface RstestConfig {
      *   mock registry is per-bundle (one bundle per file in rstest), but
      *   tests that interact with module-level singletons inside vendors
      *   (final-form's `keysCache`, msw's interceptor state) can leak.
+     * - Heap grows monotonically across files in a reused worker; the
+     *   `maxFilesPerWorker` cap (default 20) recycles workers
+     *   periodically to prevent GC pressure. Tune higher for libs with
+     *   light tests, lower for jsdom-heavy React workloads.
      * - Has precedence over `isolate`: if both are set, soft semantics win.
+     *
+     * Pass `true` to enable with defaults, or an object to customise:
+     * ```ts
+     * experiments: { softMode: { maxFilesPerWorker: 10 } }
+     * ```
      *
      * @default false
      * @experimental
      */
-    softMode?: boolean;
+    softMode?: boolean | SoftModeOptions;
   };
   /**
    * Provide global APIs


### PR DESCRIPTION
**Draft — opening for visibility, not for review yet.** No CC.

## What

Adds `experiments.softMode: boolean | { maxFilesPerWorker?: number }`
to `RstestConfig`. When enabled, the worker pool reuses processes
across test files (like `isolate: false`) but also resets per-file env
state between them — DOM, storage, fake timers, spies, prototype
mutations — so most tests written against Jest's per-file-context
isolation still pass without code changes.

```ts
defineConfig({
  experiments: { softMode: true },
});

// or with tuning:
defineConfig({
  experiments: { softMode: { maxFilesPerWorker: 10 } },
});
```

## Why

In our private workspace ~70-file jsdom-heavy libs were spending the
bulk of wall time on per-file `fork()` + `new JSDOM()` + setupFiles.
With `isolate: true` (default), each file pays that fixed cost. With
`isolate: false`, the workers are reused but ANY cross-file state
(DOM body, prototype mutations from user-event/react-aria, fake timers,
spies) leaks — practically unusable.

`experiments.softMode` is the in-between: reuse the worker AND
mechanically clean the per-file-isolated state the worker level can
see.

## What's reset between files

- `document.body` / `document.head` innerHTML, `window.history`, scroll
- `localStorage`, `sessionStorage`, `document.cookie` (path=/ only)
- DOM prototype descriptors on `HTMLElement`, `Element`, `Node`
  (snapshotted at env-setup, restored before next file). Also drops
  own-keys added since snapshot (e.g. vendor-installed
  `Symbol('patched-focus')` markers from user-event's `patchFocus`).
- Fake timers (`useRealTimers()` on the prior file's `Rstest` api)
- Tinyspy spies via worker-scope `restoreAll()`
- Pending async from the prior file is drained + absorbed at the top
  of `preparePool` so leftover `unhandledRejection`s from the prior
  file don't misattribute to the next file's slot

## Heap pressure → worker recycling

`--trace` profiling revealed individual tests running **2-3× slower**
under softMode vs `isolate: true` on a 74-file jsdom-heavy lib. Heap
instrumentation showed why:

| File seq in worker | heapUsed | heapTotal | rss |
|---:|---:|---:|---:|
| 1 | 71 MB | 136 MB | 254 MB |
| 10 | 745 MB | 937 MB | 1.5 GB |
| 50 | ~3.5 GB | ~3.7 GB | ~4 GB |
| 65 | 4.0 GB | 4.1 GB | 4.5 GB |

Sharing a JS heap across many React-heavy files = monotonic growth
(vendor module instances, React fiber roots, JSDOM nodes, accumulated
closures). By file 50 the worker GC-thrashes at 4 GB. This is the
hard limit of soft-mode reuse without `vm.Context` isolation.

**Fix**: `PoolRunner` now has `maxTasks` — when a soft-mode worker
hits N tasks, `isUsable()` flips false and the pool's existing dispose
path spawns a fresh worker. Heap pressure can't accumulate past a
known ceiling. Default cap **20** for `isolate !== true`; strict
isolate is single-use and unaffected. The cap is user-configurable
via `experiments.softMode: { maxFilesPerWorker: N }` — dial it up for
light-test libs, down for heavier ones. With recycle at 20, the
worst lib's reports-module went from individual tests being 2-3×
slower to roughly parity with `isolate: true`, while still amortizing
fork + jsdom-init across the 20-file window.

## What doesn't change

- `isolate: true` semantics — unchanged.
- `isolate: false` semantics — unchanged (still no per-file reset).
- Public type `RstestConfig.isolate` stays `boolean`.

## Why `experiments.*`

The reset semantics are pragmatic (curated to what we found in
practice). I'd rather mark this as experimental and iterate than
freeze a contract that turns out incomplete. A `logger.warn` fires if
a user sets both `isolate: false` AND `experiments.softMode` enabled.

## Files

- `packages/core/src/types/config.ts` — public `experiments?: { softMode?: boolean | SoftModeOptions }`, new `SoftModeOptions` interface, internal `NormalizedConfig.isolate: boolean | 'soft'`
- `packages/core/src/config.ts` — normalize any truthy `experiments.softMode` to internal `isolate: 'soft'`, warn on `isolate: false` + softMode conflict
- `packages/core/src/pool/index.ts` — extract `maxFilesPerWorker` from `experiments.softMode` and thread into `PoolOptions`
- `packages/core/src/pool/pool.ts`, `pool/types.ts` — reuse runners for `'soft'` in addition to `false`; pass `maxTasks` to `PoolRunner` (default 20, override via config)
- `packages/core/src/pool/poolRunner.ts` — `tasksRun` counter, `recordTaskCompleted()`, `isUsable()` cap
- `packages/core/src/runtime/worker/runInPool.ts` — env caching, prototype snapshot/restore, fake-timer reset, tinyspy `restoreAll`, drain-pending-async absorber, `beforeExit` teardown, optional `RSTEST_HEAP_TRACE=1` diagnostic
- `e2e/soft-mode/` — jsdom fixture covering DOM reset, prototype restore, fake-timer reinstall, spy restore, and absorber path (3 files: `a-init` / `b-leak` / `c-verify`)
- `e2e/soft-mode-reuse/` — `maxWorkers: 2` × 4 files, asserts actual worker reuse via pid log
- `e2e/soft-mode-happy-dom/` — happy-dom env path
- `e2e/soft-mode-recycle/` — `maxFilesPerWorker: 1` × 4 files, asserts unique pid per file (cap honored end-to-end)

## Testing

- `pnpm --filter @rstest/core test` — 242/242
- `e2e --isolate false` — 475/475 (was 472 pre-changes, +3 new soft-mode fixtures)
- `e2e` default — 627/629 (2 pre-existing browser-mode failures unrelated)

Validated in a private 348-file workspace: workspace-mode green at
3348/3348. Bench on the worst-case lib (74-file reports-module):
softMode + recycle median 23 s wall vs vanilla `isolate: true` median
33 s wall (**−30%**). Workspace-mode delta is smaller (~5%) because
parallelism across the default 11 workers dilutes the per-worker
amortization.

## Status

Marking draft. Not requesting review yet; just opening so I and a
colleague can see the cumulative diff in one place.

Followups before un-drafting:
- Heap-based recycle (recycle when heap > N MB) as an alternative to
  task-count
- Document expected wins/limits in the user-facing docs
