### PR TITLE
feat(core): trace coverage pipeline

### DIFF
--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -267,7 +267,12 @@ export async function runTests(context: Rstest): Promise<void> {
           }
         }
         const { generateCoverage } = await import('../coverage/generate');
-        await generateCoverage(context, browserCoverageMap, coverageProvider);
+        await generateCoverage(
+          context,
+          browserCoverageMap,
+          coverageProvider,
+          traceRun.span,
+        );
       }
     }
 
@@ -773,7 +778,12 @@ export async function runTests(context: Rstest): Promise<void> {
         const { generateCoverage } = await import('../coverage/generate');
 
         await runLifecycleStep('coverage report generation', () =>
-          generateCoverage(context, mergedCoverageMap!, coverageProvider),
+          generateCoverage(
+            context,
+            mergedCoverageMap!,
+            coverageProvider,
+            traceRun.span,
+          ),
         );
       }
 

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -8,7 +8,9 @@ import type {
   CoverageOptions,
   CoverageProvider,
 } from '../types/coverage';
-import { logger } from '../utils';
+import { logger, type TraceSpan } from '../utils';
+
+const traceNoop: TraceSpan = async (_name, _cat, fn) => fn();
 
 export const getIncludedFiles = async (
   coverage: CoverageOptions,
@@ -179,6 +181,7 @@ export async function generateCoverage(
   context: RstestContext,
   coverageMap: CoverageMap,
   coverageProvider: CoverageProvider,
+  traceSpan: TraceSpan = traceNoop,
 ): Promise<void> {
   const {
     rootPath,
@@ -188,51 +191,64 @@ export async function generateCoverage(
   try {
     const finalCoverageMap = coverageMap;
 
-    const rawDistPathRoot = context.normalizedConfig.output?.distPath?.root;
-    const distPathRoot = rawDistPathRoot ? normalize(rawDistPathRoot) : '';
-    const normalizedRootPath = normalize(rootPath);
-    const setupCoverageExcludes = getSetupCoverageExcludes(context);
-    const absDistPathRoot = distPathRoot
-      ? normalize(
-          isAbsolute(distPathRoot)
-            ? distPathRoot
-            : `${normalizedRootPath}/${distPathRoot}`,
-        )
-      : '';
-    finalCoverageMap.filter((filePath) => {
-      const normalizedFile = normalize(filePath);
-      const fileRelativeToRoot = normalize(
-        relative(normalizedRootPath, normalizedFile),
-      );
-      if (
-        (distPathRoot && isSameOrSubPath(fileRelativeToRoot, distPathRoot)) ||
-        (absDistPathRoot && isSameOrSubPath(normalizedFile, absDistPathRoot))
-      ) {
-        return false;
-      }
-      if (isRuntimeSentinelCoverageFile(normalizedFile)) {
-        return false;
-      }
-      // Keep setupFiles/globalSetup out of the final report for every provider.
-      // Istanbul already excludes them before instrumentation; V8 needs this
-      // post-collection pruning so both providers converge on the same output.
-      if (
-        shouldExcludeSetupCoverageFile(
-          normalizedFile,
-          normalizedRootPath,
-          setupCoverageExcludes,
-        )
-      ) {
-        return false;
-      }
-      if (!coverage.allowExternal) {
-        return isSameOrSubPath(normalizedFile, normalize(rootPath));
-      }
-      return true;
-    });
+    await traceSpan(
+      'coverage:filter-files',
+      'coverage',
+      () => {
+        const rawDistPathRoot = context.normalizedConfig.output?.distPath?.root;
+        const distPathRoot = rawDistPathRoot ? normalize(rawDistPathRoot) : '';
+        const normalizedRootPath = normalize(rootPath);
+        const setupCoverageExcludes = getSetupCoverageExcludes(context);
+        const absDistPathRoot = distPathRoot
+          ? normalize(
+              isAbsolute(distPathRoot)
+                ? distPathRoot
+                : `${normalizedRootPath}/${distPathRoot}`,
+            )
+          : '';
+        finalCoverageMap.filter((filePath) => {
+          const normalizedFile = normalize(filePath);
+          const fileRelativeToRoot = normalize(
+            relative(normalizedRootPath, normalizedFile),
+          );
+          if (
+            (distPathRoot &&
+              isSameOrSubPath(fileRelativeToRoot, distPathRoot)) ||
+            (absDistPathRoot &&
+              isSameOrSubPath(normalizedFile, absDistPathRoot))
+          ) {
+            return false;
+          }
+          if (isRuntimeSentinelCoverageFile(normalizedFile)) {
+            return false;
+          }
+          // Keep setupFiles/globalSetup out of the final report for every provider.
+          // Istanbul already excludes them before instrumentation; V8 needs this
+          // post-collection pruning so both providers converge on the same output.
+          if (
+            shouldExcludeSetupCoverageFile(
+              normalizedFile,
+              normalizedRootPath,
+              setupCoverageExcludes,
+            )
+          ) {
+            return false;
+          }
+          if (!coverage.allowExternal) {
+            return isSameOrSubPath(normalizedFile, normalizedRootPath);
+          }
+          return true;
+        });
+      },
+      { allowExternal: coverage.allowExternal },
+    );
 
     if (coverage.include?.length) {
-      const coveredFilesSet = new Set(finalCoverageMap.files().map(normalize));
+      const coveredFilesSet = await traceSpan(
+        'coverage:collect-covered-files',
+        'coverage',
+        () => new Set(finalCoverageMap.files().map(normalize)),
+      );
 
       let isTimeout = false;
 
@@ -247,14 +263,23 @@ export async function generateCoverage(
       // intermediate data be GC'd before the next one starts.
       const allFiles: string[] = [];
       for (const p of projects) {
-        const includedFiles = filterChangedFiles(
-          filterExternalFiles(
-            await getIncludedFiles(coverage, p.rootPath),
-            p.rootPath,
-            coverage.allowExternal,
-          ),
-          context.changedCoverageFilters,
-          p.rootPath,
+        const includedFiles = await traceSpan(
+          'coverage:collect-included-files',
+          'coverage',
+          async () =>
+            filterChangedFiles(
+              filterExternalFiles(
+                await getIncludedFiles(coverage, p.rootPath),
+                p.rootPath,
+                coverage.allowExternal,
+              ),
+              context.changedCoverageFilters,
+              p.rootPath,
+            ),
+          {
+            project: p.environmentName,
+            changedOnly: Boolean(context.changedCoverageFilters?.length),
+          },
         );
         allFiles.push(...includedFiles);
 
@@ -263,11 +288,21 @@ export async function generateCoverage(
         );
 
         if (uncoveredFiles.length) {
-          await generateCoverageForUntestedFiles(
-            p.environmentName,
-            uncoveredFiles,
-            finalCoverageMap,
-            coverageProvider,
+          await traceSpan(
+            'coverage:generate-untested-files',
+            'coverage',
+            () =>
+              generateCoverageForUntestedFiles(
+                p.environmentName,
+                uncoveredFiles,
+                finalCoverageMap,
+                coverageProvider,
+                traceSpan,
+              ),
+            {
+              project: p.environmentName,
+              fileCount: uncoveredFiles.length,
+            },
           );
         }
       }
@@ -280,26 +315,53 @@ export async function generateCoverage(
 
       // should be better to filter files before swc coverage is processed
       const allFilesSet = new Set(allFiles.map(normalize));
-      finalCoverageMap.filter((file) => allFilesSet.has(normalize(file)));
+      await traceSpan(
+        'coverage:filter-included-files',
+        'coverage',
+        () => {
+          finalCoverageMap.filter((file) => allFilesSet.has(normalize(file)));
+        },
+        { fileCount: allFilesSet.size },
+      );
     } else if (context.changedCoverageFilters?.length) {
-      finalCoverageMap.filter(
-        (file) =>
-          filterChangedFiles([file], context.changedCoverageFilters, rootPath)
-            .length > 0,
+      await traceSpan(
+        'coverage:filter-changed-files',
+        'coverage',
+        () => {
+          finalCoverageMap.filter(
+            (file) =>
+              filterChangedFiles(
+                [file],
+                context.changedCoverageFilters,
+                rootPath,
+              ).length > 0,
+          );
+        },
+        { filterCount: context.changedCoverageFilters.length },
       );
     }
 
     // Generate coverage reports
-    await coverageProvider.generateReports(finalCoverageMap, coverage);
+    await traceSpan('coverage:generate-reports', 'coverage', () =>
+      coverageProvider.generateReports(finalCoverageMap, coverage),
+    );
 
     if (coverage.thresholds) {
-      const { checkThresholds } = await import('../coverage/checkThresholds');
-      const thresholdResult = checkThresholds({
-        coverageMap: finalCoverageMap,
-        coverageProvider,
-        rootPath,
-        thresholds: coverage.thresholds,
-      });
+      const { thresholds } = coverage;
+      const thresholdResult = await traceSpan(
+        'coverage:check-thresholds',
+        'coverage',
+        async () => {
+          const { checkThresholds } =
+            await import('../coverage/checkThresholds');
+          return checkThresholds({
+            coverageMap: finalCoverageMap,
+            coverageProvider,
+            rootPath,
+            thresholds,
+          });
+        },
+      );
       if (!thresholdResult.success) {
         logger.log('');
         logger.stderr(thresholdResult.message);
@@ -317,6 +379,7 @@ async function generateCoverageForUntestedFiles(
   uncoveredFiles: string[],
   coverageMap: CoverageMap,
   coverageProvider: CoverageProvider,
+  traceSpan: TraceSpan = traceNoop,
 ): Promise<void> {
   if (!coverageProvider.generateCoverageForUntestedFiles) {
     logger.warn(
@@ -334,10 +397,21 @@ async function generateCoverageForUntestedFiles(
   const batchSize = 25;
 
   for (let index = 0; index < uncoveredFiles.length; index += batchSize) {
-    const coverages = await coverageProvider.generateCoverageForUntestedFiles({
-      environmentName,
-      files: uncoveredFiles.slice(index, index + batchSize),
-    });
+    const files = uncoveredFiles.slice(index, index + batchSize);
+    const coverages = await traceSpan(
+      'coverage:generate-untested-files-batch',
+      'coverage',
+      () =>
+        coverageProvider.generateCoverageForUntestedFiles!({
+          environmentName,
+          files,
+        }),
+      {
+        environmentName,
+        batchIndex: Math.floor(index / batchSize),
+        fileCount: files.length,
+      },
+    );
 
     coverages.forEach((coverageData) => {
       coverageMap.addFileCoverage(coverageData);

--- a/packages/core/src/utils/trace.ts
+++ b/packages/core/src/utils/trace.ts
@@ -28,6 +28,13 @@ export type TraceEvent = {
   args?: Record<string, string | number | boolean | undefined>;
 };
 
+export type TraceSpan = <T>(
+  name: string,
+  cat: string,
+  fn: () => T | Promise<T>,
+  args?: TraceEvent['args'],
+) => Promise<T>;
+
 // ---------------------------------------------------------------------------
 // File output
 // ---------------------------------------------------------------------------
@@ -242,6 +249,8 @@ export interface TraceRun {
    * disabled, so the pool layer skips collecting events entirely.
    */
   onEvents: ((events: TraceEvent[]) => void) | undefined;
+  /** Record a host-side Perfetto slice in the current run. */
+  span: TraceSpan;
   /**
    * Write the buffered events for this run to disk and (lazily) start or
    * refresh the Perfetto helper server. No-op when nothing was collected.
@@ -288,9 +297,35 @@ export const createTraceController = (options: {
 
   const beginRun = (): TraceRun => {
     if (!enabled) {
-      return { onEvents: undefined, finalize: async () => {} };
+      return {
+        onEvents: undefined,
+        span: async (_name, _cat, fn) => fn(),
+        finalize: async () => {},
+      };
     }
     const events: TraceEvent[] = [];
+    const pushHostSlice: TraceSpan = async (name, cat, fn, args) => {
+      const start = Date.now();
+      try {
+        return await fn();
+      } finally {
+        const end = Date.now();
+        events.push({
+          name,
+          cat,
+          ph: 'X',
+          ts: start * 1000,
+          dur: (end - start) * 1000,
+          pid: process.pid,
+          tid: 0,
+          args: {
+            testPath: '<coverage>',
+            project: 'host',
+            ...args,
+          },
+        });
+      }
+    };
     return {
       // Iterate instead of spreading: a single file with thousands of cases
       // can hand `chunk` a very large array, and `push(...chunk)` would then
@@ -299,6 +334,7 @@ export const createTraceController = (options: {
       onEvents: (chunk) => {
         for (const ev of chunk) events.push(ev);
       },
+      span: pushHostSlice,
       finalize: async () => {
         if (!events.length) return;
         const tracePath = getTraceOutputPath(rootPath);

--- a/packages/core/tests/coverage/generate.test.ts
+++ b/packages/core/tests/coverage/generate.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../src/coverage/generate';
 import type { RstestContext } from '../../src/types';
 import type { CoverageMap, CoverageProvider } from '../../src/types/coverage';
+import type { TraceSpan } from '../../src/utils';
 
 const createFileCoverage = (file: string): FileCoverageData => ({
   path: file,
@@ -367,6 +368,122 @@ describe('generateCoverage', () => {
 
     try {
       await generateCoverage(context, createCoverageMap(), provider);
+    } finally {
+      rmSync(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it('traces coverage generation pipeline steps', async () => {
+    const rootPath = mkdtempSync(path.join(tmpdir(), 'rstest-coverage-'));
+    const srcDir = path.join(rootPath, 'src');
+    mkdirSync(srcDir, { recursive: true });
+
+    writeFileSync(
+      path.join(srcDir, 'covered.ts'),
+      'export const covered = 1;\n',
+    );
+    writeFileSync(
+      path.join(srcDir, 'uncovered.ts'),
+      'export const uncovered = 1;\n',
+    );
+
+    const coveredFile = path.join(srcDir, 'covered.ts');
+    const defaultCoverage = withDefaultConfig({}).coverage;
+    const coveredFiles = new Map<string, FileCoverageData>([
+      [
+        coveredFile,
+        {
+          path: coveredFile,
+          statementMap: {},
+          fnMap: {},
+          branchMap: {},
+          s: {},
+          f: {},
+          b: {},
+          all: false,
+          _coverageSchema: 'test',
+          hash: coveredFile,
+        },
+      ],
+    ]);
+
+    const createCoverageMap = (): CoverageMap =>
+      ({
+        addFileCoverage(coverage: { path: string }) {
+          coveredFiles.set(coverage.path, coverage);
+        },
+        files() {
+          return Array.from(coveredFiles.keys());
+        },
+        filter(predicate: (filePath: string) => boolean) {
+          for (const filePath of Array.from(coveredFiles.keys())) {
+            if (!predicate(filePath)) {
+              coveredFiles.delete(filePath);
+            }
+          }
+        },
+        merge(coverage: Record<string, FileCoverageData>) {
+          Object.entries(coverage).forEach(([filePath, fileCoverage]) => {
+            coveredFiles.set(filePath, fileCoverage);
+          });
+        },
+      }) as CoverageMap;
+
+    const provider = {
+      init: () => {},
+      collect: () => null,
+      cleanup: () => {},
+      createCoverageMap: () => createCoverageMap(),
+      async generateCoverageForUntestedFiles({ files }) {
+        return files.map((file) => ({
+          path: file,
+          statementMap: {},
+          fnMap: {},
+          branchMap: {},
+          s: {},
+          f: {},
+          b: {},
+          all: false,
+          _coverageSchema: 'test',
+          hash: file,
+        }));
+      },
+      async generateReports() {},
+    } satisfies CoverageProvider;
+
+    const context = {
+      rootPath,
+      normalizedConfig: {
+        coverage: {
+          ...defaultCoverage,
+          include: ['src/**/*.ts'],
+        },
+      },
+      projects: [
+        {
+          rootPath,
+          environmentName: 'node',
+        },
+      ],
+    } as RstestContext;
+
+    const spans: string[] = [];
+    const traceSpan: TraceSpan = async (name, _cat, fn) => {
+      spans.push(name);
+      return fn();
+    };
+
+    try {
+      await generateCoverage(context, createCoverageMap(), provider, traceSpan);
+      expect(spans).toEqual([
+        'coverage:filter-files',
+        'coverage:collect-covered-files',
+        'coverage:collect-included-files',
+        'coverage:generate-untested-files',
+        'coverage:generate-untested-files-batch',
+        'coverage:filter-included-files',
+        'coverage:generate-reports',
+      ]);
     } finally {
       rmSync(rootPath, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

This PR adds host-side Perfetto trace slices around the coverage generation pipeline so `rstest --trace --coverage` can show where coverage time is spent. It traces filtering, included-file collection, untested-file generation (including batches), report generation, and threshold checks for both browser-only and node/mixed test runs.

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
