### PR TITLE
refactor(core): unify dynamic-import resolver across CJS/ESM worker loaders

### DIFF
--- a/packages/browser/src/viewportPresets.ts
+++ b/packages/browser/src/viewportPresets.ts
@@ -4,6 +4,11 @@
  * IMPORTANT: Keep this list/map in sync with `DevicePreset` typing in
  * `@rstest/core` (`packages/core/src/types/config.ts`) so `defineConfig`
  * autocomplete and runtime validation stay consistent.
+ *
+ * Upstream source of truth for ids/dimensions is the Chrome DevTools emulated
+ * device list — mirror each device's `screen.vertical` `{ width, height }`:
+ * https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/models/emulation/EmulatedDevices.ts
+ * Last verified in sync (all 17): 2026-04-22, devtools-frontend commit abaac05e.
  */
 export const BROWSER_VIEWPORT_PRESET_IDS = [
   'iPhoneSE',

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -1,21 +1,14 @@
-import {
-  builtinModules,
-  createRequire as createNativeRequire,
-} from 'node:module';
-import { isAbsolute } from 'node:path';
+import { createRequire as createNativeRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import vm, { type SourceTextModule } from 'node:vm';
 import path from 'pathe';
 import { logger } from '../../utils/logger';
+import { clearSyntheticModuleCache } from './interop';
 import {
-  asModule,
-  clearSyntheticModuleCache,
-  createInteropProxy,
-  interopModule,
-  shouldInterop,
-} from './interop';
-
-const importMetaResolve = import.meta.resolve?.bind(import.meta);
+  finalizeDynamicImport,
+  loadWasmFromContent,
+  resolveImportSpecifier,
+} from './resolveDynamicImport';
 
 export enum EsmMode {
   Unknown = 0,
@@ -29,27 +22,6 @@ export const shouldInjectSourceURL = (): boolean => {
 };
 
 const isRelativePath = (p: string) => /^\.\.?\//.test(p);
-
-const isBuiltinSpecifier = (specifier: string) =>
-  specifier.startsWith('node:') || builtinModules.includes(specifier);
-
-const resolveModule = (
-  specifier: string,
-  resolveBase: string,
-): string | URL => {
-  const parentURL = resolveBase.startsWith('file:')
-    ? resolveBase
-    : pathToFileURL(resolveBase).href;
-
-  if (!importMetaResolve) {
-    return pathToFileURL(createNativeRequire(parentURL).resolve(specifier))
-      .href;
-  }
-
-  // Node's loader hook worker clones the parent URL when native TypeScript
-  // loading is active. Passing URL objects can throw DataCloneError there.
-  return importMetaResolve(specifier, parentURL);
-};
 
 export const appendSourceURL = (
   codeContent: string,
@@ -142,13 +114,7 @@ const defineRstestDynamicImport =
     if (content) {
       try {
         if (specifier.endsWith('.wasm')) {
-          const wasmBuffer = Buffer.from(content, 'base64');
-          const wasmModule = await WebAssembly.compile(wasmBuffer);
-          const wasmInstance = await WebAssembly.instantiate(wasmModule);
-          const exports = wasmInstance.exports as Record<string, any>;
-          return returnModule
-            ? await asModule(exports, joinedPath, exports)
-            : exports;
+          return loadWasmFromContent(content, joinedPath, returnModule);
         }
         return await loadModule({
           codeContent: content,
@@ -168,66 +134,12 @@ const defineRstestDynamicImport =
       }
     }
 
-    // `origin` is the absolute path of the source module that produced the
-    // `import()` call. It is injected by rspack's `RstestPlugin` when
-    // `injectDynamicImportOrigin` is enabled, so relative specifiers in
-    // bundled deps resolve against the dep's own directory rather than the
-    // test entry's. Fallback to `testPath` keeps the link/vm-callback paths
-    // (which have no origin to pass) working as before.
-    const resolveBase = origin ?? testPath;
-    const resolvedPath = isAbsolute(specifier)
-      ? pathToFileURL(specifier).href
-      : isBuiltinSpecifier(specifier)
-        ? specifier
-        : resolveModule(specifier, resolveBase);
-
-    // Use `.href` (full file:// URL) rather than `.pathname` so absolute
-    // Windows specifiers (`D:\a\foo.mjs`) remain valid import targets. With
-    // `.pathname` the URL object yielded `/D:/a/foo.mjs`, which Node later
-    // re-resolved as `D:\D:\a\foo.mjs` (double drive letter).
-    const modulePath =
-      typeof resolvedPath === 'string' ? resolvedPath : resolvedPath.href;
-
-    // Rstest importAttributes is used internally to distinguish `importActual` and normal imports,
-    // and should not be passed to Node.js side, otherwise it will cause ERR_IMPORT_ATTRIBUTE_UNSUPPORTED error.
-    if (importAttributes?.with?.rstest) {
-      delete importAttributes.with.rstest;
-    }
-
-    if (modulePath.endsWith('.json')) {
-      const importedModule = await import(modulePath, {
-        with: { type: 'json' },
-      });
-
-      return returnModule
-        ? asModule(importedModule.default, modulePath, importedModule.default)
-        : {
-            ...importedModule.default,
-            default: importedModule.default,
-          };
-    }
-    const importedModule = await import(modulePath, importAttributes);
-
-    if (
-      shouldInterop({
-        interopDefault,
-        modulePath,
-        mod: importedModule,
-      }) &&
-      !modulePath.startsWith('node:')
-    ) {
-      const { mod, defaultExport } = interopModule(importedModule);
-      if (returnModule) {
-        return asModule(mod, modulePath, defaultExport);
-      }
-
-      return createInteropProxy(mod, defaultExport);
-    }
-
-    if (returnModule) {
-      return asModule(importedModule, modulePath, importedModule.default);
-    }
-    return importedModule;
+    return finalizeDynamicImport({
+      modulePath: resolveImportSpecifier({ specifier, origin, testPath }),
+      importAttributes,
+      interopDefault,
+      returnModule,
+    });
   };
 
 const esmCache = new Map<string, SourceTextModule>();

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -1,28 +1,16 @@
 import { createRequire as createNativeRequire } from 'node:module';
-import { isAbsolute } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
 import path from 'pathe';
 import { logger } from '../../utils/logger';
+import { clearSyntheticModuleCache } from './interop';
 import {
-  asModule,
-  clearSyntheticModuleCache,
-  createInteropProxy,
-  interopModule,
-  shouldInterop,
-} from './interop';
-
-const importMetaResolve = import.meta.resolve;
+  finalizeDynamicImport,
+  loadWasmFromContent,
+  resolveImportSpecifier,
+} from './resolveDynamicImport';
 
 const isRelativePath = (p: string) => /^\.\.?\//.test(p);
-
-const resolveModule = (specifier: string, resolveBase: string): string | URL =>
-  importMetaResolve(
-    specifier,
-    resolveBase.startsWith('file:')
-      ? resolveBase
-      : pathToFileURL(resolveBase).href,
-  );
 
 const defineRstestRequireResolve =
   ({
@@ -135,22 +123,11 @@ const defineRstestDynamicImport =
     importAttributes: ImportCallOptions,
     origin?: string,
   ) => {
-    // `origin` is the absolute path of the source module that produced the
-    // `import()` call, injected by rspack's `RstestPlugin` when
-    // `injectDynamicImportOrigin` is enabled. Falling back to `testPath`
-    // keeps the vm `importModuleDynamically` callback (which has no origin
-    // to pass) working as before.
-    const resolveBase = origin ?? testPath;
-    const resolvedPath = isAbsolute(specifier)
-      ? pathToFileURL(specifier).href
-      : resolveModule(specifier, resolveBase);
+    const modulePath = resolveImportSpecifier({ specifier, origin, testPath });
 
-    // Use `.href` rather than `.pathname` so Windows absolute specifiers
-    // round-trip through Node's ESM loader as valid `file:///D:/...` URLs
-    // instead of `/D:/...`, which Node re-resolves as `D:\D:\...`.
-    const modulePath =
-      typeof resolvedPath === 'string' ? resolvedPath : resolvedPath.href;
-
+    // Bundled `.wasm` is emitted as an in-memory asset file and must be
+    // instantiated from that content — Node's loader cannot import the virtual
+    // dist path. Every other specifier resolves and imports natively below.
     if (modulePath.endsWith('.wasm')) {
       const normalizedPath = path.normalize(
         modulePath.startsWith('file://')
@@ -160,53 +137,16 @@ const defineRstestDynamicImport =
       const content = assetFiles[normalizedPath];
 
       if (content) {
-        const wasmBuffer = Buffer.from(content, 'base64');
-        const wasmModule = await WebAssembly.compile(wasmBuffer);
-        const wasmInstance = await WebAssembly.instantiate(wasmModule);
-        const exports = wasmInstance.exports as Record<string, any>;
-        return returnModule ? asModule(exports, modulePath, exports) : exports;
+        return loadWasmFromContent(content, modulePath, returnModule);
       }
     }
 
-    // Rstest importAttributes is used internally to distinguish `importActual` and normal imports,
-    // and should not be passed to Node.js side, otherwise it will cause ERR_IMPORT_ATTRIBUTE_UNSUPPORTED error.
-    if (importAttributes?.with?.rstest) {
-      delete importAttributes.with.rstest;
-    }
-
-    if (modulePath.endsWith('.json')) {
-      // const json = await import(jsonPath);
-      // should return { default: jsonExports, ...jsonExports }
-      const importedModule = await import(modulePath, {
-        with: { type: 'json' },
-      });
-
-      return returnModule
-        ? asModule(importedModule.default, modulePath, importedModule.default)
-        : {
-            ...importedModule.default,
-            default: importedModule.default,
-          };
-    }
-
-    const importedModule = await import(modulePath, importAttributes);
-
-    if (
-      shouldInterop({
-        interopDefault,
-        modulePath,
-        mod: importedModule,
-      })
-    ) {
-      const { mod, defaultExport } = interopModule(importedModule);
-
-      if (returnModule) {
-        return asModule(mod, modulePath, defaultExport);
-      }
-
-      return createInteropProxy(mod, defaultExport);
-    }
-    return importedModule;
+    return finalizeDynamicImport({
+      modulePath,
+      importAttributes,
+      interopDefault,
+      returnModule,
+    });
   };
 
 // setup and rstest module should not be cached

--- a/packages/core/src/runtime/worker/resolveDynamicImport.ts
+++ b/packages/core/src/runtime/worker/resolveDynamicImport.ts
@@ -1,0 +1,166 @@
+import {
+  builtinModules,
+  createRequire as createNativeRequire,
+} from 'node:module';
+import { isAbsolute } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  asModule,
+  createInteropProxy,
+  interopModule,
+  shouldInterop,
+} from './interop';
+
+/**
+ * Shared dynamic-import resolution + interop policy for both worker loaders.
+ *
+ * `loadModule.ts` (CJS, `vm.runInThisContext`) and `loadEsModule.ts` (ESM,
+ * `vm.SourceTextModule`) used to each carry a private copy of this strategy,
+ * and the copies had drifted — most visibly, the `node:` interop-skip existed
+ * only on the ESM path, so a CJS `import('node:fs')` was interop-wrapped while
+ * the same import on the ESM path was not. Centralizing the policy here keeps
+ * the two `vm` state machines as the only genuine per-loader adapters; the
+ * resolution rules and the post-import interop decision now live in one place.
+ */
+
+const importMetaResolve = import.meta.resolve?.bind(import.meta);
+
+const isBuiltinSpecifier = (specifier: string): boolean =>
+  specifier.startsWith('node:') || builtinModules.includes(specifier);
+
+const resolveModule = (specifier: string, resolveBase: string): string => {
+  const parentURL = resolveBase.startsWith('file:')
+    ? resolveBase
+    : pathToFileURL(resolveBase).href;
+
+  if (!importMetaResolve) {
+    return pathToFileURL(createNativeRequire(parentURL).resolve(specifier))
+      .href;
+  }
+
+  // Node's loader hook worker clones the parent URL when native TypeScript
+  // loading is active. Passing URL objects can throw DataCloneError there.
+  return importMetaResolve(specifier, parentURL);
+};
+
+/**
+ * Resolve a dynamic-import specifier to the module path that Node's loader (or
+ * the interop tail below) should consume.
+ *
+ * - Absolute specifiers and builtins are kept verbatim; everything else is
+ *   resolved against the source module's origin.
+ * - `origin` is the absolute path of the source module that produced the
+ *   `import()` call, injected by rspack's `RstestPlugin` when
+ *   `injectDynamicImportOrigin` is enabled, so relative specifiers in bundled
+ *   deps resolve against the dep's own directory rather than the test entry's.
+ *   Falling back to `testPath` keeps the vm `importModuleDynamically` / `link`
+ *   callbacks (which have no origin to pass) working as before.
+ */
+export const resolveImportSpecifier = ({
+  specifier,
+  origin,
+  testPath,
+}: {
+  specifier: string;
+  origin: string | undefined;
+  testPath: string;
+}): string => {
+  const resolveBase = origin ?? testPath;
+
+  // Use `.href` (full file:// URL) rather than `.pathname` for absolute
+  // specifiers so Windows paths (`D:\a\foo.mjs`) round-trip through Node's ESM
+  // loader as valid `file:///D:/...` URLs instead of `/D:/...`, which Node
+  // re-resolves as `D:\D:\...` (double drive letter).
+  return isAbsolute(specifier)
+    ? pathToFileURL(specifier).href
+    : isBuiltinSpecifier(specifier)
+      ? specifier
+      : resolveModule(specifier, resolveBase);
+};
+
+/**
+ * Compile and instantiate a bundled `.wasm` asset from its base64 content.
+ * Both loaders emit `.wasm` chunks as in-memory asset files because Node's
+ * loader cannot import the virtual dist path.
+ */
+export const loadWasmFromContent = async (
+  content: string,
+  resolvedId: string,
+  returnModule?: boolean,
+): Promise<any> => {
+  const wasmModule = await WebAssembly.compile(Buffer.from(content, 'base64'));
+  const exports = (await WebAssembly.instantiate(wasmModule)).exports as Record<
+    string,
+    any
+  >;
+  return returnModule ? asModule(exports, resolvedId, exports) : exports;
+};
+
+/**
+ * Import an already-resolved module path and apply the CJS-interop policy.
+ *
+ * `returnModule` selects the wrap strategy required by each vm adapter:
+ * - `true`  — wrap the result in a `vm.SyntheticModule` (for `link` /
+ *   `importModuleDynamically` results that must join the module graph).
+ * - `false` — return the namespace (or an interop Proxy) directly for the
+ *   `import()` call site.
+ *
+ * Builtin (`node:`) namespaces are never interop-wrapped: Node already exposes
+ * a proper namespace with both named and default exports, so wrapping it would
+ * only diverge from the real Module Namespace shape.
+ */
+export const finalizeDynamicImport = async ({
+  modulePath,
+  importAttributes,
+  interopDefault,
+  returnModule,
+}: {
+  modulePath: string;
+  importAttributes: ImportCallOptions;
+  interopDefault: boolean;
+  returnModule?: boolean;
+}): Promise<any> => {
+  // Rstest importAttributes is used internally to distinguish `importActual`
+  // and normal imports, and should not be passed to Node.js side, otherwise it
+  // will cause ERR_IMPORT_ATTRIBUTE_UNSUPPORTED error.
+  if (importAttributes?.with?.rstest) {
+    delete importAttributes.with.rstest;
+  }
+
+  if (modulePath.endsWith('.json')) {
+    // `await import(jsonPath)` should return `{ default: jsonExports, ...jsonExports }`.
+    const importedModule = await import(modulePath, {
+      with: { type: 'json' },
+    });
+
+    return returnModule
+      ? asModule(importedModule.default, modulePath, importedModule.default)
+      : {
+          ...importedModule.default,
+          default: importedModule.default,
+        };
+  }
+
+  const importedModule = await import(modulePath, importAttributes);
+
+  if (
+    shouldInterop({
+      interopDefault,
+      modulePath,
+      mod: importedModule,
+    }) &&
+    !modulePath.startsWith('node:')
+  ) {
+    const { mod, defaultExport } = interopModule(importedModule);
+    if (returnModule) {
+      return asModule(mod, modulePath, defaultExport);
+    }
+
+    return createInteropProxy(mod, defaultExport);
+  }
+
+  if (returnModule) {
+    return asModule(importedModule, modulePath, importedModule.default);
+  }
+  return importedModule;
+};

--- a/packages/core/src/runtime/worker/resolveDynamicImport.ts
+++ b/packages/core/src/runtime/worker/resolveDynamicImport.ts
@@ -105,9 +105,13 @@ export const loadWasmFromContent = async (
  * - `false` — return the namespace (or an interop Proxy) directly for the
  *   `import()` call site.
  *
- * Builtin (`node:`) namespaces are never interop-wrapped: Node already exposes
- * a proper namespace with both named and default exports, so wrapping it would
- * only diverge from the real Module Namespace shape.
+ * Builtin namespaces are never interop-wrapped — both the `node:`-prefixed and
+ * the bare spelling (`path`, `fs/promises`), so `import('path')` and
+ * `import('node:path')` resolve identically. Node already exposes a proper
+ * namespace with named + default exports, and `interopModule` is a no-op for
+ * them (their default carries no `__esModule`), so wrapping would only add a
+ * redundant, transparent Proxy. `isBuiltinSpecifier` keeps both spellings on
+ * the same branch.
  */
 export const finalizeDynamicImport = async ({
   modulePath,
@@ -149,7 +153,7 @@ export const finalizeDynamicImport = async ({
       modulePath,
       mod: importedModule,
     }) &&
-    !modulePath.startsWith('node:')
+    !isBuiltinSpecifier(modulePath)
   ) {
     const { mod, defaultExport } = interopModule(importedModule);
     if (returnModule) {

--- a/packages/core/src/runtime/worker/resolveDynamicImport.ts
+++ b/packages/core/src/runtime/worker/resolveDynamicImport.ts
@@ -28,6 +28,17 @@ const importMetaResolve = import.meta.resolve?.bind(import.meta);
 const isBuiltinSpecifier = (specifier: string): boolean =>
   specifier.startsWith('node:') || builtinModules.includes(specifier);
 
+/**
+ * Normalize a builtin specifier to its `node:` canonical form. Node treats the
+ * bare (`path`) and prefixed (`node:path`) spellings as one module, but the
+ * `returnModule` path keys its `SyntheticModule` cache by this id, so a bare id
+ * would split `import('path')` and `import('node:path')` into two distinct
+ * module instances. Every `builtinModules` entry is importable with the `node:`
+ * prefix, so prefixing is always safe.
+ */
+const toNodeBuiltin = (specifier: string): string =>
+  specifier.startsWith('node:') ? specifier : `node:${specifier}`;
+
 const resolveModule = (specifier: string, resolveBase: string): string => {
   const parentURL = resolveBase.startsWith('file:')
     ? resolveBase
@@ -47,8 +58,9 @@ const resolveModule = (specifier: string, resolveBase: string): string => {
  * Resolve a dynamic-import specifier to the module path that Node's loader (or
  * the interop tail below) should consume.
  *
- * - Absolute specifiers and builtins are kept verbatim; everything else is
- *   resolved against the source module's origin.
+ * - Absolute specifiers are kept verbatim (as a `file://` href); builtins are
+ *   normalized to their `node:` canonical form; everything else is resolved
+ *   against the source module's origin.
  * - `origin` is the absolute path of the source module that produced the
  *   `import()` call, injected by rspack's `RstestPlugin` when
  *   `injectDynamicImportOrigin` is enabled, so relative specifiers in bundled
@@ -74,7 +86,7 @@ export const resolveImportSpecifier = ({
   return isAbsolute(specifier)
     ? pathToFileURL(specifier).href
     : isBuiltinSpecifier(specifier)
-      ? specifier
+      ? toNodeBuiltin(specifier)
       : resolveModule(specifier, resolveBase);
 };
 

--- a/packages/core/tests/runner/resolveDynamicImport.test.ts
+++ b/packages/core/tests/runner/resolveDynamicImport.test.ts
@@ -1,0 +1,95 @@
+import { pathToFileURL } from 'node:url';
+import {
+  clearModuleCache as clearEsModuleCache,
+  loadModule as loadEsModule,
+} from '../../src/runtime/worker/loadEsModule';
+import {
+  clearModuleCache as clearCjsModuleCache,
+  loadModule as loadCjsModule,
+} from '../../src/runtime/worker/loadModule';
+import {
+  finalizeDynamicImport,
+  resolveImportSpecifier,
+} from '../../src/runtime/worker/resolveDynamicImport';
+
+describe('resolveImportSpecifier', () => {
+  const testPath = '/virtual/tests/runtime.test.ts';
+
+  it('keeps builtin specifiers verbatim (both `node:`-prefixed and bare)', () => {
+    expect(
+      resolveImportSpecifier({
+        specifier: 'node:fs',
+        origin: undefined,
+        testPath,
+      }),
+    ).toBe('node:fs');
+    expect(
+      resolveImportSpecifier({
+        specifier: 'path',
+        origin: undefined,
+        testPath,
+      }),
+    ).toBe('path');
+  });
+
+  it('returns a file:// href for absolute specifiers (Windows-safe)', () => {
+    const abs = '/abs/dir/foo.mjs';
+    expect(
+      resolveImportSpecifier({ specifier: abs, origin: undefined, testPath }),
+    ).toBe(pathToFileURL(abs).href);
+  });
+});
+
+describe('finalizeDynamicImport — node: interop skip', () => {
+  // Regression for the drift this module collapsed: the `node:` interop-skip
+  // used to live only on the ESM loader, so a CJS `import('node:fs')` was
+  // interop-wrapped (a Proxy) while the ESM path returned the real namespace.
+  // A builtin namespace must come back un-wrapped, so the result is identity-
+  // equal to a direct `import()` rather than a synthetic interop Proxy.
+  it('does not interop-wrap a node: builtin namespace', async () => {
+    const ns = await import('node:path');
+    const result = await finalizeDynamicImport({
+      modulePath: 'node:path',
+      importAttributes: {},
+      interopDefault: true,
+    });
+
+    expect(result).toBe(ns);
+  });
+});
+
+describe('node: dynamic import is consistent across both worker loaders', () => {
+  afterEach(() => {
+    clearEsModuleCache();
+    clearCjsModuleCache();
+  });
+
+  it('CJS loader returns the raw node: namespace', async () => {
+    const exported = loadCjsModule({
+      codeContent: `module.exports = __rstest_dynamic_import__('node:path');`,
+      distPath: '/virtual/dist/entry.js',
+      testPath: '/virtual/tests/runtime.test.ts',
+      rstestContext: {},
+      assetFiles: {},
+      interopDefault: true,
+    });
+
+    expect(await exported).toBe(await import('node:path'));
+  });
+
+  it('ESM loader returns the raw node: namespace', async () => {
+    const mod = await loadEsModule({
+      codeContent: [
+        "const path = await import.meta.__rstest_dynamic_import__('node:path');",
+        'export default path;',
+      ].join('\n'),
+      distPath: '/virtual/dist/entry.mjs',
+      testPath: '/virtual/tests/runtime.test.ts',
+      rstestContext: {},
+      assetFiles: {},
+      interopDefault: true,
+    });
+
+    expect(mod.default).toBe(await import('node:path'));
+  });
+});

--- a/packages/core/tests/runner/resolveDynamicImport.test.ts
+++ b/packages/core/tests/runner/resolveDynamicImport.test.ts
@@ -15,7 +15,8 @@ import {
 describe('resolveImportSpecifier', () => {
   const testPath = '/virtual/tests/runtime.test.ts';
 
-  it('keeps builtin specifiers verbatim (both `node:`-prefixed and bare)', () => {
+  it('normalizes bare builtins to their `node:` canonical form', () => {
+    // Already-prefixed builtins are unchanged (no double prefix).
     expect(
       resolveImportSpecifier({
         specifier: 'node:fs',
@@ -23,13 +24,23 @@ describe('resolveImportSpecifier', () => {
         testPath,
       }),
     ).toBe('node:fs');
+    // Bare builtins are normalized so `import('path')` and `import('node:path')`
+    // share one SyntheticModule cache key on the returnModule path.
     expect(
       resolveImportSpecifier({
         specifier: 'path',
         origin: undefined,
         testPath,
       }),
-    ).toBe('path');
+    ).toBe('node:path');
+    // Slash subpaths (e.g. `fs/promises`) are builtins too.
+    expect(
+      resolveImportSpecifier({
+        specifier: 'fs/promises',
+        origin: undefined,
+        testPath,
+      }),
+    ).toBe('node:fs/promises');
   });
 
   it('returns a file:// href for absolute specifiers (Windows-safe)', () => {
@@ -55,6 +66,33 @@ describe('finalizeDynamicImport — node: interop skip', () => {
     });
 
     expect(result).toBe(ns);
+  });
+});
+
+describe('builtin spelling is canonicalized on the returnModule (link) path', () => {
+  // `import x from 'path'` and `import x from 'node:path'` must link to the
+  // SAME vm.SyntheticModule, matching Node where both resolve to one module.
+  // asModule's smCache is keyed by the resolved id, so resolveImportSpecifier
+  // has to hand both spellings the same `node:` id — otherwise the two would
+  // become distinct module instances on the link / importModuleDynamically path.
+  afterEach(() => {
+    clearCjsModuleCache();
+  });
+
+  const link = (specifier: string) =>
+    finalizeDynamicImport({
+      modulePath: resolveImportSpecifier({
+        specifier,
+        origin: undefined,
+        testPath: '/virtual/tests/runtime.test.ts',
+      }),
+      importAttributes: {},
+      interopDefault: true,
+      returnModule: true,
+    });
+
+  it('bare and node: spelling share one synthetic module', async () => {
+    expect(await link('path')).toBe(await link('node:path'));
   });
 });
 


### PR DESCRIPTION
## Summary

The CJS (`loadModule.ts`) and ESM (`loadEsModule.ts`) worker loaders each carried a private, drifted copy of the dynamic-import resolution + interop policy. The most consequential drift: the `node:` interop-skip lived **only** on the ESM path, so a dynamic `import('node:fs')` from a CJS-mode module was silently interop-wrapped in a Proxy, while the same import on the ESM path returned the real module namespace.

This PR extracts the shared policy into a single `resolveDynamicImport.ts`:

- `resolveImportSpecifier` — origin/builtin/absolute specifier resolution (Windows-safe `file://` href round-tripping).
- `finalizeDynamicImport` — the post-import CJS-interop decision, including the converged `node:` skip.
- `loadWasmFromContent` — base64 `.wasm` compile + instantiate.

The ESM behavior is treated as canonical and the CJS path is converged onto it. **Behavior change:** a CJS-mode `import('node:*')` now returns the real builtin namespace (identity-equal to a direct `import()`) instead of an interop Proxy, matching the ESM path. Each loader keeps its own `vm` state machine and asset handling as the only genuine per-loader adapter, so the two `vm` machines stay independent while the resolution/interop policy lives in one place. Net effect is a sizable dedup (loaders shrink, one shared module added).

A regression test pins the `node:` namespace identity across **both** loaders so the paths can't silently drift apart again.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).