### PR TITLE
fix(core): avoid cloning URL objects in ESM resolution

### DIFF
--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -12,6 +12,8 @@ import {
   shouldInterop,
 } from './interop';
 
+const importMetaResolve = import.meta.resolve;
+
 export enum EsmMode {
   Unknown = 0,
   Evaluated = 1,
@@ -27,6 +29,16 @@ const isRelativePath = (p: string) => /^\.\.?\//.test(p);
 
 const isBuiltinSpecifier = (specifier: string) =>
   specifier.startsWith('node:') || builtinModules.includes(specifier);
+
+const resolveModule = (specifier: string, resolveBase: string): string | URL =>
+  // Node's loader hook worker clones the parent URL when native TypeScript
+  // loading is active. Passing URL objects can throw DataCloneError there.
+  importMetaResolve(
+    specifier,
+    resolveBase.startsWith('file:')
+      ? resolveBase
+      : pathToFileURL(resolveBase).href,
+  );
 
 export const appendSourceURL = (
   codeContent: string,
@@ -117,10 +129,10 @@ const defineRstestDynamicImport =
     // (which have no origin to pass) working as before.
     const resolveBase = origin ?? testPath;
     const resolvedPath = isAbsolute(specifier)
-      ? pathToFileURL(specifier)
+      ? pathToFileURL(specifier).href
       : isBuiltinSpecifier(specifier)
         ? specifier
-        : import.meta.resolve(specifier, pathToFileURL(resolveBase));
+        : resolveModule(specifier, resolveBase);
 
     // Use `.href` (full file:// URL) rather than `.pathname` so absolute
     // Windows specifiers (`D:\a\foo.mjs`) remain valid import targets. With
@@ -262,7 +274,7 @@ export const loadModule = async ({
         interopDefault,
         returnModule: true,
         esmMode: EsmMode.Unlinked,
-      })(specifier, referencingModule as ImportCallOptions),
+      })(specifier, {}, referencingModule.identifier),
     );
   }
 

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -1,4 +1,4 @@
-import { builtinModules } from 'node:module';
+import { builtinModules, createRequire } from 'node:module';
 import { isAbsolute } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import vm, { type SourceTextModule } from 'node:vm';
@@ -12,7 +12,7 @@ import {
   shouldInterop,
 } from './interop';
 
-const importMetaResolve = import.meta.resolve;
+const importMetaResolve = import.meta.resolve?.bind(import.meta);
 
 export enum EsmMode {
   Unknown = 0,
@@ -30,15 +30,22 @@ const isRelativePath = (p: string) => /^\.\.?\//.test(p);
 const isBuiltinSpecifier = (specifier: string) =>
   specifier.startsWith('node:') || builtinModules.includes(specifier);
 
-const resolveModule = (specifier: string, resolveBase: string): string | URL =>
+const resolveModule = (
+  specifier: string,
+  resolveBase: string,
+): string | URL => {
+  const parentURL = resolveBase.startsWith('file:')
+    ? resolveBase
+    : pathToFileURL(resolveBase).href;
+
+  if (!importMetaResolve) {
+    return pathToFileURL(createRequire(parentURL).resolve(specifier)).href;
+  }
+
   // Node's loader hook worker clones the parent URL when native TypeScript
   // loading is active. Passing URL objects can throw DataCloneError there.
-  importMetaResolve(
-    specifier,
-    resolveBase.startsWith('file:')
-      ? resolveBase
-      : pathToFileURL(resolveBase).href,
-  );
+  return importMetaResolve(specifier, parentURL);
+};
 
 export const appendSourceURL = (
   codeContent: string,
@@ -274,7 +281,11 @@ export const loadModule = async ({
         interopDefault,
         returnModule: true,
         esmMode: EsmMode.Unlinked,
-      })(specifier, {}, referencingModule.identifier),
+      })(
+        specifier,
+        {},
+        isRelativePath(specifier) ? referencingModule.identifier : undefined,
+      ),
     );
   }
 

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -12,7 +12,17 @@ import {
   shouldInterop,
 } from './interop';
 
+const importMetaResolve = import.meta.resolve;
+
 const isRelativePath = (p: string) => /^\.\.?\//.test(p);
