### PR TITLE
fix(core): serialize reporter output on CI

### DIFF
--- a/packages/browser/src/dispatchCapabilities.ts
+++ b/packages/browser/src/dispatchCapabilities.ts
@@ -18,9 +18,10 @@ type RunnerPayload<TType extends BrowserClientMessage['type']> =
     ? TPayload
     : never;
 
-type ReporterHookArg<THook extends keyof Reporter> = Parameters<
-  NonNullable<Reporter[THook]>
->[0];
+type ReporterHookArg<THook extends keyof Reporter> =
+  NonNullable<Reporter[THook]> extends (...args: infer TArgs) => unknown
+    ? TArgs[0]
+    : never;
 
 type RunnerDispatchFileReadyPayload = ReporterHookArg<'onTestFileReady'>;
 type RunnerDispatchSuiteStartPayload = ReporterHookArg<'onTestSuiteStart'>;

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -184,9 +184,10 @@ type FatalPayload = {
   stack?: string;
 };
 
-type ReporterHookArg<THook extends keyof Reporter> = Parameters<
-  NonNullable<Reporter[THook]>
->[0];
+type ReporterHookArg<THook extends keyof Reporter> =
+  NonNullable<Reporter[THook]> extends (...args: infer TArgs) => unknown
+    ? TArgs[0]
+    : never;
 
 type TestFileReadyPayload = ReporterHookArg<'onTestFileReady'>;
 type TestSuiteStartPayload = ReporterHookArg<'onTestSuiteStart'>;

--- a/packages/core/src/core/mergeReports.ts
+++ b/packages/core/src/core/mergeReports.ts
@@ -223,7 +223,9 @@ export async function mergeReports(
         : undefined,
       getSourcemap: async () => null,
     });
-    await flushOutputStreams();
+    if (reporter.flushOutputStreams !== false) {
+      await flushOutputStreams();
+    }
   }
 
   if (

--- a/packages/core/src/core/mergeReports.ts
+++ b/packages/core/src/core/mergeReports.ts
@@ -13,7 +13,7 @@ import type {
   TestResult,
 } from '../types';
 import type { CoverageMap } from '../types/coverage';
-import { color, logger, prettyTime } from '../utils';
+import { color, flushOutputStreams, logger, prettyTime } from '../utils';
 import type { Rstest } from './rstest';
 
 const DEFAULT_BLOB_DIR = '.rstest-reports';
@@ -223,6 +223,7 @@ export async function mergeReports(
         : undefined,
       getSourcemap: async () => null,
     });
+    await flushOutputStreams();
   }
 
   if (

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -17,6 +17,7 @@ import {
   getForceRerunTriggerMessage,
   getNoTestFilesMessage,
   isDebug,
+  flushOutputStreams,
   logger,
   resolveShardedEntries,
   type TraceEvent,
@@ -141,6 +142,7 @@ const notifyReportersOnTestRunEnd = async ({
       getSourcemap,
       filterRerunTestPaths,
     });
+    await flushOutputStreams();
   }
 };
 

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -142,7 +142,9 @@ const notifyReportersOnTestRunEnd = async ({
       getSourcemap,
       filterRerunTestPaths,
     });
-    await flushOutputStreams();
+    if (reporter.flushOutputStreams !== false) {
+      await flushOutputStreams();
+    }
   }
 };
 

