### PR TITLE
fix(browser): expose process.env.RSTEST in browser mode

### DIFF
--- a/e2e/browser-mode/fixtures/env/tests/env.test.ts
+++ b/e2e/browser-mode/fixtures/env/tests/env.test.ts
@@ -35,4 +35,11 @@ describe('browser env injection', () => {
   it('should expose NODE_ENV via import.meta.env in browser mode', () => {
     expect(import.meta.env.NODE_ENV).toBe('test');
   });
+
+  it('should expose the RSTEST flag in browser mode', () => {
+    // Matches Node mode, where `prepare.ts` sets `process.env.RSTEST = 'true'`.
+    // See https://github.com/web-infra-dev/rstest/issues/1351
+    expect(process.env.RSTEST).toBe('true');
+    expect(import.meta.env.RSTEST).toBe('true');
+  });
 });

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -830,11 +830,15 @@ const getRuntimeConfigFromProject = (
   } = project.normalizedConfig;
 
   return {
-    // Propagate NODE_ENV from the host so `import.meta.env.NODE_ENV` resolves
-    // to `'test'` in browser tests (matches Node mode). User-supplied `env`
-    // wins so explicit overrides still take effect.
+    // Propagate NODE_ENV and the RSTEST flag from the host so
+    // `process.env.NODE_ENV` / `process.env.RSTEST` (rewritten to the
+    // `rstest.env` symbol store) resolve in browser tests the same way they do
+    // in Node mode, where `prepare.ts` sets them on the real `process.env`.
+    // User-supplied `env` wins so explicit overrides still take effect.
+    // See https://github.com/web-infra-dev/rstest/issues/1351
     env: {
       NODE_ENV: process.env.NODE_ENV,
+      RSTEST: 'true',
       ...env,
     },
     testNamePattern,


### PR DESCRIPTION
## Summary

`process.env.RSTEST` is documented to be `'true'` whenever the test runner is active, but it was `undefined` in browser mode (reported in #1351). In Node mode, `prepare.ts` sets `process.env.RSTEST = 'true'` on the real process and workers inherit it. Browser mode has no real `process`: `source.define` rewrites `process.env`/`import.meta.env` to the `globalThis[Symbol.for("rstest.env")]` store, which was only seeded with `NODE_ENV`. So the documented `process.env.RSTEST` check silently no-op'd, and users had to re-declare it via `source.define` as a workaround.

This seeds the browser runtime env store with `RSTEST: 'true'` alongside `NODE_ENV`, placed before the user `env` spread so explicit overrides still win — mirroring Node mode, where the inherited flag is also overridable by `config.env`. It is exposed through both `process.env.RSTEST` and `import.meta.env.RSTEST`. A regression assertion is added to the existing browser-mode env fixture.

## Related Links

- Closes #1351

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).