+
+const resolveModule = (specifier: string, resolveBase: string): string | URL =>
+  importMetaResolve(
+    specifier,
+    resolveBase.startsWith('file:')
+      ? resolveBase
+      : pathToFileURL(resolveBase).href,
+  );
 
 const createRequire = (
   filename: string,
@@ -88,8 +98,8 @@ const defineRstestDynamicImport =
     // to pass) working as before.
     const resolveBase = origin ?? testPath;
     const resolvedPath = isAbsolute(specifier)
-      ? pathToFileURL(specifier)
-      : import.meta.resolve(specifier, pathToFileURL(resolveBase));
+      ? pathToFileURL(specifier).href
+      : resolveModule(specifier, resolveBase);
 
     // Use `.href` rather than `.pathname` so Windows absolute specifiers
     // round-trip through Node's ESM loader as valid `file:///D:/...` URLs

--- a/packages/core/tests/runner/fixtures/bare-parent/bare-parent-pkg/index.mjs
+++ b/packages/core/tests/runner/fixtures/bare-parent/bare-parent-pkg/index.mjs
@@ -1,0 +1,1 @@
+export const value = 'fixture-pkg-value';

--- a/packages/core/tests/runner/fixtures/bare-parent/package.json
+++ b/packages/core/tests/runner/fixtures/bare-parent/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bare-parent",
+  "type": "module",
+  "imports": {
+    "#fixture-pkg": "./bare-parent-pkg/index.mjs"
+  }
+}

--- a/packages/core/tests/runner/fixtures/nativeTsLoader.ts
+++ b/packages/core/tests/runner/fixtures/nativeTsLoader.ts
@@ -1,0 +1,3 @@
+export default {
+  base: import.meta.dirname,
+};

--- a/packages/core/tests/runner/loadEsModule.test.ts
+++ b/packages/core/tests/runner/loadEsModule.test.ts
@@ -134,6 +134,25 @@ describe('loadEsModule', () => {
     expect(mod.default).toBe('foo-val');
   });
 
+  it('should resolve bare static imports from the test path', async () => {
+    const testPath = fixturePath('bare-parent/index.test.ts');
+    const distPath = '/virtual/dist/.rstest-temp/bare-parent_index~test~ts.mjs';
+
+    const mod = await loadModule({
+      codeContent: [
+        "import { value } from '#fixture-pkg';",
+        'export default value;',
+      ].join('\n'),
+      distPath,
+      testPath,
+      rstestContext: {},
+      assetFiles: {},
+      interopDefault: false,
+    });
+
+    expect(mod.default).toBe('fixture-pkg-value');
+  });
+
   it('should preserve the real default export of a real native ESM module', async () => {
     const mod = await loadModule({
       codeContent: [

--- a/packages/core/tests/runner/loadEsModule.test.ts
+++ b/packages/core/tests/runner/loadEsModule.test.ts
@@ -116,6 +116,24 @@ describe('loadEsModule', () => {
     expect(mod.default.bar).toBe('bar-val');
   });
 
+  it('should resolve external ESM after Node native TypeScript loader is used', async () => {
+    await import(fixturePath('nativeTsLoader.ts'));
+
+    const mod = await loadModule({
+      codeContent: [
+        `import { foo } from ${JSON.stringify(fixturePath('namedOnly.mjs'))};`,
+        'export default foo;',
+      ].join('\n'),
+      distPath: '/virtual/dist/entry.mjs',
+      testPath: __filename,
+      rstestContext: {},
+      assetFiles: {},
+      interopDefault: false,
+    });
+
+    expect(mod.default).toBe('foo-val');
+  });
+
   it('should preserve the real default export of a real native ESM module', async () => {
     const mod = await loadModule({
       codeContent: [


### PR DESCRIPTION
## Summary

This PR fixes a Node 24 native TypeScript loader interaction where reused non-isolated workers could throw `DataCloneError: Cannot clone object of unsupported type.` during ESM resolution. Rstest now passes string parent URLs to `import.meta.resolve` instead of `URL` objects, preserves absolute specifiers as `file://` strings, and keeps bare static imports resolving from the original test path while relative linked assets still resolve from the referencing module.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
