### PR TITLE
fix(core): round duration before minute formatting

### DIFF
--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -102,8 +102,9 @@ export const prettyTime = (milliseconds: number): string => {
     return `${seconds.toFixed(digits)}s`;
   };
 
-  const minutes = Math.floor(seconds / 60);
-  const secondsRemainder = seconds % 60;
+  const roundedSeconds = Math.round(seconds);
+  const minutes = Math.floor(roundedSeconds / 60);
+  const secondsRemainder = minutes > 0 ? roundedSeconds % 60 : seconds;
   let time = '';
 
   if (minutes > 0) {

--- a/packages/core/tests/utils/helper.test.ts
+++ b/packages/core/tests/utils/helper.test.ts
@@ -21,6 +21,7 @@ it('should prettyTime correctly', () => {
   expect(prettyTime(2000)).toBe('2s');
   expect(prettyTime(3000)).toBe('3s');
   expect(prettyTime(60000)).toBe('1m');
+  expect(prettyTime(299999)).toBe('5m');
   expect(prettyTime(110000)).toBe('1m 50s');
   expect(prettyTime(111100)).toBe('1m 51s');
   expect(prettyTime(111900)).toBe('1m 52s');


### PR DESCRIPTION
## Summary

Fixes duration formatting near minute boundaries so rounded seconds cannot produce output like `4m 60s`. The formatter now rounds total seconds before splitting into minutes and seconds, and adds a regression test for `299999ms -> 5m`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).