### PR TITLE
chore: include coverage-v8 in bump group

### DIFF
--- a/bump.config.mts
+++ b/bump.config.mts
@@ -14,6 +14,7 @@ export const packageGroups: Record<string, PackageGroup> = {
       'packages/browser/package.json',
       'packages/browser-react/package.json',
       'packages/coverage-istanbul/package.json',
+      'packages/coverage-v8/package.json',
       'packages/adapter-rslib/package.json',
       'packages/adapter-rsbuild/package.json',
       'packages/adapter-rspack/package.json',

--- a/packages/coverage-v8/README.md
+++ b/packages/coverage-v8/README.md
@@ -1,0 +1,28 @@
+<picture>
+  <img alt="Rstest Banner" src="https://assets.rspack.rs/rstest/rstest-banner.png">
+</picture>
+
+# @rstest/coverage-v8
+
+[V8](https://v8.dev/) coverage provider for Rstest.
+
+## Install
+
+```bash
+npm add @rstest/coverage-v8 -D
+```
+
+## Usage
+
+Enable coverage collection in `rstest.config.ts`:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    provider: 'v8',
+  },
+});
+```

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "V8 coverage provider for Rstest",
   "type": "module",
+  "license": "MIT",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -2,8 +2,8 @@
   "name": "@rstest/coverage-v8",
   "version": "0.3.0",
   "description": "V8 coverage provider for Rstest",
-  "type": "module",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

This PR adds `packages/coverage-v8/package.json` to the Rstest packages bump group so coverage-v8 is versioned together with the rest of the Rstest packages. It also adds a README for `@rstest/coverage-v8` matching the `@rstest/coverage-istanbul` package README structure.

## Related Links

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).