### PR TITLE
feat(core): add host-side trace spans

### DIFF
--- a/e2e/trace/fixtures/basic.test.ts
+++ b/e2e/trace/fixtures/basic.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from '@rstest/core';
+
+test('basic', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/e2e/trace/index.test.ts
+++ b/e2e/trace/index.test.ts
@@ -1,0 +1,45 @@
+import { readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const fixtureRoot = join(__dirname, 'fixtures');
+
+describe('performance trace', () => {
+  it('records host-side spans', async () => {
+    await rm(join(fixtureRoot, '.rstest'), { recursive: true, force: true });
+
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'basic.test.ts', '--trace'],
+      options: {
+        nodeOptions: {
+          cwd: fixtureRoot,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const tracePath = cli.stdout.match(
+      /Perfetto trace file:\s*(.*\.json)/,
+    )?.[1];
+    expect(tracePath).toBeTruthy();
+
+    const trace = JSON.parse(await readFile(tracePath!, 'utf-8')) as {
+      traceEvents: Array<{ name: string; cat?: string }>;
+    };
+    const hostEventNames = trace.traceEvents
+      .filter((event) => event.cat === 'host')
+      .map((event) => event.name);
+
+    expect(hostEventNames).toContain('host:get-rsbuild-stats');
+    expect(hostEventNames).toContain('host:build-task');
+    expect(hostEventNames).toContain('host:get-assets-by-entry');
+    expect(hostEventNames).toContain('host:pool-run-test');
+  });
+});

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -565,7 +565,9 @@ export async function runTests(context: Rstest): Promise<void> {
     // the previous rerun's `finalize`) so browser events emitted before
     // `run()` are captured.
     const traceRun = activeTraceRun;
-    const traceSpan = traceRun.onEvents ? traceRun.span : undefined;
+    // `span` is a transparent pass-through when tracing is disabled
+    // (see `beginRun` in utils/trace.ts), so call sites stay branch-free.
+    const { span } = traceRun;
 
     const returns = await Promise.all(
       projects.map(async (p) => {
@@ -578,21 +580,16 @@ export async function runTests(context: Rstest): Promise<void> {
           getSourceMaps,
           affectedEntries,
           deletedEntries,
-        } = traceSpan
-          ? await traceSpan(
-              'host:get-rsbuild-stats',
-              'host',
-              () =>
-                getRsbuildStats({
-                  environmentName: p.environmentName,
-                  fileFilters,
-                }),
-              { project: p.name, testPath: '<project>' },
-            )
-          : await getRsbuildStats({
+        } = await span(
+          'host:get-rsbuild-stats',
+          'host',
+          () =>
+            getRsbuildStats({
               environmentName: p.environmentName,
               fileFilters,
-            });
+            }),
+          { project: p.name, testPath: '<project>' },
+        );
 
         testStart ??= Date.now();
 
@@ -601,29 +598,30 @@ export async function runTests(context: Rstest): Promise<void> {
         if (entries.length && globalSetupEntries.length && !p._globalSetups) {
           p._globalSetups = true;
           const files = globalSetupEntries.flatMap((e) => e.files!);
-          const [assetFiles, sourceMaps] = traceSpan
-            ? await traceSpan(
-                'host:global-setup-assets',
-                'host',
-                () => Promise.all([getAssetFiles(files), getSourceMaps(files)]),
-                { project: p.name, testPath: '<globalSetup>' },
-              )
-            : await Promise.all([getAssetFiles(files), getSourceMaps(files)]);
+          const globalSetupTraceArgs = {
+            project: p.name,
+            testPath: '<globalSetup>',
+          };
+          const [assetFiles, sourceMaps] = await span(
+            'host:global-setup-assets',
+            'host',
+            () => Promise.all([getAssetFiles(files), getSourceMaps(files)]),
+            globalSetupTraceArgs,
+          );
 
-          const runSetup = () =>
-            runGlobalSetup({
-              globalSetupEntries,
-              assetFiles,
-              sourceMaps,
-              interopDefault: true,
-              outputModule: p.outputModule,
-            });
-          const { success, errors } = traceSpan
-            ? await traceSpan('host:global-setup', 'host', runSetup, {
-                project: p.name,
-                testPath: '<globalSetup>',
-              })
-            : await runSetup();
+          const { success, errors } = await span(
+            'host:global-setup',
+            'host',
+            () =>
+              runGlobalSetup({
+                globalSetupEntries,
+                assetFiles,
+                sourceMaps,
+                interopDefault: true,
+                outputModule: p.outputModule,
+              }),
+            globalSetupTraceArgs,
+          );
           if (!success) {
             return {
               results: [],
@@ -676,7 +674,7 @@ export async function runTests(context: Rstest): Promise<void> {
           updateSnapshot: context.snapshotManager.options.updateSnapshot,
           onCoverageResult: (coverage) => mergedCoverageMap?.merge(coverage),
           onTraceEvents: traceRun.onEvents,
-          traceSpan,
+          traceSpan: span,
         });
 
         return {

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -565,6 +565,7 @@ export async function runTests(context: Rstest): Promise<void> {
     // the previous rerun's `finalize`) so browser events emitted before
     // `run()` are captured.
     const traceRun = activeTraceRun;
+    const traceSpan = traceRun.onEvents ? traceRun.span : undefined;
 
     const returns = await Promise.all(
       projects.map(async (p) => {
@@ -577,10 +578,21 @@ export async function runTests(context: Rstest): Promise<void> {
           getSourceMaps,
           affectedEntries,
           deletedEntries,
-        } = await getRsbuildStats({
-          environmentName: p.environmentName,
-          fileFilters,
-        });
+        } = traceSpan
+          ? await traceSpan(
+              'host:get-rsbuild-stats',
+              'host',
+              () =>
+                getRsbuildStats({
+                  environmentName: p.environmentName,
+                  fileFilters,
+                }),
+              { project: p.name, testPath: '<project>' },
+            )
+          : await getRsbuildStats({
+              environmentName: p.environmentName,
+              fileFilters,
+            });
 
         testStart ??= Date.now();
 
@@ -589,20 +601,29 @@ export async function runTests(context: Rstest): Promise<void> {
         if (entries.length && globalSetupEntries.length && !p._globalSetups) {
           p._globalSetups = true;
           const files = globalSetupEntries.flatMap((e) => e.files!);
-          const assetFilesPromise = getAssetFiles(files);
-          const sourceMapsPromise = getSourceMaps(files);
-          const [assetFiles, sourceMaps] = await Promise.all([
-            assetFilesPromise,
-            sourceMapsPromise,
-          ]);
+          const [assetFiles, sourceMaps] = traceSpan
+            ? await traceSpan(
+                'host:global-setup-assets',
+                'host',
+                () => Promise.all([getAssetFiles(files), getSourceMaps(files)]),
+                { project: p.name, testPath: '<globalSetup>' },
+              )
+            : await Promise.all([getAssetFiles(files), getSourceMaps(files)]);
 
-          const { success, errors } = await runGlobalSetup({
-            globalSetupEntries,
-            assetFiles,
-            sourceMaps,
-            interopDefault: true,
-            outputModule: p.outputModule,
-          });
+          const runSetup = () =>
+            runGlobalSetup({
+              globalSetupEntries,
+              assetFiles,
+              sourceMaps,
+              interopDefault: true,
+              outputModule: p.outputModule,
+            });
+          const { success, errors } = traceSpan
+            ? await traceSpan('host:global-setup', 'host', runSetup, {
+                project: p.name,
+                testPath: '<globalSetup>',
+              })
+            : await runSetup();
           if (!success) {
             return {
               results: [],
@@ -655,6 +676,7 @@ export async function runTests(context: Rstest): Promise<void> {
           updateSnapshot: context.snapshotManager.options.updateSnapshot,
           onCoverageResult: (coverage) => mergedCoverageMap?.merge(coverage),
           onTraceEvents: traceRun.onEvents,
+          traceSpan,
         });
 
         return {

--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -8,9 +8,7 @@ import type {
   CoverageOptions,
   CoverageProvider,
 } from '../types/coverage';
-import { logger, type TraceSpan } from '../utils';
-
-const traceNoop: TraceSpan = async (_name, _cat, fn) => fn();
+import { logger, noopTraceSpan, type TraceSpan } from '../utils';
 
 export const getIncludedFiles = async (
   coverage: CoverageOptions,
@@ -181,7 +179,7 @@ export async function generateCoverage(
   context: RstestContext,
   coverageMap: CoverageMap,
   coverageProvider: CoverageProvider,
-  traceSpan: TraceSpan = traceNoop,
+  traceSpan: TraceSpan = noopTraceSpan,
 ): Promise<void> {
   const {
     rootPath,
@@ -379,7 +377,7 @@ async function generateCoverageForUntestedFiles(
   uncoveredFiles: string[],
   coverageMap: CoverageMap,
   coverageProvider: CoverageProvider,
-  traceSpan: TraceSpan = traceNoop,
+  traceSpan: TraceSpan = noopTraceSpan,
 ): Promise<void> {
   if (!coverageProvider.generateCoverageForUntestedFiles) {
     logger.warn(

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -26,7 +26,7 @@ import {
   needFlagExperimentalDetectModule,
   toError,
 } from '../utils';
-import type { TraceEvent } from '../utils/trace';
+import type { TraceEvent, TraceSpan } from '../utils/trace';
 import { isMemorySufficient } from '../utils/memory';
 import { selectMemoryGate } from './memoryGate';
 import { Pool } from './pool';
@@ -170,6 +170,7 @@ const buildTask = async ({
   getAssetFiles,
   getSourceMaps,
   rpcMethods,
+  traceSpan,
 }: {
   type: 'run' | 'collect';
   workerKind: PoolWorkerKind;
@@ -184,9 +185,15 @@ const buildTask = async ({
   getAssetFiles: PoolDispatchParams['getAssetFiles'];
   getSourceMaps: PoolDispatchParams['getSourceMaps'];
   rpcMethods: Omit<RuntimeRPC, 'getAssetsByEntry'>;
+  traceSpan?: TraceSpan;
 }) => {
   const getAssets = () =>
     filterAssetsByEntry(entryInfo, getAssetFiles, getSourceMaps, setupAssets);
+  const traceArgs = {
+    project: project.name,
+    testPath: entryInfo.testPath,
+    type,
+  };
 
   return {
     worker: workerKind,
@@ -206,12 +213,25 @@ const buildTask = async ({
       setupEntries,
       updateSnapshot,
       /** assets is only defined when memory is sufficient, otherwise we should get them via rpc getAssetsByEntry method */
-      assets: isMemorySufficient() ? await getAssets() : undefined,
+      assets: isMemorySufficient()
+        ? traceSpan
+          ? await traceSpan('host:get-assets-by-entry', 'host', getAssets, {
+              ...traceArgs,
+              mode: 'eager',
+            })
+          : await getAssets()
+        : undefined,
     },
     rpcMethods: {
       ...rpcMethods,
       // getAssetsByEntry is only used when memory is not sufficient since it may be slow
-      getAssetsByEntry: getAssets,
+      getAssetsByEntry: traceSpan
+        ? () =>
+            traceSpan('host:get-assets-by-entry', 'host', getAssets, {
+              ...traceArgs,
+              mode: 'rpc',
+            })
+        : getAssets,
     },
   };
 };
@@ -278,6 +298,8 @@ export const createPool = async ({
     onCoverageResult?: (coverage: CoverageMapData) => void;
     /** Perfetto trace events forwarded for caller-owned dumping. */
     onTraceEvents?: (events: TraceEvent[]) => void;
+    /** Records host-side pool slices in the caller-owned Perfetto trace. */
+    traceSpan?: TraceSpan;
   }) => Promise<{
     results: TestFileResult[];
     testResults: TestResult[];
@@ -464,6 +486,7 @@ export const createPool = async ({
       updateSnapshot,
       onCoverageResult,
       onTraceEvents,
+      traceSpan,
     }) => {
       const projectName = project.name;
       const runtimeConfig = getRuntimeConfig(project);
@@ -475,23 +498,62 @@ export const createPool = async ({
 
       const results = await Promise.all(
         entries.map(async (entryInfo, index) => {
-          const task = await buildTask({
-            type: 'run',
-            workerKind,
-            entryInfo,
-            index,
-            context,
-            project,
-            runtimeConfig,
-            setupEntries,
-            setupAssets,
-            updateSnapshot,
-            getAssetFiles,
-            getSourceMaps,
-            rpcMethods,
-          });
+          const traceArgs = {
+            project: projectName,
+            testPath: entryInfo.testPath,
+          };
+          const task = traceSpan
+            ? await traceSpan(
+                'host:build-task',
+                'host',
+                () =>
+                  buildTask({
+                    type: 'run',
+                    workerKind,
+                    entryInfo,
+                    index,
+                    context,
+                    project,
+                    runtimeConfig,
+                    setupEntries,
+                    setupAssets,
+                    updateSnapshot,
+                    getAssetFiles,
+                    getSourceMaps,
+                    rpcMethods,
+                    traceSpan,
+                  }),
+                traceArgs,
+              )
+            : await buildTask({
+                type: 'run',
+                workerKind,
+                entryInfo,
+                index,
+                context,
+                project,
+                runtimeConfig,
+                setupEntries,
+                setupAssets,
+                updateSnapshot,
+                getAssetFiles,
+                getSourceMaps,
+                rpcMethods,
+              });
 
-          const result = await pool.runTest(task).catch((err: unknown) => {
+          const result = await (
+            traceSpan
+              ? traceSpan(
+                  'host:pool-run-test',
+                  'host',
+                  () => pool.runTest(task),
+                  {
+                    ...traceArgs,
+                    worker: task.worker,
+                  },
+                )
+              : pool.runTest(task)
+          ).catch((err: unknown) => {
             return workerErrorToResult(
               err,
               entryInfo.testPath,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -26,7 +26,7 @@ import {
   needFlagExperimentalDetectModule,
   toError,
 } from '../utils';
-import type { TraceEvent, TraceSpan } from '../utils/trace';
+import { type TraceEvent, type TraceSpan, noopTraceSpan } from '../utils/trace';
 import { isMemorySufficient } from '../utils/memory';
 import { selectMemoryGate } from './memoryGate';
 import { Pool } from './pool';
@@ -185,7 +185,7 @@ const buildTask = async ({
   getAssetFiles: PoolDispatchParams['getAssetFiles'];
   getSourceMaps: PoolDispatchParams['getSourceMaps'];
   rpcMethods: Omit<RuntimeRPC, 'getAssetsByEntry'>;
-  traceSpan?: TraceSpan;
+  traceSpan: TraceSpan;
 }) => {
   const getAssets = () =>
     filterAssetsByEntry(entryInfo, getAssetFiles, getSourceMaps, setupAssets);
@@ -214,24 +214,20 @@ const buildTask = async ({
       updateSnapshot,
       /** assets is only defined when memory is sufficient, otherwise we should get them via rpc getAssetsByEntry method */
       assets: isMemorySufficient()
-        ? traceSpan
-          ? await traceSpan('host:get-assets-by-entry', 'host', getAssets, {
-              ...traceArgs,
-              mode: 'eager',
-            })
-          : await getAssets()
+        ? await traceSpan('host:get-assets-by-entry', 'host', getAssets, {
+            ...traceArgs,
+            mode: 'eager',
+          })
         : undefined,
     },
     rpcMethods: {
       ...rpcMethods,
       // getAssetsByEntry is only used when memory is not sufficient since it may be slow
-      getAssetsByEntry: traceSpan
-        ? () =>
-            traceSpan('host:get-assets-by-entry', 'host', getAssets, {
-              ...traceArgs,
-              mode: 'rpc',
-            })
-        : getAssets,
+      getAssetsByEntry: () =>
+        traceSpan('host:get-assets-by-entry', 'host', getAssets, {
+          ...traceArgs,
+          mode: 'rpc',
+        }),
     },
   };
 };
@@ -299,7 +295,7 @@ export const createPool = async ({
     /** Perfetto trace events forwarded for caller-owned dumping. */
     onTraceEvents?: (events: TraceEvent[]) => void;
     /** Records host-side pool slices in the caller-owned Perfetto trace. */
-    traceSpan?: TraceSpan;
+    traceSpan: TraceSpan;
   }) => Promise<{
     results: TestFileResult[];
     testResults: TestResult[];
@@ -502,30 +498,11 @@ export const createPool = async ({
             project: projectName,
             testPath: entryInfo.testPath,
           };
-          const task = traceSpan
-            ? await traceSpan(
-                'host:build-task',
-                'host',
-                () =>
-                  buildTask({
-                    type: 'run',
-                    workerKind,
-                    entryInfo,
-                    index,
-                    context,
-                    project,
-                    runtimeConfig,
-                    setupEntries,
-                    setupAssets,
-                    updateSnapshot,
-                    getAssetFiles,
-                    getSourceMaps,
-                    rpcMethods,
-                    traceSpan,
-                  }),
-                traceArgs,
-              )
-            : await buildTask({
+          const task = await traceSpan(
+            'host:build-task',
+            'host',
+            () =>
+              buildTask({
                 type: 'run',
                 workerKind,
                 entryInfo,
@@ -539,20 +516,16 @@ export const createPool = async ({
                 getAssetFiles,
                 getSourceMaps,
                 rpcMethods,
-              });
+                traceSpan,
+              }),
+            traceArgs,
+          );
 
-          const result = await (
-            traceSpan
-              ? traceSpan(
-                  'host:pool-run-test',
-                  'host',
-                  () => pool.runTest(task),
-                  {
-                    ...traceArgs,
-                    worker: task.worker,
-                  },
-                )
-              : pool.runTest(task)
+          const result = await traceSpan(
+            'host:pool-run-test',
+            'host',
+            () => pool.runTest(task),
+            { ...traceArgs, worker: task.worker },
           ).catch((err: unknown) => {
             return workerErrorToResult(
               err,
@@ -618,6 +591,8 @@ export const createPool = async ({
             getAssetFiles,
             getSourceMaps,
             rpcMethods,
+            // `collect` does not participate in tracing.
+            traceSpan: noopTraceSpan,
           });
 
           return pool.collectTests(task).catch((err: FormattedError) => {

--- a/packages/core/src/utils/trace.ts
+++ b/packages/core/src/utils/trace.ts
@@ -35,6 +35,12 @@ export type TraceSpan = <T>(
   args?: TraceEvent['args'],
 ) => Promise<T>;
 
+/**
+ * Transparent pass-through span used when tracing is disabled, so call sites
+ * can always invoke `span(...)` without branching on whether `--trace` is on.
+ */
+export const noopTraceSpan: TraceSpan = async (_name, _cat, fn) => fn();
+
 // ---------------------------------------------------------------------------
 // File output
 // ---------------------------------------------------------------------------
@@ -299,7 +305,7 @@ export const createTraceController = (options: {
     if (!enabled) {
       return {
         onEvents: undefined,
-        span: async (_name, _cat, fn) => fn(),
+        span: noopTraceSpan,
         finalize: async () => {},
       };
     }

--- a/packages/core/src/utils/trace.ts
+++ b/packages/core/src/utils/trace.ts
@@ -319,7 +319,7 @@ export const createTraceController = (options: {
           pid: process.pid,
           tid: 0,
           args: {
-            testPath: '<coverage>',
+            testPath: '<host>',
             project: 'host',
             ...args,
           },


### PR DESCRIPTION
## Summary

This PR improves `--trace` profiling by adding host-side Perfetto spans around Rsbuild stats collection, global setup, pool task construction, asset loading, and pool test dispatch. This makes it easier to distinguish worker runtime costs from host orchestration costs when investigating performance issues such as isolate-mode scheduling and asset transfer overhead.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).