### PR TITLE
ci(codspeed): split CPU per-PR / memory push-to-main, drop codspeed-macro

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -7,9 +7,6 @@ on:
         description: 'Git ref to benchmark.'
         required: false
         type: string
-  schedule:
-    # Run once a week on main to build a continuous baseline for CPU benchmark
-    - cron: '0 0 * * 0'
   # Allow manual runs on any branch (CodSpeed backtest + on-demand profiling)
   workflow_dispatch:
     inputs:
@@ -19,7 +16,9 @@ on:
         type: string
 
 concurrency:
-  group: codspeed-${{ github.event.pull_request.number || inputs.ref || github.sha }}
+  # Include event_name so a manual workflow_dispatch on the same SHA as an
+  # in-flight push/PR run doesn't cancel or collide with it.
+  group: codspeed-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.ref || github.sha }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 permissions:
@@ -28,47 +27,17 @@ permissions:
   id-token: write
 
 jobs:
-  # Skip the entire workflow when the current HEAD has already been benchmarked
-  # (e.g. a schedule run fires but no new commits landed since the last run).
-  check-skip:
-    name: Check duplicate run
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.check.outputs.should_skip }}
-    steps:
-      - name: Check for existing successful run
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Always run when manually triggered
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Query completed runs of this workflow for the current commit
-          count=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/codspeed.yml/runs?head_sha=${{ github.sha }}&status=success&per_page=1" \
-            --jq '.total_count')
-          if [ "$count" -gt 0 ]; then
-            echo "should_skip=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping: commit ${{ github.sha }} already benchmarked."
-          else
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   codspeed-cpu:
     name: Run CPU benchmarks
-    needs: check-skip
-    # CPU walltime benchmark runs on codspeed-macro (expensive), only on schedule or manual trigger
+    # CPU simulation (Callgrind) runs on a regular GitHub-hosted runner; the
+    # bench fixtures select `pool: 'threads'` so the whole test pipeline stays
+    # in the bench process and is captured by the instrumentation. See
+    # `benchmarks/suiteRun.mjs` for the full mechanism. Runs on every PR and
+    # push to main for per-commit regression tracking.
     if: |
-      needs.check-skip.outputs.should_skip != 'true' &&
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-    # Walltime mode requires CodSpeed bare-metal runners for stable measurements.
-    # CPU simulation (Valgrind) is incompatible with child_process.fork — rstest's
-    # worker pool generates excessive system calls, making flame graphs unavailable.
-    runs-on: codspeed-macro
-    timeout-minutes: 30
+      github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -95,16 +64,17 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:
-          mode: walltime
+          mode: simulation
           run: node benchmarks/suiteRun.mjs
 
   codspeed-memory:
     name: Run memory benchmark
-    needs: check-skip
-    # Memory benchmark builds baseline on push to main, runs on PRs for comparison
+    # Memory benchmark only runs on push to main (and manual dispatch) — the
+    # large jsdom fixture is too slow for per-PR feedback, and current memory
+    # measurement does not see forked worker allocations, so per-PR comparison
+    # would carry more noise than signal. Push-to-main builds a baseline.
     if: |
-      needs.check-skip.outputs.should_skip != 'true' &&
-      (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,11 +233,11 @@ jobs:
         run: pnpm run test:vscode
 
   # ======== codspeed ========
-  # Temporarily disabled: CodSpeed runner quota exhausted.
-  # Re-enable once quota resets.
   codspeed:
     needs: e2e
-    if: false
+    if: |
+      needs.e2e.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     permissions:
       actions: read
       contents: read

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,6 +52,11 @@ The CPU benchmark tracks CodSpeed CPU simulation, not wall-clock time. That
 means the primary CPU metric focuses on user-space CPU work and should not be
 read as full end-to-end runtime including all system-call-heavy overhead.
 
+Each fixture pins `pool: 'threads'` so the test pipeline runs inside the bench
+process. CodSpeed CPU simulation runs Callgrind with `--instr-atstart=no`, and
+forked workers (`fork+execve`) restart with instrumentation off; threads share
+the host process's Callgrind state, so their instructions are counted.
+
 Relevant CodSpeed docs:
 
 - Instruments overview: https://codspeed.io/docs/instruments

--- a/benchmarks/fixtures/compile/rstest.config.mts
+++ b/benchmarks/fixtures/compile/rstest.config.mts
@@ -3,4 +3,7 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   root: __dirname,
   include: ['tests/**/*.test.ts'],
+  // Keep the whole test pipeline in the bench process so CodSpeed CPU
+  // simulation (Callgrind) can measure it. See `benchmarks/suiteRun.mjs`.
+  pool: 'threads',
 });

--- a/benchmarks/fixtures/integration/rstest.config.mts
+++ b/benchmarks/fixtures/integration/rstest.config.mts
@@ -3,4 +3,7 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   root: __dirname,
   include: ['tests/**/*.test.ts'],
+  // Keep the whole test pipeline in the bench process so CodSpeed CPU
+  // simulation (Callgrind) can measure it. See `benchmarks/suiteRun.mjs`.
+  pool: 'threads',
 });

--- a/benchmarks/fixtures/runner/rstest.config.mts
+++ b/benchmarks/fixtures/runner/rstest.config.mts
@@ -3,4 +3,7 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   root: __dirname,
   include: ['tests/**/*.test.ts'],
