### PR TITLE
fix(core): flush before final summary output

### DIFF
--- a/packages/core/src/reporter/dot.ts
+++ b/packages/core/src/reporter/dot.ts
@@ -114,7 +114,7 @@ export class DotReporter implements Reporter {
       filterRerunTestPaths,
     });
 
-    if (hasErrorLogs) {
+    if (hasErrorLogs && this.flushOutputStreams) {
       await flushOutputStreams();
     }
 

--- a/packages/core/src/reporter/dot.ts
+++ b/packages/core/src/reporter/dot.ts
@@ -105,7 +105,7 @@ export class DotReporter implements Reporter {
       return;
     }
 
-    await printSummaryErrorLogs({
+    const hasErrorLogs = await printSummaryErrorLogs({
       testResults,
       results,
       unhandledErrors,
@@ -120,6 +120,7 @@ export class DotReporter implements Reporter {
       duration,
       rootPath: this.rootPath,
       snapshotSummary,
+      output: hasErrorLogs ? 'stderr' : 'stdout',
     });
   }
 

--- a/packages/core/src/reporter/dot.ts
+++ b/packages/core/src/reporter/dot.ts
@@ -10,7 +10,7 @@ import type {
   TestResult,
   UserConsoleLog,
 } from '../types';
-import { color } from '../utils';
+import { color, flushOutputStreams } from '../utils';
 import { printSummaryErrorLogs, printSummaryLog } from './summary';
 import { logUserConsoleLog } from './utils';
 
@@ -114,13 +114,16 @@ export class DotReporter implements Reporter {
       filterRerunTestPaths,
     });
 
+    if (hasErrorLogs) {
+      await flushOutputStreams();
+    }
+
     printSummaryLog({
       results,
       testResults,
       duration,
       rootPath: this.rootPath,
       snapshotSummary,
-      output: hasErrorLogs ? 'stderr' : 'stdout',
     });
   }
 

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -12,7 +12,7 @@ import type {
   TestResult,
   UserConsoleLog,
 } from '../types';
-import { isTTY } from '../utils';
+import { flushOutputStreams, isTTY } from '../utils';
 import { NonTTYProgressNotifier } from './nonTtyProgressNotifier';
 import { StatusRenderer } from './statusRenderer';
 import { printSummaryErrorLogs, printSummaryLog } from './summary';
@@ -171,13 +171,16 @@ export class DefaultReporter implements Reporter {
       filterRerunTestPaths,
     });
 
+    if (hasErrorLogs) {
+      await flushOutputStreams();
+    }
+
     printSummaryLog({
       results,
       testResults,
       duration,
       rootPath: this.rootPath,
       snapshotSummary,
-      output: hasErrorLogs ? 'stderr' : 'stdout',
     });
   }
 }

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -162,7 +162,7 @@ export class DefaultReporter implements Reporter {
       return;
     }
 
-    await printSummaryErrorLogs({
+    const hasErrorLogs = await printSummaryErrorLogs({
       testResults,
       results,
       unhandledErrors,
@@ -177,6 +177,7 @@ export class DefaultReporter implements Reporter {
       duration,
       rootPath: this.rootPath,
       snapshotSummary,
+      output: hasErrorLogs ? 'stderr' : 'stdout',
     });
   }
 }

--- a/packages/core/src/reporter/index.ts
+++ b/packages/core/src/reporter/index.ts
@@ -171,7 +171,7 @@ export class DefaultReporter implements Reporter {
       filterRerunTestPaths,
     });
 
