### PR TITLE
fix(core): disable memory gate for threads pool

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -28,7 +28,7 @@ import {
 } from '../utils';
 import type { TraceEvent } from '../utils/trace';
 import { isMemorySufficient } from '../utils/memory';
-import { createDefaultMemoryGate } from './memoryGate';
+import { selectMemoryGate } from './memoryGate';
 import { Pool } from './pool';
 import type { PoolWorkerKind } from './types';
 
@@ -384,7 +384,7 @@ export const createPool = async ({
       ...getForceColorEnv(),
       ...process.env,
     } as Record<string, string>,
-    memoryGate: createDefaultMemoryGate(),
+    memoryGate: selectMemoryGate(workerKind),
   });
 
   const createRpcMethods = ({

--- a/packages/core/src/pool/memoryGate.ts
+++ b/packages/core/src/pool/memoryGate.ts
@@ -241,3 +241,23 @@ export const createDefaultMemoryGate = (): MemoryGate | undefined => {
   if (process.env.RSTEST_MEMORY_AWARE === '0') return undefined;
   return new MemoryGate();
 };
+
+/**
+ * Decide whether the memory-aware spawn gate applies to a given pool transport.
+ *
+ * Only `forks` is supported. The gate's per-worker RSS sampling assumes each
+ * worker reports its own resident memory — which holds for `child_process.fork`
+ * but not for `worker_threads`, where `process.memoryUsage().rss` returns the
+ * *entire host process* RSS shared across all threads. Feeding those inflated
+ * samples into the gate collapses thread-pool parallelism to 1–2 workers.
+ * See rstest#1301.
+ *
+ * The `makeGate` indirection exists for unit testing only; production callers
+ * use the default `createDefaultMemoryGate`.
+ */
+export const selectMemoryGate = (
+  workerKind: 'forks' | 'threads',
+  makeGate: () => MemoryGate | undefined = createDefaultMemoryGate,
+): MemoryGate | undefined => {
+  return workerKind === 'forks' ? makeGate() : undefined;
+};

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -1,4 +1,5 @@
 import './setup';
+import { isMainThread } from 'node:worker_threads';
 import {
   isWorkerRequestEnvelope,
   serializeError,
@@ -63,9 +64,12 @@ const RESPONSE_TYPE: Record<TaskKind, 'runFinished' | 'collectFinished'> = {
   collect: 'collectFinished',
 };
 
-// Read once at worker bootstrap — toggling `RSTEST_MEMORY_AWARE` mid-run is
-// not supported (host samples it at pool construction too).
-const MEMORY_REPORTING_ENABLED = process.env.RSTEST_MEMORY_AWARE !== '0';
+// Skip RSS reporting for thread workers — `process.memoryUsage().rss` is
+// host-wide and would mislead the gate. See rstest#1301. Read once at
+// bootstrap; toggling `RSTEST_MEMORY_AWARE` mid-run is not supported (host
+// samples it at pool construction too).
+const MEMORY_REPORTING_ENABLED =
+  isMainThread && process.env.RSTEST_MEMORY_AWARE !== '0';
 
 const runTask = async (
   kind: TaskKind,

--- a/packages/core/tests/pool/memoryGate.test.ts
+++ b/packages/core/tests/pool/memoryGate.test.ts
@@ -1,5 +1,9 @@
 import v8 from 'node:v8';
-import { MemoryGate, createDefaultMemoryGate } from '../../src/pool/memoryGate';
+import {
+  MemoryGate,
+  createDefaultMemoryGate,
+  selectMemoryGate,
+} from '../../src/pool/memoryGate';
 
 const MB = 1024 * 1024;
 
@@ -188,5 +192,26 @@ describe('createDefaultMemoryGate', () => {
     } finally {
       if (prev !== undefined) process.env.RSTEST_MEMORY_AWARE = prev;
     }
+  });
+});
+
+// Locks the rstest#1301 regression: the gate's per-worker RSS sampling premise
+// (each worker reports its own resident memory) is only valid for fork-based
+// pools. For `worker_threads`, `process.memoryUsage().rss` returns the entire
+// host process RSS, which would collapse thread-pool parallelism if fed to the
+// gate. Keep this rule trivially testable so it cannot silently regress.
+describe('selectMemoryGate', () => {
+  it('should attach the gate for the forks pool', () => {
+    const sentinel = new MemoryGate();
+    expect(selectMemoryGate('forks', () => sentinel)).toBe(sentinel);
+  });
+
+  it('should NOT attach the gate for the threads pool, even when one is available', () => {
+    const sentinel = new MemoryGate();
+    expect(selectMemoryGate('threads', () => sentinel)).toBeUndefined();
+  });
+
+  it('should still respect the factory opt-out for forks (e.g. RSTEST_MEMORY_AWARE=0)', () => {
+    expect(selectMemoryGate('forks', () => undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The memory-aware spawn gate added in #1246 over-blocks the threads pool added in #1235: workers running in `worker_threads` report `process.memoryUsage().rss`, which returns the *entire host process* RSS shared across all threads — not per-worker memory. The gate samples those inflated values, p90 quickly exceeds the spawn threshold, and pool parallelism collapses to 1–2 workers, making `pool.type: 'threads'` ~3× slower than `'forks'` on small-to-medium suites.

Scope the gate to the forks pool, where each worker is a distinct process and RSS sampling is correct. Worker-side reporting is also short-circuited on `worker_threads` to skip the syscall and keep the protocol payload consistent with what the host actually consumes. The threads pool's own host-memory safety (cgroup limits, V8 heap headroom) is a separate design and out of scope.

A small unit-test seam (`selectMemoryGate`) pins the forks-only rule so it cannot silently regress.

## Related Links

- Closes #1301
- Introduced by #1246
- Threads pool: #1235

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).