### PR TITLE
docs: fix $N positional placeholders in test.each / describe.for examples

### DIFF
--- a/website/docs/en/api/runtime-api/test-api/describe.mdx
+++ b/website/docs/en/api/runtime-api/test-api/describe.mdx
@@ -121,7 +121,7 @@ Alternative to `describe.each` for more flexible parameter types.
 describe.for([
   [1, 2],
   [2, 3],
-])('math $0 + $1', ([a, b]) => {
+])('math %i + %i', ([a, b]) => {
   test('add', () => {
     // ...
   });

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -167,7 +167,7 @@ test.each([
 // adds 2 + 2 to equal 4
 ```
 
-You can also access object properties and array elements with `$` prefix:
+You can also access object properties with `$` prefix:
 
 ```ts
 test.each([
@@ -182,19 +182,6 @@ test.each([
 // adds 1 + 1 to equal 2
 // adds 1 + 2 to equal 3
 // adds 2 + 1 to equal 3
-
-test.each([
-  [1, 1, 2],
-  [1, 2, 3],
-  [2, 1, 3],
-])('add $0 + $1 to equal $2', (a, b, sum) => {
-  expect(a + b).toBe(sum);
-});
-
-// this will return
-// add 1 + 1 to equal 2
-// add 1 + 2 to equal 3
-// add 2 + 1 to equal 3
 ```
 
 ## test.for

--- a/website/docs/zh/api/runtime-api/test-api/describe.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/describe.mdx
@@ -121,7 +121,7 @@ describe.each<{ a: number; b: number; expected: number }>`
 describe.for([
   [1, 2],
   [2, 3],
-])('math $0 + $1', ([a, b]) => {
+])('math %i + %i', ([a, b]) => {
   test('add', () => {
     // ...
   });

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -167,7 +167,7 @@ test.each([
 // adds 2 + 2 to equal 4
 ```
 
-你也可以使用 `$` 前缀访问对象属性和数组元素：
+你也可以使用 `$` 前缀访问对象属性：
 
 ```ts
 test.each([
@@ -182,19 +182,6 @@ test.each([
 // adds 1 + 1 to equal 2
 // adds 1 + 2 to equal 3
 // adds 2 + 1 to equal 3
-
-test.each([
-  [1, 1, 2],
-  [1, 2, 3],
-  [2, 1, 3],
-])('add $0 + $1 to equal $2', (a, b, sum) => {
-  expect(a + b).toBe(sum);
-});
-
-// 此时将返回：
-// add 1 + 1 to equal 2
-// add 1 + 2 to equal 3
-// add 2 + 1 to equal 3
 ```
 
 ## test.for


### PR DESCRIPTION
## Summary

The `test.each` / `describe.for` examples used `$0`, `$1`, `$2` on array-tuple cases, but `$`-prefixed placeholders only resolve **object** properties. Array-tuple cases support printf-style tokens (`%i`, `%s`, `%#`) instead. As written, those examples rendered the literal `$0 + $1` text in the generated test names rather than the values.

- `describe.for`: switch the array example to `'math %i + %i'`.
- `test.each`: drop the incorrect array `$0/$1/$2` example and the "array elements with `$` prefix" claim — the printf array example just above already covers array cases, and `$` is for object properties.

Applied to both EN and ZH docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).