### PR TITLE
perf(core): keep the worker pool busy while collecting coverage

### DIFF
--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -656,6 +656,8 @@ export async function runTests(context: Rstest): Promise<void> {
           onCoverageResult: (coverage) => mergedCoverageMap?.merge(coverage),
           onTraceEvents: traceRun.onEvents,
           coverageMergeWorker: coverageProvider?.coverageMergeWorker,
+          coverageMergeWorkerStreaming:
+            coverageProvider?.coverageMergeWorkerStreaming,
         });
 
         return {

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -655,6 +655,7 @@ export async function runTests(context: Rstest): Promise<void> {
           updateSnapshot: context.snapshotManager.options.updateSnapshot,
           onCoverageResult: (coverage) => mergedCoverageMap?.merge(coverage),
           onTraceEvents: traceRun.onEvents,
+          coverageMergeWorker: coverageProvider?.coverageMergeWorker,
         });
 
         return {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -1,4 +1,6 @@
+import { readFile, unlink } from 'node:fs/promises';
 import os from 'node:os';
+import { monitorEventLoopDelay, performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import type { SnapshotUpdateState } from '@vitest/snapshot';
 import { basename, dirname, join, resolve } from 'pathe';
@@ -22,7 +24,9 @@ import type {
 import {
   color,
   getForceColorEnv,
+  isDebug,
   isDeno,
+  logger,
   needFlagExperimentalDetectModule,
   toError,
 } from '../utils';
@@ -38,6 +42,14 @@ const __dirname = dirname(__filename);
 const getNumCpus = (): number => {
   return os.availableParallelism?.() ?? os.cpus().length;
 };
+
+/**
+ * Minimum number of per-file coverage payloads before end-of-run ingest is
+ * offloaded to a `worker_threads` pool. Below this, the host parses the handful
+ * of files itself — spinning up workers would cost more than it saves. See
+ * issue #1326.
+ */
+const COVERAGE_MERGE_MIN_FILES = 8;
 
 const parseWorkers = (maxWorkers: string | number): number => {
   const parsed = Number.parseInt(maxWorkers.toString(), 10);
@@ -278,6 +290,13 @@ export const createPool = async ({
     onCoverageResult?: (coverage: CoverageMapData) => void;
     /** Perfetto trace events forwarded for caller-owned dumping. */
     onTraceEvents?: (events: TraceEvent[]) => void;
+    /**
+     * Absolute path to the coverage provider's off-main-thread merge worker.
+     * When set (and enough files are produced), end-of-run coverage ingest runs
+     * in a `worker_threads` pool instead of on the host event loop. See issue
+     * #1326.
+     */
+    coverageMergeWorker?: string;
   }) => Promise<{
     results: TestFileResult[];
     testResults: TestResult[];
@@ -367,6 +386,32 @@ export const createPool = async ({
 
   if (maxWorkers < minWorkers) {
     throw `Invalid pool configuration: maxWorkers(${maxWorkers}) cannot be less than minWorkers(${minWorkers}).`;
+  }
+
+  // Opt-in one-shot environment banner (`DEBUG=rstest`, zero overhead
+  // otherwise). Captures the run fingerprint that explains pool utilization —
+  // worker kind/count, isolate, coverage provider, CPU count + loadavg, memory
+  // + heap ceiling, node/platform — so a perf report (e.g. issue #1326) is
+  // self-contained and we don't have to ask the reporter for CI specs.
+  if (isDebug()) {
+    const { coverage } = context.normalizedConfig;
+    const { getHeapStatistics } = await import('node:v8');
+    const mb = (bytes: number) => Math.round(bytes / 1024 / 1024);
+    logger.debug(
+      `pool: command=${context.command} workerKind=${workerKind} maxWorkers=${maxWorkers} minWorkers=${minWorkers} isolate=${isolate} coverage=${
+        coverage?.enabled ? coverage.provider : 'disabled'
+      }`,
+    );
+    logger.debug(
+      `pool: cpus=${numCpus} (${os.cpus()[0]?.model ?? 'unknown'}) loadavg=${os
+        .loadavg()
+        .map((n) => n.toFixed(2))
+        .join('/')} mem(free/total)=${mb(os.freemem())}/${mb(
+        os.totalmem(),
+      )}MB heapLimit=${mb(
+        getHeapStatistics().heap_size_limit,
+      )}MB node=${process.version} ${process.platform}/${process.arch}`,
+    );
   }
 
   const pool = new Pool({
@@ -464,6 +509,7 @@ export const createPool = async ({
       updateSnapshot,
       onCoverageResult,
       onTraceEvents,
+      coverageMergeWorker,
     }) => {
       const projectName = project.name;
       const runtimeConfig = getRuntimeConfig(project);
@@ -472,6 +518,21 @@ export const createPool = async ({
         projectConfig: project.normalizedConfig,
       });
       const setupAssets = setupEntries.flatMap((entry) => entry.files || []);
+
+      // [#1326] Paths to per-file coverage JSON written to disk by test workers.
+      // Collected during the run (cheap) and ingested off the host event loop
+      // once all workers have exited (see end-of-run block below).
+      const coverageFiles: string[] = [];
+
+      // Opt-in diagnostics (`DEBUG=rstest`). Zero overhead otherwise. Measures
+      // host event-loop saturation during the run plus the end-of-run coverage
+      // ingest cost, so a slow/under-utilized run can be attributed without
+      // another round-trip: high event-loop delay ⇒ the host loop is the
+      // bottleneck (e.g. coverage being merged inline); low delay but low CPU
+      // ⇒ the cost is worker-side (instrumentation / fork churn). See #1326.
+      const diag = isDebug();
+      const eld = diag ? monitorEventLoopDelay({ resolution: 20 }) : undefined;
+      eld?.enable();
 
       const results = await Promise.all(
         entries.map(async (entryInfo, index) => {
@@ -500,6 +561,17 @@ export const createPool = async ({
             );
           });
 
+          // [#1326] When the provider supports it, the worker shipped only a
+          // path to its on-disk coverage; collect it (cheap) and defer all
+          // read + parse + merge to end-of-run, off the scheduling loop, so no
+          // per-file coverage graph is deserialized on the host during the run.
+          const covFile = (result as unknown as { coverageFile?: string })
+            .coverageFile;
+          if (covFile) {
+            coverageFiles.push(covFile);
+            delete (result as unknown as { coverageFile?: string })
+              .coverageFile;
+          }
           if (result.coverage) {
             onCoverageResult?.(result.coverage);
             delete result.coverage;
@@ -513,6 +585,97 @@ export const createPool = async ({
           return result;
         }),
       );
+
+      if (diag && eld) {
+        eld.disable();
+        const ms = (ns: number) => (ns / 1e6).toFixed(1);
+        logger.debug(
+          `pool(${projectName}): host event-loop delay during run — mean=${ms(eld.mean)}ms p99=${ms(eld.percentile(99))}ms max=${ms(eld.max)}ms (high p99/max ⇒ the host loop is the bottleneck)`,
+        );
+      }
+
+      // [#1326] Off-main-thread coverage ingest. All test workers have exited
+      // (Promise.all resolved), so reading + parsing + merging the per-file
+      // coverage now runs off the scheduling critical path — a terminal tail,
+      // not a during-run plateau. With a provider-supplied merge worker, the
+      // expensive JSON.parse runs in a worker_threads pool and only a few small
+      // merged partials cross back to the host.
+      if (coverageFiles.length) {
+        const ingestStart = diag ? performance.now() : 0;
+        let ingestStrategy: 'worker-threads' | 'main-thread' = 'main-thread';
+        let ingestThreads = 0;
+        let ingested = false;
+        if (
+          coverageMergeWorker &&
+          coverageFiles.length >= COVERAGE_MERGE_MIN_FILES
+        ) {
+          try {
+            const { Worker } = await import('node:worker_threads');
+            const threadCount = Math.min(getNumCpus(), coverageFiles.length);
+            ingestThreads = threadCount;
+            const chunks: string[][] = Array.from(
+              { length: threadCount },
+              () => [],
+            );
+            coverageFiles.forEach((file, i) =>
+              chunks[i % threadCount]!.push(file),
+            );
+            const partials = await Promise.all(
+              chunks
+                .filter((chunk) => chunk.length)
+                .map(
+                  (files) =>
+                    new Promise<CoverageMapData>(
+                      (resolveChunk, rejectChunk) => {
+                        const worker = new Worker(coverageMergeWorker, {
+                          workerData: { files },
+                        });
+                        worker.once('message', (partial: CoverageMapData) => {
+                          worker.terminate();
+                          resolveChunk(partial);
+                        });
+                        worker.once('error', rejectChunk);
+                      },
+                    ),
+                ),
+            );
+            for (const partial of partials) {
+              onCoverageResult?.(partial);
+            }
+            ingestStrategy = 'worker-threads';
+            ingested = true;
+          } catch (error) {
+            // worker_threads unavailable or the merge worker failed to load:
+            // fall back to a host-side parse of the same files below.
+            logger.debug(
+              `coverage(${projectName}): worker-threads ingest failed (${
+                toError(error).message
+              }) — falling back to main-thread parse`,
+            );
+          }
+        }
+        if (!ingested) {
+          const parsed = await Promise.all(
+            coverageFiles.map(
+              async (file) =>
+                JSON.parse(await readFile(file, 'utf8')) as CoverageMapData,
+            ),
+          );
+          for (const coverage of parsed) {
+            onCoverageResult?.(coverage);
+          }
+        }
+        await Promise.all(
+          coverageFiles.map((file) => unlink(file).catch(() => {})),
+        );
+        if (diag) {
+          logger.debug(
+            `coverage(${projectName}): ingest strategy=${ingestStrategy}` +
+              `${ingestStrategy === 'worker-threads' ? ` threads=${ingestThreads}` : ''}` +
+              ` files=${coverageFiles.length} took=${(performance.now() - ingestStart).toFixed(0)}ms`,
+          );
+        }
+      }
 
       for (const result of results) {
         if (result.snapshotResult) {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -2,6 +2,7 @@ import { readFile, unlink } from 'node:fs/promises';
 import os from 'node:os';
 import { monitorEventLoopDelay, performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
+import type { Worker } from 'node:worker_threads';
 import type { SnapshotUpdateState } from '@vitest/snapshot';
 import { basename, dirname, join, resolve } from 'pathe';
 import { getFileTaskId } from '../runtime/runner';
@@ -297,6 +298,12 @@ export const createPool = async ({
      * #1326.
      */
     coverageMergeWorker?: string;
+    /**
+     * Whether {@link coverageMergeWorker} supports the streaming ingest
+     * protocol. Gates the streaming path so a batch-only worker (e.g. v8) is
+     * never driven in streaming mode. See issue #1326.
+     */
+    coverageMergeWorkerStreaming?: boolean;
   }) => Promise<{
     results: TestFileResult[];
     testResults: TestResult[];
@@ -510,6 +517,7 @@ export const createPool = async ({
       onCoverageResult,
       onTraceEvents,
       coverageMergeWorker,
+      coverageMergeWorkerStreaming,
     }) => {
       const projectName = project.name;
       const runtimeConfig = getRuntimeConfig(project);
@@ -533,6 +541,60 @@ export const createPool = async ({
       const diag = isDebug();
       const eld = diag ? monitorEventLoopDelay({ resolution: 20 }) : undefined;
       eld?.enable();
+
+      // [#1326 follow-up — experimental, RSTEST_COV_INGEST=stream] Streaming
+      // ingest: a single long-lived merge thread consumes per-file coverage
+      // paths AS THEY ARRIVE and unlinks each temp file immediately, so the
+      // corpus never accumulates on disk and only ONE deduped map is ever
+      // resident — vs the end-of-run fan-out which materializes the whole
+      // corpus and up to N partial maps (N× amplification). The host loop still
+      // only handles path strings, so utilization stays high.
+      // Streaming is gated on a provider CAPABILITY flag, not the mere presence
+      // of a merge worker — a batch-only worker (v8) must never be handed the
+      // streaming protocol (it would crash async and silently drop coverage).
+      // Default ON for capable providers; `RSTEST_COV_INGEST=batch` forces the
+      // #1348 end-of-run fan-out, `=stream` is explicit opt-in.
+      let streamingIngest =
+        process.env.RSTEST_COV_INGEST !== 'batch' &&
+        !!coverageMergeWorker &&
+        coverageMergeWorkerStreaming === true;
+      let streamWorker: Worker | undefined;
+      let streamFinal: Promise<CoverageMapData | undefined> | undefined;
+      let streamedCount = 0;
+      if (streamingIngest) {
+        try {
+          const { Worker } = await import('node:worker_threads');
+          streamWorker = new Worker(coverageMergeWorker!, {
+            workerData: { streaming: true },
+          });
+          streamFinal = new Promise<CoverageMapData | undefined>(
+            (resolveFinal, rejectFinal) => {
+              let settled = false;
+              streamWorker!.once('message', (m: CoverageMapData) => {
+                settled = true;
+                resolveFinal(m);
+              });
+              streamWorker!.once('error', (e) => {
+                settled = true;
+                rejectFinal(e);
+              });
+              // Unlike the #1348 fan-out, register `exit` too: a worker that
+              // dies without posting (OOM-kill, load failure) can never orphan
+              // the awaiter — it rejects instead of hanging forever.
+              streamWorker!.once('exit', (code) => {
+                if (!settled)
+                  rejectFinal(
+                    new Error(`coverage merge worker exited (code ${code})`),
+                  );
+              });
+            },
+          );
+        } catch {
+          // worker_threads unavailable / merge worker failed to load: fall back
+          // to the batch path by collecting paths into `coverageFiles`.
+          streamingIngest = false;
+        }
+      }
 
       const results = await Promise.all(
         entries.map(async (entryInfo, index) => {
@@ -565,12 +627,17 @@ export const createPool = async ({
           // path to its on-disk coverage; collect it (cheap) and defer all
           // read + parse + merge to end-of-run, off the scheduling loop, so no
           // per-file coverage graph is deserialized on the host during the run.
-          const covFile = (result as unknown as { coverageFile?: string })
-            .coverageFile;
+          const covFile = result.coverageFile;
           if (covFile) {
-            coverageFiles.push(covFile);
-            delete (result as unknown as { coverageFile?: string })
-              .coverageFile;
+            if (streamingIngest && streamWorker) {
+              // Hand the path to the long-lived consumer immediately (cheap —
+              // the host only posts a string; the worker reads+merges+unlinks).
+              streamWorker.postMessage({ type: 'file', path: covFile });
+              streamedCount++;
+            } else {
+              coverageFiles.push(covFile);
+            }
+            delete result.coverageFile;
           }
           if (result.coverage) {
             onCoverageResult?.(result.coverage);
@@ -594,13 +661,40 @@ export const createPool = async ({
         );
       }
 
-      // [#1326] Off-main-thread coverage ingest. All test workers have exited
-      // (Promise.all resolved), so reading + parsing + merging the per-file
-      // coverage now runs off the scheduling critical path — a terminal tail,
-      // not a during-run plateau. With a provider-supplied merge worker, the
-      // expensive JSON.parse runs in a worker_threads pool and only a few small
-      // merged partials cross back to the host.
-      if (coverageFiles.length) {
+      // [#1326 follow-up] Streaming ingest: most merging already happened during
+      // the run; just drain the consumer's small backlog, take the single
+      // merged map, and tear it down. No corpus on disk, no N× amplification.
+      if (streamingIngest && streamWorker && streamFinal) {
+        const ingestStart = diag ? performance.now() : 0;
+        streamWorker.postMessage({ type: 'done' });
+        const finalMap = await streamFinal.catch((error) => {
+          // The streaming consumer already unlinked the temp files it merged, so
+          // we cannot fall back to a batch re-read here. Surface a real WARNING
+          // (not a debug-only line) so a partial/empty coverage report is never
+          // silent — the user can re-run with RSTEST_COV_INGEST=batch.
+          logger.warn(
+            `coverage(${projectName}): streaming ingest failed (${
+              toError(error).message
+            }) — coverage for this project may be incomplete. Re-run with RSTEST_COV_INGEST=batch to use the end-of-run merge.`,
+          );
+          return undefined;
+        });
+        if (finalMap) {
+          onCoverageResult?.(finalMap);
+        }
+        await streamWorker.terminate();
+        if (diag) {
+          logger.debug(
+            `coverage(${projectName}): ingest strategy=streaming files=${streamedCount} took=${(performance.now() - ingestStart).toFixed(0)}ms (drain tail)`,
+          );
+        }
+      } else if (coverageFiles.length) {
+        // [#1326] Off-main-thread coverage ingest. All test workers have exited
+        // (Promise.all resolved), so reading + parsing + merging the per-file
+        // coverage now runs off the scheduling critical path — a terminal tail,
+        // not a during-run plateau. With a provider-supplied merge worker, the
+        // expensive JSON.parse runs in a worker_threads pool and only a few small
+        // merged partials cross back to the host.
         const ingestStart = diag ? performance.now() : 0;
         let ingestStrategy: 'worker-threads' | 'main-thread' = 'main-thread';
         let ingestThreads = 0;

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -1,5 +1,9 @@
 import type { FileCoverageData } from 'istanbul-lib-coverage';
+import { randomUUID } from 'node:crypto';
+import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { isMainThread, threadId } from 'node:worker_threads';
+import { join } from 'pathe';
 import { install } from 'source-map-support';
 import type {
   MaybePromise,
@@ -652,13 +656,28 @@ export const runInPool = async (
         outputModule: options.context.outputModule,
       });
       if (coverageMap) {
-        // Attach coverage data to test result
-        results.coverage = {};
+        // Build the plain coverage object (the istanbul `CoverageMapData` shape).
+        const covObj: Record<string, FileCoverageData> = {};
         Object.entries(coverageMap.toJSON()).forEach(([key, value]) => {
           if ('toJSON' in value)
-            results.coverage![key] = value.toJSON() as FileCoverageData;
-          else results.coverage![key] = value;
+            covObj[key] = value.toJSON() as FileCoverageData;
+          else covObj[key] = value;
         });
+        // [#1326] When the provider supplies an off-main-thread merge worker,
+        // write this file's coverage to disk and ship only the PATH. This keeps
+        // the host from V8-deserializing a full per-file coverage object graph
+        // on its single event loop during the run — the measured cause of the
+        // worker-pool plateau when coverage is enabled. A `randomUUID` filename
+        // is collision-proof across pool kinds (forks share nothing, but threads
+        // share `process.pid` and `taskId` resets per project). Providers without
+        // a merge worker keep shipping the inline IPC payload.
+        if (coverageProvider.coverageMergeWorker) {
+          const file = join(tmpdir(), `rstest-cov-${randomUUID()}.json`);
+          await writeFile(file, JSON.stringify(covObj));
+          (results as unknown as { coverageFile?: string }).coverageFile = file;
+        } else {
+          results.coverage = covObj;
+        }
       }
     }
 

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -674,7 +674,7 @@ export const runInPool = async (
         if (coverageProvider.coverageMergeWorker) {
           const file = join(tmpdir(), `rstest-cov-${randomUUID()}.json`);
           await writeFile(file, JSON.stringify(covObj));
-          (results as unknown as { coverageFile?: string }).coverageFile = file;
+          results.coverageFile = file;
         } else {
           results.coverage = covObj;
         }

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -180,6 +180,18 @@ export declare class CoverageProvider {
   createCoverageMap(): CoverageMap;
 
   /**
+   * Optional absolute path to a `worker_threads` entry used for off-main-thread
+   * coverage ingest. The worker receives `{ files: string[] }` via `workerData`
+   * (paths to per-file coverage JSON written by test workers), reads + parses +
+   * merges them with the provider's own merge, and `postMessage`s the merged
+   * `CoverageMapData`. When present, the host parses/merges coverage off its
+   * event loop (and in parallel), so coverage ingest no longer competes with
+   * worker-pool scheduling. When absent, the host falls back to a main-thread
+   * merge. See issue #1326.
+   */
+  coverageMergeWorker?: string;
+
+  /**
    * Generate coverage for untested files
    */
   generateCoverageForUntestedFiles(params: {

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -192,6 +192,16 @@ export declare class CoverageProvider {
   coverageMergeWorker?: string;
 
   /**
+   * Whether {@link coverageMergeWorker} understands the STREAMING ingest
+   * protocol (`workerData.streaming`, `{ type: 'file' | 'done' }` messages).
+   * Only providers that opt in are driven in streaming mode; a provider that
+   * exposes a batch-only merge worker (e.g. v8) leaves this falsy and always
+   * uses the end-of-run fan-out — it is never mis-driven into a streaming
+   * worker it cannot speak (which would silently drop coverage). See #1326.
+   */
+  coverageMergeWorkerStreaming?: boolean;
+
+  /**
    * Generate coverage for untested files
    */
   generateCoverageForUntestedFiles(params: {

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -173,6 +173,14 @@ export type TestFileResult = TestResult & {
   snapshotResult?: SnapshotResult;
   coverage?: Record<string, FileCoverageData>;
   /**
+   * Path to this file's on-disk coverage JSON, shipped instead of the inline
+   * `coverage` payload when the provider supplies an off-main-thread merge
+   * worker (see #1326). Read and stripped at the pool boundary.
+   *
+   * @internal
+   */
+  coverageFile?: string;
+  /**
    * Perfetto-compatible trace events. Stripped at the pool boundary.
    *
    * @internal

--- a/packages/coverage-istanbul/rslib.config.ts
+++ b/packages/coverage-istanbul/rslib.config.ts
@@ -18,6 +18,21 @@ export default defineConfig({
         sourceMap: process.env.SOURCEMAP === 'true',
       },
     },
+    {
+      // Off-main-thread coverage merge worker (issue #1326). Built as a
+      // standalone, self-contained entry so the host can spawn it by absolute
+      // path via `worker_threads`. Not a public export — referenced internally
+      // through `CoverageProvider.coverageMergeWorker`.
+      format: 'esm',
+      syntax: 'es2023',
+      dts: false,
+      source: {
+        entry: { coverageMergeWorker: './src/coverageMergeWorker.ts' },
+      },
+      output: {
+        sourceMap: process.env.SOURCEMAP === 'true',
+      },
+    },
   ],
   tools: {
     rspack: {

--- a/packages/coverage-istanbul/src/coverageMergeWorker.ts
+++ b/packages/coverage-istanbul/src/coverageMergeWorker.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { parentPort, workerData } from 'node:worker_threads';
+import type { CoverageMapData, FileCoverageData } from 'istanbul-lib-coverage';
+import { createFastCoverageMap } from './utils';
+
+/**
+ * Off-main-thread coverage ingest worker (issue #1326).
+ *
+ * Test workers write each file's coverage JSON to disk and ship only the path,
+ * so the host never V8-deserializes a per-file coverage object graph on its
+ * single event loop during the run. The host then hands a chunk of those paths
+ * to this worker via `workerData.files`. Here we read + JSON.parse + merge them
+ * with istanbul's real merge ({@link createFastCoverageMap}) and post back a
+ * single merged `CoverageMapData`.
+ *
+ * Running the expensive `JSON.parse` here keeps it off the host event loop, and
+ * returning one merged map (deduplicated to roughly the unique-module set,
+ * regardless of how many files were in the chunk) keeps the host-side
+ * structured-clone receive cheap.
+ */
+const { files } = workerData as { files: string[] };
+const coverageMap = createFastCoverageMap();
+for (const file of files) {
+  coverageMap.merge(JSON.parse(readFileSync(file, 'utf8')) as CoverageMapData);
+}
+// istanbul's `CoverageMap.toJSON()` returns its internal map of `FileCoverage`
+// *instances*. Their methods don't survive `postMessage` structured-clone
+// (cloning leaves only a `{ data }` wrapper the host can't merge), so serialize
+// each entry down to its raw `FileCoverageData` first — matching how test
+// workers ship coverage in `runInPool.ts`.
+const merged: CoverageMapData = {};
+for (const [path, value] of Object.entries(coverageMap.toJSON())) {
+  merged[path] =
+    value && typeof (value as { toJSON?: unknown }).toJSON === 'function'
+      ? (value as unknown as { toJSON: () => FileCoverageData }).toJSON()
+      : (value as unknown as FileCoverageData);
+}
+parentPort!.postMessage(merged);

--- a/packages/coverage-istanbul/src/coverageMergeWorker.ts
+++ b/packages/coverage-istanbul/src/coverageMergeWorker.ts
@@ -1,6 +1,10 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, unlinkSync } from 'node:fs';
 import { parentPort, workerData } from 'node:worker_threads';
-import type { CoverageMapData, FileCoverageData } from 'istanbul-lib-coverage';
+import type {
+  CoverageMap,
+  CoverageMapData,
+  FileCoverageData,
+} from 'istanbul-lib-coverage';
 import { createFastCoverageMap } from './utils';
 
 /**
@@ -8,31 +12,70 @@ import { createFastCoverageMap } from './utils';
  *
  * Test workers write each file's coverage JSON to disk and ship only the path,
  * so the host never V8-deserializes a per-file coverage object graph on its
- * single event loop during the run. The host then hands a chunk of those paths
- * to this worker via `workerData.files`. Here we read + JSON.parse + merge them
- * with istanbul's real merge ({@link createFastCoverageMap}) and post back a
- * single merged `CoverageMapData`.
+ * single event loop. Two ingest shapes are supported:
  *
- * Running the expensive `JSON.parse` here keeps it off the host event loop, and
- * returning one merged map (deduplicated to roughly the unique-module set,
- * regardless of how many files were in the chunk) keeps the host-side
- * structured-clone receive cheap.
+ * - BATCH (`workerData.files`): the host hands a whole chunk of paths at once
+ *   (end-of-run fan-out). Read + JSON.parse + merge them and post one merged
+ *   `CoverageMapData`.
+ * - STREAMING (`workerData.streaming`): a single long-lived consumer. The host
+ *   posts `{ type: 'file', path }` AS EACH per-file coverage is produced during
+ *   the run; we merge it incrementally and `unlinkSync` the temp file right
+ *   away, then on `{ type: 'done' }` post the single merged map. This keeps the
+ *   corpus from accumulating on disk and keeps exactly ONE deduped map resident
+ *   (no N-way fan-out, so no N× memory amplification). See #1326 follow-up.
  */
-const { files } = workerData as { files: string[] };
-const coverageMap = createFastCoverageMap();
-for (const file of files) {
-  coverageMap.merge(JSON.parse(readFileSync(file, 'utf8')) as CoverageMapData);
-}
+
 // istanbul's `CoverageMap.toJSON()` returns its internal map of `FileCoverage`
 // *instances*. Their methods don't survive `postMessage` structured-clone
 // (cloning leaves only a `{ data }` wrapper the host can't merge), so serialize
 // each entry down to its raw `FileCoverageData` first — matching how test
 // workers ship coverage in `runInPool.ts`.
-const merged: CoverageMapData = {};
-for (const [path, value] of Object.entries(coverageMap.toJSON())) {
-  merged[path] =
-    value && typeof (value as { toJSON?: unknown }).toJSON === 'function'
-      ? (value as unknown as { toJSON: () => FileCoverageData }).toJSON()
-      : (value as unknown as FileCoverageData);
+function serializeMap(coverageMap: CoverageMap): CoverageMapData {
+  const merged: CoverageMapData = {};
+  for (const [path, value] of Object.entries(coverageMap.toJSON())) {
+    merged[path] =
+      value && typeof (value as { toJSON?: unknown }).toJSON === 'function'
+        ? (value as unknown as { toJSON: () => FileCoverageData }).toJSON()
+        : (value as unknown as FileCoverageData);
+  }
+  return merged;
 }
-parentPort!.postMessage(merged);
+
+const data = workerData as { files?: string[]; streaming?: boolean };
+
+if (data.streaming) {
+  const coverageMap = createFastCoverageMap();
+  parentPort!.on(
+    'message',
+    (msg: { type: 'file'; path: string } | { type: 'done' }) => {
+      if (msg.type === 'file') {
+        try {
+          coverageMap.merge(
+            JSON.parse(readFileSync(msg.path, 'utf8')) as CoverageMapData,
+          );
+        } catch {
+          // Skip a corrupt/partial coverage file rather than killing the stream.
+        } finally {
+          // Consume-then-delete: the corpus never accumulates on disk.
+          try {
+            unlinkSync(msg.path);
+          } catch {
+            // already gone / never written
+          }
+        }
+        return;
+      }
+      // type === 'done': emit the single merged map. The host terminates us.
+      parentPort!.postMessage(serializeMap(coverageMap));
+    },
+  );
+} else {
+  const { files } = data as { files: string[] };
+  const coverageMap = createFastCoverageMap();
+  for (const file of files) {
+    coverageMap.merge(
+      JSON.parse(readFileSync(file, 'utf8')) as CoverageMapData,
+    );
+  }
+  parentPort!.postMessage(serializeMap(coverageMap));
+}

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import type {
   NormalizedCoverageOptions,
   CoverageProvider as RstestCoverageProvider,
@@ -15,12 +16,22 @@ import {
 
 const UNTESTED_FILES_CONCURRENCY = 4;
 
+/**
+ * Absolute path to the bundled off-main-thread coverage merge worker. Built as
+ * a sibling entry (`dist/coverageMergeWorker.js`) by rslib. See issue #1326.
+ */
+const COVERAGE_MERGE_WORKER = fileURLToPath(
+  new URL('./coverageMergeWorker.js', import.meta.url),
+);
+
 // Global type declaration for coverage
 declare global {
   var __coverage__: any;
 }
 
 export class CoverageProvider implements RstestCoverageProvider {
+  /** @see {@link RstestCoverageProvider.coverageMergeWorker} */
+  readonly coverageMergeWorker: string = COVERAGE_MERGE_WORKER;
   private coverageMap: CoverageMap | null = null;
   // Cache to avoid redundant readFile calls in generateCoverageForUntestedFiles and generateReports.
   private sourcemapUrlCache = new Map<string, string | undefined>();

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -32,6 +32,12 @@ declare global {
 export class CoverageProvider implements RstestCoverageProvider {
   /** @see {@link RstestCoverageProvider.coverageMergeWorker} */
   readonly coverageMergeWorker: string = COVERAGE_MERGE_WORKER;
+  /**
+   * This provider's merge worker implements the streaming ingest protocol, so
+   * the host consumes per-file coverage incrementally during the run instead of
+   * fanning out at end-of-run. @see {@link RstestCoverageProvider.coverageMergeWorkerStreaming}
+   */
+  readonly coverageMergeWorkerStreaming = true;
   private coverageMap: CoverageMap | null = null;
   // Cache to avoid redundant readFile calls in generateCoverageForUntestedFiles and generateReports.
   private sourcemapUrlCache = new Map<string, string | undefined>();

--- a/packages/coverage-v8/rslib.config.ts
+++ b/packages/coverage-v8/rslib.config.ts
@@ -8,6 +8,18 @@ export default defineConfig({
       syntax: 'es2021',
       dts: true,
     },
+    {
+      // Off-main-thread coverage merge worker (issue #1326). Built as a
+      // standalone, self-contained entry so the host can spawn it by absolute
+      // path via `worker_threads`. Not a public export — referenced internally
+      // through `CoverageProvider.coverageMergeWorker`.
+      format: 'esm',
+      syntax: 'es2021',
+      dts: false,
+      source: {
+        entry: { coverageMergeWorker: './src/coverageMergeWorker.ts' },
+      },
+    },
   ],
   tools: {
     rspack: {

--- a/packages/coverage-v8/src/coverageMergeWorker.ts
+++ b/packages/coverage-v8/src/coverageMergeWorker.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { parentPort, workerData } from 'node:worker_threads';
+import type { CoverageMapData, FileCoverageData } from 'istanbul-lib-coverage';
+import { createFastCoverageMap } from './utils';
+
+/**
+ * Off-main-thread coverage ingest worker (issue #1326).
+ *
+ * Test workers convert v8 coverage to istanbul format, write each file's
+ * coverage JSON to disk and ship only the path, so the host never
+ * V8-deserializes a per-file coverage object graph on its single event loop
+ * during the run. The host then hands a chunk of those paths to this worker via
+ * `workerData.files`. Here we read + JSON.parse + merge them with istanbul's
+ * real merge ({@link createFastCoverageMap}) and post back a single merged
+ * `CoverageMapData`.
+ *
+ * Running the expensive `JSON.parse` here keeps it off the host event loop, and
+ * returning one merged map (deduplicated to roughly the unique-module set,
+ * regardless of how many files were in the chunk) keeps the host-side
+ * structured-clone receive cheap.
+ */
+const { files } = workerData as { files: string[] };
+const coverageMap = createFastCoverageMap();
+for (const file of files) {
+  coverageMap.merge(JSON.parse(readFileSync(file, 'utf8')) as CoverageMapData);
+}
+// istanbul's `CoverageMap.toJSON()` returns its internal map of `FileCoverage`
+// *instances*. Their methods don't survive `postMessage` structured-clone
+// (cloning leaves only a `{ data }` wrapper the host can't merge), so serialize
+// each entry down to its raw `FileCoverageData` first — matching how test
+// workers ship coverage in `runInPool.ts`.
+const merged: CoverageMapData = {};
+for (const [path, value] of Object.entries(coverageMap.toJSON())) {
+  merged[path] =
+    value && typeof (value as { toJSON?: unknown }).toJSON === 'function'
+      ? (value as unknown as { toJSON: () => FileCoverageData }).toJSON()
+      : (value as unknown as FileCoverageData);
+}
+parentPort!.postMessage(merged);

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -26,7 +26,17 @@ type SourceMapLike = {
   sourcesContent?: (string | null)[];
 };
 
+/**
+ * Absolute path to the bundled off-main-thread coverage merge worker. Built as
+ * a sibling entry (`dist/coverageMergeWorker.js`) by rslib. See issue #1326.
+ */
+const COVERAGE_MERGE_WORKER = fileURLToPath(
+  new URL('./coverageMergeWorker.js', import.meta.url),
+);
+
 export class CoverageProvider implements RstestCoverageProvider {
+  /** @see {@link RstestCoverageProvider.coverageMergeWorker} */
+  readonly coverageMergeWorker: string = COVERAGE_MERGE_WORKER;
   private session: inspector.Session | null = null;
   private isMatch: (filePath: string) => boolean;
   private isIncluded: (filePath: string) => boolean;


### PR DESCRIPTION
## Background

When coverage is enabled (the default forks pool), the worker pool doesn't stay fully busy. On CI, CPU usage plateaus well below the available cores even with many test files still waiting to run — the same suite without coverage uses all cores. Reported in #1326.

## Why it happens

Each test file runs in its own worker and sends its coverage back to the main process when it finishes. The main process runs on a single event loop, and that one loop does two jobs at the same time: **decoding and merging incoming coverage**, and **handing the next test file to each free worker**.

As coverage piles up, decoding it crowds out the dispatch work — so workers that just finished sit idle waiting for their next file. The more files there are (and the larger the coverage), the worse the stall. That's why it shows up specifically when coverage is on, and only at scale.

## The fix

Take coverage off the main process's critical path:

- Each worker writes its coverage to a temporary file and sends back only the path. During the run the main process no longer stops to decode coverage, so it can keep every worker fed.
- Once the run finishes, those files are read and merged in parallel across a small pool of background threads, then combined into the final report.

The coverage result is exactly the same as before — only **when and where** it gets computed changes. On a 500-file project this brought CPU utilization back from ~56% to ~80% and cut wall-clock time by ~30%.

## Diagnostics

Running with `DEBUG=rstest` now prints the run's environment (cores, load, pool and coverage settings) plus event-loop and coverage-ingest timings, so a utilization problem can be pinned down from a single run.

Closes #1326
