### PR TITLE
fix(cli): support filter args after coverage

### DIFF
--- a/e2e/test-coverage/index.test.ts
+++ b/e2e/test-coverage/index.test.ts
@@ -90,6 +90,45 @@ describe('test coverage-istanbul', () => {
     expectLog('Coverage enabled with istanbul', logs);
   });
 
+  it('should treat positional argument after `--coverage` as a file filter', async () => {
+    const { expectExecSuccess, expectLog, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--coverage', 'date'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expectLog('Coverage enabled with istanbul', logs);
+
+    expectLog('Test Files 1 passed', logs);
+  });
+
+  it('should treat positional argument before `--coverage` as a file filter', async () => {
+    const { expectExecSuccess, expectLog, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'date', '--coverage'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expectLog('Coverage enabled with istanbul', logs);
+    expectLog('Test Files 1 passed', logs);
+  });
+
   it('should switch coverage provider with `--coverage.provider v8`', async () => {
     const { expectExecSuccess, expectLog, cli } = await runRstestCli({
       command: 'rstest',

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -54,6 +54,7 @@ const runtimeOptionDefinitions: OptionDefinition[] = [
   ['--exclude <exclude>', 'Exclude files from test'],
   ['-u, --update', 'Update snapshot files'],
   ['--coverage', 'Enable code coverage collection'],
+  ['--coverage.enabled', 'Enable code coverage collection'],
   [
     '--coverage.provider <provider>',
     'Coverage provider to use (istanbul | v8)',

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -93,6 +93,18 @@ describe('CLI help output', () => {
     expect(parsed.options.config).toBe('rstest.config.ts');
   });
 
+  it('does not consume positional filters after --coverage', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--coverage', 'path/to/file.test.ts'],
+      { run: false },
+    );
+
+    expect(parsed.options.coverage).toEqual({
+      enabled: true,
+    });
+    expect(parsed.args).toEqual(['path/to/file.test.ts']);
+  });
+
   it('preserves nested coverage options when followed by --coverage', () => {
     const parsed = createCli().parse(
       ['node', 'rstest', 'run', '--coverage.changed=HEAD', '--coverage'],
@@ -112,7 +124,7 @@ describe('CLI help output', () => {
     );
 
     expect(parsed.options.coverage).toEqual({
-      enabled: 'false',
+      enabled: false,
       changed: 'HEAD',
     });
   });


### PR DESCRIPTION
## Summary

Minor adjustment for cli handling, found 

```
rstest --coverage somefile.ts
```

omits file filter, looks like it is treated as input for the boolean flag for `coverage` instead.  If run 

```
rstest somefile.ts --coverage
```

file filter works fine.

PR tries to align flag behavior same as `browser`, having `coverage.enabled` support and allow to accept filters next to the coverage flag.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
