### PR TITLE
fix(deps): restore rspack peer ranges

### DIFF
--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -43,8 +43,8 @@
     "@rstest/tsconfig": "workspace:*"
   },
   "peerDependencies": {
-    "@rspack/cli": "~2.0.4",
-    "@rspack/core": "~2.0.4",
+    "@rspack/cli": ">=2.0.0-0",
+    "@rspack/core": ">=2.0.0-0",
     "@rstest/core": "workspace:^"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

This PR restores the `@rstest/adapter-rspack` peer dependency ranges for `@rspack/cli` and `@rspack/core` back to the previously declared `>=2.0.0-0` range. Runtime/dev dependency pinning remains unchanged, but adapter consumers are no longer forced to install the exact pinned minor range.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
