### PR TITLE
refactor(browser): drop unused internal browser surface

### DIFF
--- a/packages/browser-ui/tsconfig.json
+++ b/packages/browser-ui/tsconfig.json
@@ -11,7 +11,6 @@
     "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
     "paths": {
-      "@rstest/browser/rpc-protocol": ["../browser/src/rpcProtocol.ts"],
       "@rstest/browser/protocol": ["../browser/src/protocol.ts"],
       "@rstest/browser/viewport-presets": ["../browser/src/viewportPresets.ts"]
     },

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -10,11 +10,6 @@ import {
 } from './hostController';
 
 export { validateBrowserConfig } from './configValidation';
-export {
-  BROWSER_VIEWPORT_PRESET_DIMENSIONS,
-  BROWSER_VIEWPORT_PRESET_IDS,
-  resolveBrowserViewportPreset,
-} from './viewportPresets';
 
 export async function runBrowserTests(
   context: Rstest,


### PR DESCRIPTION
## Summary

Follow-up to #1358, trimming dead internal surface in browser mode ahead of 1.0:

- Remove the `BROWSER_VIEWPORT_PRESET_DIMENSIONS` / `BROWSER_VIEWPORT_PRESET_IDS` / `resolveBrowserViewportPreset` re-export from `@rstest/browser`'s `./internal` entry (`src/index.ts`). It had **zero consumers**: the package internals import these from `./viewportPresets` by relative path, and the only cross-package user (`@rstest/browser-ui`, which is never published) resolves them through a tsconfig-paths source alias. The re-export only widened the `./internal` surface for nobody, so these symbols are now fully Internal with no published exposure.
- Drop the dead `@rstest/browser/rpc-protocol` tsconfig-paths alias in `browser-ui` (no import sites).

Both are pure removals of unreferenced surface; `@rstest/browser` and `@rstest/browser-ui` typecheck unchanged.

## Related Links

- web-infra-dev/rstest#1294 (item [28])
- web-infra-dev/rstest#1358 (precursor: browser host subpaths moved under `./internal`)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).