### PR TITLE
release: 0.10.2

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,7 +1,20 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "V8 coverage provider for Rstest",
+  "keywords": [
+    "rstest",
+    "coverage",
+    "v8"
+  ],
+  "bugs": {
+    "url": "https://github.com/web-infra-dev/rstest/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rstest",
+    "directory": "packages/coverage-v8"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -42,5 +55,9 @@
   },
   "peerDependencies": {
     "@rstest/core": "workspace:~"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
## What's Changed
### New Features 🎉
* feat: implement V8 coverage provider by @colinaaa in https://github.com/web-infra-dev/rstest/pull/1117
* feat(core): support using for mock restore by @9aoy in https://github.com/web-infra-dev/rstest/pull/1293
* feat(core): trace coverage pipeline by @9aoy in https://github.com/web-infra-dev/rstest/pull/1297
* feat(core): make --reporters the canonical CLI flag by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1299
### Performance 🚀
* perf(coverage-istanbul): optimize sourcemap URL scanning by @9aoy in https://github.com/web-infra-dev/rstest/pull/1296
* perf(coverage-v8): skip unnecessary coverage conversion by @9aoy in https://github.com/web-infra-dev/rstest/pull/1298
### Bug Fixes 🐞
* fix(core): normalize mixed nested CLI options by @9aoy in https://github.com/web-infra-dev/rstest/pull/1290
* fix(core): serialize reporter output on CI by @9aoy in https://github.com/web-infra-dev/rstest/pull/1304
* fix(core): surface fatal-error stack on worker IPC drop by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1306
* fix(core): disable memory gate for threads pool by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1307
* fix(core): flush before final summary output by @9aoy in https://github.com/web-infra-dev/rstest/pull/1309
### Document 📖
* docs: fix Vitest migration table formatting by @9aoy in https://github.com/web-infra-dev/rstest/pull/1295
### Other Changes
* ci: tolerate Playwright browser cache failures by @9aoy in https://github.com/web-infra-dev/rstest/pull/1305

## New Contributors
* @colinaaa made their first contribution in https://github.com/web-infra-dev/rstest/pull/1117

**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.10.1...v0.10.2