### PR TITLE
fix(core): normalize mixed nested CLI options

### DIFF
--- a/e2e/cli/index.test.ts
+++ b/e2e/cli/index.test.ts
@@ -70,6 +70,30 @@ describe.concurrent('test exit code', () => {
     await expectExecSuccess();
   });
 
+  it('should support --pool shorthand with nested pool options', async ({
+    onTestFinished,
+  }) => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        'success.test.ts',
+        '--pool',
+        'forks',
+        '--pool.maxWorkers',
+        '1',
+      ],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
   it('should return code 1 and print error correctly when test config error', async ({
     onTestFinished,
   }) => {

--- a/e2e/cli/index.test.ts
+++ b/e2e/cli/index.test.ts
@@ -94,6 +94,29 @@ describe.concurrent('test exit code', () => {
     await expectExecSuccess();
   });
 
+  it('should support browser shorthand with nested browser options', async ({
+    onTestFinished,
+  }) => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: [
+        'run',
+        'success.test.ts',
+        '--no-browser',
+        '--browser.name',
+        'chromium',
+      ],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
   it('should return code 1 and print error correctly when test config error', async ({
     onTestFinished,
   }) => {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -220,12 +220,34 @@ const normalizeCoverageCliArgs = (argv: string[]): string[] => {
   });
 };
 
-const allowMixedCoverageCliOptions = (cli: CAC): void => {
+const normalizePoolCliArgs = (argv: string[]): string[] => {
+  const hasPoolNestedOption = argv.some((arg) => arg.startsWith('--pool.'));
+
+  if (!hasPoolNestedOption) {
+    return argv;
+  }
+
+  return argv.map((arg) => {
+    if (arg === '--pool') {
+      return '--pool.type';
+    }
+    if (arg.startsWith('--pool=')) {
+      return `--pool.type=${arg.slice('--pool='.length)}`;
+    }
+
+    return arg;
+  });
+};
+
+const normalizeCliArgs = (argv: string[]): string[] =>
+  normalizePoolCliArgs(normalizeCoverageCliArgs(argv));
+
+const normalizeMixedCliOptions = (cli: CAC): void => {
   const originalParse = cli.parse.bind(cli);
 
   cli.parse = ((argv, options) =>
     originalParse(
-      normalizeCoverageCliArgs(argv ?? process.argv),
+      normalizeCliArgs(argv ?? process.argv),
       options,
     )) as CAC['parse'];
 };
@@ -861,7 +883,7 @@ export function createCli(): CAC {
       }
     });
 
-  allowMixedCoverageCliOptions(cli);
+  normalizeMixedCliOptions(cli);
 
   return cli;
 }

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -239,8 +239,32 @@ const normalizePoolCliArgs = (argv: string[]): string[] => {
   });
 };
 
+const normalizeBrowserCliArgs = (argv: string[]): string[] => {
+  const hasBrowserNestedOption = argv.some((arg) =>
+    arg.startsWith('--browser.'),
+  );
+
+  if (!hasBrowserNestedOption) {
+    return argv;
+  }
+
+  return argv.map((arg) => {
+    if (arg === '--browser') {
+      return '--browser.enabled';
+    }
+    if (arg.startsWith('--browser=')) {
+      return `--browser.enabled=${arg.slice('--browser='.length)}`;
+    }
+    if (arg === '--no-browser') {
+      return '--browser.enabled=false';
+    }
+
+    return arg;
+  });
+};
+
 const normalizeCliArgs = (argv: string[]): string[] =>
-  normalizePoolCliArgs(normalizeCoverageCliArgs(argv));
+  normalizePoolCliArgs(normalizeBrowserCliArgs(normalizeCoverageCliArgs(argv)));
 
 const normalizeMixedCliOptions = (cli: CAC): void => {
   const originalParse = cli.parse.bind(cli);

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -81,6 +81,30 @@ describe('CLI help output', () => {
     });
   });
 
+  it('preserves nested coverage options when followed by --coverage', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--coverage.changed=HEAD', '--coverage'],
+      { run: false },
+    );
+
+    expect(parsed.options.coverage).toEqual({
+      changed: 'HEAD',
+      enabled: true,
+    });
+  });
+
+  it('allows --coverage=false to be mixed with nested coverage options', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--coverage=false', '--coverage.changed=HEAD'],
+      { run: false },
+    );
+
+    expect(parsed.options.coverage).toEqual({
+      enabled: 'false',
+      changed: 'HEAD',
+    });
+  });
+
   it('allows --pool shorthand to be mixed with nested pool options', () => {
     const parsed = createCli().parse(
       ['node', 'rstest', 'run', '--pool', 'forks', '--pool.maxWorkers', '1'],
@@ -90,6 +114,66 @@ describe('CLI help output', () => {
     expect(parsed.options.pool).toEqual({
       type: 'forks',
       maxWorkers: 1,
+    });
+  });
+
+  it('preserves nested pool options when followed by --pool shorthand', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--pool.maxWorkers', '1', '--pool', 'forks'],
+      { run: false },
+    );
+
+    expect(parsed.options.pool).toEqual({
+      maxWorkers: 1,
+      type: 'forks',
+    });
+  });
+
+  it('allows --pool= shorthand to be mixed with nested pool options', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--pool=forks', '--pool.maxWorkers=1'],
+      { run: false },
+    );
+
+    expect(parsed.options.pool).toEqual({
+      type: 'forks',
+      maxWorkers: 1,
+    });
+  });
+
+  it('allows --browser shorthand to be mixed with nested browser options', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--browser', '--browser.name', 'chromium'],
+      { run: false },
+    );
+
+    expect(parsed.options.browser).toEqual({
+      enabled: true,
+      name: 'chromium',
+    });
+  });
+
+  it('preserves nested browser options when followed by --browser', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--browser.name', 'chromium', '--browser'],
+      { run: false },
+    );
+
+    expect(parsed.options.browser).toEqual({
+      name: 'chromium',
+      enabled: true,
+    });
+  });
+
+  it('allows browser disabling shorthand to be mixed with nested browser options', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--no-browser', '--browser.name', 'chromium'],
+      { run: false },
+    );
+
+    expect(parsed.options.browser).toEqual({
+      enabled: false,
+      name: 'chromium',
     });
   });
 });

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -80,6 +80,18 @@ describe('CLI help output', () => {
       changed: 'HEAD',
     });
   });
+
+  it('allows --pool shorthand to be mixed with nested pool options', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--pool', 'forks', '--pool.maxWorkers', '1'],
+      { run: false },
+    );
+
+    expect(parsed.options.pool).toEqual({
+      type: 'forks',
+      maxWorkers: 1,
+    });
+  });
 });
 
 describe('normalizeCliFilters', () => {


### PR DESCRIPTION
## Summary

This PR fixes mixed shorthand and nested CLI option parsing for `pool`, `browser`, and related coverage cases. CAC can otherwise replace an option object with a primitive (or try to write nested fields onto a primitive) for arguments like `--pool forks --pool.maxWorkers 1`, `--browser --browser.name chromium`, or when shorthand appears after nested options. The CLI now normalizes shorthand forms to their explicit nested fields before parsing so nested values are preserved regardless of argument order.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).