### PR TITLE
feat(core): emit agent-readable timing summary for --trace

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -98,7 +98,10 @@ const runtimeOptionDefinitions: OptionDefinition[] = [
   ['--disableConsoleIntercept', 'Disable console intercept'],
   ['--logHeapUsage', 'Log heap usage after each test'],
   ['--detectAsyncLeaks', 'Detect async resources that leak after tests finish'],
-  ['--trace', 'Dump a Perfetto-compatible performance trace JSON file'],
+  [
+    '--trace',
+    'Dump a Perfetto-compatible performance trace JSON file, plus a ranked markdown timing summary printed to the terminal and written next to it',
+  ],
   [
     '--slowTestThreshold <value>',
     'The number of milliseconds after which a test or suite is considered slow',

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -1,4 +1,12 @@
-import { isAbsolute, join, normalize, parse, sep } from 'pathe';
+import {
+  isAbsolute,
+  join,
+  normalize,
+  parse,
+  relative,
+  resolve,
+  sep,
+} from 'pathe';
 import type { RuntimeConfig, TestResult } from '../types';
 import { TEST_DELIMITER } from './constants';
 import { color } from './logger';
@@ -40,6 +48,17 @@ export const formatRootStr = (rootStr: string, root: string): string => {
 export function getAbsolutePath(base: string, filepath: string): string {
   return isAbsolute(filepath) ? filepath : join(base, filepath);
 }
+
+/**
+ * Render a path relative to `rootPath` when it lives inside the root, otherwise
+ * fall back to the original path. Used for trace labels and summary tables so
+ * in-repo files show as short relative paths while external/sentinel paths
+ * (e.g. `<host>`) pass through unchanged.
+ */
+export const displayPath = (filePath: string, rootPath: string): string => {
+  const rel = relative(rootPath, resolve(rootPath, filePath));
+  return rel && !rel.startsWith('..') ? rel : filePath;
+};
 
 export const parsePosix = (filePath: string): { dir: string; base: string } => {
   const { dir, base } = parse(filePath);

--- a/packages/core/src/utils/trace.ts
+++ b/packages/core/src/utils/trace.ts
@@ -1,8 +1,9 @@
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
-import { dirname, relative, resolve } from 'pathe';
-import { isTTY } from './helper';
+import { dirname, resolve } from 'pathe';
+import { displayPath, isTTY } from './helper';
 import { color, logger } from './logger';
+import { formatTraceSummary, summarizeTrace } from './traceSummary';
 
 // ---------------------------------------------------------------------------
 // Public event type
@@ -46,12 +47,17 @@ export const noopTraceSpan: TraceSpan = async (_name, _cat, fn) => fn();
 // ---------------------------------------------------------------------------
 
 /**
- * Build the absolute path for a Perfetto trace dump. The filename embeds an
- * ISO-like timestamp so repeated runs do not overwrite each other.
+ * Build the absolute paths for a run's artifacts: the Perfetto trace dump and
+ * its markdown summary sidecar. Both share one timestamped stem so the pair is
+ * named from a single source (no fragile extension rewriting), and the stamp
+ * keeps repeated runs from overwriting each other.
  */
-const getTraceOutputPath = (rootPath: string): string => {
+const getTraceOutputPaths = (
+  rootPath: string,
+): { tracePath: string; summaryPath: string } => {
   const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace('Z', '');
-  return resolve(rootPath, '.rstest', `trace-${stamp}.json`);
+  const stem = resolve(rootPath, '.rstest', `trace-${stamp}`);
+  return { tracePath: `${stem}.json`, summaryPath: `${stem}.summary.md` };
 };
 
 /**
@@ -100,11 +106,6 @@ const buildTraceFile = (
     threadIds.add(ev.tid);
   }
 
-  const displayPath = (testPath: string): string => {
-    const rel = relative(rootPath, testPath);
-    return rel && !rel.startsWith('..') ? rel : testPath;
-  };
-
   const seenPid = new Set<number>();
   const seenThread = new Set<string>();
   const metadata: TraceEvent[] = [];
@@ -119,7 +120,9 @@ const buildTraceFile = (
       const sharedWorker = (threadIdsByPid.get(ev.pid)?.size ?? 0) > 1;
       metadata.push(
         meta('process_name', ev.pid, ev.tid, {
-          name: sharedWorker ? `worker ${ev.pid}` : displayPath(testPath),
+          name: sharedWorker
+            ? `worker ${ev.pid}`
+            : displayPath(testPath, rootPath),
         }),
         meta('process_sort_index', ev.pid, ev.tid, {
           sort_index: sortIndex++,
@@ -131,7 +134,9 @@ const buildTraceFile = (
     if (!seenThread.has(threadKey)) {
       seenThread.add(threadKey);
       metadata.push(
-        meta('thread_name', ev.pid, ev.tid, { name: displayPath(testPath) }),
+        meta('thread_name', ev.pid, ev.tid, {
+          name: displayPath(testPath, rootPath),
+        }),
       );
     }
   }
@@ -300,6 +305,9 @@ export const createTraceController = (options: {
   // In watch mode we replace it on each rerun so .rstest/ does not accumulate
   // multi-MB JSONs; files from earlier sessions are left alone.
   let lastTracePath: string | undefined;
+  // Sidecar `.summary.md` produced alongside the trace; replaced on rerun in
+  // watch mode for the same reason as `lastTracePath`.
+  let lastSummaryPath: string | undefined;
 
   const beginRun = (): TraceRun => {
     if (!enabled) {
@@ -343,7 +351,7 @@ export const createTraceController = (options: {
       span: pushHostSlice,
       finalize: async () => {
         if (!events.length) return;
-        const tracePath = getTraceOutputPath(rootPath);
+        const { tracePath, summaryPath } = getTraceOutputPaths(rootPath);
         await mkdir(dirname(tracePath), { recursive: true });
         await writeFile(
           tracePath,
@@ -354,9 +362,28 @@ export const createTraceController = (options: {
           unlink(lastTracePath).catch(() => {});
         }
         lastTracePath = tracePath;
+
+        // Agent/CI-friendly text summary: the Perfetto JSON is a raw event
+        // dump meant for the visual UI, so always emit a ranked markdown
+        // digest (printed to stdout and written next to the trace) that
+        // answers "where did time go" without opening a flame graph.
+        const summaryMarkdown = formatTraceSummary(
+          summarizeTrace(events, rootPath),
+        );
+        await writeFile(summaryPath, `${summaryMarkdown}\n`);
+        if (lastSummaryPath && lastSummaryPath !== summaryPath) {
+          unlink(lastSummaryPath).catch(() => {});
+        }
+        lastSummaryPath = summaryPath;
+
+        logger.log(`\n${summaryMarkdown}\n`);
         logger.log(
           color.gray('  Perfetto trace file: '),
           color.cyan(tracePath),
+        );
+        logger.log(
+          color.gray('  Trace summary file: '),
+          color.cyan(summaryPath),
         );
         // The helper server keeps the event loop alive until SIGINT, which
         // would hang `rstest run` in CI. Only start it in an interactive TTY,

--- a/packages/core/src/utils/traceSummary.ts
+++ b/packages/core/src/utils/traceSummary.ts
@@ -1,11 +1,18 @@
 import { displayPath } from './helper';
 import type { TraceEvent } from './trace';
 
-/** A `ph: 'X'` slice of category `cat` with a numeric `dur`. */
+/** A `ph: 'X'` (complete) trace event with a numeric `dur`. */
 type Slice = TraceEvent & { dur: number };
 
-const isSlice = (ev: TraceEvent, cat: string): ev is Slice =>
-  ev.ph === 'X' && ev.cat === cat && typeof ev.dur === 'number';
+const isSlice = (ev: TraceEvent): ev is Slice =>
+  ev.ph === 'X' && typeof ev.dur === 'number';
+
+/**
+ * Slice categories the worker `PhaseTracker` emits per test file. Everything
+ * else carried on a `ph: 'X'` slice (`host:*`, `coverage:*`, and any future
+ * host-side category) is a host-side span — see {@link summarizeTrace}.
+ */
+const WORKER_SLICE_CATS = new Set(['phase', 'suite', 'case']);
 
 // ---------------------------------------------------------------------------
 // Summary model
@@ -40,7 +47,11 @@ export interface TraceCaseEntry {
 export interface TraceSummary {
   /** Per-file lifecycle phases (`cat: 'phase'`), grouped by phase name. */
   phases: TraceSummaryGroup[];
-  /** Host-side spans (`cat: 'host'`, e.g. rsbuild build), grouped by name. */
+  /**
+   * Host-side spans (`host:*`, `coverage:*`, …, i.e. any non-worker slice
+   * category — e.g. rsbuild build, coverage report generation), grouped by
+   * name.
+   */
   host: TraceSummaryGroup[];
   /** Per-file wall time (sum of the file's phase slices), ranked desc. */
   files: TraceFileEntry[];
@@ -55,7 +66,8 @@ export interface TraceSummary {
 // ---------------------------------------------------------------------------
 
 /**
- * Group `ph: 'X'` slices of a given category by `name`, summing durations.
+ * Group `ph: 'X'` slices whose category matches `matchCat` by `name`, summing
+ * durations.
  *
  * Phases and host spans are non-overlapping within their own track and are
  * aggregated across all workers, so summed durations exceed wall-clock time
@@ -65,12 +77,12 @@ export interface TraceSummary {
  */
 const groupByName = (
   events: TraceEvent[],
-  cat: string,
+  matchCat: (cat: string) => boolean,
 ): TraceSummaryGroup[] => {
   const byName = new Map<string, { totalUs: number; count: number }>();
   let total = 0;
   for (const ev of events) {
-    if (!isSlice(ev, cat)) continue;
+    if (!isSlice(ev) || !matchCat(ev.cat)) continue;
     const cur = byName.get(ev.name) ?? { totalUs: 0, count: 0 };
     cur.totalUs += ev.dur;
     cur.count += 1;
@@ -97,15 +109,18 @@ export const summarizeTrace = (
   events: TraceEvent[],
   rootPath: string,
 ): TraceSummary => {
-  const phases = groupByName(events, 'phase');
-  const host = groupByName(events, 'host');
+  const phases = groupByName(events, (cat) => cat === 'phase');
+  // Host-side spans are every other `ph: 'X'` category (`host:*`, `coverage:*`,
+  // …); aggregating by exclusion keeps coverage and future host categories in
+  // the summary instead of silently dropping them.
+  const host = groupByName(events, (cat) => !WORKER_SLICE_CATS.has(cat));
 
   // Per-file wall time = sum of that file's phase slices (phases are
   // sequential and cover the file's lifetime). Keyed by the file's testPath.
   const fileUs = new Map<string, number>();
   let phaseTotal = 0;
   for (const ev of events) {
-    if (!isSlice(ev, 'phase')) continue;
+    if (!isSlice(ev) || ev.cat !== 'phase') continue;
     const testPath =
       typeof ev.args?.testPath === 'string' ? ev.args.testPath : undefined;
     if (!testPath) continue;
@@ -121,7 +136,7 @@ export const summarizeTrace = (
     .sort((a, b) => b.totalUs - a.totalUs);
 
   const cases: TraceCaseEntry[] = events
-    .filter((ev): ev is Slice => isSlice(ev, 'case'))
+    .filter((ev): ev is Slice => isSlice(ev) && ev.cat === 'case')
     .map((ev) => ({
       name: ev.name,
       path:

--- a/packages/core/src/utils/traceSummary.ts
+++ b/packages/core/src/utils/traceSummary.ts
@@ -1,0 +1,266 @@
+import { displayPath } from './helper';
+import type { TraceEvent } from './trace';
+
+/** A `ph: 'X'` slice of category `cat` with a numeric `dur`. */
+type Slice = TraceEvent & { dur: number };
+
+const isSlice = (ev: TraceEvent, cat: string): ev is Slice =>
+  ev.ph === 'X' && ev.cat === cat && typeof ev.dur === 'number';
+
+// ---------------------------------------------------------------------------
+// Summary model
+// ---------------------------------------------------------------------------
+
+/** One aggregated row: slices sharing a `name`, summed. */
+export interface TraceSummaryGroup {
+  name: string;
+  /** Sum of slice durations (microseconds). */
+  totalUs: number;
+  /** Number of slices folded into this row. */
+  count: number;
+  /** Share of this section's total (0–100). */
+  pct: number;
+}
+
+/** One test file's wall time, derived from its phase slices. */
+export interface TraceFileEntry {
+  /** Path relative to `rootPath` when inside it, else absolute. */
+  path: string;
+  totalUs: number;
+  pct: number;
+}
+
+/** One test case slice (a leaf in the call tree). */
+export interface TraceCaseEntry {
+  name: string;
+  path: string;
+  durUs: number;
+}
+
+export interface TraceSummary {
+  /** Per-file lifecycle phases (`cat: 'phase'`), grouped by phase name. */
+  phases: TraceSummaryGroup[];
+  /** Host-side spans (`cat: 'host'`, e.g. rsbuild build), grouped by name. */
+  host: TraceSummaryGroup[];
+  /** Per-file wall time (sum of the file's phase slices), ranked desc. */
+  files: TraceFileEntry[];
+  /** Individual test cases (`cat: 'case'`), ranked by duration desc. */
+  cases: TraceCaseEntry[];
+  /** Distinct test files observed. */
+  fileCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Group `ph: 'X'` slices of a given category by `name`, summing durations.
+ *
+ * Phases and host spans are non-overlapping within their own track and are
+ * aggregated across all workers, so summed durations exceed wall-clock time
+ * when workers run in parallel — this mirrors the aggregate convention used by
+ * other JS test runners (e.g. Vitest's `Duration ... (setup Xs, collect Ys)`
+ * line). Percentages are relative to the section's own total, not wall-clock.
+ */
+const groupByName = (
+  events: TraceEvent[],
+  cat: string,
+): TraceSummaryGroup[] => {
+  const byName = new Map<string, { totalUs: number; count: number }>();
+  let total = 0;
+  for (const ev of events) {
+    if (!isSlice(ev, cat)) continue;
+    const cur = byName.get(ev.name) ?? { totalUs: 0, count: 0 };
+    cur.totalUs += ev.dur;
+    cur.count += 1;
+    byName.set(ev.name, cur);
+    total += ev.dur;
+  }
+  return [...byName.entries()]
+    .map(([name, { totalUs, count }]) => ({
+      name,
+      totalUs,
+      count,
+      pct: total === 0 ? 0 : (totalUs / total) * 100,
+    }))
+    .sort((a, b) => b.totalUs - a.totalUs);
+};
+
+/**
+ * Reduce a flat trace event list to an agent/CI-friendly summary: which phases
+ * and host spans dominated, which files were slowest, and the slowest cases.
+ * Pure and dependency-free — the same data Perfetto would visualize, collapsed
+ * to ranked tables instead of a flame graph.
+ */
+export const summarizeTrace = (
+  events: TraceEvent[],
+  rootPath: string,
+): TraceSummary => {
+  const phases = groupByName(events, 'phase');
+  const host = groupByName(events, 'host');
+
+  // Per-file wall time = sum of that file's phase slices (phases are
+  // sequential and cover the file's lifetime). Keyed by the file's testPath.
+  const fileUs = new Map<string, number>();
+  let phaseTotal = 0;
+  for (const ev of events) {
+    if (!isSlice(ev, 'phase')) continue;
+    const testPath =
+      typeof ev.args?.testPath === 'string' ? ev.args.testPath : undefined;
+    if (!testPath) continue;
+    fileUs.set(testPath, (fileUs.get(testPath) ?? 0) + ev.dur);
+    phaseTotal += ev.dur;
+  }
+  const files: TraceFileEntry[] = [...fileUs.entries()]
+    .map(([testPath, totalUs]) => ({
+      path: displayPath(testPath, rootPath),
+      totalUs,
+      pct: phaseTotal === 0 ? 0 : (totalUs / phaseTotal) * 100,
+    }))
+    .sort((a, b) => b.totalUs - a.totalUs);
+
+  const cases: TraceCaseEntry[] = events
+    .filter((ev): ev is Slice => isSlice(ev, 'case'))
+    .map((ev) => ({
+      name: ev.name,
+      path:
+        typeof ev.args?.testPath === 'string'
+          ? displayPath(ev.args.testPath, rootPath)
+          : '',
+      durUs: ev.dur,
+    }))
+    .sort((a, b) => b.durUs - a.durUs);
+
+  return { phases, host, files, cases, fileCount: fileUs.size };
+};
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+/** Human-readable duration from microseconds (`12.40s` / `345.0ms`). */
+const fmtDur = (us: number): string => {
+  const ms = us / 1000;
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  if (ms >= 1) return `${ms.toFixed(1)}ms`;
+  return `${ms.toFixed(2)}ms`;
+};
+
+const fmtPct = (pct: number): string => `${pct.toFixed(1)}%`;
+
+/**
+ * Render a markdown table whose columns are space-padded so the raw text also
+ * lines up when printed to a terminal (still valid GitHub-flavored markdown).
+ */
+const mdTable = (headers: string[], rows: string[][]): string => {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)),
+  );
+  const line = (cells: string[]) =>
+    `| ${cells.map((c, i) => c.padEnd(widths[i] ?? 0)).join(' | ')} |`;
+  const sep = `| ${widths.map((w) => '-'.repeat(w)).join(' | ')} |`;
+  return [line(headers), sep, ...rows.map(line)].join('\n');
+};
+
+/**
+ * Cap a ranked list to its top `limit` rows, returning the rows to render plus
+ * a `… and N more` note for the remainder (undefined when nothing was hidden).
+ */
+const truncated = <T>(
+  items: T[],
+  limit: number,
+  noun: string,
+): { shown: T[]; note?: string } => {
+  const shown = items.slice(0, limit);
+  const rest = items.length - shown.length;
+  return {
+    shown,
+    note: rest > 0 ? `… and ${rest} more ${noun}(s)` : undefined,
+  };
+};
+
+export interface FormatTraceSummaryOptions {
+  /** Max rows in the slowest-files table (default 10). */
+  topFiles?: number;
+  /** Max rows in the slowest-cases table (default 10). */
+  topCases?: number;
+}
+
+/**
+ * Format a {@link TraceSummary} as markdown for stdout and the `.summary.md`
+ * sidecar file. Empty sections are omitted; long tables are truncated to the
+ * top-N rows with a trailing "… and N more" note so output stays compact.
+ */
+export const formatTraceSummary = (
+  summary: TraceSummary,
+  options: FormatTraceSummaryOptions = {},
+): string => {
+  const { topFiles = 10, topCases = 10 } = options;
+  // Each block is a self-contained section (heading + blank line + table);
+  // blocks are joined with a blank line so the title and every section are
+  // separated by one empty line, matching standard markdown spacing.
+  const blocks: string[] = [
+    `# Trace summary — ${summary.fileCount} test file(s)`,
+  ];
+
+  const section = (heading: string, table: string, note?: string): void => {
+    blocks.push(`${heading}\n\n${table}${note ? `\n\n${note}` : ''}`);
+  };
+
+  if (summary.phases.length) {
+    section(
+      '## Phases (aggregate across workers)',
+      mdTable(
+        ['phase', 'total', '%', 'count'],
+        summary.phases.map((p) => [
+          p.name,
+          fmtDur(p.totalUs),
+          fmtPct(p.pct),
+          String(p.count),
+        ]),
+      ),
+    );
+  }
+
+  if (summary.host.length) {
+    section(
+      '## Host spans',
+      mdTable(
+        ['span', 'total', '%', 'count'],
+        summary.host.map((h) => [
+          h.name,
+          fmtDur(h.totalUs),
+          fmtPct(h.pct),
+          String(h.count),
+        ]),
+      ),
+    );
+  }
+
+  if (summary.files.length) {
+    const { shown, note } = truncated(summary.files, topFiles, 'file');
+    section(
+      '## Slowest files (by phase wall time)',
+      mdTable(
+        ['file', 'total', '%'],
+        shown.map((f) => [f.path, fmtDur(f.totalUs), fmtPct(f.pct)]),
+      ),
+      note,
+    );
+  }
+
+  if (summary.cases.length) {
+    const { shown, note } = truncated(summary.cases, topCases, 'case');
+    section(
+      '## Slowest test cases',
+      mdTable(
+        ['case', 'file', 'dur'],
+        shown.map((c) => [c.name, c.path, fmtDur(c.durUs)]),
+      ),
+      note,
+    );
+  }
+
+  return blocks.join('\n\n');
+};

--- a/packages/core/tests/utils/traceSummary.test.ts
+++ b/packages/core/tests/utils/traceSummary.test.ts
@@ -62,6 +62,11 @@ it('ranks files by summed phase wall time, relative to repo root', () => {
 it('collects host spans and slowest cases separately from phases', () => {
   const events: TraceEvent[] = [
     slice('host:get-rsbuild-stats', 'host', 500, '<project>'),
+    // Coverage records host-side spans under `cat: 'coverage'`; they belong in
+    // the host section, not silently dropped.
+    slice('coverage:generate-reports', 'coverage', 300, '<host>'),
+    // Suite slices are intermediate worker nodes — excluded from every section.
+    slice('describe block', 'suite', 999, 'src/a.test.ts'),
     slice('load', 'phase', 100, 'src/a.test.ts'),
     slice('fast case', 'case', 5, 'src/a.test.ts'),
     slice('slow case', 'case', 80, 'src/a.test.ts'),
@@ -69,14 +74,18 @@ it('collects host spans and slowest cases separately from phases', () => {
 
   const { host, cases } = summarizeTrace(events, ROOT);
 
+  // host + coverage, ranked desc, percentages relative to their 800ms total.
   expect(host).toEqual([
+    { name: 'host:get-rsbuild-stats', totalUs: 500_000, count: 1, pct: 62.5 },
     {
-      name: 'host:get-rsbuild-stats',
-      totalUs: 500_000,
+      name: 'coverage:generate-reports',
+      totalUs: 300_000,
       count: 1,
-      pct: 100,
+      pct: 37.5,
     },
   ]);
+  // Suite slices never surface as host spans or cases.
+  expect(host.some((h) => h.name === 'describe block')).toBe(false);
   expect(cases.map((c) => c.name)).toEqual(['slow case', 'fast case']);
   expect(cases[0]).toEqual({
     name: 'slow case',

--- a/packages/core/tests/utils/traceSummary.test.ts
+++ b/packages/core/tests/utils/traceSummary.test.ts
@@ -1,0 +1,123 @@
+import type { TraceEvent } from '../../src/utils/trace';
+import {
+  formatTraceSummary,
+  summarizeTrace,
+} from '../../src/utils/traceSummary';
+
+const ROOT = '/repo';
+
+// Durations are authored in milliseconds for readability and converted to the
+// microsecond units the trace format uses.
+const slice = (
+  name: string,
+  cat: string,
+  durMs: number,
+  testPath: string,
+  tid = 1,
+): TraceEvent => ({
+  name,
+  cat,
+  ph: 'X',
+  ts: 0,
+  dur: durMs * 1000,
+  pid: 1,
+  tid,
+  args: { testPath, project: 'default' },
+});
+
+it('aggregates phases by name across files and ranks them', () => {
+  const events: TraceEvent[] = [
+    slice('load', 'phase', 100, 'src/a.test.ts', 1),
+    slice('tests', 'phase', 300, 'src/a.test.ts', 1),
+    slice('load', 'phase', 100, 'src/b.test.ts', 2),
+    slice('tests', 'phase', 100, 'src/b.test.ts', 2),
+  ];
+
+  const { phases, fileCount } = summarizeTrace(events, ROOT);
+
+  expect(fileCount).toBe(2);
+  // tests = 400ms total, load = 200ms total; ranked desc.
+  expect(phases.map((p) => p.name)).toEqual(['tests', 'load']);
+  expect(phases[0]).toMatchObject({ totalUs: 400_000, count: 2 });
+  // 400 / 600 total phase time.
+  expect(phases[0].pct).toBeCloseTo(66.6667, 2);
+  expect(phases[1]).toMatchObject({ name: 'load', totalUs: 200_000 });
+});
+
+it('ranks files by summed phase wall time, relative to repo root', () => {
+  const events: TraceEvent[] = [
+    slice('load', 'phase', 100, 'src/a.test.ts', 1),
+    slice('tests', 'phase', 300, 'src/a.test.ts', 1),
+    slice('load', 'phase', 50, 'src/b.test.ts', 2),
+  ];
+
+  const { files } = summarizeTrace(events, ROOT);
+
+  expect(files).toEqual([
+    { path: 'src/a.test.ts', totalUs: 400_000, pct: 88.88888888888889 },
+    { path: 'src/b.test.ts', totalUs: 50_000, pct: 11.11111111111111 },
+  ]);
+});
+
+it('collects host spans and slowest cases separately from phases', () => {
+  const events: TraceEvent[] = [
+    slice('host:get-rsbuild-stats', 'host', 500, '<project>'),
+    slice('load', 'phase', 100, 'src/a.test.ts'),
+    slice('fast case', 'case', 5, 'src/a.test.ts'),
+    slice('slow case', 'case', 80, 'src/a.test.ts'),
+  ];
+
+  const { host, cases } = summarizeTrace(events, ROOT);
+
+  expect(host).toEqual([
+    {
+      name: 'host:get-rsbuild-stats',
+      totalUs: 500_000,
+      count: 1,
+      pct: 100,
+    },
+  ]);
+  expect(cases.map((c) => c.name)).toEqual(['slow case', 'fast case']);
+  expect(cases[0]).toEqual({
+    name: 'slow case',
+    path: 'src/a.test.ts',
+    durUs: 80_000,
+  });
+});
+
+it('ignores counter/metadata events and slices without a duration', () => {
+  const events: TraceEvent[] = [
+    slice('tests', 'phase', 100, 'src/a.test.ts'),
+    { name: 'heap', cat: 'memory', ph: 'C', ts: 0, pid: 1, tid: 1 },
+    { name: 'process_name', cat: '__metadata', ph: 'M', ts: 0, pid: 1, tid: 1 },
+  ];
+
+  const { phases, fileCount } = summarizeTrace(events, ROOT);
+
+  expect(phases).toHaveLength(1);
+  expect(fileCount).toBe(1);
+});
+
+it('formats markdown, omits empty sections, and truncates long tables', () => {
+  const events: TraceEvent[] = [
+    slice('tests', 'phase', 300, 'src/a.test.ts', 1),
+    slice('load', 'phase', 100, 'src/a.test.ts', 1),
+    ...Array.from({ length: 12 }, (_, i) =>
+      slice(`case ${i}`, 'case', 12 - i, 'src/a.test.ts'),
+    ),
+  ];
+
+  const md = formatTraceSummary(summarizeTrace(events, ROOT), { topCases: 10 });
+
+  expect(md).toContain('# Trace summary — 1 test file(s)');
+  // Title is followed by a blank line before the first section.
+  expect(md).toContain(
+    '# Trace summary — 1 test file(s)\n\n## Phases (aggregate across workers)\n\n|',
+  );
+  expect(md).toContain('| tests | 300.0ms | 75.0% | 1     |');
+  // No host spans in this trace → host section omitted.
+  expect(md).not.toContain('## Host spans');
+  // 12 cases, capped at 10.
+  expect(md).toContain('## Slowest test cases');
+  expect(md).toContain('… and 2 more case(s)');
+});

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -337,7 +337,7 @@ Rstest CLI options are registered per command instead of being shared by every c
 | `--testEnvironment <name>`          | The environment that will be used for testing, see [testEnvironment](/config/test/test-environment)                                                                   |
 | `-t, --testNamePattern <value>`     | Run only tests with a name that matches the regex, see [testNamePattern](/config/test/test-name-pattern)                                                              |
 | `--testTimeout <value>`             | Timeout of a test in milliseconds, see [testTimeout](/config/test/test-timeout)                                                                                       |
-| `--trace`                           | Dump a Perfetto-compatible performance trace JSON file                                                                                                                |
+| `--trace`                           | Dump a Perfetto-compatible performance trace JSON file, plus a ranked markdown timing summary printed to the terminal and written next to it                          |
 | `--unstubEnvs`                      | Restores all `process.env` values that were changed with `rs.stubEnv` before every test, see [unstubEnvs](/config/test/unstub-envs)                                   |
 | `--unstubGlobals`                   | Restores all global variables that were changed with `rs.stubGlobal` before every test, see [unstubGlobals](/config/test/unstub-globals)                              |
 | `-u, --update`                      | Update snapshot files, see [update](/config/test/update)                                                                                                              |

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -337,7 +337,7 @@ Rstest CLI 参数是按命令注册的，并不是所有命令共享同一套参
 | `--testEnvironment <name>`          | 指定测试环境，详见 [testEnvironment](/config/test/test-environment)                                                                                  |
 | `-t, --testNamePattern <value>`     | 仅运行名称匹配正则的测试，详见 [testNamePattern](/config/test/test-name-pattern)                                                                     |
 | `--testTimeout <value>`             | 设置单个测试的超时时间（毫秒），详见 [testTimeout](/config/test/test-timeout)                                                                        |
-| `--trace`                           | 导出 Perfetto 兼容的性能 trace JSON 文件                                                                                                             |
+| `--trace`                           | 导出 Perfetto 兼容的性能 trace JSON 文件，并附带一份按耗时排序的 markdown 摘要（打印到终端并写入 trace 同目录）                                      |
 | `--unstubEnvs`                      | 每个测试前恢复被 `rs.stubEnv` 修改的 `process.env`，详见 [unstubEnvs](/config/test/unstub-envs)                                                      |
 | `--unstubGlobals`                   | 每个测试前恢复被 `rs.stubGlobal` 修改的全局变量，详见 [unstubGlobals](/config/test/unstub-globals)                                                   |
 | `-u, --update`                      | 更新快照文件，详见 [update](/config/test/update)                                                                                                     |


### PR DESCRIPTION
## Summary

`--trace` only produced a Perfetto-compatible JSON dump — a raw event stream meant for the visual Perfetto UI. That format is useless to an agent or CI job that can't open a flame graph: there's no aggregation, just thousands of flat slices. This makes the flag effectively interactive-only.

This PR makes `--trace` always emit a ranked markdown timing summary alongside the JSON, answering "where did time go" without opening the UI:

- **New `summarizeTrace` / `formatTraceSummary`** (`src/utils/traceSummary.ts`) — pure, dependency-free functions that collapse the trace events into four ranked tables: phases (aggregate across workers), host spans (rsbuild build / scheduling), slowest files, and slowest test cases. Self-time semantics follow Perfetto's own `dur − Σ(child dur)`; here each `cat` is a non-overlapping partition, so per-category inclusive totals are exact.
- **`finalize()` wiring** — the summary is printed to stdout and written to a `.rstest/trace-<ts>.summary.md` sidecar (cleaned up across watch reruns like the JSON). The trace JSON, the TTY Perfetto helper link, and the non-TTY "drag the file" hint are all unchanged.
- **No new flags, no behavior change when `--trace` is off.** The summary is additive and opt-in via the existing flag.

The trace JSON and its summary sidecar are now derived from a single timestamped stem (no extension rewriting), and the path-relativization helper is shared via `helper.ts` instead of duplicated.

## Related Links

- Builds on host-side trace spans (#1344)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).