### PR TITLE
perf(coverage-istanbul): optimize sourcemap URL scanning

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -88,9 +88,15 @@
         "@rstest/browser",
       ],
     },
+    "packages/coverage-istanbul": {
+      "entry": [
+        // Test files
+        "tests/**/*.ts",
+      ],
+    },
     // No explicit entry needed for the following packages — knip auto-infers from package.json exports:
-    // packages/browser-react, packages/coverage-istanbul,
-    // packages/adapter-rslib, packages/adapter-rsbuild, packages/adapter-rspack
+    // packages/browser-react, packages/adapter-rslib,
+    // packages/adapter-rsbuild, packages/adapter-rspack
 
     "packages/vscode": {
       "entry": [

--- a/packages/coverage-istanbul/rstest.config.ts
+++ b/packages/coverage-istanbul/rstest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '../adapter-rslib/src';
+
+export default defineConfig({
+  extends: withRslibConfig({
+    cwd: __dirname,
+  }),
+  name: 'coverage-istanbul',
+  setupFiles: ['../../scripts/rstest.setup.ts'],
+  include: ['<rootDir>/tests/**/*.test.ts'],
+  globals: true,
+  source: {
+    tsconfigPath: './tests/tsconfig.json',
+  },
+  tools: {
+    rspack: {
+      watchOptions: {
+        ignored: /test-temp-.*/,
+      },
+    },
+  },
+});

--- a/packages/coverage-istanbul/src/plugin.ts
+++ b/packages/coverage-istanbul/src/plugin.ts
@@ -85,7 +85,9 @@ export const pluginCoverage: (
     });
 
     api.onExit(() => {
-      Object.assign(transformCoverageFns, {});
+      for (const environmentName of Object.keys(transformCoverageFns)) {
+        delete transformCoverageFns[environmentName];
+      }
     });
   },
 });

