### PR TITLE
perf(coverage): speed up coverage map merges

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -3,17 +3,16 @@ import type {
   CoverageProvider as RstestCoverageProvider,
 } from '@rstest/core';
 import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage';
-import istanbulLibCoverage from 'istanbul-lib-coverage';
 import { createContext } from 'istanbul-lib-report';
 import reports from 'istanbul-reports';
 import {
+  createFastCoverageMap,
   mapWithConcurrency,
   readInitialCoverage,
   registerSourceMapURL,
   transformCoverage,
 } from './utils';
 
-const { createCoverageMap } = istanbulLibCoverage;
 const UNTESTED_FILES_CONCURRENCY = 4;
 
 // Global type declaration for coverage
@@ -22,7 +21,7 @@ declare global {
 }
 
 export class CoverageProvider implements RstestCoverageProvider {
-  private coverageMap: ReturnType<typeof createCoverageMap> | null = null;
+  private coverageMap: CoverageMap | null = null;
   // Cache to avoid redundant readFile calls in generateCoverageForUntestedFiles and generateReports.
   private sourcemapUrlCache = new Map<string, string | undefined>();
 
@@ -71,7 +70,7 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   createCoverageMap(): CoverageMap {
-    return createCoverageMap({});
+    return createFastCoverageMap();
   }
 
   collect(_options?: {
@@ -84,7 +83,7 @@ export class CoverageProvider implements RstestCoverageProvider {
 
     try {
       if (!this.coverageMap) {
-        this.coverageMap = createCoverageMap();
+        this.coverageMap = this.createCoverageMap();
       }
       // Merge current coverage data
       if (this.coverageMap) {

--- a/packages/coverage-istanbul/src/utils.ts
+++ b/packages/coverage-istanbul/src/utils.ts
@@ -172,6 +172,21 @@ const hasSameBranchHitShape = (a: BranchHits, b: BranchHits): boolean => {
   return Object.keys(a).every((key) => a[key]!.length === b[key]!.length);
 };
 
+const hasSameOptionalBranchHitShape = (
+  a: BranchHits | undefined,
+  b: BranchHits | undefined,
+): boolean => {
+  if (!a && !b) {
+    return true;
+  }
+
+  if (!a || !b) {
+    return false;
+  }
+
+  return hasSameBranchHitShape(a, b);
+};
+
 const isSameRange = (a: Range, b: Range): boolean =>
   a.start.line === b.start.line &&
   a.start.column === b.start.column &&
@@ -190,7 +205,16 @@ const hasSameFunctionMap = (
   b: FileCoverageData['fnMap'],
 ): boolean =>
   hasSameKeys(a, b) &&
-  Object.keys(a).every((key) => isSameRange(a[key]!.loc, b[key]!.loc));
+  Object.keys(a).every((key) => {
+    const aFunction = a[key]!;
+    const bFunction = b[key]!;
+    return (
+      aFunction.name === bFunction.name &&
+      aFunction.line === bFunction.line &&
+      isSameRange(aFunction.decl, bFunction.decl) &&
+      isSameRange(aFunction.loc, bFunction.loc)
+    );
+  });
 
 const hasSameBranchMap = (
   a: FileCoverageData['branchMap'],
@@ -202,6 +226,8 @@ const hasSameBranchMap = (
     const bBranch = b[key]!;
     return (
       aBranch.type === bBranch.type &&
+      aBranch.line === bBranch.line &&
+      isSameRange(aBranch.loc, bBranch.loc) &&
       aBranch.locations.length === bBranch.locations.length &&
       aBranch.locations.every((loc, index) =>
         isSameRange(loc, bBranch.locations[index]!),
@@ -221,6 +247,10 @@ const canFastMergeCoverage = (
     return false;
   }
 
+  if (!hasSameOptionalBranchHitShape(existing.bT, incoming.bT)) {
+    return false;
+  }
+
   if (existing.hash && incoming.hash) {
     return existing.hash === incoming.hash;
   }
@@ -228,10 +258,7 @@ const canFastMergeCoverage = (
   if (
     !hasSameKeys(existing.s, incoming.s) ||
     !hasSameKeys(existing.f, incoming.f) ||
-    !hasSameBranchHitShape(existing.b, incoming.b) ||
-    (existing.bT && incoming.bT
-      ? !hasSameBranchHitShape(existing.bT, incoming.bT)
-      : false)
+    !hasSameBranchHitShape(existing.b, incoming.b)
   ) {
     return false;
   }

--- a/packages/coverage-istanbul/src/utils.ts
+++ b/packages/coverage-istanbul/src/utils.ts
@@ -1,8 +1,24 @@
 import { runInNewContext } from 'node:vm';
-import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage';
+import type {
+  CoverageMap,
+  CoverageMapData,
+  FileCoverage,
+  FileCoverageData,
+  Range,
+} from 'istanbul-lib-coverage';
+import istanbulLibCoverage from 'istanbul-lib-coverage';
 import type { MapStore } from 'istanbul-lib-source-maps';
 
 const SOURCE_MAP_SCAN_CONCURRENCY = 8;
+const { createCoverageMap } = istanbulLibCoverage;
+
+type BranchHits = Record<string, number[]>;
+type IstanbulFileCoverageData = FileCoverageData & {
+  all?: boolean;
+  bT?: BranchHits;
+  hash?: string;
+};
+type FileCoverageInput = FileCoverage | FileCoverageData;
 
 // ATTENTION: when swc-plugin-coverage-instrument version changed, magic value should be updated too
 // https://github.com/kwonoj/swc-plugin-coverage-instrument/blob/63e9d5e16dbe61073c62af4b7dfed3c1779cbafa/spec/util/constants.ts#L1-L2
@@ -115,6 +131,201 @@ export function registerSourceMapURL(
 
   const url = getSourceMappingURL(code);
   sourcemapUrlCache.set(filename, url);
+}
+
+const isCoverageMap = (
+  coverage: CoverageMap | CoverageMapData,
+): coverage is CoverageMap =>
+  typeof (coverage as CoverageMap).files === 'function' && 'data' in coverage;
+
+const getCoverageMapData = (
+  coverage: CoverageMap | CoverageMapData,
+): CoverageMapData => (isCoverageMap(coverage) ? coverage.data : coverage);
+
+const getFileCoverageData = (
+  coverage: FileCoverageInput,
+): IstanbulFileCoverageData =>
+  'data' in coverage
+    ? (coverage.data as IstanbulFileCoverageData)
+    : (coverage as IstanbulFileCoverageData);
+
+const getFileCoveragePath = (coverage: FileCoverageInput): string =>
+  coverage.path;
+
+const hasSameKeys = <T>(
+  a: Record<string, T>,
+  b: Record<string, T>,
+): boolean => {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+
+  return aKeys.every((key) => Object.hasOwn(b, key));
+};
+
+const hasSameBranchHitShape = (a: BranchHits, b: BranchHits): boolean => {
+  if (!hasSameKeys(a, b)) {
+    return false;
+  }
+
+  return Object.keys(a).every((key) => a[key]!.length === b[key]!.length);
+};
+
+const isSameRange = (a: Range, b: Range): boolean =>
+  a.start.line === b.start.line &&
+  a.start.column === b.start.column &&
+  a.end.line === b.end.line &&
+  a.end.column === b.end.column;
+
+const hasSameStatementMap = (
+  a: FileCoverageData['statementMap'],
+  b: FileCoverageData['statementMap'],
+): boolean =>
+  hasSameKeys(a, b) &&
+  Object.keys(a).every((key) => isSameRange(a[key]!, b[key]!));
+
+const hasSameFunctionMap = (
+  a: FileCoverageData['fnMap'],
+  b: FileCoverageData['fnMap'],
+): boolean =>
+  hasSameKeys(a, b) &&
+  Object.keys(a).every((key) => isSameRange(a[key]!.loc, b[key]!.loc));
+
+const hasSameBranchMap = (
+  a: FileCoverageData['branchMap'],
+  b: FileCoverageData['branchMap'],
+): boolean =>
+  hasSameKeys(a, b) &&
+  Object.keys(a).every((key) => {
+    const aBranch = a[key]!;
+    const bBranch = b[key]!;
+    return (
+      aBranch.type === bBranch.type &&
+      aBranch.locations.length === bBranch.locations.length &&
+      aBranch.locations.every((loc, index) =>
+        isSameRange(loc, bBranch.locations[index]!),
+      )
+    );
+  });
+
+const canFastMergeCoverage = (
+  existing: IstanbulFileCoverageData,
+  incoming: IstanbulFileCoverageData,
+): boolean => {
+  if (incoming.all === true) {
+    return true;
+  }
+
+  if (existing.all === true) {
+    return false;
+  }
+
+  if (existing.hash && incoming.hash) {
+    return existing.hash === incoming.hash;
+  }
+
+  if (
+    !hasSameKeys(existing.s, incoming.s) ||
+    !hasSameKeys(existing.f, incoming.f) ||
+    !hasSameBranchHitShape(existing.b, incoming.b) ||
+    (existing.bT && incoming.bT
+      ? !hasSameBranchHitShape(existing.bT, incoming.bT)
+      : false)
+  ) {
+    return false;
+  }
+
+  return (
+    hasSameStatementMap(existing.statementMap, incoming.statementMap) &&
+    hasSameFunctionMap(existing.fnMap, incoming.fnMap) &&
+    hasSameBranchMap(existing.branchMap, incoming.branchMap)
+  );
+};
+
+const mergeNumberHits = (
+  target: Record<string, number>,
+  source: Record<string, number>,
+): void => {
+  for (const key of Object.keys(source)) {
+    target[key] = target[key]! + source[key]!;
+  }
+};
+
+const mergeBranchHits = (target: BranchHits, source: BranchHits): void => {
+  for (const key of Object.keys(source)) {
+    const targetBranches = target[key]!;
+    const sourceBranches = source[key]!;
+    for (let index = 0; index < sourceBranches.length; index++) {
+      targetBranches[index] = targetBranches[index]! + sourceBranches[index]!;
+    }
+  }
+};
+
+const fastMergeFileCoverage = (
+  existing: IstanbulFileCoverageData,
+  incoming: IstanbulFileCoverageData,
+): boolean => {
+  if (!canFastMergeCoverage(existing, incoming)) {
+    return false;
+  }
+
+  if (incoming.all === true) {
+    return true;
+  }
+
+  mergeNumberHits(existing.s, incoming.s);
+  mergeNumberHits(existing.f, incoming.f);
+  mergeBranchHits(existing.b, incoming.b);
+
+  if (existing.bT && incoming.bT) {
+    mergeBranchHits(existing.bT, incoming.bT);
+  }
+
+  return true;
+};
+
+export function createFastCoverageMap(): CoverageMap {
+  const coverageMap = createCoverageMap({});
+  const addFileCoverage = coverageMap.addFileCoverage.bind(coverageMap);
+  let hasMergedCoverage = false;
+
+  coverageMap.addFileCoverage = (coverage: string | FileCoverageInput) => {
+    if (typeof coverage === 'string') {
+      addFileCoverage(coverage);
+      return;
+    }
+
+    const existingCoverage = coverageMap.data[getFileCoveragePath(coverage)];
+
+    if (
+      existingCoverage &&
+      fastMergeFileCoverage(
+        getFileCoverageData(existingCoverage),
+        getFileCoverageData(coverage),
+      )
+    ) {
+      return;
+    }
+
+    addFileCoverage(coverage);
+  };
+
+  coverageMap.merge = (coverage: CoverageMap | CoverageMapData) => {
+    if (!hasMergedCoverage) {
+      for (const fileCoverage of Object.values(getCoverageMapData(coverage))) {
+        addFileCoverage(fileCoverage);
+      }
+      hasMergedCoverage = true;
+      return;
+    }
+
+    for (const fileCoverage of Object.values(getCoverageMapData(coverage))) {
+      coverageMap.addFileCoverage(fileCoverage);
+    }
+  };
+
+  return coverageMap;
 }
 
 export async function mapWithConcurrency<T, R>(

--- a/packages/coverage-istanbul/tests/utils.test.ts
+++ b/packages/coverage-istanbul/tests/utils.test.ts
@@ -2,9 +2,132 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import istanbulCoverage from 'istanbul-lib-coverage';
-import { getSourceMappingURL, transformCoverage } from '../src/utils';
+import {
+  createFastCoverageMap,
+  getSourceMappingURL,
+  transformCoverage,
+} from '../src/utils';
+
+const createFileCoverage = (file: string) => ({
+  path: file,
+  statementMap: {
+    0: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+  },
+  fnMap: {
+    0: {
+      name: 'fn',
+      decl: { start: { line: 1, column: 0 }, end: { line: 1, column: 2 } },
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+      line: 1,
+    },
+  },
+  branchMap: {
+    0: {
+      type: 'if',
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+      locations: [
+        { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+        { start: { line: 1, column: 5 }, end: { line: 1, column: 10 } },
+      ],
+      line: 1,
+    },
+  },
+  s: { 0: 1 },
+  f: { 0: 2 },
+  b: { 0: [3, 4] },
+  hash: 'same',
+});
 
 describe('coverage istanbul utils', () => {
+  it('fast merges coverage when instrumentation shape matches', () => {
+    const file = '/project/src/index.ts';
+    const coverageMap = createFastCoverageMap();
+
+    coverageMap.merge({
+      [file]: createFileCoverage(file),
+    });
+    coverageMap.merge({
+      [file]: {
+        ...createFileCoverage(file),
+        s: { 0: 5 },
+        f: { 0: 7 },
+        b: { 0: [11, 13] },
+      },
+    });
+
+    expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      s: { 0: 6 },
+      f: { 0: 9 },
+      b: { 0: [14, 17] },
+    });
+  });
+
+  it('uses native add for the first coverage map merge', () => {
+    const file = '/project/src/index.ts';
+    const coverageMap = createFastCoverageMap();
+    const originalAddFileCoverage = coverageMap.addFileCoverage;
+    let addFileCoverageCalls = 0;
+
+    coverageMap.addFileCoverage = (coverage) => {
+      addFileCoverageCalls++;
+      originalAddFileCoverage(coverage);
+    };
+
+    coverageMap.merge({
+      [file]: createFileCoverage(file),
+    });
+
+    expect(addFileCoverageCalls).toBe(0);
+    expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      s: { 0: 1 },
+      f: { 0: 2 },
+      b: { 0: [3, 4] },
+    });
+  });
+
+  it('falls back to istanbul merge when coverage shapes differ', () => {
+    const file = '/project/src/index.ts';
+    const coverageMap = createFastCoverageMap();
+
+    coverageMap.merge({
+      [file]: createFileCoverage(file),
+    });
+    coverageMap.merge({
+      [file]: {
+        ...createFileCoverage(file),
+        statementMap: {
+          0: { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
+        },
+        s: { 0: 5 },
+        hash: 'different',
+      },
+    });
+
+    expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      statementMap: {
+        0: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+        1: { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
+      },
+      s: { 0: 1, 1: 5 },
+    });
+  });
+
+  it('keeps istanbul all-file merge semantics', () => {
+    const file = '/project/src/index.ts';
+    const coverageMap = createFastCoverageMap();
+
+    coverageMap.addFileCoverage({ ...createFileCoverage(file), all: true });
+    coverageMap.addFileCoverage(createFileCoverage(file));
+
+    const fileCoverage = coverageMap.fileCoverageFor(file).toJSON();
+    expect(fileCoverage).not.toHaveProperty('all');
+    expect(fileCoverage).toMatchObject({
+      s: { 0: 1 },
+      f: { 0: 2 },
+      b: { 0: [3, 4] },
+    });
+  });
+
   it('extracts the last sourceMappingURL without splitting the whole file', () => {
     const code = [
       'const sourceMappingURL = "not a comment";',

--- a/packages/coverage-istanbul/tests/utils.test.ts
+++ b/packages/coverage-istanbul/tests/utils.test.ts
@@ -38,6 +38,30 @@ const createFileCoverage = (file: string) => ({
   hash: 'same',
 });
 
+const createUnhashedFileCoverage = (file: string) => {
+  const coverage = createFileCoverage(file);
+  return {
+    ...coverage,
+    hash: undefined,
+  };
+};
+
+const trackNativeMerge = (
+  coverageMap: ReturnType<typeof createFastCoverageMap>,
+  file: string,
+) => {
+  const fileCoverage = coverageMap.fileCoverageFor(file);
+  const merge = fileCoverage.merge.bind(fileCoverage);
+  let mergeCalls = 0;
+
+  fileCoverage.merge = (coverage) => {
+    mergeCalls++;
+    merge(coverage);
+  };
+
+  return () => mergeCalls;
+};
+
 describe('coverage istanbul utils', () => {
   it('fast merges coverage when instrumentation shape matches', () => {
     const file = '/project/src/index.ts';
@@ -109,6 +133,113 @@ describe('coverage istanbul utils', () => {
         1: { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
       },
       s: { 0: 1, 1: 5 },
+    });
+  });
+
+  it('falls back to istanbul merge when branch truthiness shape differs', () => {
+    const file = '/project/src/index.ts';
+    const coverageMap = createFastCoverageMap();
+
+    coverageMap.merge({
+      [file]: createUnhashedFileCoverage(file),
+    });
+    const getNativeMergeCalls = trackNativeMerge(coverageMap, file);
+
+    coverageMap.merge({
+      [file]: {
+        ...createUnhashedFileCoverage(file),
+        bT: { 0: [17, 19] },
+        s: { 0: 5 },
+        f: { 0: 7 },
+        b: { 0: [11, 13] },
+      },
+    });
+
+    expect(getNativeMergeCalls()).toBe(1);
+    const fileCoverage = coverageMap.fileCoverageFor(file).toJSON();
+    expect(fileCoverage).not.toHaveProperty('bT');
+    expect(fileCoverage).toMatchObject({
+      s: { 0: 6 },
+      f: { 0: 9 },
+      b: { 0: [14, 17] },
+    });
+  });
+
+  it('falls back to istanbul merge when function metadata differs', () => {
+    const file = '/project/src/index.ts';
+    const coverageMap = createFastCoverageMap();
+
+    coverageMap.merge({
+      [file]: createUnhashedFileCoverage(file),
+    });
+    const getNativeMergeCalls = trackNativeMerge(coverageMap, file);
+
+    coverageMap.merge({
+      [file]: {
+        ...createUnhashedFileCoverage(file),
+        fnMap: {
+          0: {
+            ...createFileCoverage(file).fnMap[0],
+            name: 'renamed',
+          },
+        },
+        s: { 0: 5 },
+        f: { 0: 7 },
+        b: { 0: [11, 13] },
+      },
+    });
+
+    expect(getNativeMergeCalls()).toBe(1);
+    expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      s: { 0: 6 },
+      f: { 0: 9 },
+      b: { 0: [14, 17] },
+      fnMap: {
+        0: {
+          name: 'fn',
+        },
+      },
+    });
+  });
+
+  it('falls back to istanbul merge when branch metadata differs', () => {
+    const file = '/project/src/index.ts';
+    const coverageMap = createFastCoverageMap();
+
+    coverageMap.merge({
+      [file]: createUnhashedFileCoverage(file),
+    });
+    const getNativeMergeCalls = trackNativeMerge(coverageMap, file);
+
+    coverageMap.merge({
+      [file]: {
+        ...createUnhashedFileCoverage(file),
+        branchMap: {
+          0: {
+            ...createFileCoverage(file).branchMap[0],
+            loc: {
+              start: { line: 1, column: 0 },
+              end: { line: 1, column: 11 },
+            },
+            line: 2,
+          },
+        },
+        s: { 0: 5 },
+        f: { 0: 7 },
+        b: { 0: [11, 13] },
+      },
+    });
+
+    expect(getNativeMergeCalls()).toBe(1);
+    expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      s: { 0: 6 },
+      f: { 0: 9 },
+      b: { 0: [14, 17] },
+      branchMap: {
+        0: {
+          line: 1,
+        },
+      },
     });
   });
 

--- a/packages/coverage-v8/rslib.config.ts
+++ b/packages/coverage-v8/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rslib/core';
+import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
   lib: [
@@ -8,4 +9,9 @@ export default defineConfig({
       dts: true,
     },
   ],
+  tools: {
+    rspack: {
+      plugins: [rsdoctorCIPlugin()].filter(Boolean),
+    },
+  },
 });

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -9,14 +9,12 @@ import type {
 } from '@rstest/core';
 import astV8ToIstanbul from 'ast-v8-to-istanbul';
 import { Parser } from 'acorn';
-import istanbulLibCoverage, {
-  type CoverageMap,
-  type FileCoverageData,
-} from 'istanbul-lib-coverage';
+import { type CoverageMap, type FileCoverageData } from 'istanbul-lib-coverage';
 import { createContext } from 'istanbul-lib-report';
 import reports from 'istanbul-reports';
 import picomatch from 'picomatch';
 import v8ToIstanbul from 'v8-to-istanbul';
+import { createFastCoverageMap } from './utils';
 
 type SourceMapLike = {
   version: number;
@@ -384,7 +382,7 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   createCoverageMap(): CoverageMap {
-    return istanbulLibCoverage.createCoverageMap({});
+    return createFastCoverageMap();
   }
 
   async generateCoverageForUntestedFiles({

--- a/packages/coverage-v8/src/utils.ts
+++ b/packages/coverage-v8/src/utils.ts
@@ -1,0 +1,213 @@
+import type {
+  CoverageMap,
+  CoverageMapData,
+  FileCoverage,
+  FileCoverageData,
+  Range,
+} from 'istanbul-lib-coverage';
+import istanbulLibCoverage from 'istanbul-lib-coverage';
+
+const { createCoverageMap } = istanbulLibCoverage;
+
+type BranchHits = Record<string, number[]>;
+type IstanbulFileCoverageData = FileCoverageData & {
+  all?: boolean;
+  bT?: BranchHits;
+  hash?: string;
+};
+type FileCoverageInput = FileCoverage | FileCoverageData;
+
+const isCoverageMap = (
+  coverage: CoverageMap | CoverageMapData,
+): coverage is CoverageMap =>
+  typeof (coverage as CoverageMap).files === 'function' && 'data' in coverage;
+
+const getCoverageMapData = (
+  coverage: CoverageMap | CoverageMapData,
+): CoverageMapData => (isCoverageMap(coverage) ? coverage.data : coverage);
+
+const getFileCoverageData = (
+  coverage: FileCoverageInput,
+): IstanbulFileCoverageData =>
+  'data' in coverage
+    ? (coverage.data as IstanbulFileCoverageData)
+    : (coverage as IstanbulFileCoverageData);
+
+const getFileCoveragePath = (coverage: FileCoverageInput): string =>
+  coverage.path;
+
+const hasSameKeys = <T>(
+  a: Record<string, T>,
+  b: Record<string, T>,
+): boolean => {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+
+  return aKeys.every((key) => Object.hasOwn(b, key));
+};
+
+const hasSameBranchHitShape = (a: BranchHits, b: BranchHits): boolean => {
+  if (!hasSameKeys(a, b)) {
+    return false;
+  }
+
+  return Object.keys(a).every((key) => a[key]!.length === b[key]!.length);
+};
+
+const isSameRange = (a: Range, b: Range): boolean =>
+  a.start.line === b.start.line &&
+  a.start.column === b.start.column &&
+  a.end.line === b.end.line &&
+  a.end.column === b.end.column;
+
+const hasSameStatementMap = (
+  a: FileCoverageData['statementMap'],
+  b: FileCoverageData['statementMap'],
+): boolean =>
+  hasSameKeys(a, b) &&
+  Object.keys(a).every((key) => isSameRange(a[key]!, b[key]!));
+
+const hasSameFunctionMap = (
+  a: FileCoverageData['fnMap'],
+  b: FileCoverageData['fnMap'],
+): boolean =>
+  hasSameKeys(a, b) &&
+  Object.keys(a).every((key) => isSameRange(a[key]!.loc, b[key]!.loc));
+
+const hasSameBranchMap = (
+  a: FileCoverageData['branchMap'],
+  b: FileCoverageData['branchMap'],
+): boolean =>
+  hasSameKeys(a, b) &&
+  Object.keys(a).every((key) => {
+    const aBranch = a[key]!;
+    const bBranch = b[key]!;
+    return (
+      aBranch.type === bBranch.type &&
+      aBranch.locations.length === bBranch.locations.length &&
+      aBranch.locations.every((loc, index) =>
+        isSameRange(loc, bBranch.locations[index]!),
+      )
+    );
+  });
+
+const canFastMergeCoverage = (
+  existing: IstanbulFileCoverageData,
+  incoming: IstanbulFileCoverageData,
+): boolean => {
+  if (incoming.all === true) {
+    return true;
+  }
+
+  if (existing.all === true) {
+    return false;
+  }
+
+  if (existing.hash && incoming.hash) {
+    return existing.hash === incoming.hash;
+  }
+
+  if (
+    !hasSameKeys(existing.s, incoming.s) ||
+    !hasSameKeys(existing.f, incoming.f) ||
+    !hasSameBranchHitShape(existing.b, incoming.b) ||
+    (existing.bT && incoming.bT
+      ? !hasSameBranchHitShape(existing.bT, incoming.bT)
+      : false)
+  ) {
+    return false;
+  }
+
+  return (
+    hasSameStatementMap(existing.statementMap, incoming.statementMap) &&
+    hasSameFunctionMap(existing.fnMap, incoming.fnMap) &&
+    hasSameBranchMap(existing.branchMap, incoming.branchMap)
+  );
+};
+
+const mergeNumberHits = (
+  target: Record<string, number>,
+  source: Record<string, number>,
+): void => {
+  for (const key of Object.keys(source)) {
+    target[key] = target[key]! + source[key]!;
+  }
+};
+
+const mergeBranchHits = (target: BranchHits, source: BranchHits): void => {
+  for (const key of Object.keys(source)) {
+    const targetBranches = target[key]!;
+    const sourceBranches = source[key]!;
+    for (let index = 0; index < sourceBranches.length; index++) {
+      targetBranches[index] = targetBranches[index]! + sourceBranches[index]!;
+    }
+  }
+};
+
+const fastMergeFileCoverage = (
+  existing: IstanbulFileCoverageData,
+  incoming: IstanbulFileCoverageData,
+): boolean => {
+  if (!canFastMergeCoverage(existing, incoming)) {
+    return false;
+  }
+
+  if (incoming.all === true) {
+    return true;
+  }
+
+  mergeNumberHits(existing.s, incoming.s);
+  mergeNumberHits(existing.f, incoming.f);
+  mergeBranchHits(existing.b, incoming.b);
+
+  if (existing.bT && incoming.bT) {
+    mergeBranchHits(existing.bT, incoming.bT);
+  }
+
+  return true;
+};
+
+export function createFastCoverageMap(): CoverageMap {
+  const coverageMap = createCoverageMap({});
+  const addFileCoverage = coverageMap.addFileCoverage.bind(coverageMap);
+  let hasMergedCoverage = false;
+
+  coverageMap.addFileCoverage = (coverage: string | FileCoverageInput) => {
+    if (typeof coverage === 'string') {
+      addFileCoverage(coverage);
+      return;
+    }
+
+    const existingCoverage = coverageMap.data[getFileCoveragePath(coverage)];
+
+    if (
+      existingCoverage &&
+      fastMergeFileCoverage(
+        getFileCoverageData(existingCoverage),
+        getFileCoverageData(coverage),
+      )
+    ) {
+      return;
+    }
+
+    addFileCoverage(coverage);
+  };
+
+  coverageMap.merge = (coverage: CoverageMap | CoverageMapData) => {
+    if (!hasMergedCoverage) {
+      for (const fileCoverage of Object.values(getCoverageMapData(coverage))) {
+        addFileCoverage(fileCoverage);
+      }
+      hasMergedCoverage = true;
+      return;
+    }
+
+    for (const fileCoverage of Object.values(getCoverageMapData(coverage))) {
+      coverageMap.addFileCoverage(fileCoverage);
+    }
+  };
+
+  return coverageMap;
+}

--- a/packages/coverage-v8/src/utils.ts
+++ b/packages/coverage-v8/src/utils.ts
@@ -56,6 +56,21 @@ const hasSameBranchHitShape = (a: BranchHits, b: BranchHits): boolean => {
   return Object.keys(a).every((key) => a[key]!.length === b[key]!.length);
 };
 
+const hasSameOptionalBranchHitShape = (
+  a: BranchHits | undefined,
+  b: BranchHits | undefined,
+): boolean => {
+  if (!a && !b) {
+    return true;
+  }
+
+  if (!a || !b) {
+    return false;
+  }
+
+  return hasSameBranchHitShape(a, b);
+};
+
 const isSameRange = (a: Range, b: Range): boolean =>
   a.start.line === b.start.line &&
   a.start.column === b.start.column &&
@@ -74,7 +89,16 @@ const hasSameFunctionMap = (
   b: FileCoverageData['fnMap'],
 ): boolean =>
   hasSameKeys(a, b) &&
-  Object.keys(a).every((key) => isSameRange(a[key]!.loc, b[key]!.loc));
+  Object.keys(a).every((key) => {
+    const aFunction = a[key]!;
+    const bFunction = b[key]!;
+    return (
+      aFunction.name === bFunction.name &&
+      aFunction.line === bFunction.line &&
+      isSameRange(aFunction.decl, bFunction.decl) &&
+      isSameRange(aFunction.loc, bFunction.loc)
+    );
+  });
 
 const hasSameBranchMap = (
   a: FileCoverageData['branchMap'],
@@ -86,6 +110,8 @@ const hasSameBranchMap = (
     const bBranch = b[key]!;
     return (
       aBranch.type === bBranch.type &&
+      aBranch.line === bBranch.line &&
+      isSameRange(aBranch.loc, bBranch.loc) &&
       aBranch.locations.length === bBranch.locations.length &&
       aBranch.locations.every((loc, index) =>
         isSameRange(loc, bBranch.locations[index]!),
@@ -105,6 +131,10 @@ const canFastMergeCoverage = (
     return false;
   }
 
+  if (!hasSameOptionalBranchHitShape(existing.bT, incoming.bT)) {
+    return false;
+  }
+
   if (existing.hash && incoming.hash) {
     return existing.hash === incoming.hash;
   }
@@ -112,10 +142,7 @@ const canFastMergeCoverage = (
   if (
     !hasSameKeys(existing.s, incoming.s) ||
     !hasSameKeys(existing.f, incoming.f) ||
-    !hasSameBranchHitShape(existing.b, incoming.b) ||
-    (existing.bT && incoming.bT
-      ? !hasSameBranchHitShape(existing.bT, incoming.bT)
-      : false)
+    !hasSameBranchHitShape(existing.b, incoming.b)
   ) {
     return false;
   }

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -20,6 +20,36 @@ const createOptions = (
   ...overrides,
 });
 
+const createFileCoverage = (file: string) => ({
+  path: file,
+  statementMap: {
+    0: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+  },
+  fnMap: {
+    0: {
+      name: 'fn',
+      decl: { start: { line: 1, column: 0 }, end: { line: 1, column: 2 } },
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+      line: 1,
+    },
+  },
+  branchMap: {
+    0: {
+      type: 'if',
+      loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+      locations: [
+        { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+        { start: { line: 1, column: 5 }, end: { line: 1, column: 10 } },
+      ],
+      line: 1,
+    },
+  },
+  s: { 0: 1 },
+  f: { 0: 2 },
+  b: { 0: [3, 4] },
+  hash: 'same',
+});
+
 type ProviderInternals = CoverageProvider & {
   findInDict: (
     dict: Record<string, string> | undefined,
@@ -47,6 +77,30 @@ function getProviderInternals(provider: CoverageProvider): ProviderInternals {
 }
 
 describe('coverage-v8 provider', () => {
+  it('fast merges duplicate converted coverage shapes', () => {
+    const file = '/project/src/index.ts';
+    const provider = new CoverageProvider(createOptions());
+    const coverageMap = provider.createCoverageMap();
+
+    coverageMap.merge({
+      [file]: createFileCoverage(file),
+    });
+    coverageMap.merge({
+      [file]: {
+        ...createFileCoverage(file),
+        s: { 0: 5 },
+        f: { 0: 7 },
+        b: { 0: [11, 13] },
+      },
+    });
+
+    expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      s: { 0: 6 },
+      f: { 0: 9 },
+      b: { 0: [14, 17] },
+    });
+  });
+
   it('finds dictionary entries through normalized path variants', () => {
     const provider = getProviderInternals(
       new CoverageProvider(createOptions()),

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -50,6 +50,30 @@ const createFileCoverage = (file: string) => ({
   hash: 'same',
 });
 
+const createUnhashedFileCoverage = (file: string) => {
+  const coverage = createFileCoverage(file);
+  return {
+    ...coverage,
+    hash: undefined,
+  };
+};
+
+const trackNativeMerge = (
+  coverageMap: ReturnType<CoverageProvider['createCoverageMap']>,
+  file: string,
+) => {
+  const fileCoverage = coverageMap.fileCoverageFor(file);
+  const merge = fileCoverage.merge.bind(fileCoverage);
+  let mergeCalls = 0;
+
+  fileCoverage.merge = (coverage) => {
+    mergeCalls++;
+    merge(coverage);
+  };
+
+  return () => mergeCalls;
+};
+
 type ProviderInternals = CoverageProvider & {
   findInDict: (
     dict: Record<string, string> | undefined,
@@ -95,6 +119,89 @@ describe('coverage-v8 provider', () => {
     });
 
     expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      s: { 0: 6 },
+      f: { 0: 9 },
+      b: { 0: [14, 17] },
+    });
+  });
+
+  it('falls back when converted coverage metadata differs', () => {
+    const file = '/project/src/index.ts';
+    const provider = new CoverageProvider(createOptions());
+    const coverageMap = provider.createCoverageMap();
+
+    coverageMap.merge({
+      [file]: createUnhashedFileCoverage(file),
+    });
+    const getNativeMergeCalls = trackNativeMerge(coverageMap, file);
+
+    coverageMap.merge({
+      [file]: {
+        ...createUnhashedFileCoverage(file),
+        fnMap: {
+          0: {
+            ...createFileCoverage(file).fnMap[0],
+            name: 'renamed',
+          },
+        },
+        branchMap: {
+          0: {
+            ...createFileCoverage(file).branchMap[0],
+            loc: {
+              start: { line: 1, column: 0 },
+              end: { line: 1, column: 11 },
+            },
+            line: 2,
+          },
+        },
+        s: { 0: 5 },
+        f: { 0: 7 },
+        b: { 0: [11, 13] },
+      },
+    });
+
+    expect(getNativeMergeCalls()).toBe(1);
+    expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
+      s: { 0: 6 },
+      f: { 0: 9 },
+      b: { 0: [14, 17] },
+      fnMap: {
+        0: {
+          name: 'fn',
+        },
+      },
+      branchMap: {
+        0: {
+          line: 1,
+        },
+      },
+    });
+  });
+
+  it('falls back when converted branch truthiness shape differs', () => {
+    const file = '/project/src/index.ts';
+    const provider = new CoverageProvider(createOptions());
+    const coverageMap = provider.createCoverageMap();
+
+    coverageMap.merge({
+      [file]: createUnhashedFileCoverage(file),
+    });
+    const getNativeMergeCalls = trackNativeMerge(coverageMap, file);
+
+    coverageMap.merge({
+      [file]: {
+        ...createUnhashedFileCoverage(file),
+        bT: { 0: [17, 19] },
+        s: { 0: 5 },
+        f: { 0: 7 },
+        b: { 0: [11, 13] },
+      },
+    });
+
+    expect(getNativeMergeCalls()).toBe(1);
+    const fileCoverage = coverageMap.fileCoverageFor(file).toJSON();
+    expect(fileCoverage).not.toHaveProperty('bT');
+    expect(fileCoverage).toMatchObject({
       s: { 0: 6 },
       f: { 0: 9 },
       b: { 0: [14, 17] },

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -171,6 +171,7 @@ tsconfck
 tsdoc
 tsup
 unencapsulated
+Unhashed
 unocss
 unpatch
 unplugin


### PR DESCRIPTION
## Summary

This PR improves coverage collection performance by adding a fast coverage-map merge path for deterministic Istanbul coverage shapes. Both Istanbul and V8 coverage providers now avoid Istanbul's expensive generic range merge when repeated file coverage maps have the same instrumentation shape, while preserving native fallback behavior for mismatched shapes and untested-file reports.

## Performance

Benchmark project: `/Users/bytedance/Desktop/projects/rsbuild`

| Provider | Command | Before | After | Notes |
| --- | --- | ---: | ---: | --- |
| Istanbul | `time node ../rstest/packages/core/bin/rstest.js --coverage` | `real 2.62s`, Rstest `1765ms` | `real 1.98s`, Rstest `1457ms` | CPU profile no longer shows `istanbul-lib-coverage` `mergeProp` in the top list. |
| V8 | `time node ../rstest/packages/core/bin/rstest.js --coverage --coverage.provider=v8 --coverage.reporters=text` | `real 9.76s`, Rstest `9249ms` | `real 8.59s`, Rstest `7994ms` | `mergeProp` dropped from ~324ms top self time to below the top list; fast merge checks were ~35ms. |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).