### PR TITLE
refactor(core): use interface for TestContext and SuiteContext

### DIFF
--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -10,7 +10,7 @@ import type {
 } from './testSuite';
 import type { MaybePromise } from './utils';
 
-export type TestContext = {
+export interface TestContext {
   /**
    * Metadata of the current test
    */
@@ -25,7 +25,7 @@ export type TestContext = {
   expect: RstestExpect;
   onTestFinished: RunnerAPI['onTestFinished'];
   onTestFailed: RunnerAPI['onTestFailed'];
-};
+}
 
 export type TestCallbackFn<ExtraContext = object> = (
   context: TestContext & ExtraContext,

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -83,9 +83,9 @@ export type TestCase = TestCaseInfo & {
   result?: TaskResult;
 };
 
-export type SuiteContext = {
+export interface SuiteContext {
   filepath: TestPath;
-};
+}
 
 export type AfterAllListener = (ctx: SuiteContext) => MaybePromise<void>;
 


### PR DESCRIPTION
## Summary

Change `TestContext` and `SuiteContext` from `type` aliases to `interface` declarations so that downstream packages and user fixtures can extend the test context via TypeScript declaration merging.

This is part of the 1.0 public API stability preparation. Locking the container shape now means future field additions can ship as non-breaking minor releases — consumers (downstream packages like `@rstest/browser`, user-defined fixtures, custom setup code) can augment the interface without forking types or resorting to `as any`.

Pure type-layer change with zero runtime impact. Touches:

- `packages/core/src/types/api.ts` — `TestContext`
- `packages/core/src/types/testSuite.ts` — `SuiteContext`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).