### PR TITLE
refactor(core): own runtime-contract grammar for chunk names and worker import hooks

### DIFF
--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -1,10 +1,14 @@
 import path from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import pathe from 'pathe';
+import {
+  importMetaHook,
+  RSTEST_DYNAMIC_IMPORT_HOOK,
+  RSTEST_REQUIRE_RESOLVE_HOOK,
+} from '../../runtime/worker/runtimeHooks';
 import type { RstestContext } from '../../types';
 import { getTempRstestOutputDir, resolveProjectBuildCache } from '../../utils';
-
-export const RUNTIME_CHUNK_NAME = 'runtime';
+import { runtimeChunkNameForEnvironment } from '../runtimeChunk';
 
 const requireShim = `// Rstest ESM shims
 import __rstest_shim_module__ from 'node:module';
@@ -116,8 +120,8 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
               // the dynamic-import-origin rewrite onto a dedicated rspack
               // option so the two concerns stop sharing one identifier.
               config.output.importFunctionName = outputModule
-                ? 'import.meta.__rstest_dynamic_import__'
-                : '__rstest_dynamic_import__';
+                ? importMetaHook(RSTEST_DYNAMIC_IMPORT_HOOK)
+                : RSTEST_DYNAMIC_IMPORT_HOOK;
               config.output.devtoolModuleFilenameTemplate =
                 '[absolute-resource-path]';
 
@@ -142,8 +146,8 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 // call, instead of the test entry, fixing #848.
                 injectRequireResolveOrigin: {
                   functionName: outputModule
-                    ? 'import.meta.__rstest_require_resolve__'
-                    : '__rstest_require_resolve__',
+                    ? importMetaHook(RSTEST_REQUIRE_RESOLVE_HOOK)
+                    : RSTEST_REQUIRE_RESOLVE_HOOK,
                 },
               };
 
@@ -216,7 +220,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 ...(config.optimization || {}),
                 // make sure setup file and test file share the runtime
                 runtimeChunk: {
-                  name: `${name}-${RUNTIME_CHUNK_NAME}`,
+                  name: runtimeChunkNameForEnvironment(name),
                 },
               };
             },

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -16,7 +16,7 @@ import type {
 } from '../types';
 import { isDebug } from '../utils';
 import { isMemorySufficient } from '../utils/memory';
-import { pluginBasic, RUNTIME_CHUNK_NAME } from './plugins/basic';
+import { pluginBasic } from './plugins/basic';
 import { pluginCSSFilter } from './plugins/css-filter';
 import { pluginEntryWatch } from './plugins/entry';
 import { pluginExternal } from './plugins/external';
@@ -24,6 +24,7 @@ import { pluginIgnoreResolveError } from './plugins/ignoreResolveError';
 import { pluginInspect } from './plugins/inspect';
 import { pluginMockRuntime } from './plugins/mockRuntime';
 import { pluginCacheControl } from './plugins/moduleCacheControl';
+import { isRuntimeChunk, runtimeChunkNameForEnvironment } from './runtimeChunk';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -45,10 +46,7 @@ const getRuntimeChunkFiles = ({
   const runtimeChunkFiles = new Set<string>();
 
   for (const chunk of chunks || []) {
-    const isRuntimeChunk =
-      chunk.id === runtimeChunkName || chunk.names?.includes(runtimeChunkName);
-
-    if (!isRuntimeChunk) {
+    if (!isRuntimeChunk(chunk, runtimeChunkName)) {
       continue;
     }
 
@@ -221,14 +219,13 @@ const calcEntriesToRerun = (
   const runtimeChunkFiles = new Set(buildData.runtimeChunkFiles || []);
 
   for (const chunk of chunks || []) {
-    const isRuntimeChunk =
-      chunk.id === runtimeChunkName || chunk.names?.includes(runtimeChunkName);
+    const chunkIsRuntime = isRuntimeChunk(chunk, runtimeChunkName);
 
     for (const file of chunk.files || []) {
       const filePath = path.join(outputPath, String(file));
       chunkHashesByFile.set(filePath, chunk.hash ?? '');
 
-      if (isRuntimeChunk) {
+      if (chunkIsRuntime) {
         runtimeChunkFiles.add(filePath);
       }
     }
@@ -539,7 +536,7 @@ export const createRsbuildServer = async ({
     const runtimeChunkFiles = getRuntimeChunkFiles({
       chunks,
       outputPath: outputPath!,
-      runtimeChunkName: `${environmentName}-${RUNTIME_CHUNK_NAME}`,
+      runtimeChunkName: runtimeChunkNameForEnvironment(environmentName),
     });
     const entries: EntryInfo[] = [];
     const setupEntries: EntryInfo[] = [];
@@ -623,7 +620,7 @@ export const createRsbuildServer = async ({
           chunks,
           buildData[environmentName],
           outputPath!,
-          `${environmentName}-${RUNTIME_CHUNK_NAME}`,
+          runtimeChunkNameForEnvironment(environmentName),
           setupEntries,
         )
       : { affectedEntries: [], deletedEntries: [] };

--- a/packages/core/src/core/runtimeChunk.ts
+++ b/packages/core/src/core/runtimeChunk.ts
@@ -1,0 +1,26 @@
+import type { Rspack } from '@rsbuild/core';
+
+/** Base name for the Rstest runtime chunk shared by setup and test files. */
+export const RUNTIME_CHUNK_BASE_NAME = 'runtime';
+
+/**
+ * Derive the per-environment runtime chunk name (e.g. `node-runtime`).
+ *
+ * Single source of truth for the producer (rspack `runtimeChunk.name` in
+ * `core/plugins/basic.ts`) and the build/watch consumers that look the chunk
+ * back up by name in `rsbuild.ts`.
+ */
+export const runtimeChunkNameForEnvironment = (
+  environmentName: string,
+): string => `${environmentName}-${RUNTIME_CHUNK_BASE_NAME}`;
+
+/**
+ * Identify the runtime chunk within a build's stats chunks. Matches on either
+ * the chunk id or its names, mirroring how rspack reports the runtime chunk.
+ */
+export const isRuntimeChunk = (
+  chunk: Pick<Rspack.StatsChunk, 'id' | 'names'>,
+  runtimeChunkName: string,
+): boolean =>
+  chunk.id === runtimeChunkName ||
+  (chunk.names?.includes(runtimeChunkName) ?? false);

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -9,6 +9,10 @@ import {
   loadWasmFromContent,
   resolveImportSpecifier,
 } from './resolveDynamicImport';
+import {
+  RSTEST_DYNAMIC_IMPORT_HOOK,
+  RSTEST_REQUIRE_RESOLVE_HOOK,
+} from './runtimeHooks';
 
 export enum EsmMode {
   Unknown = 0,
@@ -177,7 +181,7 @@ export const loadModule = async ({
           distPath === runtimeDistPath ? distPath : testPath,
         ).toString();
         // @ts-expect-error
-        meta.__rstest_dynamic_import__ = defineRstestDynamicImport({
+        meta[RSTEST_DYNAMIC_IMPORT_HOOK] = defineRstestDynamicImport({
           assetFiles,
           testPath,
           distPath: distPath || testPath,
@@ -187,7 +191,7 @@ export const loadModule = async ({
           esmMode: EsmMode.Unknown,
         });
         // @ts-expect-error
-        meta.__rstest_require_resolve__ = defineRstestRequireResolve({
+        meta[RSTEST_REQUIRE_RESOLVE_HOOK] = defineRstestRequireResolve({
           assetFiles,
           testPath,
           distPath: distPath || testPath,

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -9,6 +9,10 @@ import {
   loadWasmFromContent,
   resolveImportSpecifier,
 } from './resolveDynamicImport';
+import {
+  RSTEST_DYNAMIC_IMPORT_HOOK,
+  RSTEST_REQUIRE_RESOLVE_HOOK,
+} from './runtimeHooks';
 
 const isRelativePath = (p: string) => /^\.\.?\//.test(p);
 
@@ -204,12 +208,12 @@ export const loadModule = ({
         );
       }
     },
-    __rstest_dynamic_import__: defineRstestDynamicImport({
+    [RSTEST_DYNAMIC_IMPORT_HOOK]: defineRstestDynamicImport({
       testPath,
       interopDefault,
       assetFiles,
     }),
-    __rstest_require_resolve__: defineRstestRequireResolve({
+    [RSTEST_REQUIRE_RESOLVE_HOOK]: defineRstestRequireResolve({
       testPath,
       distPath,
       assetFiles,

--- a/packages/core/src/runtime/worker/runtimeHooks.ts
+++ b/packages/core/src/runtime/worker/runtimeHooks.ts
@@ -1,0 +1,20 @@
+/**
+ * Magic-identifier contract between the build-time injection (rspack plugin in
+ * `core/plugins/basic.ts`) and the VM worker loaders (`loadModule.ts` /
+ * `loadEsModule.ts`).
+ *
+ * The bundle rewrites `import()` / `require.resolve()` callees to these names,
+ * and the worker exposes byte-identical names in VM scope (CJS) or on
+ * `import.meta` (ESM). Owning the spelling here keeps the emit and consume sides
+ * from drifting. These identifiers are VM-internal and must stay out of every
+ * public/internal barrel.
+ */
+export const RSTEST_DYNAMIC_IMPORT_HOOK = '__rstest_dynamic_import__' as const;
+export const RSTEST_REQUIRE_RESOLVE_HOOK =
+  '__rstest_require_resolve__' as const;
+
+/**
+ * Derive the `import.meta.`-prefixed emit form used in the ESM / `outputModule`
+ * path (the bare form is used for the CJS path).
+ */
+export const importMetaHook = (name: string): string => `import.meta.${name}`;

--- a/packages/core/tests/core/runtimeChunk.test.ts
+++ b/packages/core/tests/core/runtimeChunk.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  isRuntimeChunk,
+  RUNTIME_CHUNK_BASE_NAME,
+  runtimeChunkNameForEnvironment,
+} from '../../src/core/runtimeChunk';
+
+describe('runtime chunk grammar', () => {
+  it('derives the per-environment runtime chunk name', () => {
+    expect(RUNTIME_CHUNK_BASE_NAME).toBe('runtime');
+    // Pins the exact strings the rsbuild snapshot asserts.
+    expect(runtimeChunkNameForEnvironment('test')).toBe('test-runtime');
+    expect(runtimeChunkNameForEnvironment('test-node')).toBe(
+      'test-node-runtime',
+    );
+  });
+
+  it('identifies the runtime chunk by id or names membership', () => {
+    expect(
+      isRuntimeChunk({ id: 'test-runtime', names: [] }, 'test-runtime'),
+    ).toBe(true);
+    expect(
+      isRuntimeChunk({ id: 'x', names: ['a', 'test-runtime'] }, 'test-runtime'),
+    ).toBe(true);
+    expect(
+      isRuntimeChunk({ id: 'main', names: ['main'] }, 'test-runtime'),
+    ).toBe(false);
+    expect(isRuntimeChunk({ id: 'main' }, 'test-runtime')).toBe(false);
+  });
+});

--- a/packages/core/tests/runner/requireResolveOrigin.test.ts
+++ b/packages/core/tests/runner/requireResolveOrigin.test.ts
@@ -10,6 +10,10 @@ import {
   clearModuleCache as clearCjsModuleCache,
   loadModule,
 } from '../../src/runtime/worker/loadModule';
+import {
+  importMetaHook,
+  RSTEST_REQUIRE_RESOLVE_HOOK,
+} from '../../src/runtime/worker/runtimeHooks';
 
 describe('require.resolve origin runtime helper', () => {
   afterEach(() => {
@@ -26,7 +30,7 @@ describe('require.resolve origin runtime helper', () => {
     const testPath = path.join(dir, 'test', 'template.spec.ts');
     const origin = path.join(depDir, 'index.js');
     const exports = loadModule({
-      codeContent: `module.exports = __rstest_require_resolve__('./exportHelper', ${JSON.stringify(origin)});`,
+      codeContent: `module.exports = ${RSTEST_REQUIRE_RESOLVE_HOOK}('./exportHelper', ${JSON.stringify(origin)});`,
       distPath: path.join(dir, 'bundle.js'),
       testPath,
       rstestContext: {},
@@ -53,7 +57,7 @@ describe('require.resolve origin runtime helper', () => {
 
     const origin = path.join(dir, 'src', 'index.js');
     const exports = loadModule({
-      codeContent: `module.exports = __rstest_require_resolve__('foo', { paths: [${JSON.stringify(targetDir)}] }, ${JSON.stringify(origin)});`,
+      codeContent: `module.exports = ${RSTEST_REQUIRE_RESOLVE_HOOK}('foo', { paths: [${JSON.stringify(targetDir)}] }, ${JSON.stringify(origin)});`,
       distPath: path.join(dir, 'bundle.js'),
       testPath: path.join(dir, 'test.spec.ts'),
       rstestContext: {},
@@ -95,7 +99,7 @@ describe('require.resolve origin runtime helper', () => {
 
     const origin = path.join(depDir, 'index.mjs');
     const mod = await loadEsModule({
-      codeContent: `export default import.meta.__rstest_require_resolve__('./exportHelper', ${JSON.stringify(origin)});`,
+      codeContent: `export default ${importMetaHook(RSTEST_REQUIRE_RESOLVE_HOOK)}('./exportHelper', ${JSON.stringify(origin)});`,
       distPath: path.join(dir, 'bundle.mjs'),
       testPath: path.join(dir, 'test.spec.ts'),
       rstestContext: {},

--- a/packages/core/tests/runner/resolveDynamicImport.test.ts
+++ b/packages/core/tests/runner/resolveDynamicImport.test.ts
@@ -11,6 +11,10 @@ import {
   finalizeDynamicImport,
   resolveImportSpecifier,
 } from '../../src/runtime/worker/resolveDynamicImport';
+import {
+  importMetaHook,
+  RSTEST_DYNAMIC_IMPORT_HOOK,
+} from '../../src/runtime/worker/runtimeHooks';
 
 describe('resolveImportSpecifier', () => {
   const testPath = '/virtual/tests/runtime.test.ts';
@@ -104,7 +108,7 @@ describe('node: dynamic import is consistent across both worker loaders', () => 
 
   it('CJS loader returns the raw node: namespace', async () => {
     const exported = loadCjsModule({
-      codeContent: `module.exports = __rstest_dynamic_import__('node:path');`,
+      codeContent: `module.exports = ${RSTEST_DYNAMIC_IMPORT_HOOK}('node:path');`,
       distPath: '/virtual/dist/entry.js',
       testPath: '/virtual/tests/runtime.test.ts',
       rstestContext: {},
@@ -118,7 +122,7 @@ describe('node: dynamic import is consistent across both worker loaders', () => 
   it('ESM loader returns the raw node: namespace', async () => {
     const mod = await loadEsModule({
       codeContent: [
-        "const path = await import.meta.__rstest_dynamic_import__('node:path');",
+        `const path = await ${importMetaHook(RSTEST_DYNAMIC_IMPORT_HOOK)}('node:path');`,
         'export default path;',
       ].join('\n'),
       distPath: '/virtual/dist/entry.mjs',

--- a/packages/core/tests/runtime/worker/runtimeHooks.test.ts
+++ b/packages/core/tests/runtime/worker/runtimeHooks.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  importMetaHook,
+  RSTEST_DYNAMIC_IMPORT_HOOK,
+  RSTEST_REQUIRE_RESOLVE_HOOK,
+} from '../../../src/runtime/worker/runtimeHooks';
+
+describe('runtime hook identifier contract', () => {
+  it('pins the wire spelling shared by the rspack plugin and the VM loaders', () => {
+    // These strings are a cross-tool contract: rspack rewrites import() /
+    // require.resolve() callees to them and the VM loaders must expose the
+    // byte-identical names. An accidental rename must break this unit test.
+    expect(RSTEST_DYNAMIC_IMPORT_HOOK).toBe('__rstest_dynamic_import__');
+    expect(RSTEST_REQUIRE_RESOLVE_HOOK).toBe('__rstest_require_resolve__');
+  });
+
+  it('derives the import.meta emit form for the ESM path', () => {
+    expect(importMetaHook(RSTEST_DYNAMIC_IMPORT_HOOK)).toBe(
+      'import.meta.__rstest_dynamic_import__',
+    );
+    expect(importMetaHook(RSTEST_REQUIRE_RESOLVE_HOOK)).toBe(
+      'import.meta.__rstest_require_resolve__',
+    );
+  });
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -12,6 +12,7 @@ brotli
 browserslistrc
 bundleless
 bytedance
+callees
 caniuse
 canyonjs
 catchable


### PR DESCRIPTION
## Summary

Independent, behavior-preserving refactor — one of a series that splits a larger core↔browser seam cleanup into separately reviewable PRs.

The runtime chunk-name format and the dynamic-import / require-resolve magic-hook identifiers were duplicated across the build plugin, the rsbuild integration, and the CJS/ESM worker loaders. This PR gives each a single owner:

- `runtimeChunk.ts` owns the `<env>-runtime` chunk-name format and the `isRuntimeChunk` predicate.
- `runtimeHooks.ts` owns the `__rstest_dynamic_import__` / `__rstest_require_resolve__` identifiers and the `import.meta.<hook>` form.

Consumers (`plugins/basic.ts`, `rsbuild.ts`, `loadModule.ts`, `loadEsModule.ts`) now import from these owners. Generated chunk names and hook identifiers are byte-identical, so there is no behavior change.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
