### PR TITLE
feat(core): support TestOptions as third arg of test/it

### DIFF
--- a/e2e/test-api/fixtures/testOptionsOnFinishedScope.test.ts
+++ b/e2e/test-api/fixtures/testOptionsOnFinishedScope.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from '@rstest/core';
+
+// Regression: handlers registered via context.onTestFinished /
+// context.onTestFailed inside the test body must be scoped to a single
+// attempt — they should not stack across retries or repeats.
+let runs = 0;
+let cleanupCalls = 0;
+
+it(
+  'onTestFinished does not leak across repeats',
+  ({ onTestFinished }) => {
+    runs++;
+    onTestFinished(() => {
+      cleanupCalls++;
+    });
+  },
+  { repeats: 2 },
+);
+
+let retryAttempts = 0;
+let retryCleanupCalls = 0;
+it(
+  'onTestFinished does not leak across retries',
+  ({ onTestFinished }) => {
+    retryAttempts++;
+    onTestFinished(() => {
+      retryCleanupCalls++;
+    });
+    // Force a retry by failing the first attempt.
+    expect(retryAttempts).toBe(2);
+  },
+  { retry: 1 },
+);
+
+it('cleanup count matches the number of attempts', () => {
+  expect(runs).toBe(3);
+  expect(cleanupCalls).toBe(3);
+  expect(retryAttempts).toBe(2);
+  expect(retryCleanupCalls).toBe(2);
+});

--- a/e2e/test-api/fixtures/testOptionsRepeatsErrorScope.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsErrorScope.test.ts
@@ -1,0 +1,30 @@
+import { expect, it } from '@rstest/core';
+
+// Regression: errors from earlier repeats that ultimately passed must not
+// contaminate the final failure's error list.
+let runs = 0;
+it(
+  'each repeat reports only its own retry errors',
+  () => {
+    runs++;
+    // Repeat 0: fail then pass on retry.
+    if (runs === 1) {
+      throw new Error('REPEAT_0_RECOVERED');
+    }
+    if (runs === 2) {
+      return;
+    }
+    // Repeat 1: both attempts fail.
+    if (runs === 3) {
+      throw new Error('REPEAT_1_ATTEMPT_A');
+    }
+    throw new Error('REPEAT_1_ATTEMPT_B');
+  },
+  { retry: 1, repeats: 1 },
+);
+
+// Sanity guard: ensure the test fn ran exactly 4 times. If runner short-circuits
+// or skips a repeat, this assertion catches the regression.
+it('repeat scheduling sanity', () => {
+  expect(runs).toBe(4);
+});

--- a/e2e/test-api/fixtures/testOptionsRepeatsFail.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsFail.test.ts
@@ -1,0 +1,12 @@
+import { expect, it } from '@rstest/core';
+
+// repeats short-circuits on first failure. Total executions <= repeats + 1.
+let runs = 0;
+it(
+  'fails on the second repeat',
+  () => {
+    runs++;
+    expect(runs).toBeLessThan(2);
+  },
+  { repeats: 4 },
+);

--- a/e2e/test-api/fixtures/testOptionsRepeatsInvalid.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsInvalid.test.ts
@@ -1,0 +1,34 @@
+import { expect, it } from '@rstest/core';
+
+// Regression: invalid `repeats` values (negative, NaN, fractional) must not
+// cause the runner to silently skip the test — they should clamp to 0.
+let neg = 0;
+it(
+  'negative repeats clamps to a single run',
+  () => {
+    neg++;
+    expect(neg).toBe(1);
+  },
+  { repeats: -3 },
+);
+
+let nan = 0;
+it(
+  'NaN repeats clamps to a single run',
+  () => {
+    nan++;
+    expect(nan).toBe(1);
+  },
+  { repeats: Number.NaN },
+);
+
+let frac = 0;
+it(
+  'fractional repeats floors',
+  () => {
+    frac++;
+    expect(frac).toBeGreaterThanOrEqual(1);
+    expect(frac).toBeLessThanOrEqual(2);
+  },
+  { repeats: 1.9 },
+);

