### PR TITLE
refactor(core): simplify mock runtime plugin

### DIFF
--- a/packages/core/src/core/plugins/mockRuntime.ts
+++ b/packages/core/src/core/plugins/mockRuntime.ts
@@ -28,39 +28,8 @@ class MockRuntimeRspackPlugin {
 
     compiler.hooks.compilation.tap('RstestMockPlugin', (compilation) => {
       compilation.hooks.runtimeModule.tap(
-        'RstestMockChunkLoadingRuntimePlugin',
+        'RstestWasmRuntimePlugin',
         (module) => {
-          if (module.name === 'require_chunk_loading') {
-            const finalSource = module.source!.source.toString('utf-8').replace(
-              // Hard coded in EJS template https://github.com/web-infra-dev/rspack/blob/5b89b0b9810f15c6bd6494b9a3389db3071d93d1/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.ejs.
-              'for (var moduleId in moreModules) {',
-              'for (var moduleId in moreModules) {\n' +
-                '\t\tif (Object.keys(__webpack_require__.rstest_original_modules).includes(moduleId) || Object.keys(__webpack_require__.rstest_original_module_factories).includes(moduleId)) continue;',
-            );
-            module.source!.source = Buffer.from(finalSource);
-          }
-
-          if (module.name === 'module_chunk_loading') {
-            const finalSource = module.source!.source.toString('utf-8').replace(
-              // Hard coded in EJS template https://github.com/web-infra-dev/rspack/blob/5b89b0b9810f15c6bd6494b9a3389db3071d93d1/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.ejs.
-              'for (moduleId in __webpack_modules__) {',
-              'for (moduleId in __webpack_modules__) {\n' +
-                '\t\tif (Object.keys(__webpack_require__.rstest_original_modules).includes(moduleId) || Object.keys(__webpack_require__.rstest_original_module_factories).includes(moduleId)) continue;',
-            );
-            module.source!.source = Buffer.from(finalSource);
-          }
-
-          if (module.name === 'define_property_getters') {
-            const finalSource = module.source!.source.toString('utf-8').replace(
-              // Sets the object configurable so that imported properties can be spied
-              // Hard coded in EJS template https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_plugin_runtime/src/runtime_module/runtime/define_property_getters.ejs
-              'enumerable: true, get:',
-              'enumerable: true, configurable: true, get:',
-            );
-
-            module.source!.source = Buffer.from(finalSource);
-          }
-
           if (module.name === 'async_wasm_loading') {
             const finalSource = module.source!.source.toString('utf-8').replace(
               // Replace readFile with readWasmFile to use the custom WASM file loader


### PR DESCRIPTION
## Summary

Remove the Rstest-side runtime patches for chunk loading and export getter configurability now that these adjustments are handled by Rspack's builtin `RstestPlugin`. The mock runtime plugin now only keeps the remaining WASM loader runtime rewrite.

## Related Links

https://github.com/web-infra-dev/rspack/pull/14181

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).