-    if (hasErrorLogs) {
+    if (hasErrorLogs && this.flushOutputStreams) {
       await flushOutputStreams();
     }
 

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -96,17 +96,10 @@ export const getPlainSummaryStatusString = (
  * This method is modified based on source found in
  * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/node/reporters/renderers/utils.ts#L67
  */
-type SummaryOutput = 'stderr' | 'stdout';
-
-const getSummaryLogger = (output: SummaryOutput) =>
-  output === 'stderr' ? logger.stderr : logger.log;
-
 const printSnapshotSummaryLog = (
   snapshots: SnapshotSummary,
   rootDir: string,
-  output: SummaryOutput,
 ): void => {
-  const log = getSummaryLogger(output);
   const summary: string[] = [];
 
   if (snapshots.added) {
@@ -159,7 +152,7 @@ const printSnapshotSummaryLog = (
 
   for (const [index, snapshot] of summary.entries()) {
     const title = index === 0 ? 'Snapshots' : '';
-    log(`${color.gray(title.padStart(12))} ${snapshot}`);
+    logger.log(`${color.gray(title.padStart(12))} ${snapshot}`);
   }
 };
 
@@ -175,26 +168,22 @@ export const printSummaryLog = ({
   snapshotSummary,
   duration,
   rootPath,
-  output = 'stdout',
 }: {
   results: TestFileResult[];
   testResults: TestResult[];
   snapshotSummary: SnapshotSummary;
   duration: Duration;
   rootPath: string;
-  output?: SummaryOutput;
 }): void => {
-  const log = getSummaryLogger(output);
+  logger.log('');
+  printSnapshotSummaryLog(snapshotSummary, rootPath);
+  logger.log(`${TestFileSummaryLabel} ${getSummaryStatusString(results)}`);
+  logger.log(`${TestSummaryLabel} ${getSummaryStatusString(testResults)}`);
 
-  log('');
-  printSnapshotSummaryLog(snapshotSummary, rootPath, output);
-  log(`${TestFileSummaryLabel} ${getSummaryStatusString(results)}`);
-  log(`${TestSummaryLabel} ${getSummaryStatusString(testResults)}`);
-
-  log(
+  logger.log(
     `${DurationLabel} ${prettyTime(duration.totalTime)} ${color.gray(`(build ${prettyTime(duration.buildTime)}, tests ${prettyTime(duration.testTime)})`)}`,
   );
-  log('');
+  logger.log('');
 };
 
 export const printSummaryErrorLogs = async ({

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -96,10 +96,17 @@ export const getPlainSummaryStatusString = (
  * This method is modified based on source found in
  * https://github.com/vitest-dev/vitest/blob/e8ce94cfb5520a8b69f9071cc5638a53129130d6/packages/vitest/src/node/reporters/renderers/utils.ts#L67
  */
+type SummaryOutput = 'stderr' | 'stdout';
+
+const getSummaryLogger = (output: SummaryOutput) =>
+  output === 'stderr' ? logger.stderr : logger.log;
+
 const printSnapshotSummaryLog = (
   snapshots: SnapshotSummary,
   rootDir: string,
+  output: SummaryOutput,
 ): void => {
+  const log = getSummaryLogger(output);
   const summary: string[] = [];
 
   if (snapshots.added) {
@@ -152,7 +159,7 @@ const printSnapshotSummaryLog = (
 
   for (const [index, snapshot] of summary.entries()) {
     const title = index === 0 ? 'Snapshots' : '';
-    logger.log(`${color.gray(title.padStart(12))} ${snapshot}`);
+    log(`${color.gray(title.padStart(12))} ${snapshot}`);
   }
 };
 
@@ -168,22 +175,26 @@ export const printSummaryLog = ({
   snapshotSummary,
   duration,
   rootPath,
+  output = 'stdout',
 }: {
   results: TestFileResult[];
   testResults: TestResult[];
   snapshotSummary: SnapshotSummary;
   duration: Duration;
   rootPath: string;
+  output?: SummaryOutput;
 }): void => {
-  logger.log('');
-  printSnapshotSummaryLog(snapshotSummary, rootPath);
-  logger.log(`${TestFileSummaryLabel} ${getSummaryStatusString(results)}`);
-  logger.log(`${TestSummaryLabel} ${getSummaryStatusString(testResults)}`);
+  const log = getSummaryLogger(output);
 
-  logger.log(
+  log('');
+  printSnapshotSummaryLog(snapshotSummary, rootPath, output);
+  log(`${TestFileSummaryLabel} ${getSummaryStatusString(results)}`);
+  log(`${TestSummaryLabel} ${getSummaryStatusString(testResults)}`);
+
+  log(
     `${DurationLabel} ${prettyTime(duration.totalTime)} ${color.gray(`(build ${prettyTime(duration.buildTime)}, tests ${prettyTime(duration.testTime)})`)}`,
   );
-  logger.log('');
+  log('');
 };
 
 export const printSummaryErrorLogs = async ({
@@ -200,7 +211,7 @@ export const printSummaryErrorLogs = async ({
   getSourcemap: GetSourcemap;
   filterRerunTestPaths?: string[];
   unhandledErrors?: Error[];
-}): Promise<void> => {
+}): Promise<boolean> => {
   const failedTests: TestResult[] = [
     ...results.filter(
       (i) =>
@@ -220,7 +231,7 @@ export const printSummaryErrorLogs = async ({
   ];
 
   if (failedTests.length === 0 && !unhandledErrors?.length) {
-    return;
+    return false;
   }
 
   logger.stderr('');
@@ -249,4 +260,6 @@ export const printSummaryErrorLogs = async ({
       }
     }
   }
+
+  return true;
 };

--- a/packages/core/tests/reporter/summary.test.ts
+++ b/packages/core/tests/reporter/summary.test.ts
@@ -1,0 +1,180 @@
+import { stripVTControlCharacters } from 'node:util';
+import { describe, expect, it, onTestFinished, rs } from '@rstest/core';
+import { DefaultReporter } from '../../src/reporter/index';
+import type {
+  Duration,
+  NormalizedConfig,
+  RstestTestState,
+  SnapshotSummary,
+  TestFileResult,
+  TestResult,
+} from '../../src/types';
+
+const baseConfig = {
+  hideSkippedTestFiles: false,
+  hideSkippedTests: false,
+  slowTestThreshold: 300,
+} as NormalizedConfig;
+
+const emptySnapshotSummary: SnapshotSummary = {
+  added: 0,
+  didUpdate: false,
+  failure: false,
+  filesAdded: 0,
+  filesRemoved: 0,
+  filesRemovedList: [],
+  filesUnmatched: 0,
+  filesUpdated: 0,
+  matched: 0,
+  total: 0,
+  unchecked: 0,
+  uncheckedKeysByFile: [],
+  unmatched: 0,
+  updated: 0,
+};
+
+const duration: Duration = {
+  totalTime: 500,
+  buildTime: 100,
+  testTime: 300,
+};
+
+const createTestState = (results: TestFileResult[]): RstestTestState => ({
+  getRunningModules: () => new Map(),
+  getTestModules: () => results,
+  getTestFiles: () => results.map((result) => result.testPath),
+});
+
+const createFailureResults = () => {
+  const testResult: TestResult = {
+    status: 'fail',
+    name: 'should fail',
+    testPath: '/test/root/example.test.ts',
+    duration: 200,
+    errors: [
+      {
+        message: 'Snapshot `example 1` mismatched',
+        name: 'Error',
+        diff: '- Expected\n+ Received',
+      },
+    ],
+    parentNames: ['suite'],
+    project: 'default',
+    testId: 'case-1',
+  };
+
+  const fileResult: TestFileResult = {
+    status: 'fail',
+    name: 'example.test.ts',
+    testPath: '/test/root/example.test.ts',
+    duration: 300,
+    errors: testResult.errors,
+    results: [testResult],
+    project: 'default',
+    testId: 'file-1',
+  };
+
+  return { fileResult, testResult };
+};
+
+describe('DefaultReporter summary streams', () => {
+  it('prints failure details and summary to stderr when the run failed', async () => {
+    const { fileResult, testResult } = createFailureResults();
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    rs.spyOn(console, 'log').mockImplementation((...args) => {
+      stdout.push(args.join(' '));
+    });
+    rs.spyOn(console, 'error').mockImplementation((...args) => {
+      stderr.push(args.join(' '));
+    });
+
+    onTestFinished(() => {
+      rs.resetAllMocks();
+    });
+
+    const reporter = new DefaultReporter({
+      rootPath: '/test/root',
+      config: baseConfig,
+      options: {},
+      testState: createTestState([fileResult]),
+    });
+
+    await reporter.onTestRunEnd({
+      results: [fileResult],
+      testResults: [testResult],
+      duration,
+      snapshotSummary: {
+        ...emptySnapshotSummary,
+        unmatched: 1,
+      },
+      getSourcemap: async () => null,
+    });
+
+    const stderrText = stripVTControlCharacters(stderr.join('\n'));
+
+    expect(stdout).toEqual([]);
+    expect(stderrText).toContain('Summary of all failing tests:');
+    expect(stderrText).toContain('FAIL  example.test.ts > suite > should fail');
+    expect(stderrText).toContain('Snapshots 1 failed');
+    expect(stderrText).toContain('Test Files 1 failed');
+    expect(stderrText).toContain('Tests 1 failed');
+    expect(stderrText).toContain('Duration 500ms (build 100ms, tests 300ms)');
+  });
+
+  it('keeps the summary on stdout when there are no failures', async () => {
+    const testResult: TestResult = {
+      status: 'pass',
+      name: 'should pass',
+      testPath: '/test/root/example.test.ts',
+      duration: 200,
+      project: 'default',
+      testId: 'case-1',
+    };
+    const fileResult: TestFileResult = {
+      status: 'pass',
+      name: 'example.test.ts',
+      testPath: '/test/root/example.test.ts',
+      duration: 300,
+      results: [testResult],
+      project: 'default',
+      testId: 'file-1',
+    };
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    rs.spyOn(console, 'log').mockImplementation((...args) => {
+      stdout.push(args.join(' '));
+    });
+    rs.spyOn(console, 'error').mockImplementation((...args) => {
+      stderr.push(args.join(' '));
+    });
+
+    onTestFinished(() => {
+      rs.resetAllMocks();
+    });
+
+    const reporter = new DefaultReporter({
+      rootPath: '/test/root',
+      config: baseConfig,
+      options: {},
+      testState: createTestState([fileResult]),
+    });
+
+    await reporter.onTestRunEnd({
+      results: [fileResult],
+      testResults: [testResult],
+      duration,
+      snapshotSummary: emptySnapshotSummary,
+      getSourcemap: async () => null,
+    });
+
+    const stdoutText = stripVTControlCharacters(stdout.join('\n'));
+
+    expect(stderr).toEqual([]);
+    expect(stdoutText).toContain('Test Files 1 passed');
+    expect(stdoutText).toContain('Tests 1 passed');
+    expect(stdoutText).toContain('Duration 500ms (build 100ms, tests 300ms)');
+  });
+});

--- a/packages/core/tests/reporter/summary.test.ts
+++ b/packages/core/tests/reporter/summary.test.ts
@@ -77,22 +77,52 @@ const createFailureResults = () => {
   return { fileResult, testResult };
 };
 
+const spyOnConsole = () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  rs.spyOn(console, 'log').mockImplementation((...args) => {
+    stdout.push(args.join(' '));
+  });
+  rs.spyOn(console, 'error').mockImplementation((...args) => {
+    stderr.push(args.join(' '));
+  });
+
+  onTestFinished(() => {
+    rs.resetAllMocks();
+  });
+
+  return { stdout, stderr };
+};
+
 describe('DefaultReporter summary streams', () => {
-  it('prints failure details and summary to stderr when the run failed', async () => {
+  it('flushes error output before printing the failed summary to stdout', async () => {
     const { fileResult, testResult } = createFailureResults();
-    const stdout: string[] = [];
-    const stderr: string[] = [];
+    const { stdout, stderr } = spyOnConsole();
+    const writes: string[] = [];
 
-    rs.spyOn(console, 'log').mockImplementation((...args) => {
-      stdout.push(args.join(' '));
-    });
-    rs.spyOn(console, 'error').mockImplementation((...args) => {
-      stderr.push(args.join(' '));
-    });
-
-    onTestFinished(() => {
-      rs.resetAllMocks();
-    });
+    rs.spyOn(process.stderr, 'write').mockImplementation(
+      (_chunk, _encoding, callback) => {
+        writes.push('flush stderr');
+        if (typeof _encoding === 'function') {
+          _encoding();
+        } else {
+          callback?.();
+        }
+        return true;
+      },
+    );
+    rs.spyOn(process.stdout, 'write').mockImplementation(
+      (_chunk, _encoding, callback) => {
+        writes.push('flush stdout');
+        if (typeof _encoding === 'function') {
+          _encoding();
+        } else {
+          callback?.();
+        }
+        return true;
+      },
+    );
 
     const reporter = new DefaultReporter({
       rootPath: '/test/root',
@@ -113,14 +143,16 @@ describe('DefaultReporter summary streams', () => {
     });
 
     const stderrText = stripVTControlCharacters(stderr.join('\n'));
+    const stdoutText = stripVTControlCharacters(stdout.join('\n'));
 
-    expect(stdout).toEqual([]);
+    expect(writes).toEqual(['flush stderr', 'flush stdout']);
     expect(stderrText).toContain('Summary of all failing tests:');
     expect(stderrText).toContain('FAIL  example.test.ts > suite > should fail');
-    expect(stderrText).toContain('Snapshots 1 failed');
-    expect(stderrText).toContain('Test Files 1 failed');
-    expect(stderrText).toContain('Tests 1 failed');
-    expect(stderrText).toContain('Duration 500ms (build 100ms, tests 300ms)');
+    expect(stderrText).toContain('Error: Snapshot `example 1` mismatched');
+    expect(stdoutText).toContain('Snapshots 1 failed');
+    expect(stdoutText).toContain('Test Files 1 failed');
+    expect(stdoutText).toContain('Tests 1 failed');
+    expect(stdoutText).toContain('Duration 500ms (build 100ms, tests 300ms)');
   });
 
   it('keeps the summary on stdout when there are no failures', async () => {
@@ -141,19 +173,8 @@ describe('DefaultReporter summary streams', () => {
       project: 'default',
       testId: 'file-1',
     };
-    const stdout: string[] = [];
-    const stderr: string[] = [];
-
-    rs.spyOn(console, 'log').mockImplementation((...args) => {
-      stdout.push(args.join(' '));
-    });
-    rs.spyOn(console, 'error').mockImplementation((...args) => {
-      stderr.push(args.join(' '));
-    });
-
-    onTestFinished(() => {
-      rs.resetAllMocks();
-    });
+    const { stdout, stderr } = spyOnConsole();
+    const write = rs.spyOn(process.stdout, 'write');
 
     const reporter = new DefaultReporter({
       rootPath: '/test/root',
@@ -173,6 +194,7 @@ describe('DefaultReporter summary streams', () => {
     const stdoutText = stripVTControlCharacters(stdout.join('\n'));
 
     expect(stderr).toEqual([]);
+    expect(write).not.toHaveBeenCalled();
     expect(stdoutText).toContain('Test Files 1 passed');
     expect(stdoutText).toContain('Tests 1 passed');
     expect(stdoutText).toContain('Duration 500ms (build 100ms, tests 300ms)');

--- a/packages/core/tests/reporter/summary.test.ts
+++ b/packages/core/tests/reporter/summary.test.ts
@@ -155,6 +155,43 @@ describe('DefaultReporter summary streams', () => {
     expect(stdoutText).toContain('Duration 500ms (build 100ms, tests 300ms)');
   });
 
+  it('does not flush process streams when using a custom logger', async () => {
+    const { fileResult, testResult } = createFailureResults();
+    const { stdout, stderr } = spyOnConsole();
+    const stdoutWrite = rs.spyOn(process.stdout, 'write');
+    const stderrWrite = rs.spyOn(process.stderr, 'write');
+
+    const reporter = new DefaultReporter({
+      rootPath: '/test/root',
+      config: baseConfig,
+      options: {
+        logger: {
+          outputStream: process.stdout,
+          errorStream: process.stderr,
+          getColumns: () => 80,
+        },
+      },
+      testState: createTestState([fileResult]),
+    });
+
+    await reporter.onTestRunEnd({
+      results: [fileResult],
+      testResults: [testResult],
+      duration,
+      snapshotSummary: emptySnapshotSummary,
+      getSourcemap: async () => null,
+    });
+
+    expect(stdoutWrite).not.toHaveBeenCalled();
+    expect(stderrWrite).not.toHaveBeenCalled();
+    expect(stripVTControlCharacters(stderr.join('\n'))).toContain(
+      'Summary of all failing tests:',
+    );
+    expect(stripVTControlCharacters(stdout.join('\n'))).toContain(
+      'Test Files 1 failed',
+    );
+  });
+
   it('keeps the summary on stdout when there are no failures', async () => {
     const testResult: TestResult = {
       status: 'pass',


### PR DESCRIPTION
## Summary

- preserve the existing stdout/stderr split: failure details stay on stderr, final summary stays on stdout
- flush stderr/stdout after failure details before printing the final summary
- cover the failed summary path so regressions catch missing stream flushing


before:
https://github.com/web-infra-dev/rstest/actions/runs/26276046866/job/77341429699?pr=1302
<img width="1183" height="550" alt="image" src="https://github.com/user-attachments/assets/e0cad07a-37a7-4279-8b94-ca64d3084548" />


after:
https://github.com/web-infra-dev/rstest/actions/runs/26277861169/job/77346767655?pr=1310

<img width="877" height="555" alt="image" src="https://github.com/user-attachments/assets/180c6314-5da8-4777-9c53-a11f64b5f8f2" />

## Validation

- `node_modules/.bin/rstest packages/core/tests/reporter/summary.test.ts packages/core/tests/reporter/githubActions.test.ts`
- `node_modules/.bin/rstest packages/core/tests/reporter/summary.test.ts packages/core/tests/reporter/githubActions.test.ts packages/core/tests/reporter/json.test.ts packages/core/tests/reporter/junit.test.ts packages/core/tests/reporter/md.test.ts`
- `node_modules/.bin/prettier --check packages/core/src/reporter/summary.ts packages/core/src/reporter/index.ts packages/core/src/reporter/dot.ts packages/core/tests/reporter/summary.test.ts`
- `node_modules/.bin/knip`
- `git diff --check`