--- a/e2e/test-api/fixtures/testOptionsRepeatsPass.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsPass.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, expect, it } from '@rstest/core';
+
+// Track that beforeEach/afterEach fire for every repeat.
+let beforeEachCalls = 0;
+let afterEachCalls = 0;
+let runs = 0;
+
+beforeEach(() => {
+  beforeEachCalls++;
+});
+
+afterEach(() => {
+  afterEachCalls++;
+  // afterEach runs *after* the test body, so this assertion observes the body
+  // count for the current repeat plus all prior repeats.
+  expect(beforeEachCalls).toBe(afterEachCalls);
+});
+
+it(
+  'repeats 3 times when all pass',
+  () => {
+    runs++;
+    expect(beforeEachCalls).toBe(runs);
+  },
+  { repeats: 2 },
+);

--- a/e2e/test-api/fixtures/testOptionsRetry.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRetry.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, expect, it } from '@rstest/core';
+
+// `it` per-test retry should override config.retry (run without --retry).
+let attempts = 0;
+let beforeEachCalls = 0;
+
+beforeEach(() => {
+  beforeEachCalls++;
+});
+
+it(
+  'per-test retry overrides config retry',
+  () => {
+    attempts++;
+    // Pass on the third attempt (initial + 2 retries).
+    expect(attempts).toBe(3);
+    // beforeEach should have run for every attempt, including the passing one.
+    expect(beforeEachCalls).toBe(attempts);
+  },
+  { retry: 2 },
+);

--- a/e2e/test-api/fixtures/testOptionsRetryOverride.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRetryOverride.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from '@rstest/core';
+
+// Two cases share one file so a single `--retry=5` config exposes both
+// directions of override.
+
+let extendingAttempts = 0;
+it(
+  'options.retry can extend config.retry',
+  () => {
+    extendingAttempts++;
+    // Pass on attempt 8, which exceeds config.retry=5 but fits options.retry=9.
+    expect(extendingAttempts).toBe(8);
+  },
+  { retry: 9 },
+);
+
+let disablingAttempts = 0;
+it(
+  'options.retry: 0 disables config.retry',
+  () => {
+    disablingAttempts++;
+    // Force a failure; options.retry=0 should stop retries immediately even
+    // though config.retry=5 is set.
+    throw new Error(`attempt ${disablingAttempts}`);
+  },
+  { retry: 0 },
+);

--- a/e2e/test-api/fixtures/testOptionsRetryRepeats.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRetryRepeats.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from '@rstest/core';
+
+// retry × repeats: each repeat gets an independent retry budget. With
+// retry: 1 and repeats: 2, the first repeat passes on attempt 2 (retry used),
+// the second repeat passes on attempt 2 (retry used again), the third repeat
+// passes on attempt 2 (retry used a third time). Total executions = 6.
+let runs = 0;
+it(
+  'retry budget is per-repeat',
+  () => {
+    runs++;
+    // Fail on odd attempts (1, 3, 5) and pass on even attempts (2, 4, 6).
+    expect(runs % 2).toBe(0);
+  },
+  { retry: 1, repeats: 2 },
+);

--- a/e2e/test-api/fixtures/testOptionsTimeout.test.ts
+++ b/e2e/test-api/fixtures/testOptionsTimeout.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from '@rstest/core';
+import { sleep } from '../../scripts';
+
+describe('timeout shorthand vs options', () => {
+  it('numeric shorthand still trips on slow body', async ({ expect }) => {
+    await sleep(100);
+    expect(1 + 1).toBe(2);
+  }, 50);
+
+  it(
+    'options.timeout trips on slow body',
+    async ({ expect }) => {
+      await sleep(100);
+      expect(1 + 1).toBe(2);
+    },
+    { timeout: 50 },
+  );
+});

