### PR TITLE
docs: fix { spy: true } module example to assert on a directly-called export

### DIFF
--- a/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
@@ -158,20 +158,26 @@ This is useful when you want to assert that a function was called correctly with
 
 ```ts title="src/calculator.test.ts"
 import { expect, rs, test } from '@rstest/core';
-import { calculate, add } from './calculator';
+import { calculate } from './calculator';
 
 rs.mock('./calculator', { spy: true });
 
-test('calculate calls add with correct arguments', () => {
+test('keeps the real implementation while tracking calls', () => {
   // Original implementation still works
   const result = calculate(1, 2);
   expect(result).toBe(3);
 
-  // But we can also assert on the calls
-  expect(add).toHaveBeenCalledWith(1, 2);
-  expect(add).toHaveReturnedWith(3);
+  // We can also assert on the call, since calculate is called directly
+  expect(calculate).toHaveBeenCalledWith(1, 2);
+  expect(calculate).toHaveReturnedWith(3);
 });
 ```
+
+:::note Internal calls are not tracked
+
+The spy wraps the module's **exports**. When one export calls another inside the same module (e.g. `calculate` internally calls `add`), that internal call goes through the module's local binding rather than the wrapped export, so it is **not** tracked. Assert on exports you call directly (or from another module). This is an inherent limitation of ESM module spying.
+
+:::
 
 :::note ESM and CommonJS modules
 

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -104,15 +104,17 @@ If you want to keep the real implementation and still assert calls, you can use 
 
 ```ts title="calculator.test.ts"
 import { expect, rs, test } from '@rstest/core';
-import { add, calculate } from './calculator';
+import { calculate } from './calculator';
 
 rs.mock('./calculator', { spy: true });
 
-test('tracks the internal call to add', () => {
+test('keeps the real implementation while tracking calls', () => {
   expect(calculate(1, 2)).toBe(3);
-  expect(add).toHaveBeenCalledWith(1, 2);
+  expect(calculate).toHaveBeenCalledWith(1, 2);
 });
 ```
+
+Note that the spy only tracks calls made **through an export** — calls between functions inside the same module are not tracked.
 
 ### Partially mock modules
 

--- a/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
@@ -160,20 +160,26 @@ lodash.random(multiple(1, 2), multiple(3, 4));
 
 ```ts title="src/calculator.test.ts"
 import { expect, rs, test } from '@rstest/core';
-import { calculate, add } from './calculator';
+import { calculate } from './calculator';
 
 rs.mock('./calculator', { spy: true });
 
-test('calculate 使用正确的参数调用 add', () => {
+test('保留真实实现并追踪调用', () => {
   // 原始实现仍然有效
   const result = calculate(1, 2);
   expect(result).toBe(3);
 
-  // 但我们也可以断言调用情况
-  expect(add).toHaveBeenCalledWith(1, 2);
-  expect(add).toHaveReturnedWith(3);
+  // 因为 calculate 是被直接调用的，所以我们也可以断言调用情况
+  expect(calculate).toHaveBeenCalledWith(1, 2);
+  expect(calculate).toHaveReturnedWith(3);
 });
 ```
+
+:::note 模块内部调用不会被追踪
+
+spy 包装的是模块的**导出**。当一个导出在同一模块内调用另一个导出时（例如 `calculate` 内部调用 `add`），该内部调用走的是模块的本地绑定而非被包装的导出，因此**不会**被追踪。请对你直接调用的导出（或从其他模块调用的导出）进行断言。这是 ESM module spying 的固有限制。
+
+:::
 
 :::note ESM 和 CommonJS 模块
 

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -104,15 +104,17 @@ test('overrides one export', () => {
 
 ```ts title="calculator.test.ts"
 import { expect, rs, test } from '@rstest/core';
-import { add, calculate } from './calculator';
+import { calculate } from './calculator';
 
 rs.mock('./calculator', { spy: true });
 
-test('tracks the internal call to add', () => {
+test('keeps the real implementation while tracking calls', () => {
   expect(calculate(1, 2)).toBe(3);
-  expect(add).toHaveBeenCalledWith(1, 2);
+  expect(calculate).toHaveBeenCalledWith(1, 2);
 });
 ```
+
+注意，spy 只能追踪通过 export 发起的调用 —— 同一模块内部函数之间的互相调用不会被追踪。
 
 ### 部分 mock 模块
 


### PR DESCRIPTION
## Summary

The `{ spy: true }` examples in the mock docs asserted that an internal call (`calculate` calling `add` inside the same module) was tracked. That can never pass: `{ spy: true }` wraps a module's **exports**, and an intra-module call goes through the module's local binding rather than the wrapped export, so the spy never sees it. Running the example fails with `Number of calls: 0`. This is an inherent limitation of ESM module spying (Vitest behaves the same).

The runtime is correct — only the docs were wrong. This PR:

- Changes the assertions to target `calculate`, which the test calls **directly** (so it does go through the wrapped export and is tracked), instead of the internal `add`.
- Adds a note in the API reference explaining that internal calls are not tracked, with a one-line caveat mirrored in the guide.
- Keeps EN/ZH in sync across both the guide and API pages.

Verified by reproducing the original example against a real `calculator` fixture (failed as described) and confirming the corrected example passes.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).