### PR TITLE
ci: tolerate Playwright browser cache failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
           fi
 
       - name: Cache Playwright Browsers
+        continue-on-error: true
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
@@ -215,6 +216,7 @@ jobs:
           fi
 
       - name: Cache Playwright Browsers
+        continue-on-error: true
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}


### PR DESCRIPTION
## Summary

This PR prevents transient `actions/cache` restore failures for Playwright browser binaries from blocking the test workflow before browser installation and E2E tests can run. The Playwright browser cache is only a performance optimization, so both unit-test and E2E jobs now continue when that cache step fails and fall back to `npx playwright install chromium webkit`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).