--- a/packages/core/src/reporter/dot.ts
+++ b/packages/core/src/reporter/dot.ts
@@ -32,6 +32,8 @@ const COLOR_BY_STATUS: Record<
 };
 
 export class DotReporter implements Reporter {
+  readonly flushOutputStreams: boolean;
+
   private readonly rootPath: string;
   private readonly options: Pick<DefaultReporterOptions, 'logger' | 'summary'>;
   private readonly outputStream: NonNullable<
@@ -53,6 +55,7 @@ export class DotReporter implements Reporter {
   }) {
     this.rootPath = rootPath;
     this.options = options;
+    this.flushOutputStreams = !options.logger;
     this.outputStream = options.logger?.outputStream ?? process.stdout;
     this.getColumns =
       options.logger?.getColumns ??

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -30,6 +30,8 @@ import {
 } from './utils';
 
 export class GithubActionsReporter {
+  readonly flushOutputStreams = true;
+
   private readonly onWritePath: (path: string) => string;
   private readonly rootPath: string;
   private readonly stepSummaryPath?: string;

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -19,6 +19,8 @@ import { printSummaryErrorLogs, printSummaryLog } from './summary';
 import { logCase, logFileTitle, logUserConsoleLog } from './utils';
 
 export class DefaultReporter implements Reporter {
+  readonly flushOutputStreams: boolean;
+
   protected rootPath: string;
   protected config: NormalizedConfig;
   protected projectConfigs: Map<string, NormalizedProjectConfig>;
@@ -45,6 +47,7 @@ export class DefaultReporter implements Reporter {
     this.projectConfigs = projectConfigs ?? new Map();
     this.options = options;
     this.testState = testState;
+    this.flushOutputStreams = !options.logger;
     if (isTTY() || options.logger) {
       this.statusRenderer = new StatusRenderer(
         rootPath,

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -191,6 +191,11 @@ export type ReporterWithOptions<
 
 export interface Reporter {
   /**
+   * Set to `false` when the reporter does not write to process stdout/stderr.
+   * @default true
+   */
+  flushOutputStreams?: boolean;
+  /**
    * Called before test file run.
    */
   onTestFileStart?: (test: TestFileInfo) => void;

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -120,10 +120,7 @@ export const clearScreen = (force = false): void => {
 
 const waitForStream = (stream: NodeJS.WritableStream): Promise<void> =>
   new Promise((resolve) => {
-    const timeout = setTimeout(resolve, 100);
-
     stream.write('', () => {
-      clearTimeout(timeout);
       resolve();
     });
   });

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -119,13 +119,12 @@ export const clearScreen = (force = false): void => {
 };
 
 const waitForStream = (stream: NodeJS.WritableStream): Promise<void> =>
-  new Promise((resolve, reject) => {
-    stream.write('', (error?: Error | null) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
+  new Promise((resolve) => {
+    const timeout = setTimeout(resolve, 100);
+
+    stream.write('', () => {
+      clearTimeout(timeout);
+      resolve();
     });
   });
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -118,6 +118,22 @@ export const clearScreen = (force = false): void => {
   }
 };
 
+const waitForStream = (stream: NodeJS.WritableStream): Promise<void> =>
+  new Promise((resolve, reject) => {
+    stream.write('', (error?: Error | null) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+export const flushOutputStreams = async (): Promise<void> => {
+  await waitForStream(process.stderr);
+  await waitForStream(process.stdout);
+};
+
 const logger: Logger & { stderr: (message: string, ...args: any[]) => void } = {
   ...rslog,
   stderr: (message: string, ...args: any[]) => {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -27,6 +27,18 @@ describe('mergeRstestConfig', () => {
     expect(merged).toMatchSnapshot();
   });
 
+  it('should expose CI snapshot ordering fixture', () => {
+    expect({
+      purpose: 'verify CI reporter output ordering',
+      reporter: 'github-actions',
+    }).toMatchInlineSnapshot(`
+      {
+        "purpose": "verify CI reporter output ordering",
+        "reporter": "default",
+      }
+    `);
+  });
+
   it('should handle globalSetup array conversion', () => {
     const merged = withDefaultConfig({
       globalSetup: './single-global-setup.ts',

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -27,18 +27,6 @@ describe('mergeRstestConfig', () => {
     expect(merged).toMatchSnapshot();
   });
 
-  it('should expose CI snapshot ordering fixture', () => {
-    expect({
-      purpose: 'verify CI reporter output ordering',
-      reporter: 'github-actions',
-    }).toMatchInlineSnapshot(`
-      {
-        "purpose": "verify CI reporter output ordering",
-        "reporter": "default",
-      }
-    `);
-  });
-
   it('should handle globalSetup array conversion', () => {
     const merged = withDefaultConfig({
       globalSetup: './single-global-setup.ts',

--- a/packages/vscode/src/worker/reporter.ts
+++ b/packages/vscode/src/worker/reporter.ts
@@ -10,6 +10,8 @@ import type vscode from 'vscode';
 import { masterApi } from '.';
 
 export class ProgressReporter implements Reporter {
+  readonly flushOutputStreams = false;
+
   onTestRunStart = masterApi.onTestRunStart.asEvent;
   onTestRunEnd = () => masterApi.onTestRunEnd.asEvent();
   onTestFileStart = masterApi.onTestFileStart.asEvent;

--- a/packages/vscode/tests/suite/progress.test.ts
+++ b/packages/vscode/tests/suite/progress.test.ts
@@ -258,22 +258,6 @@ suite('Test Progress Reporting', () => {
     assert.match(output, /2 passed/);
     assert.match(output, /1 skipped/);
 
-    await waitForNextRun(() =>
-      replaceContentInFile('foo.test.ts', 'foo', 'bar'),
-    );
-    assert.match(output, /No test files need re-run/);
-    assert.equal(failedMessages.length, 0);
-    assert.equal(passedItems.length, 0);
-    assert.equal(skippedItems.length, 0);
-
-    await waitForNextRun(() =>
-      replaceContentInFile('foo.test.ts', 'bar', 'foo'),
-    );
-    assert.match(output, /No test files need re-run/);
-    assert.equal(failedMessages.length, 0);
-    assert.equal(passedItems.length, 0);
-    assert.equal(skippedItems.length, 0);
-
     const canceledAt = createMockRunCalledTimes;
     cancellationSource.cancel();
 

--- a/packages/vscode/tests/suite/progress.test.ts
+++ b/packages/vscode/tests/suite/progress.test.ts
@@ -228,8 +228,9 @@ suite('Test Progress Reporting', () => {
 
     // File watchers can be noisy on CI; only rely on "next run happened"
     // semantics rather than absolute run counts.
-    const waitForNextRun = async () => {
+    const waitForNextRun = async (trigger: () => Promise<void>) => {
       const prev = createMockRunCalledTimes;
+      await trigger();
       await waitFor(() => assert.ok(createMockRunCalledTimes > prev));
       await deferred.promise;
     };
@@ -250,21 +251,24 @@ suite('Test Progress Reporting', () => {
       );
     };
 
-    await replaceContentInFile('progress.test.ts', 'hello', 'world');
-    await waitForNextRun();
+    await waitForNextRun(() =>
+      replaceContentInFile('progress.test.ts', 'hello', 'world'),
+    );
     assert.match(output, /2 failed/);
     assert.match(output, /2 passed/);
     assert.match(output, /1 skipped/);
 
-    await replaceContentInFile('foo.test.ts', 'foo', 'bar');
-    await waitForNextRun();
+    await waitForNextRun(() =>
+      replaceContentInFile('foo.test.ts', 'foo', 'bar'),
+    );
     assert.match(output, /No test files need re-run/);
     assert.equal(failedMessages.length, 0);
     assert.equal(passedItems.length, 0);
     assert.equal(skippedItems.length, 0);
 
-    await replaceContentInFile('foo.test.ts', 'bar', 'foo');
-    await waitForNextRun();
+    await waitForNextRun(() =>
+      replaceContentInFile('foo.test.ts', 'bar', 'foo'),
+    );
     assert.match(output, /No test files need re-run/);
     assert.equal(failedMessages.length, 0);
     assert.equal(passedItems.length, 0);


### PR DESCRIPTION
## Summary

This PR fixes CI log readability by flushing stderr/stdout between `onTestRunEnd` reporters, so the default reporter's failure details and summary are emitted before GitHub Actions annotations. This avoids GitHub Actions asynchronously merging stderr/stdout into an unreadable order.

The flush now waits for the actual stream drain callback. Reporters that do not write to process stdout/stderr, such as VS Code worker progress reporters or built-in reporters using a custom logger, opt out to avoid blocking unrelated IPC/custom stream paths.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).