### PR TITLE
perf(coverage-v8): skip unnecessary coverage conversion

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -94,9 +94,15 @@
         "tests/**/*.ts",
       ],
     },
+    "packages/coverage-v8": {
+      "entry": [
+        // Test files
+        "tests/**/*.ts",
+      ],
+    },
     // No explicit entry needed for the following packages — knip auto-infers from package.json exports:
-    // packages/browser-react, packages/adapter-rslib,
-    // packages/adapter-rsbuild, packages/adapter-rspack
+    // packages/browser-react, packages/adapter-rslib, packages/adapter-rsbuild,
+    // packages/adapter-rspack
 
     "packages/vscode": {
       "entry": [

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "rslib build",
+    "test": "rstest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/coverage-v8/rstest.config.ts
+++ b/packages/coverage-v8/rstest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '../adapter-rslib/src';
+
+export default defineConfig({
+  extends: withRslibConfig({
+    cwd: __dirname,
+  }),
+  name: 'coverage-v8',
+  setupFiles: ['../../scripts/rstest.setup.ts'],
+  include: ['<rootDir>/tests/**/*.test.ts'],
+  globals: true,
+  source: {
+    tsconfigPath: './tests/tsconfig.json',
+  },
+  tools: {
+    rspack: {
+      watchOptions: {
+        ignored: /test-temp-.*/,
+      },
+    },
+  },
+});

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -193,6 +193,20 @@ export class CoverageProvider implements RstestCoverageProvider {
     );
   }
 
+  private hasInlineSourceMap(code: string): boolean {
+    return /[#@]\s*sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,/m.test(
+      code,
+    );
+  }
+
+  private async hasInlineSourceMapOnDisk(filePath: string): Promise<boolean> {
+    try {
+      return this.hasInlineSourceMap(await fs.readFile(filePath, 'utf-8'));
+    } catch (_err) {
+      return false;
+    }
+  }
+
   private async getTransformedSource(
     filePath: string,
     options?: {
@@ -330,15 +344,14 @@ export class CoverageProvider implements RstestCoverageProvider {
 
         const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
         const assetSource = this.findInDict(options?.assetFiles, filePath);
-        const hasSourceMap = Boolean(
-          sourceMapStr ||
-          (assetSource &&
-            /[#@]\s*sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,/m.test(
-              assetSource,
-            )),
+        let hasSourceMap = Boolean(
+          sourceMapStr || (assetSource && this.hasInlineSourceMap(assetSource)),
         );
 
-        if (!this.shouldProcessEntry(filePath) && !hasSourceMap) return;
+        if (!this.shouldProcessEntry(filePath) && !hasSourceMap) {
+          hasSourceMap = await this.hasInlineSourceMapOnDisk(filePath);
+          if (!hasSourceMap) return;
+        }
 
         if (!hasSourceMap) {
           const originalTestPath = this.toProjectRelativePath(filePath);
@@ -346,7 +359,8 @@ export class CoverageProvider implements RstestCoverageProvider {
             this.isExcluded(originalTestPath) ||
             !this.isIncluded(originalTestPath)
           ) {
-            return;
+            hasSourceMap = await this.hasInlineSourceMapOnDisk(filePath);
+            if (!hasSourceMap) return;
           }
         }
 

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -33,6 +33,10 @@ export class CoverageProvider implements RstestCoverageProvider {
   private isMatch: (filePath: string) => boolean;
   private isIncluded: (filePath: string) => boolean;
   private isExcluded: (filePath: string) => boolean;
+  private dictLookupCache = new WeakMap<
+    Record<string, string>,
+    Map<string, string>
+  >();
 
   constructor(
     public options: NormalizedCoverageOptions,
@@ -94,21 +98,33 @@ export class CoverageProvider implements RstestCoverageProvider {
     if (!dict) return undefined;
     if (dict[filePath]) return dict[filePath];
 
-    for (const [key, value] of Object.entries(dict)) {
-      const normalizedKey = key.replace(/\\/g, '/');
-      if (normalizedKey === filePath) return value;
-      if (
-        filePath.startsWith('/private/') &&
-        normalizedKey === filePath.slice('/private'.length)
-      ) {
-        return value;
+    let lookup = this.dictLookupCache.get(dict);
+    if (!lookup) {
+      lookup = new Map();
+      for (const [key, value] of Object.entries(dict)) {
+        const normalizedKey = key.replace(/\\/g, '/');
+        if (!lookup.has(normalizedKey)) {
+          lookup.set(normalizedKey, value);
+        }
+
+        const lowerKey = normalizedKey.toLowerCase();
+        if (!lookup.has(lowerKey)) {
+          lookup.set(lowerKey, value);
+        }
       }
-      if (normalizedKey.toLowerCase() === filePath.toLowerCase()) {
-        return value;
-      }
+      this.dictLookupCache.set(dict, lookup);
     }
 
-    return undefined;
+    const normalizedPath = filePath.replace(/\\/g, '/');
+    const directMatch = lookup.get(normalizedPath);
+    if (directMatch) return directMatch;
+
+    if (filePath.startsWith('/private/')) {
+      const privateMatch = lookup.get(filePath.slice('/private'.length));
+      if (privateMatch) return privateMatch;
+    }
+
+    return lookup.get(normalizedPath.toLowerCase());
   }
 
   private isNodeModulesPath(filePath: string): boolean {
@@ -317,6 +333,16 @@ export class CoverageProvider implements RstestCoverageProvider {
         );
 
         if (!this.shouldProcessEntry(filePath) && !hasSourceMap) return;
+
+        if (!hasSourceMap) {
+          const originalTestPath = this.toProjectRelativePath(filePath);
+          if (
+            this.isExcluded(originalTestPath) ||
+            !this.isIncluded(originalTestPath)
+          ) {
+            return;
+          }
+        }
 
         try {
           const istanbulData = await this.convertWithAst(

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -328,8 +328,14 @@ export class CoverageProvider implements RstestCoverageProvider {
 
         if (!this.isMatch(filePath)) return;
 
+        const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
+        const assetSource = this.findInDict(options?.assetFiles, filePath);
         const hasSourceMap = Boolean(
-          this.findInDict(options?.sourceMaps, filePath),
+          sourceMapStr ||
+          (assetSource &&
+            /[#@]\s*sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,/m.test(
+              assetSource,
+            )),
         );
 
         if (!this.shouldProcessEntry(filePath) && !hasSourceMap) return;

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -194,7 +194,7 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   private hasInlineSourceMap(code: string): boolean {
-    return /[#@]\s*sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,/m.test(
+    return /[#@]\s*sourceMappingURL\s*=\s*data:application\/json(?:;[^'",\s]*)*,/i.test(
       code,
     );
   }

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import type { NormalizedCoverageOptions } from '@rstest/core';
+import type { FileCoverageData } from 'istanbul-lib-coverage';
 import { CoverageProvider } from '../src/provider';
 
 const createOptions = (
@@ -24,6 +25,19 @@ type ProviderInternals = CoverageProvider & {
     dict: Record<string, string> | undefined,
     filePath: string,
   ) => string | undefined;
+  convertWithAst: (
+    filePath: string,
+    entry: {
+      url: string;
+      scriptId: string;
+      functions: [];
+    },
+    options?: {
+      assetFiles?: Record<string, string>;
+      sourceMaps?: Record<string, string>;
+      outputModule?: boolean;
+    },
+  ) => Promise<Record<string, FileCoverageData>>;
 };
 
 function getProviderInternals(provider: CoverageProvider): ProviderInternals {
@@ -53,7 +67,7 @@ describe('coverage-v8 provider', () => {
   });
 
   it('skips excluded no-sourcemap files before reading or converting them', async () => {
-    const root = join(tmpdir(), 'rstest-coverage-v8-prefilter');
+    const root = join(tmpdir(), 'rstest-coverage-v8-early-filter');
     const file = join(root, 'excluded.js');
     const provider = new CoverageProvider(
       createOptions({
@@ -104,6 +118,72 @@ describe('coverage-v8 provider', () => {
     } finally {
       console.error = originalError;
       process.exitCode = originalExitCode;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps excluded files with inline source maps for remapping', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-inline-map');
+    const file = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const provider = new CoverageProvider(
+      createOptions({
+        include: ['src/**/*.ts'],
+        exclude: ['dist/**'],
+      }),
+      root,
+    );
+    const providerInternals = getProviderInternals(provider);
+    const fileCoverage = {
+      path: originalFile,
+      statementMap: {},
+      fnMap: {},
+      branchMap: {},
+      s: {},
+      f: {},
+      b: {},
+    } satisfies FileCoverageData;
+
+    Object.defineProperty(provider, 'session', {
+      configurable: true,
+      value: {
+        post: async (method: string) => {
+          if (method === 'Profiler.takePreciseCoverage') {
+            return {
+              result: [
+                {
+                  url: pathToFileURL(file).href,
+                  scriptId: '1',
+                  functions: [],
+                },
+              ],
+            };
+          }
+
+          return {};
+        },
+      },
+    });
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async () => ({
+        [originalFile]: fileCoverage,
+      }),
+    });
+
+    try {
+      mkdirSync(root, { recursive: true });
+
+      const coverageMap = await provider.collect({
+        assetFiles: {
+          [file]:
+            'value();\n//# sourceMappingURL=data:application/json;base64,e30=',
+        },
+        sourceMaps: {},
+      });
+
+      expect(coverageMap?.files()).toEqual([originalFile]);
+    } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
@@ -122,8 +122,8 @@ describe('coverage-v8 provider', () => {
     }
   });
 
-  it('keeps excluded files with inline source maps for remapping', async () => {
-    const root = join(tmpdir(), 'rstest-coverage-v8-inline-map');
+  it('keeps excluded asset files with inline source maps for remapping', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-inline-asset-map');
     const file = join(root, 'dist', 'bundle.js');
     const originalFile = join(root, 'src', 'original.ts');
     const provider = new CoverageProvider(
@@ -179,6 +179,73 @@ describe('coverage-v8 provider', () => {
           [file]:
             'value();\n//# sourceMappingURL=data:application/json;base64,e30=',
         },
+        sourceMaps: {},
+      });
+
+      expect(coverageMap?.files()).toEqual([originalFile]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps excluded disk files with inline source maps for remapping', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-inline-disk-map');
+    const file = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const provider = new CoverageProvider(
+      createOptions({
+        include: ['src/**/*.ts'],
+        exclude: ['dist/**'],
+      }),
+      root,
+    );
+    const providerInternals = getProviderInternals(provider);
+    const fileCoverage = {
+      path: originalFile,
+      statementMap: {},
+      fnMap: {},
+      branchMap: {},
+      s: {},
+      f: {},
+      b: {},
+    } satisfies FileCoverageData;
+
+    Object.defineProperty(provider, 'session', {
+      configurable: true,
+      value: {
+        post: async (method: string) => {
+          if (method === 'Profiler.takePreciseCoverage') {
+            return {
+              result: [
+                {
+                  url: pathToFileURL(file).href,
+                  scriptId: '1',
+                  functions: [],
+                },
+              ],
+            };
+          }
+
+          return {};
+        },
+      },
+    });
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async () => ({
+        [originalFile]: fileCoverage,
+      }),
+    });
+
+    try {
+      mkdirSync(join(root, 'dist'), { recursive: true });
+      writeFileSync(
+        file,
+        'value();\n//# sourceMappingURL=data:application/json;base64,e30=',
+      );
+
+      const coverageMap = await provider.collect({
+        assetFiles: {},
         sourceMaps: {},
       });
 

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import type { NormalizedCoverageOptions } from '@rstest/core';
+import { CoverageProvider } from '../src/provider';
+
+const createOptions = (
+  overrides: Partial<NormalizedCoverageOptions> = {},
+): NormalizedCoverageOptions => ({
+  enabled: true,
+  exclude: [],
+  provider: 'v8',
+  reporters: [],
+  reportsDirectory: 'coverage',
+  clean: true,
+  reportOnFailure: false,
+  allowExternal: false,
+  ...overrides,
+});
+
+type ProviderInternals = CoverageProvider & {
+  findInDict: (
+    dict: Record<string, string> | undefined,
+    filePath: string,
+  ) => string | undefined;
+};
+
+function getProviderInternals(provider: CoverageProvider): ProviderInternals {
+  // Access private helpers in tests to lock compatibility without exporting
+  // test-only APIs from the package.
+  return provider as unknown as ProviderInternals;
+}
+
+describe('coverage-v8 provider', () => {
+  it('finds dictionary entries through normalized path variants', () => {
+    const provider = getProviderInternals(
+      new CoverageProvider(createOptions()),
+    );
+    const dict = {
+      'src\\index.ts': 'slash-normalized',
+      '/Project/src/Case.ts': 'case-insensitive',
+      '/tmp/project/src/private.ts': 'private-prefix',
+    };
+
+    expect(provider.findInDict(dict, 'src/index.ts')).toBe('slash-normalized');
+    expect(provider.findInDict(dict, '/project/src/case.ts')).toBe(
+      'case-insensitive',
+    );
+    expect(
+      provider.findInDict(dict, '/private/tmp/project/src/private.ts'),
+    ).toBe('private-prefix');
+  });
+
+  it('skips excluded no-sourcemap files before reading or converting them', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-prefilter');
+    const file = join(root, 'excluded.js');
+    const provider = new CoverageProvider(
+      createOptions({
+        exclude: ['excluded.js'],
+      }),
+      root,
+    );
+    const originalError = console.error;
+    const originalExitCode = process.exitCode;
+    let hasError = false;
+
+    Object.defineProperty(provider, 'session', {
+      configurable: true,
+      value: {
+        post: async (method: string) => {
+          if (method === 'Profiler.takePreciseCoverage') {
+            return {
+              result: [
+                {
+                  url: pathToFileURL(file).href,
+                  scriptId: '1',
+                  functions: [],
+                },
+              ],
+            };
+          }
+
+          return {};
+        },
+      },
+    });
+
+    console.error = () => {
+      hasError = true;
+    };
+
+    try {
+      mkdirSync(root, { recursive: true });
+      rmSync(file, { force: true });
+
+      const coverageMap = await provider.collect({
+        sourceMaps: {},
+      });
+
+      expect(coverageMap?.files()).toEqual([]);
+      expect(hasError).toBe(false);
+      expect(process.exitCode).toBe(originalExitCode);
+    } finally {
+      console.error = originalError;
+      process.exitCode = originalExitCode;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -177,7 +177,7 @@ describe('coverage-v8 provider', () => {
       const coverageMap = await provider.collect({
         assetFiles: {
           [file]:
-            'value();\n//# sourceMappingURL=data:application/json;base64,e30=',
+            'value();\n//# sourceMappingURL=data:application/json;charset=UTF-8,%7B%7D',
         },
         sourceMaps: {},
       });
@@ -241,7 +241,7 @@ describe('coverage-v8 provider', () => {
       mkdirSync(join(root, 'dist'), { recursive: true });
       writeFileSync(
         file,
-        'value();\n//# sourceMappingURL=data:application/json;base64,e30=',
+        'value();\n//# sourceMappingURL=data:application/json,%7B%7D',
       );
 
       const coverageMap = await provider.collect({

--- a/packages/coverage-v8/tests/tsconfig.json
+++ b/packages/coverage-v8/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node", "@rstest/core/globals"]
+  },
+  "include": ["**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

This PR improves V8 coverage collection performance by skipping AST conversion for no-sourcemap scripts that coverage include/exclude rules would drop, and by caching normalized lookups for in-memory asset/source map dictionaries. This reduces repeated worker-side coverage conversion work without changing public APIs or coverage behavior.

Performance was compared with the Rsbuild repository using:

```bash
node ../rstest/packages/core/bin/rstest.js --coverage --coverage.provider v8 --trace
```

| State | real | user | sys | trace cumulative `coverage` |
| --- | ---: | ---: | ---: | ---: |
| Original baseline cold | 6.40s | 50.22s | 5.30s | 38530ms |
| Original baseline warm | 6.29s | 50.37s | 5.27s | 40378ms |
| Optimized cold | 5.17s | 40.87s | 4.41s | 26804ms |
| Optimized warm | 5.09s | 41.62s | 4.20s | 30875ms |

This is roughly a 19-20% wall-time reduction and a 20-30% reduction in traced coverage work for this benchmark.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