+  // Keep the whole test pipeline in the bench process so CodSpeed CPU
+  // simulation (Callgrind) can measure it. See `benchmarks/suiteRun.mjs`.
+  pool: 'threads',
 });

--- a/benchmarks/suiteRun.mjs
+++ b/benchmarks/suiteRun.mjs
@@ -25,6 +25,17 @@ import { Bench } from 'tinybench';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesRoot = resolve(__dirname, 'fixtures');
 
+// CodSpeed simulation mode injects V8 introspection flags (e.g.
+// `--allow-natives-syntax`, `--predictable`, `--hash-seed=1`) into the parent
+// process's CLI for deterministic Callgrind measurement. Those flags have
+// already taken effect on the parent's V8 engine, but `node:worker_threads`
+// rejects any execArgv entry outside its allow list, so propagating the
+// parent's `process.execArgv` to the threads pool's Worker throws
+// `Initiated Worker with invalid execArgv flags`. Clearing the snapshot is
+// safe: parent determinism is preserved, and the bench fixtures don't need
+// any inherited Node flags in their workers.
+process.execArgv = [];
+
 const { initCli, createRstest } = await import('@rstest/core');
 
 const bench = withCodSpeed(

--- a/benchmarks/suiteRun.mjs
+++ b/benchmarks/suiteRun.mjs
@@ -27,13 +27,6 @@ const fixturesRoot = resolve(__dirname, 'fixtures');
 
 const { initCli, createRstest } = await import('@rstest/core');
 
-const benchmarkOptions = {
-  // Empty `reporters` silences default reporters during the bench. Note the
-  // option key is `reporters` (plural) — `reporter` is silently ignored, which
-  // would leak reporter formatting/stdout work into the Callgrind window.
-  reporters: [],
-};
-
 const bench = withCodSpeed(
   new Bench({
     time: 0,
@@ -46,7 +39,6 @@ const bench = withCodSpeed(
 async function runFixture(fixtureName) {
   const { config, configFilePath, projects } = await initCli({
     root: resolve(fixturesRoot, fixtureName),
-    ...benchmarkOptions,
   });
 
   const rstest = createRstest({ config, configFilePath, projects }, 'run', []);

--- a/benchmarks/suiteRun.mjs
+++ b/benchmarks/suiteRun.mjs
@@ -4,6 +4,15 @@
  * Instead of one large mixed suite, we keep focused fixtures for compile,
  * runner, and a small end-to-end integration flow.
  *
+ * Runs under CodSpeed CPU simulation (Callgrind) on `ubuntu-latest`. The
+ * runner invokes Valgrind with `--instr-atstart=no` and the tinybench plugin
+ * toggles instrumentation around each task via `callgrind_start_instrumentation`
+ * — a process-wide Callgrind client request. Forked workers go through
+ * `fork+execve`, which resets the new process's instrumentation state to the
+ * CLI default (off); they never call the start hook, so their work would not
+ * be measured. Each fixture therefore opts into `pool: 'threads'` so the whole
+ * test pipeline stays in the bench process and counts toward the measurement.
+ *
  * Usage:
  *   pnpm --filter @rstest/benchmarks bench:cpu
  */
@@ -19,7 +28,10 @@ const fixturesRoot = resolve(__dirname, 'fixtures');
 const { initCli, createRstest } = await import('@rstest/core');
 
 const benchmarkOptions = {
-  reporter: [],
+  // Empty `reporters` silences default reporters during the bench. Note the
+  // option key is `reporters` (plural) — `reporter` is silently ignored, which
+  // would leak reporter formatting/stdout work into the Callgrind window.
+  reporters: [],
 };
 
 const bench = withCodSpeed(

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -6,12 +6,14 @@ apos
 applescript
 Asus
 atrules
+atstart
 autodocs
 Birpc
 brotli
 browserslistrc
 bundleless
 bytedance
+Callgrind
 caniuse
 canyonjs
 cdup
@@ -46,6 +48,7 @@ elifecycle
 endgroup
 envinfo
 estree
+execve
 facti
 fastpaths
 fi3ework


### PR DESCRIPTION
## Summary

CodSpeed was disabled because the walltime + `codspeed-macro` setup exhausted the bare-metal runner quota. This PR brings per-commit perf tracking back without that dependency.

- **CPU bench** runs on every PR and push to main, using `mode: simulation` (Callgrind) on `ubuntu-latest`. The three bench fixtures pin `pool: 'threads'` because Callgrind runs with `--instr-atstart=no` — forked workers go through `fork+execve` and restart with instrumentation off, so their work would not be measured. Threads share the host process's Callgrind state, so the whole test pipeline is captured.
- **Memory bench** is demoted from per-PR to push-to-main only (plus manual dispatch). The jsdom + antd + three fixture is heavy and memory regressions are slow-moving — a per-commit baseline on main plus on-demand dispatch is a better fit than burning PR CI minutes for low-signal diffs. Note: CodSpeed's memory instrument uses memtrack (eBPF + libc malloc uprobes + `sched_process_fork` tracepoint), so forked-worker allocations are tracked across the fork boundary — visibility was never the issue.
- **Cleanup**: drop the weekly schedule and the `check-skip` job — both existed only to keep the macro-runner CPU baseline maintained on a low-cost cadence. Per-commit triggers cover baseline maintenance directly. Concurrency group now includes \`event_name\` so a manual dispatch on the same SHA does not collide with the push run.

## Related Links

- CodSpeed CPU instrument: https://codspeed.io/docs/instruments/cpu
- Threads pool feature: #1235