### PR TITLE
fix(core): type runtime hook registration as sync

### DIFF
--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -91,7 +91,7 @@ class RunnerRuntime {
   afterAll(
     fn: AfterAllListener,
     timeout: number = this.runtimeConfig.hookTimeout,
-  ): MaybePromise<void> {
+  ): void {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
       currentSuite,
@@ -108,7 +108,7 @@ class RunnerRuntime {
   beforeAll(
     fn: BeforeAllListener,
     timeout: number = this.runtimeConfig.hookTimeout,
-  ): MaybePromise<void> {
+  ): void {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
       currentSuite,
@@ -125,7 +125,7 @@ class RunnerRuntime {
   afterEach(
     fn: AfterEachListener,
     timeout: number = this.runtimeConfig.hookTimeout,
-  ): MaybePromise<void> {
+  ): void {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
       currentSuite,
@@ -142,7 +142,7 @@ class RunnerRuntime {
   beforeEach(
     fn: BeforeEachListener,
     timeout: number = this.runtimeConfig.hookTimeout,
-  ): MaybePromise<void> {
+  ): void {
     const currentSuite = this.getCurrentSuite();
     registerTestSuiteListener(
       currentSuite,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -233,10 +233,10 @@ export type RunnerAPI = {
   describe: DescribeAPI;
   it: TestAPIs;
   test: TestAPIs;
-  beforeAll: (fn: BeforeAllListener, timeout?: number) => MaybePromise<void>;
-  afterAll: (fn: AfterAllListener, timeout?: number) => MaybePromise<void>;
-  beforeEach: (fn: BeforeEachListener, timeout?: number) => MaybePromise<void>;
-  afterEach: (fn: AfterEachListener, timeout?: number) => MaybePromise<void>;
+  beforeAll: (fn: BeforeAllListener, timeout?: number) => void;
+  afterAll: (fn: AfterAllListener, timeout?: number) => void;
+  beforeEach: (fn: BeforeEachListener, timeout?: number) => void;
+  afterEach: (fn: AfterEachListener, timeout?: number) => void;
   onTestFinished: (fn: OnTestFinishedHandler, timeout?: number) => void;
   onTestFailed: (fn: OnTestFailedHandler, timeout?: number) => void;
 };


### PR DESCRIPTION
## Summary

- Narrow the return type of the `beforeAll`, `afterAll`, `beforeEach`, and `afterEach` registration APIs to `void`. The previous `MaybePromise<void>` return type could make type-aware lint rules such as `@typescript-eslint/no-floating-promises` report normal hook registration calls as unhandled promises, even though registration is synchronous.
- Keep the hook callback listener types as `MaybePromise` so async hooks and returned cleanup functions continue to work as before.
- Align the registration return type with Vitest's hook API typing, which also exposes these hook registration functions as returning `void`.
- This fits the 1.0 API stabilization work because it tightens the public hook registration contract before the API is locked.

## Related Links

- https://github.com/web-infra-dev/rstest/issues/1294
- https://typescript-eslint.io/rules/no-floating-promises/
- https://github.com/vitest-dev/vitest/blob/main/packages/runner/src/hooks.ts#L154

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).