--- a/e2e/test-api/testOptions.test.ts
+++ b/e2e/test-api/testOptions.test.ts
@@ -1,0 +1,139 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('TestOptions', () => {
+  it('per-test retry overrides config.retry', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsRetry.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecSuccess();
+  });
+
+  it('repeats re-runs a passing test the requested number of times', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsRepeatsPass.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecSuccess();
+  });
+
+  it('repeats short-circuits on the first failure', async () => {
+    const { cli, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsRepeatsFail.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+    const logs = cli.stdout.split('\n').filter(Boolean);
+    expectLog(/Tests 1 failed/, logs);
+  });
+
+  it('retry budget is per-repeat when combined', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsRetryRepeats.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecSuccess();
+  });
+
+  it('options.retry overrides config.retry both up and down', async () => {
+    const { cli, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsRetryOverride.test.ts', '--retry=5'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    // Second case sets retry: 0 and always throws, so the file fails overall.
+    expect(cli.exec.process?.exitCode).toBe(1);
+    const logs = cli.stdout.split('\n').filter(Boolean);
+    // 1 passed (extending retry beyond config), 1 failed (retry: 0 disables).
+    expectLog(/Tests 1 failed/, logs);
+    expectLog(/1 passed/, logs);
+    // The failing case ran exactly once (no retries via config.retry=5).
+    expectLog(/attempt 1$/, cli.stderr.split('\n').filter(Boolean));
+    expect(cli.stderr).not.toContain('attempt 2');
+  });
+
+  it('each repeat reports only its own retry errors', async () => {
+    const { cli, expectLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsRepeatsErrorScope.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+    const stderrLines = cli.stderr.split('\n').filter(Boolean);
+    const stdoutLines = cli.stdout.split('\n').filter(Boolean);
+    // Failing repeat's own attempts must be reported.
+    expectLog(/REPEAT_1_ATTEMPT_A/, stderrLines);
+    expectLog(/REPEAT_1_ATTEMPT_B/, stderrLines);
+    // An earlier repeat that recovered must not leak into the final fail.
+    expect(cli.stderr).not.toContain('REPEAT_0_RECOVERED');
+    // Sanity test must still have observed all 4 executions.
+    expectLog(/Tests 1 failed/, stdoutLines);
+    expectLog(/1 passed/, stdoutLines);
+  });
+
+  it('invalid repeats values do not silently skip', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsRepeatsInvalid.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecSuccess();
+  });
+
+  it('options.timeout matches numeric shorthand behavior', async () => {
+    const { cli, expectStderrLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsTimeout.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+    // Both tests (shorthand + options) should report the same 50ms timeout.
+    expectStderrLog(/test timed out in 50ms/);
+  }, 10000);
+});

--- a/e2e/test-api/testOptions.test.ts
+++ b/e2e/test-api/testOptions.test.ts
@@ -121,6 +121,19 @@ describe('TestOptions', () => {
     await expectExecSuccess();
   });
 
