### PR TITLE
feat(core): add --coverage.reporters CLI flag

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -60,6 +60,10 @@ const runtimeOptionDefinitions: OptionDefinition[] = [
     'Coverage provider to use (istanbul | v8)',
   ],
   [
+    '--coverage.reporters <reporter>',
+    'Coverage reporter to use (repeat the flag for multiple reporters)',
+  ],
+  [
     '--coverage.changed [commit]',
     'Collect coverage only for changed files, optionally since a commit',
   ],
@@ -215,6 +219,7 @@ const valueTakingOptions = new Set([
   '--config-loader',
   '--coverage.changed',
   '--coverage.provider',
+  '--coverage.reporters',
   '--exclude',
   '--hookTimeout',
   '--include',

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -64,6 +64,7 @@ export type CommonOptions = {
         enabled?: boolean | string;
         allowExternal?: boolean;
         provider?: 'istanbul' | 'v8';
+        reporters?: string | string[];
         changed?: boolean | string;
       };
   passWithNoTests?: boolean;
@@ -211,6 +212,12 @@ function mergeWithCLIOptions(
       }
       if (options.coverage.provider !== undefined) {
         config.coverage.provider = options.coverage.provider;
+        shouldEnableCoverage = true;
+      }
+      if (options.coverage.reporters !== undefined) {
+        config.coverage.reporters = castArray(
+          options.coverage.reporters,
+        ) as typeof config.coverage.reporters;
         shouldEnableCoverage = true;
       }
       if (options.coverage.changed !== undefined) {

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -546,6 +546,79 @@ describe('resolveProjects', () => {
         provider: 'v8',
       });
     });
+
+    it('should apply a single coverage.reporters from CLI as an array', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [
+            {
+              name: 'test-project',
+            },
+          ],
+        },
+        root: rootPath,
+        options: {
+          coverage: {
+            reporters: 'html',
+          },
+        },
+      });
+
+      expect(projects[0]!.config.coverage).toMatchObject({
+        enabled: true,
+        reporters: ['html'],
+      });
+    });
+
+    it('should apply repeated coverage.reporters from CLI as an array', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [
+            {
+              name: 'test-project',
+            },
+          ],
+        },
+        root: rootPath,
+        options: {
+          coverage: {
+            reporters: ['text', 'html'],
+          },
+        },
+      });
+
+      expect(projects[0]!.config.coverage).toMatchObject({
+        enabled: true,
+        reporters: ['text', 'html'],
+      });
+    });
+
+    it('should let CLI coverage.reporters override config reporters', async () => {
+      const projects = await resolveProjects({
+        config: {
+          projects: [
+            {
+              name: 'test-project',
+              coverage: {
+                enabled: true,
+                reporters: ['text', ['json', { file: 'coverage.json' }]],
+              },
+            },
+          ],
+        },
+        root: rootPath,
+        options: {
+          coverage: {
+            reporters: ['lcov'],
+          },
+        },
+      });
+
+      expect(projects[0]!.config.coverage).toMatchObject({
+        enabled: true,
+        reporters: ['lcov'],
+      });
+    });
   });
 
   describe('pool CLI options', () => {

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -280,56 +280,57 @@ Rstest CLI options are registered per command instead of being shared by every c
 
 `rstest`, `rstest run`, and `rstest watch` share the same test runtime options:
 
-| Flag                             | Description                                                                                                                                                           |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-c, --config <config>`          | Specify the configuration file, can be a relative or absolute path, see [Specify config file](/guide/basic/configure-rstest#specify-config-file)                      |
-| `--config-loader <loader>`       | Specify the config loader (`auto` \| `jiti` \| `native`), see [Rsbuild - Specify config loader](https://rsbuild.rs/guide/configuration/rsbuild#specify-config-loader) |
-| `-r, --root <root>`              | Specify the project root directory, see [root](/config/test/root)                                                                                                     |
-| `--related`                      | Treat positional arguments as source file paths and only run related tests                                                                                            |
-| `--findRelatedTests`             | Alias for `--related` for Jest compatibility                                                                                                                          |
-| `--changed [commit]`             | Run tests related to changed files in the current Git repository, optionally since a commit                                                                           |
-| `--globals`                      | Provide global APIs, see [globals](/config/test/globals)                                                                                                              |
-| `--isolate`                      | Run tests in an isolated environment, see [isolate](/config/test/isolate)                                                                                             |
-| `--reporters <name>`             | Specify the test reporter(s), see [reporters](/config/test/reporters)                                                                                                 |
-| `--exclude <exclude>`            | Exclude files from test, see [exclude](/config/test/exclude)                                                                                                          |
-| `-u, --update`                   | Update snapshot files, see [update](/config/test/update)                                                                                                              |
-| `--coverage`                     | Enable code coverage collection, see [coverage](/config/test/coverage)                                                                                                |
-| `--coverage.provider <provider>` | Choose the coverage provider (`istanbul` \| `v8`), see [coverage.provider](/config/test/coverage#provider)                                                            |
-| `--coverage.changed [commit]`    | Collect coverage only for changed files in the current Git repository, optionally since a commit                                                                      |
-| `--passWithNoTests`              | Allows the test suite to pass when no files are found, see [passWithNoTests](/config/test/pass-with-no-tests)                                                         |
-| `--silent [value]`               | Silence intercepted test console output, or keep logs only for failed tasks with `passed-only`, see [silent](/config/test/silent)                                     |
-| `--printConsoleTrace`            | Print console traces when calling any console method, see [printConsoleTrace](/config/test/print-console-trace)                                                       |
-| `--project <name>`               | Only run tests for the specified project, see [Filter by project name](/guide/basic/test-filter#filter-by-project-name)                                               |
-| `--disableConsoleIntercept`      | Disable console intercept, see [disableConsoleIntercept](/config/test/disable-console-intercept)                                                                      |
-| `--slowTestThreshold <value>`    | The number of milliseconds after which a test or suite is considered slow, see [slowTestThreshold](/config/test/slow-test-threshold)                                  |
-| `-t, --testNamePattern <value>`  | Run only tests with a name that matches the regex, see [testNamePattern](/config/test/test-name-pattern)                                                              |
-| `--testEnvironment <name>`       | The environment that will be used for testing, see [testEnvironment](/config/test/test-environment)                                                                   |
-| `--testTimeout <value>`          | Timeout of a test in milliseconds, see [testTimeout](/config/test/test-timeout)                                                                                       |
-| `--hookTimeout <value>`          | Timeout of hook in milliseconds, see [hookTimeout](/config/test/hook-timeout)                                                                                         |
-| `--retry <retry>`                | Number of times to retry a test if it fails, see [retry](/config/test/retry)                                                                                          |
-| `--bail [number]`                | Abort the test run after the specified number of test failures, see [bail](/config/test/bail)                                                                         |
-| `--browser, --browser.enabled`   | Run tests in Browser Mode, see [browser](/config/test/browser)                                                                                                        |
-| `--browser.name <name>`          | Browser to use: `chromium`, `firefox`, `webkit` (default: `chromium`), see [browser](/config/test/browser)                                                            |
-| `--browser.headless`             | Run browser in headless mode (default: `true` in CI), see [browser](/config/test/browser)                                                                             |
-| `--browser.port <port>`          | Port for the Browser Mode dev server, see [browser](/config/test/browser)                                                                                             |
-| `--browser.strictPort`           | Exit if the specified port is already in use, see [browser](/config/test/browser)                                                                                     |
-| `--maxConcurrency <value>`       | Maximum number of concurrent tests, see [maxConcurrency](/config/test/max-concurrency)                                                                                |
-| `--clearMocks`                   | Automatically clear mock calls, instances, contexts and results before every test, see [clearMocks](/config/test/clear-mocks)                                         |
-| `--resetMocks`                   | Automatically reset mock state before every test, see [resetMocks](/config/test/reset-mocks)                                                                          |
-| `--restoreMocks`                 | Automatically restore mock state and implementation before every test, see [restoreMocks](/config/test/restore-mocks)                                                 |
-| `--unstubGlobals`                | Restores all global variables that were changed with `rs.stubGlobal` before every test, see [unstubGlobals](/config/test/unstub-globals)                              |
-| `--unstubEnvs`                   | Restores all `process.env` values that were changed with `rs.stubEnv` before every test, see [unstubEnvs](/config/test/unstub-envs)                                   |
-| `--include <include>`            | Specify test file matching pattern, see [include](/config/test/include)                                                                                               |
-| `--logHeapUsage`                 | Print heap usage for each test, see [logHeapUsage](/config/test/log-heap-usage)                                                                                       |
-| `--detectAsyncLeaks`             | Detect async resources that leak after tests finish, see [detectAsyncLeaks](/config/test/detect-async-leaks)                                                          |
-| `--hideSkippedTests`             | Do not display skipped test logs, see [hideSkippedTests](/config/test/hide-skipped-tests)                                                                             |
-| `--hideSkippedTestFiles`         | Do not display skipped test file logs, see [hideSkippedTestFiles](/config/test/hide-skipped-test-files)                                                               |
-| `--pool <type>`                  | Shorthand for `--pool.type`, see [pool](/config/test/pool)                                                                                                            |
-| `--pool.type <type>`             | Specify the test pool type, see [pool](/config/test/pool)                                                                                                             |
-| `--pool.maxWorkers <value>`      | Maximum number or percentage of workers, see [pool](/config/test/pool)                                                                                                |
-| `--pool.minWorkers <value>`      | Minimum number or percentage of workers, see [pool](/config/test/pool)                                                                                                |
-| `--pool.execArgv <arg>`          | Additional Node.js execArgv for worker processes (repeatable), see [pool](/config/test/pool)                                                                          |
-| `-h, --help`                     | Display help for command                                                                                                                                              |
+| Flag                              | Description                                                                                                                                                           |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-c, --config <config>`           | Specify the configuration file, can be a relative or absolute path, see [Specify config file](/guide/basic/configure-rstest#specify-config-file)                      |
+| `--config-loader <loader>`        | Specify the config loader (`auto` \| `jiti` \| `native`), see [Rsbuild - Specify config loader](https://rsbuild.rs/guide/configuration/rsbuild#specify-config-loader) |
+| `-r, --root <root>`               | Specify the project root directory, see [root](/config/test/root)                                                                                                     |
+| `--related`                       | Treat positional arguments as source file paths and only run related tests                                                                                            |
+| `--findRelatedTests`              | Alias for `--related` for Jest compatibility                                                                                                                          |
+| `--changed [commit]`              | Run tests related to changed files in the current Git repository, optionally since a commit                                                                           |
+| `--globals`                       | Provide global APIs, see [globals](/config/test/globals)                                                                                                              |
+| `--isolate`                       | Run tests in an isolated environment, see [isolate](/config/test/isolate)                                                                                             |
+| `--reporters <name>`              | Specify the test reporter(s), see [reporters](/config/test/reporters)                                                                                                 |
+| `--exclude <exclude>`             | Exclude files from test, see [exclude](/config/test/exclude)                                                                                                          |
+| `-u, --update`                    | Update snapshot files, see [update](/config/test/update)                                                                                                              |
+| `--coverage`                      | Enable code coverage collection, see [coverage](/config/test/coverage)                                                                                                |
+| `--coverage.provider <provider>`  | Choose the coverage provider (`istanbul` \| `v8`), see [coverage.provider](/config/test/coverage#provider)                                                            |
+| `--coverage.reporters <reporter>` | Coverage reporter to use; repeat the flag for multiple reporters, see [coverage.reporters](/config/test/coverage#reporters)                                           |
+| `--coverage.changed [commit]`     | Collect coverage only for changed files in the current Git repository, optionally since a commit                                                                      |
+| `--passWithNoTests`               | Allows the test suite to pass when no files are found, see [passWithNoTests](/config/test/pass-with-no-tests)                                                         |
+| `--silent [value]`                | Silence intercepted test console output, or keep logs only for failed tasks with `passed-only`, see [silent](/config/test/silent)                                     |
+| `--printConsoleTrace`             | Print console traces when calling any console method, see [printConsoleTrace](/config/test/print-console-trace)                                                       |
+| `--project <name>`                | Only run tests for the specified project, see [Filter by project name](/guide/basic/test-filter#filter-by-project-name)                                               |
+| `--disableConsoleIntercept`       | Disable console intercept, see [disableConsoleIntercept](/config/test/disable-console-intercept)                                                                      |
+| `--slowTestThreshold <value>`     | The number of milliseconds after which a test or suite is considered slow, see [slowTestThreshold](/config/test/slow-test-threshold)                                  |
+| `-t, --testNamePattern <value>`   | Run only tests with a name that matches the regex, see [testNamePattern](/config/test/test-name-pattern)                                                              |
+| `--testEnvironment <name>`        | The environment that will be used for testing, see [testEnvironment](/config/test/test-environment)                                                                   |
+| `--testTimeout <value>`           | Timeout of a test in milliseconds, see [testTimeout](/config/test/test-timeout)                                                                                       |
+| `--hookTimeout <value>`           | Timeout of hook in milliseconds, see [hookTimeout](/config/test/hook-timeout)                                                                                         |
+| `--retry <retry>`                 | Number of times to retry a test if it fails, see [retry](/config/test/retry)                                                                                          |
+| `--bail [number]`                 | Abort the test run after the specified number of test failures, see [bail](/config/test/bail)                                                                         |
+| `--browser, --browser.enabled`    | Run tests in Browser Mode, see [browser](/config/test/browser)                                                                                                        |
+| `--browser.name <name>`           | Browser to use: `chromium`, `firefox`, `webkit` (default: `chromium`), see [browser](/config/test/browser)                                                            |
+| `--browser.headless`              | Run browser in headless mode (default: `true` in CI), see [browser](/config/test/browser)                                                                             |
+| `--browser.port <port>`           | Port for the Browser Mode dev server, see [browser](/config/test/browser)                                                                                             |
+| `--browser.strictPort`            | Exit if the specified port is already in use, see [browser](/config/test/browser)                                                                                     |
+| `--maxConcurrency <value>`        | Maximum number of concurrent tests, see [maxConcurrency](/config/test/max-concurrency)                                                                                |
+| `--clearMocks`                    | Automatically clear mock calls, instances, contexts and results before every test, see [clearMocks](/config/test/clear-mocks)                                         |
+| `--resetMocks`                    | Automatically reset mock state before every test, see [resetMocks](/config/test/reset-mocks)                                                                          |
+| `--restoreMocks`                  | Automatically restore mock state and implementation before every test, see [restoreMocks](/config/test/restore-mocks)                                                 |
+| `--unstubGlobals`                 | Restores all global variables that were changed with `rs.stubGlobal` before every test, see [unstubGlobals](/config/test/unstub-globals)                              |
+| `--unstubEnvs`                    | Restores all `process.env` values that were changed with `rs.stubEnv` before every test, see [unstubEnvs](/config/test/unstub-envs)                                   |
+| `--include <include>`             | Specify test file matching pattern, see [include](/config/test/include)                                                                                               |
+| `--logHeapUsage`                  | Print heap usage for each test, see [logHeapUsage](/config/test/log-heap-usage)                                                                                       |
+| `--detectAsyncLeaks`              | Detect async resources that leak after tests finish, see [detectAsyncLeaks](/config/test/detect-async-leaks)                                                          |
+| `--hideSkippedTests`              | Do not display skipped test logs, see [hideSkippedTests](/config/test/hide-skipped-tests)                                                                             |
+| `--hideSkippedTestFiles`          | Do not display skipped test file logs, see [hideSkippedTestFiles](/config/test/hide-skipped-test-files)                                                               |
+| `--pool <type>`                   | Shorthand for `--pool.type`, see [pool](/config/test/pool)                                                                                                            |
+| `--pool.type <type>`              | Specify the test pool type, see [pool](/config/test/pool)                                                                                                             |
+| `--pool.maxWorkers <value>`       | Maximum number or percentage of workers, see [pool](/config/test/pool)                                                                                                |
+| `--pool.minWorkers <value>`       | Minimum number or percentage of workers, see [pool](/config/test/pool)                                                                                                |
+| `--pool.execArgv <arg>`           | Additional Node.js execArgv for worker processes (repeatable), see [pool](/config/test/pool)                                                                          |
+| `-h, --help`                      | Display help for command                                                                                                                                              |
 
 `rstest` also supports `-w, --watch`, which switches the default command into watch mode.
 

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -280,56 +280,57 @@ Rstest CLI 参数是按命令注册的，并不是所有命令共享同一套参
 
 `rstest`、`rstest run` 和 `rstest watch` 共享同一组测试运行参数：
 
-| 参数                             | 说明                                                                                                                                                 |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-c, --config <config>`          | 指定配置文件路径（相对或绝对路径），详见 [指定配置文件](/guide/basic/configure-rstest#指定配置文件)                                                  |
-| `--config-loader <loader>`       | 指定配置加载器 （`auto` \| `jiti` \| `native`），详见 [Rsbuild - 指定加载方式](https://rsbuild.rs/guide/configuration/rsbuild#specify-config-loader) |
-| `-r, --root <root>`              | 指定项目根目录，详见 [root](/config/test/root)                                                                                                       |
-| `--related`                      | 将位置参数视为源码文件路径，只运行相关测试                                                                                                           |
-| `--findRelatedTests`             | `--related` 的 Jest 兼容别名                                                                                                                         |
-| `--changed [commit]`             | 运行当前 Git 仓库中变更文件相关的测试，也可以指定从某个 commit 以来的变更                                                                            |
-| `--globals`                      | 提供全局 API，详见 [globals](/config/test/globals)                                                                                                   |
-| `--isolate`                      | 在隔离环境中运行测试，详见 [isolate](/config/test/isolate)                                                                                           |
-| `--exclude <exclude>`            | 排除指定文件，详见 [exclude](/config/test/exclude)                                                                                                   |
-| `-u, --update`                   | 更新快照文件，详见 [update](/config/test/update)                                                                                                     |
-| `--coverage`                     | 启用代码覆盖率收集，详见 [coverage](/config/test/coverage)                                                                                           |
-| `--coverage.provider <provider>` | 选择覆盖率 provider（`istanbul` \| `v8`），详见 [coverage.provider](/config/test/coverage#provider)                                                  |
-| `--coverage.changed [commit]`    | 只收集当前 Git 仓库中变更文件的覆盖率，也可以指定从某个 commit 以来的变更                                                                            |
-| `--passWithNoTests`              | 当未找到测试文件时允许测试通过，详见 [passWithNoTests](/config/test/pass-with-no-tests)                                                              |
-| `--silent [value]`               | 静默被拦截的测试 console 输出，或用 `passed-only` 仅保留失败任务日志，详见 [silent](/config/test/silent)                                             |
-| `--printConsoleTrace`            | 调用 console 方法时打印调用栈，详见 [printConsoleTrace](/config/test/print-console-trace)                                                            |
-| `--project <name>`               | 仅运行指定项目的测试，详见 [根据项目名称过滤](/guide/basic/test-filter#根据项目名称过滤)                                                             |
-| `--disableConsoleIntercept`      | 禁用 console 拦截，详见 [disableConsoleIntercept](/config/test/disable-console-intercept)                                                            |
-| `--slowTestThreshold <value>`    | 设置测试或套件被视为慢的阈值（毫秒），详见 [slowTestThreshold](/config/test/slow-test-threshold)                                                     |
-| `-t, --testNamePattern <value>`  | 仅运行名称匹配正则的测试，详见 [testNamePattern](/config/test/test-name-pattern)                                                                     |
-| `--testEnvironment <name>`       | 指定测试环境，详见 [testEnvironment](/config/test/test-environment)                                                                                  |
-| `--testTimeout <value>`          | 设置单个测试的超时时间（毫秒），详见 [testTimeout](/config/test/test-timeout)                                                                        |
-| `--hookTimeout <value>`          | 设置单个测试 hook 的超时时间（毫秒），详见 [hookTimeout](/config/test/hook-timeout)                                                                  |
-| `--retry <retry>`                | 测试失败时重试次数，详见 [retry](/config/test/retry)                                                                                                 |
-| `--bail [number]`                | 指定个数的测试失败后停止运行，详见 [bail](/config/test/bail)                                                                                         |
-| `--browser, --browser.enabled`   | 在浏览器模式下运行测试，详见 [browser](/config/test/browser)                                                                                         |
-| `--browser.name <name>`          | 使用的浏览器：`chromium`、`firefox`、`webkit`（默认：`chromium`），详见 [browser](/config/test/browser)                                              |
-| `--browser.headless`             | 在无头模式下运行浏览器（CI 环境默认：`true`），详见 [browser](/config/test/browser)                                                                  |
-| `--browser.port <port>`          | 浏览器模式开发服务器的端口，详见 [browser](/config/test/browser)                                                                                     |
-| `--browser.strictPort`           | 如果指定端口已被占用则退出，详见 [browser](/config/test/browser)                                                                                     |
-| `--reporters <name>`             | 指定一个或多个测试报告器，详见 [reporters](/config/test/reporters)                                                                                   |
-| `--maxConcurrency <value>`       | 最大并发测试数，详见 [maxConcurrency](/config/test/max-concurrency)                                                                                  |
-| `--clearMocks`                   | 每个测试前自动清除 mock 调用、实例、上下文和结果，详见 [clearMocks](/config/test/clear-mocks)                                                        |
-| `--resetMocks`                   | 每个测试前自动重置 mock 状态，详见 [resetMocks](/config/test/reset-mocks)                                                                            |
-| `--restoreMocks`                 | 每个测试前自动恢复 mock 状态和实现，详见 [restoreMocks](/config/test/restore-mocks)                                                                  |
-| `--unstubGlobals`                | 每个测试前恢复被 `rs.stubGlobal` 修改的全局变量，详见 [unstubGlobals](/config/test/unstub-globals)                                                   |
-| `--unstubEnvs`                   | 每个测试前恢复被 `rs.stubEnv` 修改的 `process.env`，详见 [unstubEnvs](/config/test/unstub-envs)                                                      |
-| `--include <include>`            | 指定测试文件匹配模式，详见 [include](/config/test/include)                                                                                           |
-| `--logHeapUsage`                 | 打印每个测试的堆内存使用情况，详见 [logHeapUsage](/config/test/log-heap-usage)                                                                       |
-| `--detectAsyncLeaks`             | 检测测试结束后仍然存活的异步资源，详见 [detectAsyncLeaks](/config/test/detect-async-leaks)                                                           |
-| `--hideSkippedTests`             | 不展示跳过测试的日志，详见 [hideSkippedTests](/config/test/hide-skipped-tests)                                                                       |
-| `--hideSkippedTestFiles`         | 不展示跳过测试文件的日志，详见 [hideSkippedTestFiles](/config/test/hide-skipped-test-files)                                                          |
-| `--pool <type>`                  | `--pool.type` 的 shorthand，详见 [pool](/config/test/pool)                                                                                           |
-| `--pool.type <type>`             | 指定测试线程池类型，详见 [pool](/config/test/pool)                                                                                                   |
-| `--pool.maxWorkers <value>`      | 最大 worker 数量或百分比，详见 [pool](/config/test/pool)                                                                                             |
-| `--pool.minWorkers <value>`      | 最小 worker 数量或百分比，详见 [pool](/config/test/pool)                                                                                             |
-| `--pool.execArgv <arg>`          | 传给 worker 进程的额外 Node.js execArgv（可重复传入），详见 [pool](/config/test/pool)                                                                |
-| `-h, --help`                     | 显示帮助信息                                                                                                                                         |
+| 参数                              | 说明                                                                                                                                                 |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-c, --config <config>`           | 指定配置文件路径（相对或绝对路径），详见 [指定配置文件](/guide/basic/configure-rstest#指定配置文件)                                                  |
+| `--config-loader <loader>`        | 指定配置加载器 （`auto` \| `jiti` \| `native`），详见 [Rsbuild - 指定加载方式](https://rsbuild.rs/guide/configuration/rsbuild#specify-config-loader) |
+| `-r, --root <root>`               | 指定项目根目录，详见 [root](/config/test/root)                                                                                                       |
+| `--related`                       | 将位置参数视为源码文件路径，只运行相关测试                                                                                                           |
+| `--findRelatedTests`              | `--related` 的 Jest 兼容别名                                                                                                                         |
+| `--changed [commit]`              | 运行当前 Git 仓库中变更文件相关的测试，也可以指定从某个 commit 以来的变更                                                                            |
+| `--globals`                       | 提供全局 API，详见 [globals](/config/test/globals)                                                                                                   |
+| `--isolate`                       | 在隔离环境中运行测试，详见 [isolate](/config/test/isolate)                                                                                           |
+| `--exclude <exclude>`             | 排除指定文件，详见 [exclude](/config/test/exclude)                                                                                                   |
+| `-u, --update`                    | 更新快照文件，详见 [update](/config/test/update)                                                                                                     |
+| `--coverage`                      | 启用代码覆盖率收集，详见 [coverage](/config/test/coverage)                                                                                           |
+| `--coverage.provider <provider>`  | 选择覆盖率 provider（`istanbul` \| `v8`），详见 [coverage.provider](/config/test/coverage#provider)                                                  |
+| `--coverage.reporters <reporter>` | 选择覆盖率 reporter；多次传入该 flag 可指定多个 reporter，详见 [coverage.reporters](/config/test/coverage#reporters)                                 |
+| `--coverage.changed [commit]`     | 只收集当前 Git 仓库中变更文件的覆盖率，也可以指定从某个 commit 以来的变更                                                                            |
+| `--passWithNoTests`               | 当未找到测试文件时允许测试通过，详见 [passWithNoTests](/config/test/pass-with-no-tests)                                                              |
+| `--silent [value]`                | 静默被拦截的测试 console 输出，或用 `passed-only` 仅保留失败任务日志，详见 [silent](/config/test/silent)                                             |
+| `--printConsoleTrace`             | 调用 console 方法时打印调用栈，详见 [printConsoleTrace](/config/test/print-console-trace)                                                            |
+| `--project <name>`                | 仅运行指定项目的测试，详见 [根据项目名称过滤](/guide/basic/test-filter#根据项目名称过滤)                                                             |
+| `--disableConsoleIntercept`       | 禁用 console 拦截，详见 [disableConsoleIntercept](/config/test/disable-console-intercept)                                                            |
+| `--slowTestThreshold <value>`     | 设置测试或套件被视为慢的阈值（毫秒），详见 [slowTestThreshold](/config/test/slow-test-threshold)                                                     |
+| `-t, --testNamePattern <value>`   | 仅运行名称匹配正则的测试，详见 [testNamePattern](/config/test/test-name-pattern)                                                                     |
+| `--testEnvironment <name>`        | 指定测试环境，详见 [testEnvironment](/config/test/test-environment)                                                                                  |
+| `--testTimeout <value>`           | 设置单个测试的超时时间（毫秒），详见 [testTimeout](/config/test/test-timeout)                                                                        |
+| `--hookTimeout <value>`           | 设置单个测试 hook 的超时时间（毫秒），详见 [hookTimeout](/config/test/hook-timeout)                                                                  |
+| `--retry <retry>`                 | 测试失败时重试次数，详见 [retry](/config/test/retry)                                                                                                 |
+| `--bail [number]`                 | 指定个数的测试失败后停止运行，详见 [bail](/config/test/bail)                                                                                         |
+| `--browser, --browser.enabled`    | 在浏览器模式下运行测试，详见 [browser](/config/test/browser)                                                                                         |
+| `--browser.name <name>`           | 使用的浏览器：`chromium`、`firefox`、`webkit`（默认：`chromium`），详见 [browser](/config/test/browser)                                              |
+| `--browser.headless`              | 在无头模式下运行浏览器（CI 环境默认：`true`），详见 [browser](/config/test/browser)                                                                  |
+| `--browser.port <port>`           | 浏览器模式开发服务器的端口，详见 [browser](/config/test/browser)                                                                                     |
+| `--browser.strictPort`            | 如果指定端口已被占用则退出，详见 [browser](/config/test/browser)                                                                                     |
+| `--reporters <name>`              | 指定一个或多个测试报告器，详见 [reporters](/config/test/reporters)                                                                                   |
+| `--maxConcurrency <value>`        | 最大并发测试数，详见 [maxConcurrency](/config/test/max-concurrency)                                                                                  |
+| `--clearMocks`                    | 每个测试前自动清除 mock 调用、实例、上下文和结果，详见 [clearMocks](/config/test/clear-mocks)                                                        |
+| `--resetMocks`                    | 每个测试前自动重置 mock 状态，详见 [resetMocks](/config/test/reset-mocks)                                                                            |
+| `--restoreMocks`                  | 每个测试前自动恢复 mock 状态和实现，详见 [restoreMocks](/config/test/restore-mocks)                                                                  |
+| `--unstubGlobals`                 | 每个测试前恢复被 `rs.stubGlobal` 修改的全局变量，详见 [unstubGlobals](/config/test/unstub-globals)                                                   |
+| `--unstubEnvs`                    | 每个测试前恢复被 `rs.stubEnv` 修改的 `process.env`，详见 [unstubEnvs](/config/test/unstub-envs)                                                      |
+| `--include <include>`             | 指定测试文件匹配模式，详见 [include](/config/test/include)                                                                                           |
+| `--logHeapUsage`                  | 打印每个测试的堆内存使用情况，详见 [logHeapUsage](/config/test/log-heap-usage)                                                                       |
+| `--detectAsyncLeaks`              | 检测测试结束后仍然存活的异步资源，详见 [detectAsyncLeaks](/config/test/detect-async-leaks)                                                           |
+| `--hideSkippedTests`              | 不展示跳过测试的日志，详见 [hideSkippedTests](/config/test/hide-skipped-tests)                                                                       |
+| `--hideSkippedTestFiles`          | 不展示跳过测试文件的日志，详见 [hideSkippedTestFiles](/config/test/hide-skipped-test-files)                                                          |
+| `--pool <type>`                   | `--pool.type` 的 shorthand，详见 [pool](/config/test/pool)                                                                                           |
+| `--pool.type <type>`              | 指定测试线程池类型，详见 [pool](/config/test/pool)                                                                                                   |
+| `--pool.maxWorkers <value>`       | 最大 worker 数量或百分比，详见 [pool](/config/test/pool)                                                                                             |
+| `--pool.minWorkers <value>`       | 最小 worker 数量或百分比，详见 [pool](/config/test/pool)                                                                                             |
+| `--pool.execArgv <arg>`           | 传给 worker 进程的额外 Node.js execArgv（可重复传入），详见 [pool](/config/test/pool)                                                                |
+| `-h, --help`                      | 显示帮助信息                                                                                                                                         |
 
 `rstest` 默认命令还额外支持 `-w, --watch`，可直接切换到 watch 模式。
 


### PR DESCRIPTION
## Summary

Adds a `--coverage.reporters` CLI flag that mirrors the existing `coverage.reporters: SupportedReporter[]` config field, so coverage reporters can be selected from the command line without editing a config file. The flag name uses the plural form to match the config field name verbatim (consistent with the top-level `--reporters` alias added recently).

Behavior:

- Repeat the flag to provide multiple reporters: `--coverage.reporters text --coverage.reporters html`. cac aggregates the values into an array; a single occurrence is normalized via `castArray`.
- Passing the flag auto-enables coverage, matching the existing behavior of `--coverage.provider` and `--coverage.allowExternal`.
- CLI overrides any `coverage.reporters` set in the config file.

Reporter tuple form (e.g. `['html', { subdir: 'html-report' }]`) is not expressible from the CLI; users who need it must continue to use the config file.

## Related Links

- Closes part of https://github.com/web-infra-dev/rstest/issues/1332