### PR TITLE
feat(core): add @rstest/core/api programmatic runner

### DIFF
--- a/e2e/programmatic/fixtures/disk/failing.test.ts
+++ b/e2e/programmatic/fixtures/disk/failing.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('disk failing', () => {
+  it('boom', () => {
+    expect(1).toBe(2);
+  });
+});

--- a/e2e/programmatic/fixtures/disk/sum.test.ts
+++ b/e2e/programmatic/fixtures/disk/sum.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('disk sum', () => {
+  it('1 + 2 = 3', () => {
+    expect(1 + 2).toBe(3);
+  });
+
+  it('passes second case', () => {
+    expect('hello').toBe('hello');
+  });
+});

--- a/e2e/programmatic/fixtures/run-failing.mjs
+++ b/e2e/programmatic/fixtures/run-failing.mjs
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { runRstest } from '@rstest/core/api';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cwd = join(__dirname, 'disk');
+
+const result = await runRstest({
+  cwd,
+  inlineConfig: {
+    include: ['failing.test.ts'],
+    reporters: [],
+  },
+});
+
+console.log(
+  `__RSTEST_API_RESULT__${JSON.stringify({
+    ok: result.ok,
+    stats: result.stats,
+    hostExitCode: process.exitCode ?? 0,
+  })}__END__`,
+);

--- a/e2e/programmatic/fixtures/run-inline.mjs
+++ b/e2e/programmatic/fixtures/run-inline.mjs
@@ -1,0 +1,30 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { runRstest } from '@rstest/core/api';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cwd = join(__dirname, 'disk');
+
+const result = await runRstest({
+  cwd,
+  inlineConfig: {
+    include: ['*.test.ts'],
+    exclude: ['failing.test.ts'],
+    reporters: [],
+  },
+});
+
+console.log(
+  `__RSTEST_API_RESULT__${JSON.stringify({
+    ok: result.ok,
+    stats: result.stats,
+    files: result.files.map((f) => ({
+      status: f.status,
+      // strip absolute path so snapshot is stable across machines
+      testPath: f.testPath.split('/').pop(),
+    })),
+    unhandledErrors: result.unhandledErrors,
+    duration: { hasTotal: typeof result.duration.total === 'number' },
+    snapshotPresent: typeof result.snapshot === 'object',
+  })}__END__`,
+);

--- a/e2e/programmatic/fixtures/run-virtual.mjs
+++ b/e2e/programmatic/fixtures/run-virtual.mjs
@@ -1,0 +1,44 @@
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { runRstest } from '@rstest/core/api';
+import { rspack } from '@rsbuild/core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const virtualTests = {
+  'virtual/programmatic.test.ts': `
+import { describe, expect, it } from '@rstest/core';
+
+describe('programmatic virtual', () => {
+  it('inline + virtual entry works', () => {
+    expect(2 * 3).toBe(6);
+  });
+});
+`,
+};
+
+const result = await runRstest({
+  cwd: __dirname,
+  inlineConfig: {
+    include: Object.keys(virtualTests),
+    reporters: [],
+    tools: {
+      rspack: (_config, { appendPlugins }) => {
+        appendPlugins(
+          new rspack.experiments.VirtualModulesPlugin(virtualTests),
+        );
+      },
+    },
+  },
+});
+
+console.log(
+  `__RSTEST_API_RESULT__${JSON.stringify({
+    ok: result.ok,
+    stats: result.stats,
+    files: result.files.map((f) => ({
+      status: f.status,
+      testName: f.testPath.split('/').slice(-2).join('/'),
+    })),
+  })}__END__`,
+);

--- a/e2e/programmatic/index.test.ts
+++ b/e2e/programmatic/index.test.ts
@@ -1,0 +1,88 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, 'fixtures');
+
+const PAYLOAD_RE = /__RSTEST_API_RESULT__(.*?)__END__/;
+
+const parsePayload = (stdout: string) => {
+  const match = stdout.match(PAYLOAD_RE);
+  const payload = match?.[1];
+  if (!payload) {
+    throw new Error(
+      `runRstest payload not found in stdout. Got:\n${stdout.slice(0, 4000)}`,
+    );
+  }
+  return JSON.parse(payload) as Record<string, any>;
+};
+
+describe('programmatic runRstest', () => {
+  it('runs disk tests via inlineConfig + returns nested stats', async ({
+    onTestFinished,
+  }) => {
+    const { cli } = await runRstestCli({
+      command: 'node',
+      args: ['run-inline.mjs'],
+      onTestFinished,
+      options: { nodeOptions: { cwd: fixturesDir } },
+    });
+
+    await cli.exec;
+    const result = parsePayload(cli.stdout);
+
+    expect(result.ok).toBe(true);
+    expect(result.stats).toEqual({
+      tests: { total: 2, passed: 2, failed: 0, skipped: 0, todo: 0 },
+      files: { total: 1, failed: 0 },
+    });
+    expect(result.files).toEqual([{ status: 'pass', testPath: 'sum.test.ts' }]);
+    expect(result.unhandledErrors).toEqual([]);
+    expect(result.duration.hasTotal).toBe(true);
+    expect(result.snapshotPresent).toBe(true);
+  });
+
+  it('reports failures via ok=false without poisoning host process.exitCode', async ({
+    onTestFinished,
+  }) => {
+    const { cli } = await runRstestCli({
+      command: 'node',
+      args: ['run-failing.mjs'],
+      onTestFinished,
+      options: { nodeOptions: { cwd: fixturesDir } },
+    });
+
+    const exec = await cli.exec;
+    const result = parsePayload(cli.stdout);
+
+    expect(result.ok).toBe(false);
+    expect(result.stats.tests.failed).toBe(1);
+    expect(result.stats.files.failed).toBe(1);
+    // Host script exited 0 — the API didn't set process.exitCode.
+    expect(result.hostExitCode).toBe(0);
+    expect(exec.exitCode).toBe(0);
+  });
+
+  it('accepts inline config + virtual modules plugin (Midscene shape)', async ({
+    onTestFinished,
+  }) => {
+    const { cli } = await runRstestCli({
+      command: 'node',
+      args: ['run-virtual.mjs'],
+      onTestFinished,
+      options: { nodeOptions: { cwd: fixturesDir } },
+    });
+
+    await cli.exec;
+    const result = parsePayload(cli.stdout);
+
+    expect(result.ok).toBe(true);
+    expect(result.stats.tests.passed).toBe(1);
+    expect(result.files).toEqual([
+      { status: 'pass', testName: 'virtual/programmatic.test.ts' },
+    ]);
+  });
+});

--- a/e2e/virtualEntry/fixtures/rstest.config.ts
+++ b/e2e/virtualEntry/fixtures/rstest.config.ts
@@ -1,0 +1,32 @@
+import { rspack } from '@rsbuild/core';
+import { defineConfig } from '@rstest/core';
+
+const virtualTests: Record<string, string> = {
+  'virtual/sum.test.ts': `
+import { describe, expect, it } from '@rstest/core';
+
+describe('virtual sum', () => {
+  it('1 + 1 = 2', () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+`,
+  'virtual/diff.test.ts': `
+import { describe, expect, it } from '@rstest/core';
+
+describe('virtual diff', () => {
+  it('3 - 1 = 2', () => {
+    expect(3 - 1).toBe(2);
+  });
+});
+`,
+};
+
+export default defineConfig({
+  include: Object.keys(virtualTests),
+  tools: {
+    rspack: (_config, { appendPlugins }) => {
+      appendPlugins(new rspack.experiments.VirtualModulesPlugin(virtualTests));
+    },
+  },
+});