+  it('onTestFinished/onTestFailed do not leak across retries or repeats', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsOnFinishedScope.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecSuccess();
+  });
+
   it('options.timeout matches numeric shorthand behavior', async () => {
     const { cli, expectStderrLog } = await runRstestCli({
       command: 'rstest',

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -101,6 +101,13 @@ export class TestRunner {
 
       let result: TestResult | undefined;
 
+      // `onTestFinished` / `onTestFailed` are registered from inside the test
+      // body, so each retry / repeat would otherwise stack new handlers on
+      // top of leftovers from prior attempts and rerun them. Snapshot the
+      // current lengths and truncate back after the attempt completes.
+      const onFinishedSnapshot = test.onFinished.length;
+      const onFailedSnapshot = test.onFailed.length;
+
       this.beforeEach(test, state, api);
 
       const cleanups: AfterEachListener[] = [];
@@ -227,6 +234,9 @@ export class TestRunner {
         // should not be updated for snapshots that have not been run when the test run fails
         snapshotClient.skipTest(testPath, getTaskNameWithPrefix(test));
       }
+
+      test.onFinished.length = onFinishedSnapshot;
+      test.onFailed.length = onFailedSnapshot;
 
       this.resetCurrentTest();
 

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -30,6 +30,7 @@ import {
   getTestStatus,
   limitConcurrency,
   markAllTestAsSkipped,
+  sanitizeAttemptCount,
   wrapTimeout,
 } from './task';
 
@@ -408,7 +409,17 @@ export class TestRunner {
           },
           async () => {
             const start = RealDate.now();
-            let retryCount = 0;
+            // Per-test override wins over config.retry. `retry` (the runtime
+            // config) is the suite-wide default.
+            const retryBudget = sanitizeAttemptCount(test.retry ?? retry);
+            // Treat negative / NaN / fractional repeats as 0 so the outer
+            // loop always runs at least once. Without this, an invalid
+            // `repeats` value would silently report the case as skipped.
+            const repeats = sanitizeAttemptCount(test.repeats ?? 0);
+            let totalRetryCount = 0;
+            // `retryErrors` aggregates every failed attempt across all
+            // repeats so a final pass can surface the full flakiness picture
+            // via `result.retryErrors`.
             const retryErrors: FormattedError[] = [];
 
             hooks.onTestCaseStart?.({
@@ -424,26 +435,41 @@ export class TestRunner {
               runMode: test.runMode,
             });
 
-            do {
-              const currentResult = await runTestsCase(test, parentHooks);
+            for (let repeat = 0; repeat <= repeats; repeat++) {
+              let retryCount = 0;
+              // Scoped per repeat so a terminal failure does not get
+              // attributed errors from earlier repeats that already passed.
+              const repeatRetryErrors: FormattedError[] = [];
+              do {
+                const currentResult = await runTestsCase(test, parentHooks);
 
-              if (currentResult.status === 'fail') {
-                retryErrors.push(...(currentResult.errors || []));
+                if (currentResult.status === 'fail') {
+                  repeatRetryErrors.push(...(currentResult.errors || []));
+                }
+
+                result = {
+                  ...currentResult,
+                  errors:
+                    currentResult.status === 'fail'
+                      ? [...repeatRetryErrors]
+                      : currentResult.errors,
+                };
+
+                retryCount++;
+              } while (retryCount <= retryBudget && result.status === 'fail');
+
+              totalRetryCount += retryCount - 1;
+              retryErrors.push(...repeatRetryErrors);
+
+              // `repeats` semantics: any failure short-circuits remaining
+              // repeats. Pass/skip/todo continue to the next repeat.
+              if (result.status === 'fail') {
+                break;
               }
-
-              result = {
-                ...currentResult,
-                errors:
-                  currentResult.status === 'fail'
-                    ? [...retryErrors]
-                    : currentResult.errors,
-              };
-
-              retryCount++;
-            } while (retryCount <= retry && result.status === 'fail');
+            }
 
             result.duration = RealDate.now() - start;
-            result.retryCount = retryCount - 1;
+            result.retryCount = totalRetryCount;
             if (result.status === 'pass' && retryErrors.length > 0) {
               result.retryErrors = retryErrors;
             }

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -22,6 +22,7 @@ import type {
   TestCase,
   TestEachFn,
   TestForFn,
+  TestOptions,
   TestRunMode,
   TestSuite,
 } from '../../types';
@@ -30,6 +31,7 @@ import { castArray, generateFilePathHash } from '../../utils/helper';
 import {
   formatName,
   isTemplateStringsArray,
+  normalizeTestOptions,
   parseTemplateTable,
   TestRegisterError,
 } from '../util';
@@ -330,6 +332,8 @@ class RunnerRuntime {
     originalFn = fn,
     fixtures,
     timeout = this.runtimeConfig.testTimeout,
+    retry,
+    repeats,
     runMode = 'run',
     fails = false,
     each = false,
@@ -342,6 +346,8 @@ class RunnerRuntime {
     originalFn?: TestCallbackFn;
     fn?: TestCallbackFn;
     timeout?: number;
+    retry?: number;
+    repeats?: number;
     runMode?: TestRunMode;
     each?: boolean;
     fails?: boolean;
@@ -359,6 +365,8 @@ class RunnerRuntime {
       runMode,
       type: 'case',
       timeout,
+      retry,
+      repeats,
       fixtures,
       concurrent,
       sequential,
@@ -429,8 +437,13 @@ class RunnerRuntime {
     concurrent?: boolean;
     sequential?: boolean;
     location?: Location;
-  }): (name: string, fn?: (...args: any[]) => any, timeout?: number) => void {
-    return (name, fn, timeout = this.runtimeConfig.testTimeout) => {
+  }): (
+    name: string,
+    fn?: (...args: any[]) => any,
+    testOptions?: number | TestOptions,
+  ) => void {
+    return (name, fn, testOptions) => {
+      const { timeout, retry, repeats } = normalizeTestOptions(testOptions);
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
         const params = castArray(param) as any[];
@@ -439,7 +452,9 @@ class RunnerRuntime {
           name: formatName(name, param, i),
           originalFn: fn,
           fn: () => fn?.(...params),
-          timeout,
+          timeout: timeout ?? this.runtimeConfig.testTimeout,
+          retry,
+          repeats,
           ...options,
           each: true,
         });
@@ -457,8 +472,13 @@ class RunnerRuntime {
     concurrent?: boolean;
     sequential?: boolean;
     location?: Location;
-  }): (name: string, fn?: (...args: any[]) => any, timeout?: number) => void {
-    return (name, fn, timeout = this.runtimeConfig.testTimeout) => {
+  }): (
+    name: string,
+    fn?: (...args: any[]) => any,
+    testOptions?: number | TestOptions,
+  ) => void {
+    return (name, fn, testOptions) => {
+      const { timeout, retry, repeats } = normalizeTestOptions(testOptions);
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
 
@@ -466,7 +486,9 @@ class RunnerRuntime {
           name: formatName(name, param, i),
           originalFn: fn,
           fn: (context) => fn?.(param, context),
-          timeout,
+          timeout: timeout ?? this.runtimeConfig.testTimeout,
+          retry,
+          repeats,
           ...options,
           each: true,
         });
@@ -536,14 +558,18 @@ export const createRuntimeAPI = ({
       location?: Location;
     } = {},
   ): TestAPI => {
-    const testFn = ((name, fn, timeout) =>
+    const testFn = ((name, fn, testOptions) => {
+      const { timeout, retry, repeats } = normalizeTestOptions(testOptions);
       runtimeInstance.it({
         name,
         fn,
         timeout,
+        retry,
+        repeats,
         ...options,
         location: options.location ?? getLocation(),
-      })) as TestAPI;
+      });
+    }) as TestAPI;
 
     for (const { name, overrides } of [
       { name: 'fails', overrides: { fails: true } },

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -11,6 +11,18 @@ import { ROOT_SUITE_NAME, TEST_DELIMITER } from '../../utils/constants';
 import { getTaskNameWithPrefix } from '../../utils/helper';
 import { getRealTimers } from '../util';
 
+/**
+ * Coerce a user-supplied retry/repeats count into a non-negative integer.
+ * Negative, NaN, Infinity, and fractional values collapse to 0 so loop
+ * bounds stay well-defined.
+ */
+export const sanitizeAttemptCount = (value: number | undefined): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+};
+
 export const getTestStatus = (
   results: TestResult[],
   defaultStatus: TestResultStatus,

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -1,4 +1,17 @@
-import type { FormattedError, Test } from '../types';
+import type { FormattedError, Test, TestOptions } from '../types';
+
+/**
+ * Normalize the third argument of `test` / `it` / `test.each` / `test.for`.
+ * Accepts `number` (shorthand for `{ timeout }`) or a full `TestOptions` object.
+ */
+export const normalizeTestOptions = (
+  input?: number | TestOptions,
+): TestOptions => {
+  if (typeof input === 'number') {
+    return { timeout: input };
+  }
+  return input ?? {};
+};
 
 const loadDiffModules = async () => {
   const [{ diff }, { format, plugins }] = await Promise.all([

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -31,10 +31,39 @@ export type TestCallbackFn<ExtraContext = object> = (
   context: TestContext & ExtraContext,
 ) => MaybePromise<void>;
 
+/**
+ * Per-test options accepted as the third argument of `test` / `it` / `test.each` /
+ * `test.for`. Passing a plain `number` is equivalent to `{ timeout: n }`.
+ *
+ * Declared as an `interface` so consumers can use module augmentation to add
+ * fields in the future without breaking source compatibility.
+ */
+export interface TestOptions {
+  /**
+   * Per-test timeout in milliseconds. Overrides `test.testTimeout`.
+   */
+  timeout?: number;
+  /**
+   * Number of times to retry the test if it fails. Overrides `test.retry`.
+   *
+   * @default 0
+   */
+  retry?: number;
+  /**
+   * Number of times to re-run the test after it has already passed. The test is
+   * considered failed as soon as any run fails. Total executions per case is
+   * `repeats + 1`. Orthogonal to `retry`: each repeat independently honors the
+   * configured retry budget.
+   *
+   * @default 0
+   */
+  repeats?: number;
+}
+
 type TestFn<ExtraContext = object> = (
   description: string,
   fn?: TestCallbackFn<ExtraContext>,
-  timeout?: number,
+  options?: number | TestOptions,
 ) => void;
 
 export interface TestEachFn {
@@ -43,21 +72,21 @@ export interface TestEachFn {
   ): (
     description: string,
     fn?: (param: T) => MaybePromise<void>,
-    timeout?: number,
+    options?: number | TestOptions,
   ) => void;
   <T extends readonly [unknown, ...unknown[]]>(
     cases: readonly T[],
   ): (
     description: string,
     fn: (...args: [...T]) => MaybePromise<void>,
-    timeout?: number,
+    options?: number | TestOptions,
   ) => void;
   <T>(
     cases: readonly T[],
   ): (
     description: string,
     fn: (...args: T[]) => MaybePromise<void>,
-    timeout?: number,
+    options?: number | TestOptions,
   ) => void;
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
@@ -65,7 +94,7 @@ export interface TestEachFn {
   ): (
     description: string,
     fn?: (param: T) => MaybePromise<void>,
-    timeout?: number,
+    options?: number | TestOptions,
   ) => void;
 }
 
@@ -75,7 +104,7 @@ export interface TestForFn<ExtraContext = object> {
   ): (
     description: string,
     fn?: (param: T, context: TestContext & ExtraContext) => MaybePromise<void>,
-    timeout?: number,
+    options?: number | TestOptions,
   ) => void;
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
@@ -83,7 +112,7 @@ export interface TestForFn<ExtraContext = object> {
   ): (
     description: string,
     fn?: (param: T, context: TestContext & ExtraContext) => MaybePromise<void>,
-    timeout?: number,
+    options?: number | TestOptions,
   ) => void;
 }
 

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -57,6 +57,16 @@ export type TestCase = TestCaseInfo & {
   inTestEach?: boolean;
   context: TestContext;
   only?: boolean;
+  /**
+   * Per-test override for the number of retries on failure. When undefined,
+   * the runner falls back to `runtimeConfig.retry`.
+   */
+  retry?: number;
+  /**
+   * Number of additional runs to perform on top of the first run; any failure
+   * short-circuits remaining repeats. Currently per-test only.
+   */
+  repeats?: number;
   onFinished: OnTestFinishedHandler[];
   onFailed: OnTestFailedHandler[];
   /**

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -1,5 +1,5 @@
 import { createRuntimeAPI } from '../../src/runtime/runner/runtime';
-import type { RuntimeConfig, TestSuite } from '../../src/types';
+import type { RuntimeConfig, TestCase, TestSuite } from '../../src/types';
 import { generateFilePathHash } from '../../src/utils/helper';
 
 describe('RunnerRuntime', () => {
@@ -106,5 +106,79 @@ describe('RunnerRuntime', () => {
         (test) => test.name,
       ),
     ).toEqual(['test - 1 - 1']);
+  });
+
+  describe('TestOptions third argument', () => {
+    const createApi = (testTimeout = 5000) =>
+      createRuntimeAPI({
+        testPath: __filename,
+        runtimeConfig: { testTimeout } as RuntimeConfig,
+        project: 'rstest',
+      });
+
+    it('treats a numeric third arg as timeout shorthand', async () => {
+      const { api, instance } = createApi();
+      api.it('case', () => {}, 250);
+
+      const [first] = await instance.getTests();
+      const testCase = first as TestCase;
+      expect(testCase.type).toBe('case');
+      expect(testCase.timeout).toBe(250);
+      expect(testCase.retry).toBeUndefined();
+      expect(testCase.repeats).toBeUndefined();
+    });
+
+    it('reads timeout/retry/repeats from a TestOptions object', async () => {
+      const { api, instance } = createApi();
+      api.it('case', () => {}, { timeout: 250, retry: 2, repeats: 3 });
+
+      const testCase = (await instance.getTests())[0] as TestCase;
+      expect(testCase.timeout).toBe(250);
+      expect(testCase.retry).toBe(2);
+      expect(testCase.repeats).toBe(3);
+    });
+
+    it('falls back to config.testTimeout when timeout omitted', async () => {
+      const { api, instance } = createApi(123);
+      api.it('case', () => {}, { retry: 1 });
+
+      const testCase = (await instance.getTests())[0] as TestCase;
+      expect(testCase.timeout).toBe(123);
+      expect(testCase.retry).toBe(1);
+    });
+
+    it('propagates options through test.each', async () => {
+      const { api, instance } = createApi();
+      api.it.each([1, 2])('case %s', () => {}, { timeout: 50, retry: 1 });
+
+      const cases = (await instance.getTests()) as TestCase[];
+      expect(cases).toHaveLength(2);
+      for (const c of cases) {
+        expect(c.timeout).toBe(50);
+        expect(c.retry).toBe(1);
+      }
+    });
+
+    it('propagates options through test.for', async () => {
+      const { api, instance } = createApi();
+      api.it.for([1, 2])('case %s', () => {}, { timeout: 50, repeats: 2 });
+
+      const cases = (await instance.getTests()) as TestCase[];
+      expect(cases).toHaveLength(2);
+      for (const c of cases) {
+        expect(c.timeout).toBe(50);
+        expect(c.repeats).toBe(2);
+      }
+    });
+
+    it('still accepts numeric shorthand on test.each / test.for', async () => {
+      const { api, instance } = createApi();
+      api.it.each([1])('a %s', () => {}, 99);
+      api.it.for([2])('b %s', () => {}, 88);
+
+      const [a, b] = (await instance.getTests()) as TestCase[];
+      expect(a!.timeout).toBe(99);
+      expect(b!.timeout).toBe(88);
+    });
   });
 });

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -28,7 +28,7 @@ test('should add two numbers correctly', () => {
 
 ### TestOptions
 
-<ApiMeta addedVersion="1.0.0" />
+<ApiMeta addedVersion="0.10.3" />
 
 The third argument tunes the behavior of a single test. Passing a number is shorthand for `{ timeout: n }` so existing code keeps working:
 

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -3,6 +3,8 @@ title: Test
 description: test defines a test case. It supports chainable modifiers and fixture extension for flexible and powerful test definitions.
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Test
 
 `test` defines a test case. It supports chainable modifiers and fixture extension for flexible and powerful test definitions.
@@ -11,7 +13,7 @@ Alias: `it`.
 
 ## test
 
-- **Type:** `(name: string, fn: (testContext: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **Type:** `(name: string, fn: (testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
 
 Defines a test case.
 
@@ -23,6 +25,53 @@ test('should add two numbers correctly', () => {
   expect(1 + 2).toBe(3);
 });
 ```
+
+### TestOptions
+
+<ApiMeta addedVersion="1.0.0" />
+
+The third argument tunes the behavior of a single test. Passing a number is shorthand for `{ timeout: n }` so existing code keeps working:
+
+```ts
+test('runs within 3s', async () => {
+  /* ... */
+}, 3000);
+
+// equivalent to:
+test(
+  'runs within 3s',
+  async () => {
+    /* ... */
+  },
+  { timeout: 3000 },
+);
+```
+
+`TestOptions` accepts:
+
+- `timeout?: number` — per-test timeout in milliseconds. Overrides [`test.testTimeout`](/config/test/test-timeout).
+- `retry?: number` — re-runs the test up to this many times if it fails, stopping at the first pass. Overrides [`test.retry`](/config/test/retry).
+- `repeats?: number` — re-runs an already-passing test this many extra times; any failure marks the whole case as failed. Each repeat runs the full `beforeEach`/`afterEach` lifecycle and gets an independent `retry` budget.
+
+```ts
+test(
+  'flaky network call',
+  async () => {
+    /* ... */
+  },
+  { retry: 3 },
+);
+
+test(
+  'stays green across runs',
+  async () => {
+    /* ... */
+  },
+  { repeats: 9 },
+); // 10 total runs; first failure short-circuits the rest
+```
+
+`test.each` and `test.for` accept the same third argument and apply it to every generated case.
 
 ## test.only
 
@@ -54,7 +103,7 @@ test.todo('should implement this test');
 
 ## test.each
 
-- **Type:** `test.each(cases: ReadonlyArray<T>)(name: string, fn: (param: T) => void | Promise<void>, timeout?: number) => void`
+- **Type:** `test.each(cases: ReadonlyArray<T>)(name: string, fn: (param: T) => void | Promise<void>, options?: number | TestOptions) => void`
 
 Runs the same test logic for each item in the provided array.
 
@@ -150,7 +199,7 @@ test.each([
 
 ## test.for
 
-- **Type:** `test.for(cases: ReadonlyArray<T>)(name: string, fn: (param: T, testContext: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **Type:** `test.for(cases: ReadonlyArray<T>)(name: string, fn: (param: T, testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
 
 Alternative to `test.each` to provide `TestContext`.
 

--- a/website/docs/en/config/test/retry.mdx
+++ b/website/docs/en/config/test/retry.mdx
@@ -11,6 +11,8 @@ overviewHeaders: []
 
 Retry the test specific number of times if it fails. This is useful for some flaky or non-deterministic test failures.
 
+A single test can override this with [`TestOptions.retry`](/api/runtime-api/test-api/test#testoptions), including `{ retry: 0 }` to disable retries for one test even when this config is set.
+
 ## Example
 
 You can get two retries by setting `retry:2` when the test fails:

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -3,6 +3,8 @@ title: Test
 description: test 用于定义一个测试用例，支持链式调用和 fixture 扩展。
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Test
 
 `test` 用于定义一个测试用例，支持链式调用和 fixture 扩展。
@@ -11,7 +13,7 @@ description: test 用于定义一个测试用例，支持链式调用和 fixture
 
 ## test
 
-- **类型：** `(name: string, fn: (testContext: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **类型：** `(name: string, fn: (testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
 
 定义一个测试用例。
 
@@ -23,6 +25,53 @@ test('should add two numbers correctly', () => {
   expect(1 + 2).toBe(3);
 });
 ```
+
+### TestOptions
+
+<ApiMeta addedVersion="1.0.0" />
+
+第三个参数用于细化单个测试的运行行为。传入数字等价于 `{ timeout: n }`，原有写法保持兼容：
+
+```ts
+test('runs within 3s', async () => {
+  /* ... */
+}, 3000);
+
+// 等价于：
+test(
+  'runs within 3s',
+  async () => {
+    /* ... */
+  },
+  { timeout: 3000 },
+);
+```
+
+`TestOptions` 支持以下字段：
+
+- `timeout?: number` — 单测超时（毫秒），覆盖 [`test.testTimeout`](/config/test/test-timeout)。
+- `retry?: number` — 测试失败时的重跑次数，首次通过即停。覆盖 [`test.retry`](/config/test/retry)。
+- `repeats?: number` — 在通过的前提下额外重跑指定次数，任一次失败则整体判定为失败。每次重跑会完整执行 `beforeEach` / `afterEach`，并各自享有独立的 `retry` 配额。
+
+```ts
+test(
+  'flaky network call',
+  async () => {
+    /* ... */
+  },
+  { retry: 3 },
+);
+
+test(
+  'stays green across runs',
+  async () => {
+    /* ... */
+  },
+  { repeats: 9 },
+); // 共执行 10 次；任一次失败即短路后续重跑
+```
+
+`test.each` 与 `test.for` 第三参语义相同，会作用于生成的每个 case。
 
 ## test.only
 
@@ -54,7 +103,7 @@ test.todo('should implement this test');
 
 ## test.each
 
-- **类型：** `test.each(cases: ReadonlyArray<T>)(name: string, fn: (param: T) => void | Promise<void>, timeout?: number) => void`
+- **类型：** `test.each(cases: ReadonlyArray<T>)(name: string, fn: (param: T) => void | Promise<void>, options?: number | TestOptions) => void`
 
 对提供的数组中的每一项运行相同的测试逻辑。
 
@@ -150,7 +199,7 @@ test.each([
 
 ## test.for
 
-- **类型：** `test.for(cases: ReadonlyArray<T>)(name: string, fn: (param: T, testContext: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **类型：** `test.for(cases: ReadonlyArray<T>)(name: string, fn: (param: T, testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
 
 `test.each` 的替代方案，提供 `TestContext`。
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -28,7 +28,7 @@ test('should add two numbers correctly', () => {
 
 ### TestOptions
 
-<ApiMeta addedVersion="1.0.0" />
+<ApiMeta addedVersion="0.10.3" />
 
 第三个参数用于细化单个测试的运行行为。传入数字等价于 `{ timeout: n }`，原有写法保持兼容：
 

--- a/website/docs/zh/config/test/retry.mdx
+++ b/website/docs/zh/config/test/retry.mdx
@@ -11,6 +11,8 @@ overviewHeaders: []
 
 如果测试执行失败，则重试特定次数。这对于一些会产生不稳定结果的测试用例很有帮助。
 
+单个测试可以通过 [`TestOptions.retry`](/api/runtime-api/test-api/test#testoptions) 覆盖该配置；传入 `{ retry: 0 }` 即可在保留全局 retry 的同时为某个测试关闭重试。
+
 ## 示例
 
 你可以通过设置 `retry: 2` 来指定测试失败后重试两次：


### PR DESCRIPTION
## Summary

The third argument of `test` / `it` / `test.each` / `test.for` accepted only a numeric timeout, so per-test retry and repeated runs had to be configured globally or not at all. This PR widens that argument to `number | TestOptions`, keeping the numeric form as shorthand for `{ timeout: n }`.

`TestOptions` adds two fields:

- `retry?: number` — overrides `config.retry` for one test. `{ retry: 0 }` opts a single test out even when the global retry is non-zero.
- `repeats?: number` — re-runs an already-passing test that many extra times; any failure short-circuits the rest and fails the case. Each repeat runs the full `beforeEach` / `afterEach` lifecycle and gets an independent retry budget.

Retry errors are now scoped per repeat, so a terminal failure no longer carries errors from earlier repeats that already passed. Invalid `retry` / `repeats` values (negative, `NaN`, fractional) clamp to non-negative integers so a typo cannot silently report a test as skipped.

`TestOptions` is declared as an `interface` to leave room for module-augmentation extensions in future releases.