### PR TITLE
docs: clarify relationship between output.bundleDependencies and output.externals

### DIFF
--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -222,15 +222,39 @@ Patterns only affect dependency requests that rstest can still process in the cu
 
 ### Relationship with output.externals
 
-`output.bundleDependencies` controls the overall bundling strategy for all `node_modules` dependencies, while [`output.externals`](#outputexternals) allows fine-grained control over individual packages. When both are configured, `output.externals` takes higher priority:
+Both options decide whether a dependency is bundled or externalized, but they work at different levels. Think of it as "set the baseline first, then make exceptions":
 
-- `bundleDependencies: true` + `externals: ['lodash']`: Bundle all dependencies, but externalize `lodash`.
-- `bundleDependencies: false` + `externals` is not needed, since all dependencies are already externalized.
+- **`output.bundleDependencies` sets the overall baseline**: it decides, in one shot, whether all `node_modules` dependencies default to being bundled or externalized.
+- **[`output.externals`](#outputexternals) makes per-package exceptions**: on top of that baseline, it targets individual packages, and takes higher priority.
 
-In practice, the two options are most useful in opposite situations:
+#### Listing a package has the opposite effect
 
-- Use `bundleDependencies` patterns when most dependencies should stay external, and you only want to bundle a small set of packages or subpaths.
-- Use `output.externals` when most dependencies should stay bundled, and you only want to externalize a small set of packages.
+When you only need to adjust a few packages, the two options express opposite intents:
+
+- `bundleDependencies: ['foo']` externalizes every dependency by default and bundles only `foo`.
+- `externals: ['foo']` bundles every dependency by default and externalizes only `foo`.
+
+Which one to use depends on the behavior most of your dependencies should keep:
+
+- Most dependencies should stay externalized, and only a few need bundling → list the packages to bundle in `bundleDependencies`.
+- Most dependencies should stay bundled, and only a few need externalizing → list the packages to externalize in `output.externals`.
+
+#### When both are set, `output.externals` wins
+
+`output.externals` is a native Rspack capability and takes effect before Rstest's overall strategy. So you can use `bundleDependencies` to set a broad baseline, then use `externals` to precisely override individual packages:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    // Baseline: bundle all third-party dependencies
+    bundleDependencies: true,
+    // Exception: keep lodash externalized
+    externals: ['lodash'],
+  },
+});
+```
 
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 

--- a/website/docs/en/config/build/output.mdx
+++ b/website/docs/en/config/build/output.mdx
@@ -237,7 +237,7 @@ When you only need to adjust a few packages, the two options express opposite in
 Which one to use depends on the behavior most of your dependencies should keep:
 
 - Most dependencies should stay externalized, and only a few need bundling → list the packages to bundle in `bundleDependencies`.
-- Most dependencies should stay bundled, and only a few need externalizing → list the packages to externalize in `output.externals`.
+- Most dependencies should stay bundled, and only a few need externalizing → list the packages to externalize in `output.externals`. This assumes a bundling baseline (a browser-like environment, or `bundleDependencies: true`), since `output.externals` only adds exceptions on top of the current baseline and does not change it.
 
 #### When both are set, `output.externals` wins
 

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -220,15 +220,39 @@ export default defineConfig({
 
 ### 与 output.externals 的关系
 
-`output.bundleDependencies` 控制所有 `node_modules` 依赖的整体打包策略，而 [`output.externals`](#outputexternals) 允许对单个包进行细粒度控制。当两者同时配置时，`output.externals` 的优先级更高：
+这两个配置都能决定「某个依赖是被打包还是被 external」，但它们工作在不同的层面，可以理解为「先定基调，再开例外」：
 
-- `bundleDependencies: true` + `externals: ['lodash']`：打包所有依赖，但外部化 `lodash`。
-- `bundleDependencies: false` + `externals` 无需配置，因为所有依赖已被外部化。
+- **`output.bundleDependencies` 定整体基调**：一次性决定所有 `node_modules` 依赖默认是打包还是 external。
+- **[`output.externals`](#outputexternals) 做逐包例外**：在基调之上，针对个别包精确指定，且优先级更高。
 
-实际使用时，这两个配置更适合相反的场景：
+#### 列出同一个包，效果正好相反
 
-- 当大部分依赖都应该保持 external，只有少量包或子路径需要被打包时，更适合使用 `bundleDependencies` pattern。
-- 当大部分依赖都应该保持打包，只有少量包需要被 externalize 时，更适合使用 `output.externals`。
+当你只需要调整少数几个包时，这两个配置表达的意图正好相反：
+
+- `bundleDependencies: ['foo']`：默认将所有依赖 external，仅打包 `foo`。
+- `externals: ['foo']`：默认打包所有依赖，仅将 `foo` external。
+
+选择哪一个，取决于大多数依赖应当保持的处理方式：
+
+- 大多数依赖需保持 external，仅少数需要打包 → 在 `bundleDependencies` 中列出需要打包的包。
+- 大多数依赖需保持打包，仅少数需要 external → 在 `output.externals` 中列出需要 external 的包。
+
+#### 同时配置时，`output.externals` 优先级更高
+
+`output.externals` 是 Rspack 原生能力，会先于 Rstest 的整体策略生效。因此你可以用 `bundleDependencies` 定一个宽泛的基调，再用 `externals` 精确覆盖个别包：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  output: {
+    // 基调：打包所有第三方依赖
+    bundleDependencies: true,
+    // 例外：唯独 lodash 仍然保持 external
+    externals: ['lodash'],
+  },
+});
+```
 
 ## output.cssModules <RsbuildDocBadge path="/config/output/css-modules" text="output.cssModules" />
 

--- a/website/docs/zh/config/build/output.mdx
+++ b/website/docs/zh/config/build/output.mdx
@@ -235,7 +235,7 @@ export default defineConfig({
 选择哪一个，取决于大多数依赖应当保持的处理方式：
 
 - 大多数依赖需保持 external，仅少数需要打包 → 在 `bundleDependencies` 中列出需要打包的包。
-- 大多数依赖需保持打包，仅少数需要 external → 在 `output.externals` 中列出需要 external 的包。
+- 大多数依赖需保持打包，仅少数需要 external → 在 `output.externals` 中列出需要 external 的包。这里假设基调本身已是「打包」（类浏览器环境，或设置了 `bundleDependencies: true`），因为 `output.externals` 只在现有基调之上添加例外，并不会改变基调。
 
 #### 同时配置时，`output.externals` 优先级更高
 


### PR DESCRIPTION
## Summary

The "Relationship with output.externals" section under `output.bundleDependencies` was hard to follow — it jumped straight to "externals takes higher priority" and "useful in opposite situations" without first giving readers a mental model, so users couldn't tell whether the two options are simply inverses of each other.

This PR rewrites that section (EN + ZH) around a clearer model:

- **Baseline vs. exception**: `output.bundleDependencies` sets the overall bundle/externalize baseline; `output.externals` makes per-package exceptions and takes higher priority.
- **Listing a package has the opposite effect**: spells out that `bundleDependencies: ['foo']` and `externals: ['foo']` express opposite intents, with a "which one to use" guideline based on the majority case.
- **Precedence example**: replaces the empty `bundleDependencies: false + externals not needed` bullet with a runnable `bundleDependencies: true` + `externals: ['lodash']` example.

Docs-only; no behavior change.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).