--- a/packages/coverage-istanbul/src/utils.ts
+++ b/packages/coverage-istanbul/src/utils.ts
@@ -82,20 +82,27 @@ const sourceMappingURLRegex = new RegExp(
  * @param {string} code source code content
  * @returns {string | undefined} source mapping information
  */
-function getSourceMappingURL(code: string): string | undefined {
-  const lines = code.split(/^/m);
-  let match: RegExpMatchArray | null | undefined = null;
+export function getSourceMappingURL(code: string): string | undefined {
+  let searchIndex = code.lastIndexOf('sourceMappingURL');
 
-  for (let i = lines.length - 1; i >= 0; i--) {
-    match = lines[i]?.match(sourceMappingURLRegex);
+  while (searchIndex !== -1) {
+    const lineStart = code.lastIndexOf('\n', searchIndex);
+    const lineEnd = code.indexOf('\n', searchIndex);
+    const line = code.slice(
+      lineStart + 1,
+      lineEnd === -1 ? code.length : lineEnd,
+    );
+    const match = line.match(sourceMappingURLRegex);
+
     if (match) {
-      break;
+      const sourceMappingURL = match[1] || match[2] || '';
+      return sourceMappingURL ? decodeURI(sourceMappingURL) : undefined;
     }
+
+    searchIndex = code.lastIndexOf('sourceMappingURL', lineStart - 1);
   }
 
-  const sourceMappingURL = match ? match[1] || match[2] || '' : '';
-
-  return sourceMappingURL ? decodeURI(sourceMappingURL) : sourceMappingURL;
+  return undefined;
 }
 
 export function registerSourceMapURL(
@@ -135,28 +142,34 @@ export async function transformCoverage(
   coverageMap: CoverageMap,
   sourcemapUrlCache: Map<string, string | undefined>,
 ): Promise<CoverageMap> {
-  await mapWithConcurrency(
-    coverageMap
-      .files()
-      // process js/cjs/mjs file only
-      .filter((filename) => filename.endsWith('js')),
-    SOURCE_MAP_SCAN_CONCURRENCY,
-    async (filename) => {
-      let url = sourcemapUrlCache.get(filename);
-      if (!url) {
-        const { readFile } = await import('node:fs/promises');
-        url = await readFile(filename, 'utf8').then(
+  const jsFiles = coverageMap
+    .files()
+    // process js/cjs/mjs file only
+    .filter((filename) => filename.endsWith('js'));
+
+  const uncachedFiles = jsFiles.filter(
+    (filename) => !sourcemapUrlCache.has(filename),
+  );
+
+  if (uncachedFiles.length) {
+    const { readFile } = await import('node:fs/promises');
+    await mapWithConcurrency(
+      uncachedFiles,
+      SOURCE_MAP_SCAN_CONCURRENCY,
+      async (filename) => {
+        const url = await readFile(filename, 'utf8').then(
           (content) => getSourceMappingURL(content),
           () => undefined,
         );
-      }
-      sourcemapUrlCache.set(filename, url);
-    },
-  );
+        sourcemapUrlCache.set(filename, url);
+      },
+    );
+  }
 
   // Call createSourceMapStore as needed
   let store: MapStore | undefined;
-  for (const [filename, url] of sourcemapUrlCache) {
+  for (const filename of jsFiles) {
+    const url = sourcemapUrlCache.get(filename);
     if (url) {
       if (!store) {
         const { createSourceMapStore } =

--- a/packages/coverage-istanbul/src/utils.ts
+++ b/packages/coverage-istanbul/src/utils.ts
@@ -157,11 +157,13 @@ export async function transformCoverage(
       uncachedFiles,
       SOURCE_MAP_SCAN_CONCURRENCY,
       async (filename) => {
-        const url = await readFile(filename, 'utf8').then(
-          (content) => getSourceMappingURL(content),
-          () => undefined,
-        );
-        sourcemapUrlCache.set(filename, url);
+        try {
+          const content = await readFile(filename, 'utf8');
+          sourcemapUrlCache.set(filename, getSourceMappingURL(content));
+        } catch {
+          // Do not cache failed reads. The file may be temporarily unavailable
+          // during watch-mode rebuilds, so retry it on the next report.
+        }
       },
     );
   }

--- a/packages/coverage-istanbul/tests/tsconfig.json
+++ b/packages/coverage-istanbul/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node", "@rstest/core/globals"]
+  },
+  "include": ["**/*.test.ts"]
+}

--- a/packages/coverage-istanbul/tests/utils.test.ts
+++ b/packages/coverage-istanbul/tests/utils.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import istanbulCoverage from 'istanbul-lib-coverage';
+import { getSourceMappingURL, transformCoverage } from '../src/utils';
+
+describe('coverage istanbul utils', () => {
+  it('extracts the last sourceMappingURL without splitting the whole file', () => {
+    const code = [
+      'const sourceMappingURL = "not a comment";',
+      '//# sourceMappingURL=first.js.map',
+      'console.log("hello");',
+      '//# sourceMappingURL=second.js.map',
+    ].join('\n');
+
+    expect(getSourceMappingURL(code)).toBe('second.js.map');
+  });
+
+  it('returns undefined when sourceMappingURL only appears outside comments', () => {
+    expect(getSourceMappingURL('const sourceMappingURL = "inline";')).toBe(
+      undefined,
+    );
+  });
+
+  it('does not reread files whose sourcemap cache entry is already undefined', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'rstest-coverage-cache-'));
+    const file = path.join(root, 'index.js');
+    writeFileSync(file, 'export const value = 1;\n');
+
+    const coverageMap = istanbulCoverage.createCoverageMap({
+      [file]: {
+        path: file,
+        statementMap: {},
+        fnMap: {},
+        branchMap: {},
+        s: {},
+        f: {},
+        b: {},
+      },
+    });
+    const sourcemapUrlCache = new Map<string, string | undefined>([
+      [file, undefined],
+    ]);
+
+    try {
+      rmSync(file);
+      await expect(
+        transformCoverage(coverageMap, sourcemapUrlCache),
+      ).resolves.toBe(coverageMap);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/coverage-istanbul/tests/utils.test.ts
+++ b/packages/coverage-istanbul/tests/utils.test.ts
@@ -51,4 +51,39 @@ describe('coverage istanbul utils', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('retries sourcemap reads after filesystem errors', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'rstest-coverage-retry-'));
+    const file = path.join(root, 'index.js');
+
+    const coverageMap = istanbulCoverage.createCoverageMap({
+      [file]: {
+        path: file,
+        statementMap: {},
+        fnMap: {},
+        branchMap: {},
+        s: {},
+        f: {},
+        b: {},
+      },
+    });
+    const sourcemapUrlCache = new Map<string, string | undefined>();
+
+    try {
+      await expect(
+        transformCoverage(coverageMap, sourcemapUrlCache),
+      ).resolves.toBe(coverageMap);
+      expect(sourcemapUrlCache.has(file)).toBe(false);
+
+      writeFileSync(file, 'export const value = 1;\n');
+
+      await expect(
+        transformCoverage(coverageMap, sourcemapUrlCache),
+      ).resolves.toBe(coverageMap);
+      expect(sourcemapUrlCache.has(file)).toBe(true);
+      expect(sourcemapUrlCache.get(file)).toBe(undefined);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

This PR reduces coverage report overhead in `@rstest/coverage-istanbul` by avoiding full-file line splitting when extracting `sourceMappingURL` comments and by honoring cached `undefined` sourcemap lookups. This keeps files without sourcemaps from being reread on repeated coverage transforms, and also fixes the coverage plugin exit cleanup so registered transform functions are actually released.

Performance comparison from a local micro benchmark on Node.js v24.14.0:

| Scenario | Before | After |
| --- | ---: | ---: |
| Extract sourcemap URL, 100 iterations over ~100k-line JS file with sourcemap | 360.04ms | 0.04ms |
| Extract sourcemap URL, 100 iterations over ~100k-line JS file without sourcemap | 511.74ms | 74.96ms |
| Repeat transform scan over 100 cached no-sourcemap JS files | 18.60ms | 0.07ms |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
