### PR TITLE
refactor(core, browser): deepen core↔browser seams and dedupe shared primitives

### DIFF
--- a/packages/browser/src/AGENTS.md
+++ b/packages/browser/src/AGENTS.md
@@ -15,6 +15,9 @@ flowchart LR
     SR["sessionRegistry.ts\nRunnerSessionRegistry"]
     WP["watchRerunPlanner.ts"]
     LS["headlessLatestRerunScheduler.ts"]
+    HT["headlessTransport.ts\nattachHeadlessRunnerTransport()"]
+    CC["concurrency.ts\ngetHeadlessConcurrency()"]
+    HQ["headedSerialTaskQueue.ts\ncreateHeadedSerialTaskQueue()"]
   end
 
   subgraph UI["@rstest/browser-ui container (headed path)"]
@@ -35,6 +38,9 @@ flowchart LR
   WP --> LS
   HC --> RL
   RL --> SR
+  HC --> CC
+  HC --> HQ
+  HC --> HT
 
   UR <--> HC
   MSG --> MH
@@ -42,7 +48,7 @@ flowchart LR
   RPC --> CH
   CH --> UR
 
-  HC -."headless bridge:\nexposeFunction(__rstest_dispatch__, __rstest_dispatch_rpc__)".-> Runner
+  HT -."headless bridge:\nexposeFunction(__rstest_dispatch__, __rstest_dispatch_rpc__)".-> Runner
 ```
 
 ## Headed transport path

--- a/packages/browser/src/concurrency.ts
+++ b/packages/browser/src/concurrency.ts
@@ -1,5 +1,9 @@
-import os from 'node:os';
+import { getNumCpus, parseWorkers } from '@rstest/core/internal/browser';
 import type { Rstest } from '@rstest/core/internal/browser';
+
+// Re-export the shared worker primitives so existing consumers (and unit tests
+// importing from `../src/concurrency`) keep a stable import surface.
+export { getNumCpus, parseWorkers };
 
 // Shared headless concurrency policy.
 // Keep this in one place so executors reuse the same worker semantics.
@@ -11,24 +15,6 @@ type HeadlessConcurrencyContext = Pick<Rstest, 'command'> & {
       maxWorkers?: string | number;
     };
   };
-};
-
-const getNumCpus = (): number => {
-  return os.availableParallelism?.() ?? os.cpus().length;
-};
-
-export const parseWorkers = (
-  maxWorkers: string | number,
-  numCpus = getNumCpus(),
-): number => {
-  const parsed = Number.parseInt(maxWorkers.toString(), 10);
-
-  if (typeof maxWorkers === 'string' && maxWorkers.trim().endsWith('%')) {
-    const workers = Math.floor((parsed / 100) * numCpus);
-    return Math.max(workers, 1);
-  }
-
-  return parsed > 0 ? parsed : 1;
 };
 
 export const resolveDefaultHeadlessWorkers = (

--- a/packages/browser/src/configValidation.ts
+++ b/packages/browser/src/configValidation.ts
@@ -1,4 +1,4 @@
-import type { Rstest } from '@rstest/core/internal/browser';
+import type { RstestContext } from '@rstest/core/internal/browser';
 import { resolveBrowserViewportPreset } from './viewportPresets';
 
 const SUPPORTED_PROVIDERS = ['playwright'] as const;
@@ -42,7 +42,7 @@ const validateViewport = (viewport: unknown): void => {
   );
 };
 
-export const validateBrowserConfig = (context: Rstest): void => {
+export const validateBrowserConfig = (context: RstestContext): void => {
   for (const project of context.projects) {
     const { browser, output } = project.normalizedConfig;
     if (!browser.enabled) {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -22,7 +22,7 @@ import {
   PhaseTracker,
   type ProjectContext,
   type Reporter,
-  type Rstest,
+  type RstestContext,
   type RuntimeConfig,
   resolveProjectBuildCache,
   rsbuild,
@@ -868,7 +868,7 @@ const getRuntimeConfigFromProject = (
   };
 };
 
-const getBrowserProjects = (context: Rstest): ProjectContext[] => {
+const getBrowserProjects = (context: RstestContext): ProjectContext[] => {
   return context.projects.filter(
     (project) => project.normalizedConfig.browser.enabled,
   );
@@ -940,7 +940,7 @@ const resolveProviderForTestPath = ({
 };
 
 const collectProjectEntries = async (
-  context: Rstest,
+  context: RstestContext,
 ): Promise<BrowserProjectEntries[]> => {
   // Only collect entries for browser mode projects
   const browserProjects = getBrowserProjects(context);
@@ -1215,7 +1215,7 @@ const createBrowserRuntime = async ({
   containerDevServer,
   forceHeadless,
 }: {
-  context: Rstest;
+  context: RstestContext;
   manifestPath: string;
   manifestSource: string;
   tempDir: string;
@@ -1681,7 +1681,7 @@ const createBrowserRuntime = async ({
 };
 
 async function resolveProjectEntries(
-  context: Rstest,
+  context: RstestContext,
   shardedEntries?: Map<string, { entries: Record<string, string> }>,
 ): Promise<BrowserProjectEntries[]> {
   if (shardedEntries) {
@@ -1711,7 +1711,7 @@ async function resolveProjectEntries(
 // ============================================================================
 
 export const runBrowserController = async (
-  context: Rstest,
+  context: RstestContext,
   options?: BrowserTestRunOptions,
 ): Promise<BrowserTestRunResult | void> => {
   const {
@@ -3606,7 +3606,7 @@ export type ListBrowserTestsResult = {
  * and collects their test structure (describe/test declarations).
  */
 export const listBrowserTests = async (
-  context: Rstest,
+  context: RstestContext,
   options?: {
     shardedEntries?: Map<string, { entries: Record<string, string> }>;
   },

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,28 +1,44 @@
 import type {
+  BrowserHostModule,
   BrowserTestRunOptions,
   BrowserTestRunResult,
-  Rstest,
+  RstestContext,
 } from '@rstest/core/internal/browser';
+import { validateBrowserConfig } from './configValidation';
 import {
   type ListBrowserTestsResult,
   listBrowserTests as listBrowserTestsImpl,
   runBrowserController,
 } from './hostController';
 
-export { validateBrowserConfig } from './configValidation';
+export { validateBrowserConfig };
 
 export async function runBrowserTests(
-  context: Rstest,
+  context: RstestContext,
   options?: BrowserTestRunOptions,
 ): Promise<BrowserTestRunResult | void> {
   return runBrowserController(context, options);
 }
 
 export async function listBrowserTests(
-  context: Rstest,
+  context: RstestContext,
+  options?: Pick<BrowserTestRunOptions, 'shardedEntries'>,
 ): Promise<ListBrowserTestsResult> {
-  return listBrowserTestsImpl(context);
+  // Forward `options` (e.g. `shardedEntries`) so `rstest list --shard` lists
+  // only the current shard's browser test files, matching the run path.
+  return listBrowserTestsImpl(context, options);
 }
+
+/**
+ * Compile-time guard: ensure the public host exports satisfy the core-owned
+ * {@link BrowserHostModule} contract. This catches drift such as a dropped
+ * `options` argument at the load boundary. No runtime side effect.
+ */
+void ({
+  validateBrowserConfig,
+  runBrowserTests,
+  listBrowserTests,
+} satisfies BrowserHostModule);
 
 export type {
   BrowserTestRunOptions,

--- a/packages/browser/src/watchCliShortcuts.ts
+++ b/packages/browser/src/watchCliShortcuts.ts
@@ -1,8 +1,6 @@
-import { color, logger } from '@rstest/core/internal/browser';
+import { color, isTTY, logger } from '@rstest/core/internal/browser';
 
-const isTTY = (): boolean => Boolean(process.stdin.isTTY && !process.env.CI);
-
-export const isBrowserWatchCliShortcutsEnabled = (): boolean => isTTY();
+export const isBrowserWatchCliShortcutsEnabled = (): boolean => isTTY('stdin');
 
 export const getBrowserWatchCliShortcutsHintMessage = (): string => {
   return `  ${color.dim('press')} ${color.bold('q')} ${color.dim('to quit')}\n`;

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -7,20 +7,15 @@
 // Re-export @rsbuild/core for @rstest/browser to avoid duplicate dependency
 import * as rsbuild from '@rsbuild/core';
 
+// Core-owned contract for the host module that @rstest/browser implements
+export type { BrowserHostModule } from './core/browserLoader';
 // Re-export Rstest type for convenience
 export type { Rstest } from './core/rstest';
 // Coverage support for browser mode
 export { createCoverageProvider, loadCoverageProvider } from './coverage';
-// Runtime API
-export { createRstestRuntime } from './runtime/api';
-// Public runtime API (for browser client usage)
-// These are the test APIs that run in the browser (describe, it, expect, etc.)
-export * from './runtime/api/public';
-export { setRealTimers } from './runtime/util';
 // Trace primitives — the browser host instantiates PhaseTracker per test file
 // and forwards its events via `BrowserTestRunOptions.onTraceEvents`.
 export { PhaseTracker } from './runtime/worker/phaseTracker';
-export type { TraceEvent } from './utils/trace';
 // Types
 export type {
   BrowserTestRunOptions,
@@ -31,6 +26,7 @@ export type {
   ListCommandResult,
   ProjectContext,
   Reporter,
+  RstestContext,
   RunnerHooks,
   RuntimeConfig,
   Test,
@@ -44,15 +40,14 @@ export {
   color,
   getNoTestFilesMessage,
   isDebug,
+  isTTY,
   logger,
   serializableConfig,
 } from './utils';
+// Worker concurrency primitives shared with @rstest/browser
+export { getNumCpus, parseWorkers } from './utils/workers';
 // Constants
-export {
-  globalApis,
-  resolveProjectBuildCache,
-  TEMP_RSTEST_OUTPUT_DIR,
-} from './utils/constants';
+export { resolveProjectBuildCache } from './utils/constants';
 export { getSetupFiles } from './utils/getSetupFiles';
 export { getTestEntries } from './utils/testFiles';
 export { rsbuild };

--- a/packages/core/src/core/browserLoader.ts
+++ b/packages/core/src/core/browserLoader.ts
@@ -4,25 +4,30 @@ import type {
   BrowserTestRunOptions,
   BrowserTestRunResult,
   ListCommandResult,
+  RstestContext,
 } from '../types';
 import { color, logger } from '../utils';
 
 export type { BrowserTestRunOptions, BrowserTestRunResult } from '../types';
 
 /**
- * Type definition for the @rstest/browser internal exports.
+ * Core-owned contract for the `@rstest/browser/internal` host module.
+ *
+ * This is the single source of truth for the core↔browser load boundary:
+ * `loadBrowserModule` returns it, and `@rstest/browser`'s public entry
+ * constrains its exports against it via `satisfies`. The `context` is typed
+ * as {@link RstestContext} (not `unknown`) so drift between the two sides —
+ * such as a dropped `options` argument — surfaces as a type error.
  */
-interface BrowserModule {
-  validateBrowserConfig: (context: unknown) => void;
+export interface BrowserHostModule {
+  validateBrowserConfig: (context: RstestContext) => void;
   runBrowserTests: (
-    context: unknown,
+    context: RstestContext,
     options?: BrowserTestRunOptions,
   ) => Promise<BrowserTestRunResult | void>;
   listBrowserTests: (
-    context: unknown,
-    options?: {
-      shardedEntries?: Map<string, { entries: Record<string, string> }>;
-    },
+    context: RstestContext,
+    options?: Pick<BrowserTestRunOptions, 'shardedEntries'>,
   ) => Promise<{
     list: ListCommandResult[];
     close: () => Promise<void>;
@@ -53,11 +58,11 @@ interface LoadBrowserModuleOptions {
  */
 export async function loadBrowserModule(
   options: LoadBrowserModuleOptions = {},
-): Promise<BrowserModule> {
+): Promise<BrowserHostModule> {
   const coreVersion = RSTEST_VERSION;
   const { projectRoots = [], embedded = false } = options;
 
-  let browserModule: BrowserModule;
+  let browserModule: BrowserHostModule;
   let browserVersion: string;
 
   // Build resolution bases list with project roots first
@@ -83,7 +88,11 @@ export async function loadBrowserModule(
         '@rstest/browser/package.json',
       );
 
-      browserModule = await import(pathToFileURL(browserPath).href);
+      // The dynamic import namespace is unknown-shaped; the runtime contract is
+      // guaranteed on the `@rstest/browser` side via `satisfies BrowserHostModule`.
+      browserModule = (await import(
+        pathToFileURL(browserPath).href
+      )) as BrowserHostModule;
       const browserPkg = userRequire(browserPkgPath);
       browserVersion = browserPkg.version;
 

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -4,23 +4,6 @@ declare const RSTEST_VERSION: string;
 declare const RSTEST_SELF_CI: boolean;
 declare const PLAYWRIGHT_VERSION: string;
 
-/**
- * Module declaration for @rstest/browser/internal (optional peer dependency).
- * These host-side entries live on the `./internal` subpath, not the public `.`
- * entry; core loads them via `@rstest/browser/internal` (see browserLoader.ts).
- * The actual types come from the package when installed.
- */
-declare module '@rstest/browser/internal' {
-  import type { ListCommandResult, RstestContext } from './types';
-
-  export function validateBrowserConfig(context: RstestContext): void;
-  export function runBrowserTests(context: RstestContext): Promise<void>;
-  export function listBrowserTests(context: RstestContext): Promise<{
-    list: ListCommandResult[];
-    close: () => Promise<void>;
-  }>;
-}
-
 declare module '@rstest/browser/package.json' {
   const content: {
     name: string;

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -1,4 +1,3 @@
-import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import type { SnapshotUpdateState } from '@vitest/snapshot';
 import { basename, dirname, join, resolve } from 'pathe';
@@ -28,28 +27,13 @@ import {
 } from '../utils';
 import { type TraceEvent, type TraceSpan, noopTraceSpan } from '../utils/trace';
 import { isMemorySufficient } from '../utils/memory';
+import { getNumCpus, parseWorkers } from '../utils/workers';
 import { selectMemoryGate } from './memoryGate';
 import { Pool } from './pool';
 import type { PoolWorkerKind } from './types';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-const getNumCpus = (): number => {
-  return os.availableParallelism?.() ?? os.cpus().length;
-};
-
-const parseWorkers = (maxWorkers: string | number): number => {
-  const parsed = Number.parseInt(maxWorkers.toString(), 10);
-
-  if (typeof maxWorkers === 'string' && maxWorkers.trim().endsWith('%')) {
-    const numCpus = getNumCpus();
-    const workers = Math.floor((parsed / 100) * numCpus);
-    return Math.max(workers, 1);
-  }
-
-  return parsed > 0 ? parsed : 1;
-};
 
 const getRuntimeConfig = (context: ProjectContext): RuntimeConfig => {
   const {
@@ -374,11 +358,11 @@ export const createPool = async ({
       : Math.min(recommendWorkerCount, threadsCount);
 
   const maxWorkers = poolOptions.maxWorkers
-    ? parseWorkers(poolOptions.maxWorkers)
+    ? parseWorkers(poolOptions.maxWorkers, numCpus)
     : recommendCount;
 
   const minWorkers = poolOptions.minWorkers
-    ? parseWorkers(poolOptions.minWorkers)
+    ? parseWorkers(poolOptions.minWorkers, numCpus)
     : maxWorkers < recommendCount
       ? maxWorkers
       : recommendCount;

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -111,6 +111,12 @@ export type RstestContext = {
     results: TestFileResult[];
     testResults: TestResult[];
   };
+  /** Merge a batch of file/test results into `reporterResults`. */
+  updateReporterResultState: (
+    results: TestFileResult[],
+    testResults: TestResult[],
+    deletedEntries?: string[],
+  ) => void;
 };
 
 export type ListCommandOptions = {

--- a/packages/core/src/utils/workers.ts
+++ b/packages/core/src/utils/workers.ts
@@ -1,0 +1,20 @@
+import os from 'node:os';
+
+export const getNumCpus = (): number => {
+  return os.availableParallelism?.() ?? os.cpus().length;
+};
+
+export const parseWorkers = (
+  maxWorkers: string | number,
+  numCpus?: number,
+): number => {
+  const parsed = Number.parseInt(maxWorkers.toString(), 10);
+
+  if (typeof maxWorkers === 'string' && maxWorkers.trim().endsWith('%')) {
+    // Resolve the CPU count lazily — only the percentage path needs it.
+    const workers = Math.floor((parsed / 100) * (numCpus ?? getNumCpus()));
+    return Math.max(workers, 1);
+  }
+
+  return parsed > 0 ? parsed : 1;
+};


### PR DESCRIPTION
## Summary

The `@rstest/core` ↔ `@rstest/browser` boundary had accumulated several drifting seams: the same primitives were hand-copied across the package line, the `internal/browser` barrel re-exported dead runtime APIs, and the load-time host contract was declared three times with `unknown`-typed context — which let a real bug slip past the type checker. This PR deepens those seams into single owners and tightens the contract.

- **Single-owner worker concurrency**: extract `getNumCpus`/`parseWorkers` into `core/src/utils/workers.ts` (keeping the injectable `numCpus` test seam, resolved lazily) and consume it from both `pool` and `browser/concurrency` instead of two byte-identical copies.
- **Reuse `isTTY`**: re-export core's `isTTY` through the `internal/browser` barrel and call `isTTY('stdin')` in `watchCliShortcuts` instead of forking the `process.stdin.isTTY && !process.env.CI` predicate.
- **Narrow the `@rstest/core/internal/browser` barrel**: drop the dead web-runtime re-exports (`createRstestRuntime`, `runtime/api/public`, `setRealTimers`, `TraceEvent`, `globalApis`, `TEMP_RSTEST_OUTPUT_DIR`); `browserRuntime.ts` remains the single source for the web runtime test surface.
- **Unify the load contract**: collapse the three drifted declarations into one core-owned `BrowserHostModule` (typed on `RstestContext`), constrained on the public side with `satisfies` and deleting the dead `@rstest/browser/internal` ambient module. `RstestContext` now declares `updateReporterResultState`, so the host can be typed end-to-end without casting.
- **Behavior fix**: the public `listBrowserTests` wrapper silently dropped its `options`, so `rstest list --shard` listed *all* browser test files instead of the current shard's subset (the run path already forwarded `shardedEntries`). The wrapper now forwards `options`, matching the run path.
- **Docs**: fix the `browser/src/AGENTS.md` module topology — add the missing scheduling nodes (`headlessTransport`, `concurrency`, `headedSerialTaskQueue`) and give the headless-bridge edge an owning node.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).