### PR TITLE
docs: split console config group

### DIFF
--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -74,13 +74,18 @@ const OVERVIEW_GROUPS: BasicGroup[] = [
     items: [
       'coverage',
       'reporters',
-      'silent',
       'includeTaskLocation',
       'logHeapUsage',
       'hideSkippedTests',
       'hideSkippedTestFiles',
       'slowTestThreshold',
       'chaiConfig',
+    ],
+  },
+  {
+    name: 'console',
+    items: [
+      'silent',
       'onConsoleLog',
       'printConsoleTrace',
       'disableConsoleIntercept',


### PR DESCRIPTION
## Summary

This PR optimizes the Rstest config overview grouping by moving console-specific options out of the broader `output` group. `silent`, `onConsoleLog`, `printConsoleTrace`, and `disableConsoleIntercept` now appear under a dedicated `console` group, while reporter and result-output options remain under `output`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).