--- a/e2e/virtualEntry/index.test.ts
+++ b/e2e/virtualEntry/index.test.ts
@@ -1,0 +1,54 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const fixturesDir = join(__dirname, 'fixtures');
+
+describe('virtual test entries', () => {
+  it('runs virtual entries injected via experiments.VirtualModulesPlugin', async ({
+    onTestFinished,
+  }) => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--reporter=verbose'],
+      onTestFinished,
+      options: { nodeOptions: { cwd: fixturesDir } },
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).toContain('virtual/sum.test.ts');
+    expect(cli.stdout).toContain('virtual/diff.test.ts');
+    expect(cli.stdout).toContain('virtual sum > 1 + 1 = 2');
+    expect(cli.stdout).toContain('virtual diff > 3 - 1 = 2');
+    expect(cli.stdout).toContain('Test Files 2 passed');
+  });
+
+  it('lists virtual entries', async ({ onTestFinished }) => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['list'],
+      onTestFinished,
+      options: { nodeOptions: { cwd: fixturesDir } },
+    });
+
+    await cli.exec;
+    expect(cli.stdout).toContain('virtual/sum.test.ts');
+    expect(cli.stdout).toContain('virtual/diff.test.ts');
+  });
+
+  it('matches virtual entries via fileFilter', async ({ onTestFinished }) => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'sum', '--reporter=verbose'],
+      onTestFinished,
+      options: { nodeOptions: { cwd: fixturesDir } },
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).toContain('virtual sum > 1 + 1 = 2');
+    expect(cli.stdout).not.toContain('virtual diff');
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./api": {
+      "types": "./dist/api/index.d.ts",
+      "default": "./dist/api/index.js"
+    },
     "./browser": {
       "types": "./dist/browser.d.ts",
       "default": "./dist/browser.js"

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
       source: {
         entry: {
           index: './src/index.ts',
+          'api/index': './src/api/index.ts',
           browser: './src/browser.ts',
           worker: './src/runtime/worker/index.ts',
           globalSetupWorker: './src/runtime/worker/globalSetupWorker.ts',

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,0 +1,288 @@
+/**
+ * Programmatic Node API for running Rstest in-process.
+ *
+ * Stability: Public surface; field-frozen at 1.0.0. Adding optional fields is
+ * a minor change; removing or repurposing fields requires a major bump.
+ *
+ * @see RFC-programmatic-node-api.md
+ */
+import { loadConfig, mergeRstestConfig, resolveExtends } from '../config';
+import { resolveProjects } from '../cli/init';
+import { createRstest } from '../core';
+import type {
+  CoverageMapData,
+  FormattedError,
+  Reporter,
+  RstestConfig,
+  SnapshotSummary,
+  TestFileResult,
+} from '../types';
+import { getAbsolutePath } from '../utils';
+
+export type { Reporter, TestFileResult } from '../types';
+/** Inline configuration shape; same type the `rstest.config.ts` exports. */
+export type { RstestConfig as RstestUserConfig } from '../types';
+
+/**
+ * Cross-IPC-safe error shape. Returned in `TestRunResult.unhandledErrors`.
+ * Assertion-specific fields (`diff`, `actual`, `expected`) are only set for
+ * `@vitest/expect`-style errors.
+ */
+export interface SerializedError {
+  name: string;
+  message: string;
+  stack?: string;
+  diff?: string;
+  actual?: string;
+  expected?: string;
+  cause?: SerializedError;
+}
+
+export interface RunRstestOptions {
+  /** Working directory. Defaults to `process.cwd()`. */
+  cwd?: string;
+
+  /**
+   * Path to a config file. Unlike the CLI, the programmatic API does NOT
+   * auto-discover a config file from `cwd` — pass an explicit path or omit
+   * to run with `inlineConfig` only.
+   */
+  config?: string;
+
+  /**
+   * Inline configuration. Shallow-merged with disk config (inline wins for
+   * scalars; arrays follow `mergeRstestConfig` semantics — see `src/config.ts`).
+   */
+  inlineConfig?: RstestConfig;
+
+  /**
+   * Exact test file paths to run. When provided, only matching paths
+   * execute; other discovered entries are ignored.
+   */
+  files?: string[];
+
+  /**
+   * Regex (or string-coerced regex) matched against test names. Equivalent
+   * to the CLI's `-t, --testNamePattern` flag.
+   */
+  testNamePattern?: RegExp | string;
+}
+
+export interface TestRunResult {
+  /** `stats.tests.failed === 0 && unhandledErrors.length === 0`. */
+  ok: boolean;
+
+  /** Per-file aggregate results. */
+  files: TestFileResult[];
+
+  /** Pre-computed counts. Add optional fields under `stats.*` in minor releases. */
+  stats: {
+    tests: {
+      total: number;
+      passed: number;
+      failed: number;
+      skipped: number;
+      todo: number;
+    };
+    files: {
+      total: number;
+      failed: number;
+    };
+  };
+
+  /** Errors not attributable to a single test (worker crash, config load). */
+  unhandledErrors: SerializedError[];
+
+  /** Wall-clock duration in ms. Sub-phase fields may be added under `duration.*`. */
+  duration: { total: number };
+
+  /** Snapshot summary. Absent only when the run aborted before any test executed (e.g. config load error). */
+  snapshot?: SnapshotSummary;
+
+  /** Coverage data. Only present when `coverage.enabled` in the resolved config. */
+  coverage?: CoverageMapData;
+}
+
+const toSerializedError = (err: unknown): SerializedError => {
+  if (!err || typeof err !== 'object') {
+    return { name: 'Error', message: String(err) };
+  }
+  const e = err as Partial<FormattedError> & { cause?: unknown };
+  return {
+    name: e.name || 'Error',
+    message: e.message ?? String(err),
+    stack: e.stack,
+    diff: e.diff,
+    actual: e.actual,
+    expected: e.expected,
+    cause: e.cause !== undefined ? toSerializedError(e.cause) : undefined,
+  };
+};
+
+const computeStats = (
+  files: readonly TestFileResult[],
+): TestRunResult['stats'] => {
+  const stats: TestRunResult['stats'] = {
+    tests: { total: 0, passed: 0, failed: 0, skipped: 0, todo: 0 },
+    files: { total: files.length, failed: 0 },
+  };
+  for (const file of files) {
+    if (file.status === 'fail') {
+      stats.files.failed++;
+    }
+    for (const t of file.results) {
+      stats.tests.total++;
+      switch (t.status) {
+        case 'pass':
+          stats.tests.passed++;
+          break;
+        case 'fail':
+          stats.tests.failed++;
+          break;
+        case 'skip':
+          stats.tests.skipped++;
+          break;
+        case 'todo':
+          stats.tests.todo++;
+          break;
+      }
+    }
+  }
+  return stats;
+};
+
+const loadConfigForApi = async ({
+  cwd,
+  configPath,
+  inlineConfig,
+}: {
+  cwd: string;
+  configPath?: string;
+  inlineConfig?: RstestConfig;
+}): Promise<{ content: RstestConfig; filePath?: string }> => {
+  let diskContent: RstestConfig = {};
+  let filePath: string | undefined;
+
+  if (configPath) {
+    const loaded = await loadConfig({ cwd, path: configPath });
+    diskContent = loaded.content;
+    filePath = loaded.filePath ?? undefined;
+  }
+
+  let merged = mergeRstestConfig(diskContent, inlineConfig ?? {});
+
+  // `loadConfig` already resolved `extends` on disk content. If the inline
+  // config introduced its own `extends`, resolve them here so the final
+  // merged config is fully expanded.
+  if (inlineConfig?.extends) {
+    merged = await resolveExtends(merged);
+  }
+
+  return { content: merged, filePath };
+};
+
+/**
+ * Run Rstest in-process and return structured results.
+ *
+ * Resolves on every termination path — including config errors and worker
+ * crashes — with `ok` reflecting overall success. The returned promise only
+ * rejects for programmer errors (e.g. invalid argument types).
+ */
+export async function runRstest(
+  options: RunRstestOptions = {},
+): Promise<TestRunResult> {
+  const cwd = options.cwd
+    ? getAbsolutePath(process.cwd(), options.cwd)
+    : process.cwd();
+
+  const captured: {
+    unhandledErrors: SerializedError[];
+    duration: { total: number };
+    coverage?: CoverageMapData;
+    snapshot?: SnapshotSummary;
+  } = {
+    unhandledErrors: [],
+    duration: { total: 0 },
+  };
+
+  const captureReporter: Reporter = {
+    onTestRunEnd: ({
+      unhandledErrors,
+      duration,
+      coverage,
+      snapshotSummary,
+    }) => {
+      captured.unhandledErrors = (unhandledErrors ?? []).map(toSerializedError);
+      captured.duration = { total: duration.totalTime };
+      captured.coverage = coverage;
+      captured.snapshot = snapshotSummary;
+    },
+  };
+
+  let files: TestFileResult[] = [];
+  let initError: SerializedError | undefined;
+
+  try {
+    const { content: userConfig, filePath: configFilePath } =
+      await loadConfigForApi({
+        cwd,
+        configPath: options.config,
+        inlineConfig: options.inlineConfig,
+      });
+
+    if (!userConfig.root) {
+      userConfig.root = cwd;
+    }
+
+    if (options.testNamePattern !== undefined) {
+      userConfig.testNamePattern = options.testNamePattern;
+    }
+
+    const projects = await resolveProjects({
+      config: userConfig,
+      root: userConfig.root,
+      options: {},
+    });
+
+    const fileFilters = options.files ?? [];
+    const fileFilterMode = options.files?.length ? 'exact' : 'fuzzy';
+
+    const rstest = createRstest(
+      {
+        config: userConfig,
+        configFilePath,
+        projects,
+        cwd,
+        embedded: true,
+      },
+      'run',
+      fileFilters,
+      fileFilterMode,
+    );
+
+    rstest.context.reporters.push(captureReporter);
+
+    await rstest.runTests();
+
+    files = rstest.context.reporterResults.results;
+  } catch (err) {
+    initError = toSerializedError(err);
+  }
+
+  const allErrors = initError
+    ? [initError, ...captured.unhandledErrors]
+    : captured.unhandledErrors;
+
+  const stats = computeStats(files);
+  const ok = stats.tests.failed === 0 && allErrors.length === 0;
+
+  return {
+    ok,
+    files,
+    stats,
+    unhandledErrors: allErrors,
+    duration: captured.duration,
+    snapshot: captured.snapshot,
+    coverage: captured.coverage,
+  };
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -282,6 +282,36 @@ const loadConfigForApi = async ({
 };
 
 /**
+ * Snapshot the process-global state an embedded run mutates and return a
+ * `restore()` that puts it back. `runRstest` runs inside a long-lived host, so —
+ * unlike the CLI, which exits — it must contain every global the engine touches
+ * in one place: add future globals here rather than as another inline
+ * save/restore pair at the call site.
+ *
+ * - `process.exitCode`: deep layers (globalSetup teardown, coverage thresholds,
+ *   no-test-files) set this unconditionally without consulting `embedded`.
+ * - `process.env`: `initRstestEnv` sets NODE_ENV/RSTEST and `globalSetup` may
+ *   mutate arbitrary vars before workers inherit them.
+ */
+const snapshotProcessGuards = (): (() => void) => {
+  const exitCode = process.exitCode;
+  const env = { ...process.env };
+
+  return () => {
+    process.exitCode = exitCode;
+    // Drop keys added during the run (e.g. by globalSetup) and reset mutated
+    // ones. Workers already inherited the run-time env when they spawned, so
+    // this only affects the host process.
+    for (const key of Object.keys(process.env)) {
+      if (!(key in env)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, env);
+  };
+};
+
+/**
  * Run Rstest in-process and return structured results.
  *
  * Resolves on every termination path — including config errors and worker
@@ -293,151 +323,140 @@ const loadConfigForApi = async ({
 export async function runRstest(
   options: RunRstestOptions = {},
 ): Promise<TestRunResult> {
-  // Match the CLI's environment setup so tests run through the programmatic
-  // API observe `NODE_ENV=test` / `RSTEST=true` (workers inherit `process.env`
-  // at spawn time). Snapshot and restore around the run so a long-lived
-  // embedding host isn't left with these mutated globally after we resolve.
-  const envSnapshot = {
-    NODE_ENV: process.env.NODE_ENV,
-    RSTEST: process.env.RSTEST,
-  };
+  // Capture host process globals up front; `restoreProcessGuards` puts them back
+  // in the outer `finally` so an embedding host isn't left with leaked state.
+  const restoreProcessGuards = snapshotProcessGuards();
+
+  // Match the CLI's environment setup so tests run through the programmatic API
+  // observe `NODE_ENV=test` / `RSTEST=true` (workers inherit `process.env` at
+  // spawn time).
   initRstestEnv();
 
-  const cwd = options.cwd
-    ? getAbsolutePath(process.cwd(), options.cwd)
-    : process.cwd();
-
-  // Snapshot `process.exitCode` and restore it in `finally`. Belt-and-suspenders
-  // against unconditional `process.exitCode = 1` mutations in deeper layers
-  // (globalSetup teardown, coverage threshold failures, etc.) that don't
-  // consult `context.embedded`. The CLI path never goes through this function.
-  const originalExitCode = process.exitCode;
-
-  const captured: {
-    unhandledErrors: SerializedError[];
-    duration: { total: number };
-    coverage?: CoverageMapData;
-    snapshot?: SnapshotSummary;
-  } = {
-    unhandledErrors: [],
-    duration: { total: 0 },
-  };
-
-  const captureReporter: Reporter = {
-    onTestRunEnd: ({
-      unhandledErrors,
-      duration,
-      coverage,
-      snapshotSummary,
-    }) => {
-      captured.unhandledErrors = (unhandledErrors ?? []).map((err) =>
-        toSerializedError(err),
-      );
-      captured.duration = { total: duration.totalTime };
-      captured.coverage = coverage;
-      captured.snapshot = snapshotSummary;
-    },
-  };
-
-  let files: TestFileResult[] = [];
-  let rstest: ReturnType<typeof createRstest> | undefined;
-
   try {
-    const { content: userConfig, filePath: configFilePath } =
-      await loadConfigForApi({
-        cwd,
-        configPath: options.config,
-        inlineConfig: options.inlineConfig,
+    const cwd = options.cwd
+      ? getAbsolutePath(process.cwd(), options.cwd)
+      : process.cwd();
+
+    const captured: {
+      unhandledErrors: SerializedError[];
+      duration: { total: number };
+      coverage?: CoverageMapData;
+      snapshot?: SnapshotSummary;
+    } = {
+      unhandledErrors: [],
+      duration: { total: 0 },
+    };
+
+    const captureReporter: Reporter = {
+      onTestRunEnd: ({
+        unhandledErrors,
+        duration,
+        coverage,
+        snapshotSummary,
+      }) => {
+        captured.unhandledErrors = (unhandledErrors ?? []).map((err) =>
+          toSerializedError(err),
+        );
+        captured.duration = { total: duration.totalTime };
+        captured.coverage = coverage;
+        captured.snapshot = snapshotSummary;
+      },
+    };
+
+    let files: TestFileResult[] = [];
+    let rstest: ReturnType<typeof createRstest> | undefined;
+
+    try {
+      const { content: userConfig, filePath: configFilePath } =
+        await loadConfigForApi({
+          cwd,
+          configPath: options.config,
+          inlineConfig: options.inlineConfig,
+        });
+
+      // Resolve config + projects through the same pipeline the CLI uses
+      // (`mergeWithCLIOptions` + `resolveProjects`) so CLI-style options
+      // propagate to the root config AND every project config from one place,
+      // instead of being re-derived per API option. Map the API surface onto
+      // `CommonOptions`; `mergeWithCLIOptions`/`resolveProjects` skip `undefined`.
+      const cliOptions: CommonOptions = {
+        testNamePattern: options.testNamePattern,
+      };
+      mergeWithCLIOptions(userConfig, cliOptions);
+
+      // Absolutize `root` against the API cwd exactly like `createRstest` does,
+      // so `resolveProjects` runs its filesystem lookups (existsSync/glob) from
+      // the same base where tests will actually run.
+      userConfig.root = userConfig.root
+        ? getAbsolutePath(cwd, userConfig.root)
+        : cwd;
+
+      const projects = await resolveProjects({
+        config: userConfig,
+        root: userConfig.root,
+        options: cliOptions,
       });
 
-    // Resolve config + projects through the same pipeline the CLI uses
-    // (`mergeWithCLIOptions` + `resolveProjects`) so CLI-style options propagate
-    // to the root config AND every project config from one place, instead of
-    // being re-derived per API option. Map the API surface onto `CommonOptions`;
-    // `mergeWithCLIOptions`/`resolveProjects` skip `undefined` values.
-    const cliOptions: CommonOptions = {
-      testNamePattern: options.testNamePattern,
-    };
-    mergeWithCLIOptions(userConfig, cliOptions);
+      // `options.files !== undefined` (not `?.length`) so an explicit empty
+      // array runs zero files instead of falling back to fuzzy/no-filter mode.
+      const fileFilters = options.files ?? [];
+      const fileFilterMode = options.files !== undefined ? 'exact' : 'fuzzy';
 
-    // Absolutize `root` against the API cwd exactly like `createRstest` does, so
-    // `resolveProjects` runs its filesystem lookups (existsSync/glob) from the
-    // same base where tests will actually run.
-    userConfig.root = userConfig.root
-      ? getAbsolutePath(cwd, userConfig.root)
-      : cwd;
-
-    const projects = await resolveProjects({
-      config: userConfig,
-      root: userConfig.root,
-      options: cliOptions,
-    });
-
-    // `options.files !== undefined` (not `?.length`) so an explicit empty
-    // array runs zero files instead of falling back to fuzzy/no-filter mode.
-    const fileFilters = options.files ?? [];
-    const fileFilterMode = options.files !== undefined ? 'exact' : 'fuzzy';
-
-    rstest = createRstest(
-      {
-        config: userConfig,
-        configFilePath,
-        projects,
-        cwd,
-        embedded: true,
-      },
-      'run',
-      fileFilters,
-      fileFilterMode,
-    );
-
-    rstest.context.reporters.push(captureReporter);
-
-    await rstest.runTests();
-  } catch (err) {
-    captured.unhandledErrors.unshift(toSerializedError(err));
-  } finally {
-    // Read collected per-file results here (not at the end of `try`) so a
-    // failure in a post-run step — coverage report, global teardown, pool or
-    // server cleanup — doesn't discard results already gathered during the run.
-    if (rstest) {
-      files = rstest.context.reporterResults.results.map(
-        toPublicTestFileResult,
+      rstest = createRstest(
+        {
+          config: userConfig,
+          configFilePath,
+          projects,
+          cwd,
+          embedded: true,
+        },
+        'run',
+        fileFilters,
+        fileFilterMode,
       );
-    }
-    process.exitCode = originalExitCode;
-    for (const [key, value] of Object.entries(envSnapshot)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
+
+      rstest.context.reporters.push(captureReporter);
+
+      await rstest.runTests();
+    } catch (err) {
+      captured.unhandledErrors.unshift(toSerializedError(err));
+    } finally {
+      // Read collected per-file results here (not at the end of `try`) so a
+      // failure in a post-run step — coverage report, global teardown, pool or
+      // server cleanup — doesn't discard results already gathered during the run.
+      if (rstest) {
+        files = rstest.context.reporterResults.results.map(
+          toPublicTestFileResult,
+        );
       }
     }
+
+    const stats = computeStats(files);
+
+    // Mirror the CLI: discovering no test files is a failure unless
+    // `passWithNoTests` is set. `process.exitCode` is restored by the guards, so
+    // `ok` must derive this independently rather than reading the exit code.
+    const noTestsFailure =
+      !!rstest &&
+      files.length === 0 &&
+      !rstest.context.normalizedConfig.passWithNoTests;
+
+    const ok =
+      stats.tests.failed === 0 &&
+      stats.files.failed === 0 &&
+      captured.unhandledErrors.length === 0 &&
+      !noTestsFailure;
+
+    return {
+      ok,
+      files,
+      stats,
+      unhandledErrors: captured.unhandledErrors,
+      duration: captured.duration,
+      snapshot: captured.snapshot,
+      coverage: captured.coverage,
+    };
+  } finally {
+    restoreProcessGuards();
   }
-
-  const stats = computeStats(files);
-
-  // Mirror the CLI: discovering no test files is a failure unless
-  // `passWithNoTests` is set. `process.exitCode` is restored in `finally`, so
-  // `ok` must derive this independently rather than reading the exit code.
-  const noTestsFailure =
-    !!rstest &&
-    files.length === 0 &&
-    !rstest.context.normalizedConfig.passWithNoTests;
-
-  const ok =
-    stats.tests.failed === 0 &&
-    stats.files.failed === 0 &&
-    captured.unhandledErrors.length === 0 &&
-    !noTestsFailure;
-
-  return {
-    ok,
-    files,
-    stats,
-    unhandledErrors: captured.unhandledErrors,
-    duration: captured.duration,
-    snapshot: captured.snapshot,
-    coverage: captured.coverage,
-  };
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,6 +1,4 @@
 /**
- * @module @rstest/core/api
- *
  * Programmatic Node API for running Rstest in-process.
  *
  * @experimental
@@ -327,6 +325,7 @@ export async function runRstest(
   };
 
   let files: TestFileResult[] = [];
+  let rstest: ReturnType<typeof createRstest> | undefined;
 
   try {
     const { content: userConfig, filePath: configFilePath } =
@@ -355,7 +354,7 @@ export async function runRstest(
     const fileFilters = options.files ?? [];
     const fileFilterMode = options.files !== undefined ? 'exact' : 'fuzzy';
 
-    const rstest = createRstest(
+    rstest = createRstest(
       {
         config: userConfig,
         configFilePath,
@@ -371,11 +370,17 @@ export async function runRstest(
     rstest.context.reporters.push(captureReporter);
 
     await rstest.runTests();
-
-    files = rstest.context.reporterResults.results.map(toPublicTestFileResult);
   } catch (err) {
     captured.unhandledErrors.unshift(toSerializedError(err));
   } finally {
+    // Read collected per-file results here (not at the end of `try`) so a
+    // failure in a post-run step — coverage report, global teardown, pool or
+    // server cleanup — doesn't discard results already gathered during the run.
+    if (rstest) {
+      files = rstest.context.reporterResults.results.map(
+        toPublicTestFileResult,
+      );
+    }
     process.exitCode = originalExitCode;
   }
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -8,7 +8,11 @@
  * semantic changes may land in any minor release in the 0.x line. Pin the
  * exact patch version of `@rstest/core` if you depend on these APIs today.
  */
-import { resolveProjects } from '../cli/init';
+import {
+  type CommonOptions,
+  mergeWithCLIOptions,
+  resolveProjects,
+} from '../cli/init';
 import { initRstestEnv } from '../cli/prepare';
 import { loadConfig, mergeRstestConfig, resolveExtends } from '../config';
 import { createRstest } from '../core';
@@ -290,7 +294,13 @@ export async function runRstest(
   options: RunRstestOptions = {},
 ): Promise<TestRunResult> {
   // Match the CLI's environment setup so tests run through the programmatic
-  // API observe `NODE_ENV=test` / `RSTEST=true` (workers inherit `process.env`).
+  // API observe `NODE_ENV=test` / `RSTEST=true` (workers inherit `process.env`
+  // at spawn time). Snapshot and restore around the run so a long-lived
+  // embedding host isn't left with these mutated globally after we resolve.
+  const envSnapshot = {
+    NODE_ENV: process.env.NODE_ENV,
+    RSTEST: process.env.RSTEST,
+  };
   initRstestEnv();
 
   const cwd = options.cwd
@@ -340,18 +350,27 @@ export async function runRstest(
         inlineConfig: options.inlineConfig,
       });
 
-    if (!userConfig.root) {
-      userConfig.root = cwd;
-    }
+    // Resolve config + projects through the same pipeline the CLI uses
+    // (`mergeWithCLIOptions` + `resolveProjects`) so CLI-style options propagate
+    // to the root config AND every project config from one place, instead of
+    // being re-derived per API option. Map the API surface onto `CommonOptions`;
+    // `mergeWithCLIOptions`/`resolveProjects` skip `undefined` values.
+    const cliOptions: CommonOptions = {
+      testNamePattern: options.testNamePattern,
+    };
+    mergeWithCLIOptions(userConfig, cliOptions);
 
-    if (options.testNamePattern !== undefined) {
-      userConfig.testNamePattern = options.testNamePattern;
-    }
+    // Absolutize `root` against the API cwd exactly like `createRstest` does, so
+    // `resolveProjects` runs its filesystem lookups (existsSync/glob) from the
+    // same base where tests will actually run.
+    userConfig.root = userConfig.root
+      ? getAbsolutePath(cwd, userConfig.root)
+      : cwd;
 
     const projects = await resolveProjects({
       config: userConfig,
       root: userConfig.root,
-      options: {},
+      options: cliOptions,
     });
 
     // `options.files !== undefined` (not `?.length`) so an explicit empty
@@ -387,6 +406,13 @@ export async function runRstest(
       );
     }
     process.exitCode = originalExitCode;
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
   }
 
   const stats = computeStats(files);

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -329,73 +329,69 @@ export async function runRstest(
   let files: TestFileResult[] = [];
 
   try {
-    try {
-      const { content: userConfig, filePath: configFilePath } =
-        await loadConfigForApi({
-          cwd,
-          configPath: options.config,
-          inlineConfig: options.inlineConfig,
-        });
-
-      if (!userConfig.root) {
-        userConfig.root = cwd;
-      }
-
-      if (options.testNamePattern !== undefined) {
-        userConfig.testNamePattern = options.testNamePattern;
-      }
-
-      const projects = await resolveProjects({
-        config: userConfig,
-        root: userConfig.root,
-        options: {},
+    const { content: userConfig, filePath: configFilePath } =
+      await loadConfigForApi({
+        cwd,
+        configPath: options.config,
+        inlineConfig: options.inlineConfig,
       });
 
-      // `options.files !== undefined` (not `?.length`) so an explicit empty
-      // array runs zero files instead of falling back to fuzzy/no-filter mode.
-      const fileFilters = options.files ?? [];
-      const fileFilterMode = options.files !== undefined ? 'exact' : 'fuzzy';
-
-      const rstest = createRstest(
-        {
-          config: userConfig,
-          configFilePath,
-          projects,
-          cwd,
-          embedded: true,
-        },
-        'run',
-        fileFilters,
-        fileFilterMode,
-      );
-
-      rstest.context.reporters.push(captureReporter);
-
-      await rstest.runTests();
-
-      files = rstest.context.reporterResults.results.map(
-        toPublicTestFileResult,
-      );
-    } catch (err) {
-      captured.unhandledErrors.unshift(toSerializedError(err));
+    if (!userConfig.root) {
+      userConfig.root = cwd;
     }
 
-    const stats = computeStats(files);
-    const ok =
-      stats.tests.failed === 0 &&
-      stats.files.failed === 0 &&
-      captured.unhandledErrors.length === 0;
+    if (options.testNamePattern !== undefined) {
+      userConfig.testNamePattern = options.testNamePattern;
+    }
 
-    return {
-      ok,
-      files,
-      stats,
-      unhandledErrors: captured.unhandledErrors,
-      duration: captured.duration,
-      snapshot: captured.snapshot,
-      coverage: captured.coverage,
-    };
+    const projects = await resolveProjects({
+      config: userConfig,
+      root: userConfig.root,
+      options: {},
+    });
+
+    // `options.files !== undefined` (not `?.length`) so an explicit empty
+    // array runs zero files instead of falling back to fuzzy/no-filter mode.
+    const fileFilters = options.files ?? [];
+    const fileFilterMode = options.files !== undefined ? 'exact' : 'fuzzy';
+
+    const rstest = createRstest(
+      {
+        config: userConfig,
+        configFilePath,
+        projects,
+        cwd,
+        embedded: true,
+      },
+      'run',
+      fileFilters,
+      fileFilterMode,
+    );
+
+    rstest.context.reporters.push(captureReporter);
+
+    await rstest.runTests();
+
+    files = rstest.context.reporterResults.results.map(toPublicTestFileResult);
+  } catch (err) {
+    captured.unhandledErrors.unshift(toSerializedError(err));
   } finally {
     process.exitCode = originalExitCode;
   }
+
+  const stats = computeStats(files);
+  const ok =
+    stats.tests.failed === 0 &&
+    stats.files.failed === 0 &&
+    captured.unhandledErrors.length === 0;
+
+  return {
+    ok,
+    files,
+    stats,
+    unhandledErrors: captured.unhandledErrors,
+    duration: captured.duration,
+    snapshot: captured.snapshot,
+    coverage: captured.coverage,
+  };
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,13 +1,17 @@
 /**
+ * @module @rstest/core/api
+ *
  * Programmatic Node API for running Rstest in-process.
  *
- * Stability: Public surface; field-frozen at 1.0.0. Adding optional fields is
- * a minor change; removing or repurposing fields requires a major bump.
- *
- * @see RFC-programmatic-node-api.md
+ * @experimental
+ * All exports from this entrypoint are **experimental** and subject to change
+ * in any release until Rstest reaches 1.0.0, at which point this surface will
+ * be stabilized. Field additions are non-breaking; field removals, renames, or
+ * semantic changes may land in any minor release in the 0.x line. Pin the
+ * exact patch version of `@rstest/core` if you depend on these APIs today.
  */
-import { loadConfig, mergeRstestConfig, resolveExtends } from '../config';
 import { resolveProjects } from '../cli/init';
+import { loadConfig, mergeRstestConfig, resolveExtends } from '../config';
 import { createRstest } from '../core';
 import type {
   CoverageMapData,
@@ -15,18 +19,37 @@ import type {
   Reporter,
   RstestConfig,
   SnapshotSummary,
-  TestFileResult,
+  TestFileResult as InternalTestFileResult,
+  TestResult as InternalTestResult,
+  TestResultStatus,
 } from '../types';
 import { getAbsolutePath } from '../utils';
 
-export type { Reporter, TestFileResult } from '../types';
-/** Inline configuration shape; same type the `rstest.config.ts` exports. */
+/**
+ * @experimental Subject to change until 1.0.0.
+ */
+export type { Reporter } from '../types';
+
+/**
+ * Inline configuration shape; same type the `rstest.config.ts` exports.
+ *
+ * @experimental Subject to change until 1.0.0.
+ */
 export type { RstestConfig as RstestUserConfig } from '../types';
 
 /**
- * Cross-IPC-safe error shape. Returned in `TestRunResult.unhandledErrors`.
- * Assertion-specific fields (`diff`, `actual`, `expected`) are only set for
- * `@vitest/expect`-style errors.
+ * Per-test result status.
+ *
+ * @experimental Subject to change until 1.0.0.
+ */
+export type { TestResultStatus } from '../types';
+
+/**
+ * Cross-IPC-safe error shape. Returned in `TestRunResult.unhandledErrors` and
+ * in per-test `errors`/`retryErrors`. Assertion-specific fields (`diff`,
+ * `actual`, `expected`) are only set for `@vitest/expect`-style errors.
+ *
+ * @experimental Subject to change until 1.0.0.
  */
 export interface SerializedError {
   name: string;
@@ -38,6 +61,50 @@ export interface SerializedError {
   cause?: SerializedError;
 }
 
+/**
+ * Public per-test result. Intentionally a curated subset of the internal
+ * reporter type so refactors of internal reporter state do not break this
+ * surface.
+ *
+ * @experimental Subject to change until 1.0.0.
+ */
+export interface TestResult {
+  /** Final state of the test case. */
+  status: TestResultStatus;
+  /** Test case name (no parent suite names included). */
+  name: string;
+  /** Absolute path to the test file. */
+  testPath: string;
+  /** Names of parent `describe` blocks, outermost first. */
+  parentNames?: string[];
+  /** Wall-clock duration in ms; absent for skipped/todo tests. */
+  duration?: number;
+  /** Errors from the final attempt. */
+  errors?: SerializedError[];
+  /** Errors from previous failed attempts when `retry` is configured. */
+  retryErrors?: SerializedError[];
+  /** Number of retries performed (0 when the first attempt passed). */
+  retryCount?: number;
+  /** Project name from `projects` config; default project is `'default'`. */
+  project: string;
+}
+
+/**
+ * Public per-file result. Extends {@link TestResult} with the per-case
+ * breakdown.
+ *
+ * @experimental Subject to change until 1.0.0.
+ */
+export interface TestFileResult extends TestResult {
+  /** Flattened list of test cases discovered in this file. */
+  results: TestResult[];
+}
+
+/**
+ * Options for {@link runRstest}.
+ *
+ * @experimental Subject to change until 1.0.0.
+ */
 export interface RunRstestOptions {
   /** Working directory. Defaults to `process.cwd()`. */
   cwd?: string;
@@ -68,8 +135,13 @@ export interface RunRstestOptions {
   testNamePattern?: RegExp | string;
 }
 
+/**
+ * Result of a {@link runRstest} call.
+ *
+ * @experimental Subject to change until 1.0.0.
+ */
 export interface TestRunResult {
-  /** `stats.tests.failed === 0 && unhandledErrors.length === 0`. */
+  /** `stats.tests.failed === 0 && stats.files.failed === 0 && unhandledErrors.length === 0`. */
   ok: boolean;
 
   /** Per-file aggregate results. */
@@ -103,10 +175,17 @@ export interface TestRunResult {
   coverage?: CoverageMapData;
 }
 
-const toSerializedError = (err: unknown): SerializedError => {
+const toSerializedError = (
+  err: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): SerializedError => {
   if (!err || typeof err !== 'object') {
     return { name: 'Error', message: String(err) };
   }
+  if (seen.has(err)) {
+    return { name: 'Error', message: '[Circular]' };
+  }
+  seen.add(err);
   const e = err as Partial<FormattedError> & { cause?: unknown };
   return {
     name: e.name || 'Error',
@@ -115,9 +194,26 @@ const toSerializedError = (err: unknown): SerializedError => {
     diff: e.diff,
     actual: e.actual,
     expected: e.expected,
-    cause: e.cause !== undefined ? toSerializedError(e.cause) : undefined,
+    cause: e.cause !== undefined ? toSerializedError(e.cause, seen) : undefined,
   };
 };
+
+const toPublicTestResult = (r: InternalTestResult): TestResult => ({
+  status: r.status,
+  name: r.name,
+  testPath: r.testPath,
+  parentNames: r.parentNames,
+  duration: r.duration,
+  errors: r.errors?.map((err) => toSerializedError(err)),
+  retryErrors: r.retryErrors?.map((err) => toSerializedError(err)),
+  retryCount: r.retryCount,
+  project: r.project,
+});
+
+const toPublicTestFileResult = (f: InternalTestFileResult): TestFileResult => ({
+  ...toPublicTestResult(f),
+  results: f.results.map(toPublicTestResult),
+});
 
 const computeStats = (
   files: readonly TestFileResult[],
@@ -169,14 +265,15 @@ const loadConfigForApi = async ({
     filePath = loaded.filePath ?? undefined;
   }
 
-  let merged = mergeRstestConfig(diskContent, inlineConfig ?? {});
-
-  // `loadConfig` already resolved `extends` on disk content. If the inline
-  // config introduced its own `extends`, resolve them here so the final
-  // merged config is fully expanded.
-  if (inlineConfig?.extends) {
-    merged = await resolveExtends(merged);
+  // `loadConfig` already resolved `extends` on disk content. Resolve inline
+  // extends *before* merging so the merged result doesn't carry both copies
+  // (which would double-apply disk extends if we re-ran resolveExtends here).
+  let resolvedInline: RstestConfig = inlineConfig ?? {};
+  if (resolvedInline.extends) {
+    resolvedInline = await resolveExtends(resolvedInline);
   }
+
+  const merged = mergeRstestConfig(diskContent, resolvedInline);
 
   return { content: merged, filePath };
 };
@@ -187,6 +284,8 @@ const loadConfigForApi = async ({
  * Resolves on every termination path — including config errors and worker
  * crashes — with `ok` reflecting overall success. The returned promise only
  * rejects for programmer errors (e.g. invalid argument types).
+ *
+ * @experimental Subject to change until 1.0.0.
  */
 export async function runRstest(
   options: RunRstestOptions = {},
@@ -194,6 +293,12 @@ export async function runRstest(
   const cwd = options.cwd
     ? getAbsolutePath(process.cwd(), options.cwd)
     : process.cwd();
+
+  // Snapshot `process.exitCode` and restore it in `finally`. Belt-and-suspenders
+  // against unconditional `process.exitCode = 1` mutations in deeper layers
+  // (globalSetup teardown, coverage threshold failures, etc.) that don't
+  // consult `context.embedded`. The CLI path never goes through this function.
+  const originalExitCode = process.exitCode;
 
   const captured: {
     unhandledErrors: SerializedError[];
@@ -212,7 +317,9 @@ export async function runRstest(
       coverage,
       snapshotSummary,
     }) => {
-      captured.unhandledErrors = (unhandledErrors ?? []).map(toSerializedError);
+      captured.unhandledErrors = (unhandledErrors ?? []).map((err) =>
+        toSerializedError(err),
+      );
       captured.duration = { total: duration.totalTime };
       captured.coverage = coverage;
       captured.snapshot = snapshotSummary;
@@ -220,69 +327,75 @@ export async function runRstest(
   };
 
   let files: TestFileResult[] = [];
-  let initError: SerializedError | undefined;
 
   try {
-    const { content: userConfig, filePath: configFilePath } =
-      await loadConfigForApi({
-        cwd,
-        configPath: options.config,
-        inlineConfig: options.inlineConfig,
+    try {
+      const { content: userConfig, filePath: configFilePath } =
+        await loadConfigForApi({
+          cwd,
+          configPath: options.config,
+          inlineConfig: options.inlineConfig,
+        });
+
+      if (!userConfig.root) {
+        userConfig.root = cwd;
+      }
+
+      if (options.testNamePattern !== undefined) {
+        userConfig.testNamePattern = options.testNamePattern;
+      }
+
+      const projects = await resolveProjects({
+        config: userConfig,
+        root: userConfig.root,
+        options: {},
       });
 
-    if (!userConfig.root) {
-      userConfig.root = cwd;
+      // `options.files !== undefined` (not `?.length`) so an explicit empty
+      // array runs zero files instead of falling back to fuzzy/no-filter mode.
+      const fileFilters = options.files ?? [];
+      const fileFilterMode = options.files !== undefined ? 'exact' : 'fuzzy';
+
+      const rstest = createRstest(
+        {
+          config: userConfig,
+          configFilePath,
+          projects,
+          cwd,
+          embedded: true,
+        },
+        'run',
+        fileFilters,
+        fileFilterMode,
+      );
+
+      rstest.context.reporters.push(captureReporter);
+
+      await rstest.runTests();
+
+      files = rstest.context.reporterResults.results.map(
+        toPublicTestFileResult,
+      );
+    } catch (err) {
+      captured.unhandledErrors.unshift(toSerializedError(err));
     }
 
-    if (options.testNamePattern !== undefined) {
-      userConfig.testNamePattern = options.testNamePattern;
-    }
+    const stats = computeStats(files);
+    const ok =
+      stats.tests.failed === 0 &&
+      stats.files.failed === 0 &&
+      captured.unhandledErrors.length === 0;
 
-    const projects = await resolveProjects({
-      config: userConfig,
-      root: userConfig.root,
-      options: {},
-    });
-
-    const fileFilters = options.files ?? [];
-    const fileFilterMode = options.files?.length ? 'exact' : 'fuzzy';
-
-    const rstest = createRstest(
-      {
-        config: userConfig,
-        configFilePath,
-        projects,
-        cwd,
-        embedded: true,
-      },
-      'run',
-      fileFilters,
-      fileFilterMode,
-    );
-
-    rstest.context.reporters.push(captureReporter);
-
-    await rstest.runTests();
-
-    files = rstest.context.reporterResults.results;
-  } catch (err) {
-    initError = toSerializedError(err);
+    return {
+      ok,
+      files,
+      stats,
+      unhandledErrors: captured.unhandledErrors,
+      duration: captured.duration,
+      snapshot: captured.snapshot,
+      coverage: captured.coverage,
+    };
+  } finally {
+    process.exitCode = originalExitCode;
   }
-
-  const allErrors = initError
-    ? [initError, ...captured.unhandledErrors]
-    : captured.unhandledErrors;
-
-  const stats = computeStats(files);
-  const ok = stats.tests.failed === 0 && allErrors.length === 0;
-
-  return {
-    ok,
-    files,
-    stats,
-    unhandledErrors: allErrors,
-    duration: captured.duration,
-    snapshot: captured.snapshot,
-    coverage: captured.coverage,
-  };
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -9,6 +9,7 @@
  * exact patch version of `@rstest/core` if you depend on these APIs today.
  */
 import { resolveProjects } from '../cli/init';
+import { initRstestEnv } from '../cli/prepare';
 import { loadConfig, mergeRstestConfig, resolveExtends } from '../config';
 import { createRstest } from '../core';
 import type {
@@ -288,6 +289,10 @@ const loadConfigForApi = async ({
 export async function runRstest(
   options: RunRstestOptions = {},
 ): Promise<TestRunResult> {
+  // Match the CLI's environment setup so tests run through the programmatic
+  // API observe `NODE_ENV=test` / `RSTEST=true` (workers inherit `process.env`).
+  initRstestEnv();
+
   const cwd = options.cwd
     ? getAbsolutePath(process.cwd(), options.cwd)
     : process.cwd();
@@ -385,10 +390,20 @@ export async function runRstest(
   }
 
   const stats = computeStats(files);
+
+  // Mirror the CLI: discovering no test files is a failure unless
+  // `passWithNoTests` is set. `process.exitCode` is restored in `finally`, so
+  // `ok` must derive this independently rather than reading the exit code.
+  const noTestsFailure =
+    !!rstest &&
+    files.length === 0 &&
+    !rstest.context.normalizedConfig.passWithNoTests;
+
   const ok =
     stats.tests.failed === 0 &&
     stats.files.failed === 0 &&
-    captured.unhandledErrors.length === 0;
+    captured.unhandledErrors.length === 0 &&
+    !noTestsFailure;
 
   return {
     ok,

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -124,7 +124,7 @@ const normalizeBooleanLikeCliValue = (
   return value;
 };
 
-function mergeWithCLIOptions(
+export function mergeWithCLIOptions(
   config: RstestConfig,
   options: CommonOptions,
 ): RstestConfig {

--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -6,10 +6,18 @@ function initNodeEnv() {
   }
 }
 
-export function prepareCli(): void {
+/**
+ * Initialize the test environment variables that worker processes inherit via
+ * `process.env`. Shared by the CLI (`prepareCli`) and the programmatic API
+ * (`runRstest`) so both paths run tests with `NODE_ENV=test` and `RSTEST=true`.
+ */
+export function initRstestEnv(): void {
   initNodeEnv();
-
   process.env.RSTEST = 'true';
+}
+
+export function prepareCli(): void {
+  initRstestEnv();
 
   // Print a blank line to keep the greet log nice.
   // Some package managers automatically output a blank line, some do not.

--- a/packages/core/src/core/browserLoader.ts
+++ b/packages/core/src/core/browserLoader.ts
@@ -35,6 +35,11 @@ interface LoadBrowserModuleOptions {
    * This allows resolving from project-specific node_modules in monorepo setups.
    */
   projectRoots?: string[];
+  /**
+   * When true, a missing or version-mismatched `@rstest/browser` throws instead
+   * of calling `process.exit(1)`. See the `embedded` option on `createRstest`.
+   */
+  embedded?: boolean;
 }
 
 /**
@@ -50,7 +55,7 @@ export async function loadBrowserModule(
   options: LoadBrowserModuleOptions = {},
 ): Promise<BrowserModule> {
   const coreVersion = RSTEST_VERSION;
-  const { projectRoots = [] } = options;
+  const { projectRoots = [], embedded = false } = options;
 
   let browserModule: BrowserModule;
   let browserVersion: string;
@@ -84,6 +89,13 @@ export async function loadBrowserModule(
 
       // Successfully resolved, validate version and return
       if (browserVersion !== coreVersion) {
+        if (embedded) {
+          throw new Error(
+            `Version mismatch between @rstest/core (${coreVersion}) and ` +
+              `@rstest/browser (${browserVersion}). Install matching versions: ` +
+              `npm install @rstest/browser@${coreVersion}`,
+          );
+        }
         logger.error(
           `\n${color.red('Error:')} Version mismatch between ${color.cyan('@rstest/core')} and ${color.cyan('@rstest/browser')}.\n`,
         );
@@ -111,6 +123,12 @@ export async function loadBrowserModule(
   }
 
   // All resolution strategies failed
+  if (embedded) {
+    throw new Error(
+      `Browser mode requires @rstest/browser to be installed: ` +
+        `npm install @rstest/browser@${coreVersion}`,
+    );
+  }
   logger.error(
     `\n${color.red('Error:')} Browser mode requires ${color.cyan('@rstest/browser')} to be installed.\n`,
   );

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -25,10 +25,11 @@ export function createRstest(
     /** Working directory; defaults to `process.cwd()`. */
     cwd?: string;
     /**
-     * When true, `runTests()` will not mutate `process.exitCode` or attach
-     * process signal handlers. Set by the `@rstest/core/api` adapter.
-     *
-     * @internal
+     * When true, Rstest won't install `process.on('exit' | 'SIG*')` handlers
+     * and config errors throw instead of calling `process.exit()`, so a
+     * programmatic run can't kill the host process. (`process.exitCode` is
+     * still written; `runRstest` restores it via try/finally.) Set by the
+     * `@rstest/core/api` adapter.
      */
     embedded?: boolean;
   },

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -14,12 +14,23 @@ export function createRstest(
     projects,
     configFilePath,
     trace,
+    cwd = process.cwd(),
+    embedded = false,
   }: {
     config: RstestConfig;
     configFilePath?: string;
     projects: Project[];
     /** CLI-only `--trace` switch; not exposed via user config. */
     trace?: boolean;
+    /** Working directory; defaults to `process.cwd()`. */
+    cwd?: string;
+    /**
+     * When true, `runTests()` will not mutate `process.exitCode` or attach
+     * process signal handlers. Set by the `@rstest/core/api` adapter.
+     *
+     * @internal
+     */
+    embedded?: boolean;
   },
   command: RstestCommand,
   fileFilters: string[],
@@ -27,13 +38,14 @@ export function createRstest(
 ): RstestInstance {
   const context = new Rstest(
     {
-      cwd: process.cwd(),
+      cwd,
       command,
       fileFilters,
       fileFilterMode,
       configFilePath,
       projects,
       trace,
+      embedded,
     },
     config,
   );

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -308,6 +308,7 @@ const collectBrowserTests = async ({
   const projectRoots = browserProjects.map((p) => p.rootPath);
   const { validateBrowserConfig, listBrowserTests } = await loadBrowserModule({
     projectRoots,
+    embedded: context.embedded,
   });
   validateBrowserConfig(context);
   return listBrowserTests(context, { shardedEntries });

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname, isAbsolute, join, relative } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
+import { relative } from 'pathe';
 import { createPool } from '../pool';
 import type {
   FormattedError,

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -50,6 +50,14 @@ type Options = {
   configFilePath?: string;
   projects: Project[];
   trace?: boolean;
+  /**
+   * When true, `runTests()` will not mutate `process.exitCode` or attach
+   * `process.on('exit' | 'SIG*')` handlers. Used by the programmatic API so
+   * test failures don't poison the host process.
+   *
+   * @internal
+   */
+  embedded?: boolean;
 };
 
 export class Rstest implements RstestContext {
@@ -64,6 +72,8 @@ export class Rstest implements RstestContext {
   public relatedRerunReason?: 'forceRerunTrigger';
   public relatedRerunFiles?: string[];
   public configFilePath?: string;
+  /** @internal */
+  public embedded: boolean;
   public reporters: Reporter[];
   public snapshotManager: SnapshotManager;
   public trace: boolean;
@@ -103,6 +113,7 @@ export class Rstest implements RstestContext {
       configFilePath,
       projects,
       trace = false,
+      embedded = false,
     }: Options,
     userConfig: RstestConfig,
   ) {
@@ -112,6 +123,7 @@ export class Rstest implements RstestContext {
     this.fileFilters = fileFilters;
     this.fileFilterMode = fileFilterMode;
     this.configFilePath = configFilePath;
+    this.embedded = embedded;
 
     const rootPath = userConfig.root
       ? getAbsolutePath(cwd, userConfig.root)

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -140,7 +140,11 @@ export class Rstest implements RstestContext {
     );
 
     if (command === 'watch' && rstestConfig.shard) {
-      logger.error('Test sharding is not supported in watch mode.');
+      const message = 'Test sharding is not supported in watch mode.';
+      if (embedded) {
+        throw new Error(message);
+      }
+      logger.error(message);
       process.exit(1);
     }
 
@@ -162,13 +166,16 @@ export class Rstest implements RstestContext {
             (project.config.shard.count !== rstestConfig.shard?.count ||
               project.config.shard.index !== rstestConfig.shard?.index)
           ) {
-            logger.error(
+            const message =
               'The `shard` option is a global option and cannot be set per-project.\n' +
-                'global `shard` option:\n' +
-                `  count: ${rstestConfig.shard?.count}, index: ${rstestConfig.shard?.index}\n` +
-                `project "${project.config.name}" shard option:\n` +
-                `  count: ${project.config.shard.count}, index: ${project.config.shard.index}`,
-            );
+              'global `shard` option:\n' +
+              `  count: ${rstestConfig.shard?.count}, index: ${rstestConfig.shard?.index}\n` +
+              `project "${project.config.name}" shard option:\n` +
+              `  count: ${project.config.shard.count}, index: ${project.config.shard.index}`;
+            if (embedded) {
+              throw new Error(message);
+            }
+            logger.error(message);
             process.exit(1);
           }
 

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -63,13 +63,7 @@ type Options = {
   configFilePath?: string;
   projects: Project[];
   trace?: boolean;
-  /**
-   * When true, `runTests()` will not mutate `process.exitCode` or attach
-   * `process.on('exit' | 'SIG*')` handlers. Used by the programmatic API so
-   * test failures don't poison the host process.
-   *
-   * @internal
-   */
+  /** See the `embedded` option on `createRstest`. */
   embedded?: boolean;
 };
 
@@ -85,7 +79,6 @@ export class Rstest implements RstestContext {
   public relatedRerunReason?: 'forceRerunTrigger';
   public relatedRerunFiles?: string[];
   public configFilePath?: string;
-  /** @internal */
   public embedded: boolean;
   public reporters: Reporter[];
   public snapshotManager: SnapshotManager;

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -42,6 +42,19 @@ function formatEnvironmentName(name: string): string {
   return name.replace(/[^a-zA-Z0-9\-_$]/g, '_');
 }
 
+/**
+ * Report a fatal configuration error. In embedded (programmatic) mode the
+ * caller owns the process, so throw and let `runRstest` surface it; otherwise
+ * log and exit the CLI process.
+ */
+function failConfig(embedded: boolean, message: string): never {
+  if (embedded) {
+    throw new Error(message);
+  }
+  logger.error(message);
+  process.exit(1);
+}
+
 type Options = {
   cwd: string;
   command: RstestCommand;
@@ -140,12 +153,7 @@ export class Rstest implements RstestContext {
     );
 
     if (command === 'watch' && rstestConfig.shard) {
-      const message = 'Test sharding is not supported in watch mode.';
-      if (embedded) {
-        throw new Error(message);
-      }
-      logger.error(message);
-      process.exit(1);
+      failConfig(embedded, 'Test sharding is not supported in watch mode.');
     }
 
     const snapshotManager = new SnapshotManager({
@@ -166,17 +174,14 @@ export class Rstest implements RstestContext {
             (project.config.shard.count !== rstestConfig.shard?.count ||
               project.config.shard.index !== rstestConfig.shard?.index)
           ) {
-            const message =
+            failConfig(
+              embedded,
               'The `shard` option is a global option and cannot be set per-project.\n' +
-              'global `shard` option:\n' +
-              `  count: ${rstestConfig.shard?.count}, index: ${rstestConfig.shard?.index}\n` +
-              `project "${project.config.name}" shard option:\n` +
-              `  count: ${project.config.shard.count}, index: ${project.config.shard.index}`;
-            if (embedded) {
-              throw new Error(message);
-            }
-            logger.error(message);
-            process.exit(1);
+                'global `shard` option:\n' +
+                `  count: ${rstestConfig.shard?.count}, index: ${rstestConfig.shard?.index}\n` +
+                `project "${project.config.name}" shard option:\n` +
+                `  count: ${project.config.shard.count}, index: ${project.config.shard.index}`,
+            );
           }
 
           // TODO: support extend projects config

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -760,7 +760,7 @@ export async function runTests(context: Rstest): Promise<void> {
 
       const isFailure = nodeHasFailure || browserHasFailure;
 
-      if (isFailure) {
+      if (isFailure && !context.embedded) {
         process.exitCode = 1;
       }
 
@@ -1072,7 +1072,9 @@ export async function runTests(context: Rstest): Promise<void> {
           logger.log(color.red(`Error in global teardown: ${error}`));
         });
 
-        process.exitCode = 1;
+        if (!context.embedded) {
+          process.exitCode = 1;
+        }
       }
     };
 
@@ -1083,10 +1085,21 @@ export async function runTests(context: Rstest): Promise<void> {
       process.exit(getSignalExitCode(signal));
     };
 
-    process.on('exit', unExpectedExit);
-    process.on('SIGINT', handleSignal);
-    process.on('SIGTERM', handleSignal);
-    process.on('SIGTSTP', handleSignal);
+    // In embedded (programmatic) mode the caller owns process lifecycle and
+    // signal routing, so this is a no-op pair.
+    const uninstallProcessHandlers = (() => {
+      if (context.embedded) return () => {};
+      process.on('exit', unExpectedExit);
+      process.on('SIGINT', handleSignal);
+      process.on('SIGTERM', handleSignal);
+      process.on('SIGTSTP', handleSignal);
+      return () => {
+        process.off('exit', unExpectedExit);
+        process.off('SIGINT', handleSignal);
+        process.off('SIGTERM', handleSignal);
+        process.off('SIGTSTP', handleSignal);
+      };
+    })();
 
     try {
       await run();
@@ -1097,10 +1110,7 @@ export async function runTests(context: Rstest): Promise<void> {
       // Run global teardown after all tests are done
       await runLifecycleStep('global teardown', () => runGlobalTeardown());
     } finally {
-      process.off('exit', unExpectedExit);
-      process.off('SIGINT', handleSignal);
-      process.off('SIGTERM', handleSignal);
-      process.off('SIGTSTP', handleSignal);
+      uninstallProcessHandlers();
     }
 
     await runLifecycleStep('trace wait for exit', () =>

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -81,6 +81,10 @@ const reportNoTestFiles = ({
       logger.error(color.red(message));
     }
 
+    // `process.exitCode` mutations here (and in deeper layers such as
+    // globalSetup teardown, coverage threshold checks) are restored to their
+    // pre-run value by `runRstest` in the embedded path via try/finally, so
+    // we don't need to gate them per-call site.
     process.exitCode = code;
   }
 
@@ -760,7 +764,7 @@ export async function runTests(context: Rstest): Promise<void> {
 
       const isFailure = nodeHasFailure || browserHasFailure;
 
-      if (isFailure && !context.embedded) {
+      if (isFailure) {
         process.exitCode = 1;
       }
 
@@ -1072,9 +1076,7 @@ export async function runTests(context: Rstest): Promise<void> {
           logger.log(color.red(`Error in global teardown: ${error}`));
         });
 
-        if (!context.embedded) {
-          process.exitCode = 1;
-        }
+        process.exitCode = 1;
       }
     };
 
@@ -1086,20 +1088,13 @@ export async function runTests(context: Rstest): Promise<void> {
     };
 
     // In embedded (programmatic) mode the caller owns process lifecycle and
-    // signal routing, so this is a no-op pair.
-    const uninstallProcessHandlers = (() => {
-      if (context.embedded) return () => {};
+    // signal routing, so we skip installing host-process handlers.
+    if (!context.embedded) {
       process.on('exit', unExpectedExit);
       process.on('SIGINT', handleSignal);
       process.on('SIGTERM', handleSignal);
       process.on('SIGTSTP', handleSignal);
-      return () => {
-        process.off('exit', unExpectedExit);
-        process.off('SIGINT', handleSignal);
-        process.off('SIGTERM', handleSignal);
-        process.off('SIGTSTP', handleSignal);
-      };
-    })();
+    }
 
     try {
       await run();
@@ -1110,7 +1105,12 @@ export async function runTests(context: Rstest): Promise<void> {
       // Run global teardown after all tests are done
       await runLifecycleStep('global teardown', () => runGlobalTeardown());
     } finally {
-      uninstallProcessHandlers();
+      if (!context.embedded) {
+        process.off('exit', unExpectedExit);
+        process.off('SIGINT', handleSignal);
+        process.off('SIGTERM', handleSignal);
+        process.off('SIGTSTP', handleSignal);
+      }
     }
 
     await runLifecycleStep('trace wait for exit', () =>

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -44,6 +44,7 @@ async function runBrowserModeTests(
   const projectRoots = browserProjects.map((p) => p.rootPath);
   const { validateBrowserConfig, runBrowserTests } = await loadBrowserModule({
     projectRoots,
+    embedded: context.embedded,
   });
   validateBrowserConfig(context);
   return runBrowserTests(context, options);
@@ -857,9 +858,13 @@ export async function runTests(context: Rstest): Promise<void> {
       process.exit(getSignalExitCode(signal));
     };
 
-    process.on('SIGINT', handleSignal);
-    process.on('SIGTERM', handleSignal);
-    process.on('SIGTSTP', handleSignal);
+    // In embedded (programmatic) mode the caller owns process lifecycle and
+    // signal routing, so we skip installing host-process handlers.
+    if (!context.embedded) {
+      process.on('SIGINT', handleSignal);
+      process.on('SIGTERM', handleSignal);
+      process.on('SIGTSTP', handleSignal);
+    }
 
     const afterTestsWatchRun = () => {
       logger.log(color.green('  Waiting for file changes...'));

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -1109,6 +1109,16 @@ export async function runTests(context: Rstest): Promise<void> {
 
       // Run global teardown after all tests are done
       await runLifecycleStep('global teardown', () => runGlobalTeardown());
+    } catch (error) {
+      // In embedded (programmatic) mode the caller's process keeps running, so
+      // release the worker pool, Rsbuild server, and run global teardown here
+      // when `run()` (or a post-run step) throws — otherwise they leak into the
+      // host. `cleanup()` is idempotent, so this won't double-close on the happy
+      // path. The CLI path relies on process exit + its `exit` handler instead.
+      if (context.embedded) {
+        await cleanup();
+      }
+      throw error;
     } finally {
       if (!context.embedded) {
         process.off('exit', unExpectedExit);

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -102,6 +102,8 @@ export type RstestContext = {
    * @internal
    */
   trace: boolean;
+  /** See the `embedded` option on `createRstest`. */
+  embedded: boolean;
   reporters: Reporter[];
   snapshotManager: SnapshotManager;
   stateManager: TestStateManager;

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -13,7 +13,9 @@ export const filterFiles = (
   mode: FileFilterMode = 'fuzzy',
 ): string[] => {
   if (!filters.length) {
-    return testFiles;
+    // `exact` mode: an empty filter list matches zero files; `fuzzy` mode keeps
+    // the "no filter = all files" convenience.
+    return mode === 'exact' ? [] : testFiles;
   }
 
   const fileFilters =

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import pathe from 'pathe';
 import { glob, isDynamicPattern } from 'tinyglobby';
@@ -111,43 +112,39 @@ export const getTestEntries = async ({
   fileFilterMode?: FileFilterMode;
   projectRoot: string;
 }): Promise<Record<string, string>> => {
-  // Literal include entries are treated as explicit paths (real file or virtual
-  // module backed by `experiments.VirtualModulesPlugin`). They bypass fs
-  // existence checks so virtual modules pass through tinyglobby's filter.
-  // Use tinyglobby's own `isDynamicPattern` to stay consistent with the glob
-  // call below.
-  const literalIncludes: string[] = [];
-  const globIncludes: string[] = [];
-  for (const pattern of include) {
-    (isDynamicPattern(pattern) ? globIncludes : literalIncludes).push(pattern);
-  }
-
   const globOptions = {
     cwd: projectRoot,
     absolute: true,
     ignore: exclude,
     dot: true,
     expandDirectories: false,
-  } as const;
+  };
 
-  // The include glob and the in-source glob are independent, so run them
-  // concurrently rather than serializing two filesystem walks.
+  // The include glob and the in-source glob are independent filesystem walks,
+  // so run them concurrently. Passing the full `include` (literal entries
+  // included) keeps `exclude` behaving exactly as before for real files.
   const [globbedFiles, sourceFiles] = await Promise.all([
-    globIncludes.length ? glob(globIncludes, globOptions) : [],
+    glob(include, globOptions),
     includeSource?.length ? glob(includeSource, globOptions) : [],
   ]);
 
-  // Literal includes bypass tinyglobby's `ignore: exclude`, so apply an
-  // exact-string exclude filter here. Glob exclude patterns against literal
-  // includes are not supported (would require pulling in picomatch).
-  const excludeSet = new Set(exclude);
-  const literalFiles = literalIncludes
-    .filter((p) => !excludeSet.has(p))
-    .map((p) =>
-      pathe.isAbsolute(p) ? pathe.normalize(p) : pathe.resolve(projectRoot, p),
-    );
+  // Virtual modules (backed by `experiments.VirtualModulesPlugin`) are listed
+  // as literal includes but don't exist on disk, so the glob above drops them
+  // — add those back. Real literal includes already flowed through the glob, so
+  // `exclude` applies to them; only genuinely-missing paths qualify as virtual
+  // here, and `exclude` does not apply to those. `isDynamicPattern` mirrors
+  // tinyglobby's own glob/literal split, so a glob that matches nothing is
+  // never mistaken for a virtual path.
+  const virtualFiles = include
+    .filter((pattern) => !isDynamicPattern(pattern))
+    .map((p) => pathe.resolve(projectRoot, p))
+    .filter((abs) => !existsSync(abs));
 
-  const testFiles = Array.from(new Set([...globbedFiles, ...literalFiles]));
+  // glob already returns a unique list (as on `main`), so only build a Set to
+  // dedupe when virtual entries are actually present.
+  const testFiles = virtualFiles.length
+    ? Array.from(new Set([...globbedFiles, ...virtualFiles]))
+    : globbedFiles;
 
   if (sourceFiles.length) {
     await Promise.all<void>(

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -132,9 +132,15 @@ export const getTestEntries = async ({
       })
     : [];
 
-  const literalFiles = literalIncludes.map((p) =>
-    pathe.isAbsolute(p) ? pathe.normalize(p) : pathe.resolve(projectRoot, p),
-  );
+  // Literal includes bypass tinyglobby's `ignore: exclude`, so apply an
+  // exact-string exclude filter here. Glob exclude patterns against literal
+  // includes are not supported (would require pulling in picomatch).
+  const excludeSet = new Set(exclude);
+  const literalFiles = literalIncludes
+    .filter((p) => !excludeSet.has(p))
+    .map((p) =>
+      pathe.isAbsolute(p) ? pathe.normalize(p) : pathe.resolve(projectRoot, p),
+    );
 
   const testFiles = Array.from(new Set([...globbedFiles, ...literalFiles]));
 

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -122,15 +122,20 @@ export const getTestEntries = async ({
     (isDynamicPattern(pattern) ? globIncludes : literalIncludes).push(pattern);
   }
 
-  const globbedFiles = globIncludes.length
-    ? await glob(globIncludes, {
-        cwd: projectRoot,
-        absolute: true,
-        ignore: exclude,
-        dot: true,
-        expandDirectories: false,
-      })
-    : [];
+  const globOptions = {
+    cwd: projectRoot,
+    absolute: true,
+    ignore: exclude,
+    dot: true,
+    expandDirectories: false,
+  } as const;
+
+  // The include glob and the in-source glob are independent, so run them
+  // concurrently rather than serializing two filesystem walks.
+  const [globbedFiles, sourceFiles] = await Promise.all([
+    globIncludes.length ? glob(globIncludes, globOptions) : [],
+    includeSource?.length ? glob(includeSource, globOptions) : [],
+  ]);
 
   // Literal includes bypass tinyglobby's `ignore: exclude`, so apply an
   // exact-string exclude filter here. Glob exclude patterns against literal
@@ -144,15 +149,7 @@ export const getTestEntries = async ({
 
   const testFiles = Array.from(new Set([...globbedFiles, ...literalFiles]));
 
-  if (includeSource?.length) {
-    const sourceFiles = await glob(includeSource, {
-      cwd: projectRoot,
-      absolute: true,
-      ignore: exclude,
-      dot: true,
-      expandDirectories: false,
-    });
-
+  if (sourceFiles.length) {
     await Promise.all<void>(
       sourceFiles.map(async (file) => {
         try {

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import pathe from 'pathe';
-import { glob } from 'tinyglobby';
+import { glob, isDynamicPattern } from 'tinyglobby';
 import type { FileFilterMode, Project } from '../types';
 import { castArray, parsePosix } from './helper';
 import { color } from './logger';
@@ -111,13 +111,32 @@ export const getTestEntries = async ({
   fileFilterMode?: FileFilterMode;
   projectRoot: string;
 }): Promise<Record<string, string>> => {
-  const testFiles = await glob(include, {
-    cwd: projectRoot,
-    absolute: true,
-    ignore: exclude,
-    dot: true,
-    expandDirectories: false,
-  });
+  // Literal include entries are treated as explicit paths (real file or virtual
+  // module backed by `experiments.VirtualModulesPlugin`). They bypass fs
+  // existence checks so virtual modules pass through tinyglobby's filter.
+  // Use tinyglobby's own `isDynamicPattern` to stay consistent with the glob
+  // call below.
+  const literalIncludes: string[] = [];
+  const globIncludes: string[] = [];
+  for (const pattern of include) {
+    (isDynamicPattern(pattern) ? globIncludes : literalIncludes).push(pattern);
+  }
+
+  const globbedFiles = globIncludes.length
+    ? await glob(globIncludes, {
+        cwd: projectRoot,
+        absolute: true,
+        ignore: exclude,
+        dot: true,
+        expandDirectories: false,
+      })
+    : [];
+
+  const literalFiles = literalIncludes.map((p) =>
+    pathe.isAbsolute(p) ? pathe.normalize(p) : pathe.resolve(projectRoot, p),
+  );
+
+  const testFiles = Array.from(new Set([...globbedFiles, ...literalFiles]));
 
   if (includeSource?.length) {
     const sourceFiles = await glob(includeSource, {

--- a/packages/core/tests/utils/testFiles.test.ts
+++ b/packages/core/tests/utils/testFiles.test.ts
@@ -1,8 +1,12 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
+import pathe from 'pathe';
 import {
   filterFiles,
   filterProjects,
   formatTestEntryName,
+  getTestEntries,
 } from '../../src/utils/testFiles';
 
 describe('test filterFiles', () => {
@@ -32,6 +36,88 @@ test('formatTestEntryName', () => {
   expect(formatTestEntryName('setup.ts')).toBe('setup~ts');
   expect(formatTestEntryName('some.setup.ts')).toBe('some~setup~ts');
   expect(formatTestEntryName('some/setup.ts')).toBe('some_setup~ts');
+});
+
+describe('getTestEntries literal/glob handling', () => {
+  let rootPath: string;
+  let cleanup: string;
+
+  beforeEach(() => {
+    rootPath = mkdtempSync(path.join(tmpdir(), 'rstest-entries-'));
+    cleanup = rootPath;
+  });
+
+  afterEach(() => {
+    rmSync(cleanup, { recursive: true, force: true });
+  });
+
+  const baseArgs = (projectRoot: string) => ({
+    exclude: [],
+    includeSource: [],
+    fileFilters: [],
+    rootPath: projectRoot,
+    projectRoot,
+  });
+
+  test('literal include without fs file is preserved (virtual entry contract)', async () => {
+    const virtualName = 'virtual/login.yaml.test.ts';
+    const entries = await getTestEntries({
+      ...baseArgs(rootPath),
+      include: [virtualName],
+    });
+    const values = Object.values(entries);
+    expect(values).toHaveLength(1);
+    expect(pathe.normalize(values[0])).toBe(
+      pathe.join(pathe.normalize(rootPath), virtualName),
+    );
+  });
+
+  test('absolute literal include is preserved without fs check', async () => {
+    const absVirtual = pathe.join(
+      pathe.normalize(rootPath),
+      'absolute.virtual.test.ts',
+    );
+    const entries = await getTestEntries({
+      ...baseArgs(rootPath),
+      include: [absVirtual],
+    });
+    expect(Object.values(entries)).toEqual([absVirtual]);
+  });
+
+  test('glob include still filters by fs existence', async () => {
+    writeFileSync(path.join(rootPath, 'real.test.ts'), 'export {}');
+    const entries = await getTestEntries({
+      ...baseArgs(rootPath),
+      include: ['*.test.ts'],
+    });
+    expect(Object.values(entries)).toEqual([
+      pathe.join(pathe.normalize(rootPath), 'real.test.ts'),
+    ]);
+  });
+
+  test('literal + glob are merged and deduplicated', async () => {
+    mkdirSync(path.join(rootPath, 'src'), { recursive: true });
+    writeFileSync(path.join(rootPath, 'src', 'a.test.ts'), 'export {}');
+    writeFileSync(path.join(rootPath, 'src', 'b.test.ts'), 'export {}');
+
+    const entries = await getTestEntries({
+      ...baseArgs(rootPath),
+      include: [
+        'src/**/*.test.ts', // glob, matches a + b
+        'src/a.test.ts', // literal duplicate of glob hit
+        'virtual/c.test.ts', // literal virtual entry
+      ],
+    });
+
+    const sortedValues = Object.values(entries).sort();
+    expect(sortedValues).toEqual(
+      [
+        pathe.join(pathe.normalize(rootPath), 'src', 'a.test.ts'),
+        pathe.join(pathe.normalize(rootPath), 'src', 'b.test.ts'),
+        pathe.join(pathe.normalize(rootPath), 'virtual', 'c.test.ts'),
+      ].sort(),
+    );
+  });
 });
 
 test('filterProjects', () => {

--- a/packages/core/tests/utils/testFiles.test.ts
+++ b/packages/core/tests/utils/testFiles.test.ts
@@ -118,6 +118,21 @@ describe('getTestEntries literal/glob handling', () => {
       ].sort(),
     );
   });
+
+  test('glob exclude applies to a literal include pointing to a real file', async () => {
+    mkdirSync(path.join(rootPath, 'generated'), { recursive: true });
+    writeFileSync(path.join(rootPath, 'generated', 'foo.test.ts'), 'export {}');
+
+    const entries = await getTestEntries({
+      ...baseArgs(rootPath),
+      include: ['generated/foo.test.ts'], // literal, real file on disk
+      exclude: ['**/generated/**'], // glob exclude that matches it
+    });
+
+    // The real file must be filtered by the glob `exclude`, exactly as it would
+    // be for a glob include. (Virtual literals — absent from disk — still pass.)
+    expect(Object.values(entries)).toEqual([]);
+  });
 });
 
 test('filterProjects', () => {


### PR DESCRIPTION
## Summary

Adds `@rstest/core/api`, a subpath that exposes an in-process programmatic runner. The CLI path is unchanged.

> **Note on intent and stability.** This programmatic API is built for **Midscene** to drive Rstest in-process. It is **intentionally not added to the public documentation** — the integration is coordinated with Midscene directly. Every export from `@rstest/core/api` is marked `@experimental` and may change in any `0.x` release; the surface will be **stabilized before `1.0.0`**.

**1. `runRstest(options)`** — runs Rstest in-process and returns a structured result:

```ts
import { runRstest } from '@rstest/core/api';

const result = await runRstest({
  cwd,             // optional
  config,          // optional path to rstest.config.*; no auto-discovery
  inlineConfig,    // optional RstestUserConfig merged on top of disk config
  files,           // optional exact file paths (fileFilterMode: 'exact')
  testNamePattern, // optional, equivalent to CLI -t
});
```

`TestRunResult`:

```ts
{
  ok: boolean;                          // stats.tests.failed === 0 && stats.files.failed === 0 && unhandledErrors.length === 0
  files: TestFileResult[];
  stats: {
    tests: { total, passed, failed, skipped, todo };
    files: { total, failed };
  };
  unhandledErrors: SerializedError[];   // config load errors, worker crashes, etc.
  duration: { total: number };
  snapshot?: SnapshotSummary;
  coverage?: CoverageMapData;
}
```

- Resolves on every termination path — config errors and worker crashes flow into `unhandledErrors`. The promise only rejects on programmer errors (invalid argument shapes).
- No auto-discovery of `rstest.config.*` from `cwd` — programmatic callers either pass an explicit `config` path or rely entirely on `inlineConfig`.
- Public result types (`TestResult` / `TestFileResult` / `SerializedError`) are a curated facade over internal reporter types, so internal refactors don't break this surface.

**2. Virtual test entries.** `getTestEntries` runs the `include` glob over all patterns (so `exclude` keeps applying to real files exactly as before), then adds back **literal `include` paths that don't exist on disk** as entries. Combined with `tools.rspack` + `experiments.VirtualModulesPlugin`, callers can inject test sources entirely in memory:

```ts
import { rspack } from '@rsbuild/core';

await runRstest({
  inlineConfig: {
    include: ['virtual/case.test.ts'],
    tools: {
      rspack: (_, { appendPlugins }) =>
        appendPlugins(
          new rspack.experiments.VirtualModulesPlugin({
            'virtual/case.test.ts': '...source...',
          }),
        ),
    },
  },
});
```

- Only **literal** (non-glob) include paths are treated as virtual candidates; a glob pattern that matches nothing is never resurrected. `exclude` does not apply to virtual entries (there is no on-disk path to filter).

**3. `embedded` flag.** An internal flag (defaults to `false`, set only by the programmatic API) that keeps a programmatic run from killing or poisoning the host process. When `embedded` is set:

- signal / `exit` handlers are **not installed** (both the run and watch paths);
- fatal config errors and a missing / version-mismatched `@rstest/browser` **throw** instead of calling `process.exit()`;
- `runRstest` snapshots and restores `process.exitCode` around the run, so a test failure (which still sets `process.exitCode = 1` in deeper layers) doesn't leak into the host.

The CLI path is unaffected (`embedded` stays `false`).

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). — **intentionally omitted**; this API is for Midscene's internal use and will be documented when stabilized for `1.0.0` (see note above).
