### PR TITLE
ci(preview): post pkg.pr.new install URLs back to the dispatched PR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,10 @@ on:
 
 permissions:
   contents: read
+  # Required so the workflow can post / update the preview-release comment
+  # on the PR associated with the dispatched commit. See `Comment on
+  # associated PR` step below.
+  pull-requests: write
 
 jobs:
   preview:
@@ -31,33 +35,25 @@ jobs:
           npm install -g corepack@latest --force
           corepack enable
 
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "packages/**"
-              - "!packages/document/**"
-
       - name: Setup Node.js
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: 'pnpm'
 
       - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm install
 
       - name: Publish Preview
         id: publish
-        if: steps.changes.outputs.changed == 'true'
-        run: pnpx pkg-pr-new publish --pnpm ./packages/*
+        # `pnpm exec` (not `pnpx`/`pnpm dlx`) per pkg.pr.new CAUTION:
+        # https://github.com/stackblitz-labs/pkg.pr.new#setup
+        # `--comment=off` because this workflow is dispatched manually, so
+        # pkg.pr.new's webhook never sees a PR context and can't auto-comment.
+        # We post the comment ourselves in the next step via `commits/{sha}/pulls`.
+        run: pnpm exec pkg-pr-new publish --pnpm --comment=off ./packages/*
 
       - name: Preview summary
-        if: steps.changes.outputs.changed == 'true'
         run: |
           sha='${{ steps.publish.outputs.sha }}'
           packages='${{ steps.publish.outputs.packages }}'
@@ -90,3 +86,41 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           echo "::notice title=pkg.pr.new::sha=$shaDisplay (see Summary for packages/urls)"
+
+      - name: Comment on associated PR
+        if: steps.publish.outputs.sha != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SHA: ${{ steps.publish.outputs.sha }}
+          URLS: ${{ steps.publish.outputs.urls }}
+        with:
+          script: |
+            const { SHA, URLS } = process.env;
+            // `listPullRequestsAssociatedWithCommit` returns both `open` and
+            // `merged` PRs — pick the first `open` one so we never re-comment
+            // on an already-merged PR.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              ...context.repo,
+              commit_sha: SHA,
+            });
+            const pr = prs.find((p) => p.state === 'open');
+            if (!pr) {
+              core.info(`No open PR contains ${SHA} — skipping comment.`);
+              return;
+            }
+            const { owner, repo } = context.repo;
+            // PR-scoped commit URL lands inside the PR's commit list (highlighted)
+            // rather than the bare repo commit page.
+            const commitUrl = `${context.serverUrl}/${owner}/${repo}/pull/${pr.number}/commits/${SHA}`;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              `## pkg.pr.new preview [\`${SHA}\`](${commitUrl}) · [workflow run](${runUrl})`,
+              '',
+              ...URLS.split(/\s+/).filter(Boolean).map((u) => `- \`pnpm add ${u}\``),
+            ].join('\n');
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: pr.number,
+              body,
+            });
+            core.info(`Posted preview comment to PR #${pr.number}.`);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "knip": "^6.14.2",
     "lefthook": "^2.1.8",
     "path-serializer": "0.6.0",
+    "pkg-pr-new": "^0.0.75",
     "playwright": "^1.60.0",
     "prettier": "^3.8.3",
     "prettier-plugin-packagejson": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       path-serializer:
         specifier: 0.6.0
         version: 0.6.0
+      pkg-pr-new:
+        specifier: ^0.0.75
+        version: 0.0.75
       playwright:
         specifier: ^1.60.0
         version: 1.60.0
@@ -6566,6 +6569,10 @@ packages:
 
   pixelmatch@5.3.0:
     resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
+    hasBin: true
+
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
     hasBin: true
 
   playwright-core@1.60.0:
@@ -14107,6 +14114,8 @@ snapshots:
   pixelmatch@5.3.0:
     dependencies:
       pngjs: 6.0.0
+
+  pkg-pr-new@0.0.75: {}
 
   playwright-core@1.60.0: {}
 


### PR DESCRIPTION
## Summary

The `Preview Release` workflow is `workflow_dispatch` only. pkg.pr.new's webhook never sees a PR context for this trigger type, so its built-in auto-comment (`--comment=update`) silently does nothing — every dispatched preview has been going unnoticed unless someone manually pastes the install URL.

### Fixes

- pin `pkg-pr-new` in `devDependencies` and invoke via `pnpm exec` (upstream [CAUTION](https://github.com/stackblitz-labs/pkg.pr.new#setup) against `pnpx`/`pnpm dlx`)
- pass `--comment=off` to make the no-op explicit
- new `Comment on associated PR` step:
  - reverse-looks-up the open PR containing the published commit via [`listPullRequestsAssociatedWithCommit`](https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit)
  - posts a minimal `## pkg.pr.new preview <sha>` comment with one `pnpm add <url>` per published package
  - silently no-ops when the dispatched branch has no open PR (e.g. dispatching `main` or a bare diagnostic branch)
- grant `pull-requests: write` (was `contents: read` only)

Implementation uses `actions/github-script` (Octokit + template literals) rather than shell + `gh` + `jq` — far less error-prone.

### Verification

This PR will be used to verify itself: dispatching `Preview Release` with `Use workflow from: ci/pkg-pr-new-comment-back` should produce a self-comment listing the 8 published preview package URLs.

## Test plan

- [ ] Dispatch `Preview Release` on this branch
- [ ] Verify the workflow run posts a `## pkg.pr.new preview <sha>` comment on this PR
- [ ] Verify the comment body matches the format previewed during review