### PR TITLE
fix(core): handle stream write callbacks in status renderer

### DIFF
--- a/packages/core/src/reporter/windowedRenderer.ts
+++ b/packages/core/src/reporter/windowedRenderer.ts
@@ -206,7 +206,10 @@ export class WindowRenderer {
     const original = stream.write.bind(stream);
 
     // @ts-expect-error -- not sure how 2 overloads should be typed
-    stream.write = (chunk, _, callback) => {
+    stream.write = (chunk, encoding, callback) => {
+      const writeCallback =
+        typeof encoding === 'function' ? encoding : callback;
+
       if (chunk) {
         if (this.finished || !this.started || this.hiddenForOutputCount > 0) {
           this.write(chunk.toString(), type);
@@ -214,7 +217,8 @@ export class WindowRenderer {
           this.buffer.push({ type, message: chunk.toString() });
         }
       }
-      callback?.();
+      writeCallback?.();
+      return true;
     };
 
     return function restore() {

--- a/packages/core/tests/reporter/windowedRenderer.test.ts
+++ b/packages/core/tests/reporter/windowedRenderer.test.ts
@@ -1,0 +1,39 @@
+import { Writable } from 'node:stream';
+import { describe, expect, it, onTestFinished } from '@rstest/core';
+import { WindowRenderer } from '../../src/reporter/windowedRenderer';
+import { flushOutputStreams } from '../../src/utils/logger';
+
+const createWritable = () =>
+  new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+
+describe('WindowRenderer', () => {
+  it('does not block stream flushing when write callback is the second argument', async () => {
+    const renderer = new WindowRenderer({
+      getWindow: () => [],
+      logger: {
+        outputStream: createWritable(),
+        errorStream: createWritable(),
+        getColumns: () => 80,
+      },
+    });
+
+    onTestFinished(() => {
+      renderer.stop();
+    });
+
+    renderer.start();
+
+    const flushed = await Promise.race([
+      flushOutputStreams().then(() => true),
+      new Promise<boolean>((resolve) => {
+        setTimeout(() => resolve(false), 100);
+      }),
+    ]);
+
+    expect(flushed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes an unexpected `Rstest exited unexpectedly with code 0` termination when the status renderer intercepts output streams. `WindowRenderer` now handles the `stream.write(chunk, callback)` overload, so `flushOutputStreams()` can resolve its callback instead of leaving the run pending while Node exits cleanly.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).