### PR TITLE
fix(core): prevent late console logs from failing the run (isolate: false)

### DIFF
--- a/e2e/log/console-hook-error.test.ts
+++ b/e2e/log/console-hook-error.test.ts
@@ -1,0 +1,36 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Companion to `late-console.test.ts` for https://github.com/web-infra-dev/rstest/issues/1367.
+// The worker forwards console output fire-and-forget (it never awaits the
+// result, and swallows the rejected send), so a user `onConsoleLog` filter (or a
+// reporter's `onUserConsoleLog`) that throws while the host handles a forwarded
+// log cannot travel back to fail the test — and would be hidden by that swallow.
+// The host must surface that error as a diagnostic instead, while the passing
+// test stays green. Assert this for both pools (the host handler is pool-agnostic).
+describe('console hook error (issue #1367)', () => {
+  for (const pool of ['forks', 'threads'] as const) {
+    it(`should surface a throwing onConsoleLog hook without failing the run (${pool} pool)`, async () => {
+      const { cli, expectExecSuccess } = await runRstestCli({
+        command: 'rstest',
+        args: ['run', '--pool', pool],
+        options: {
+          nodeOptions: {
+            cwd: join(__dirname, 'fixtures/console-hook-error'),
+          },
+        },
+      });
+
+      await expectExecSuccess();
+
+      // The hook error must be surfaced on the host, not silently swallowed.
+      expect(cli.log).toContain('Failed to handle console log');
+      expect(cli.log).toContain('onConsoleLog hook boom');
+    });
+  }
+});

--- a/e2e/log/fixtures/console-hook-error/a.test.ts
+++ b/e2e/log/fixtures/console-hook-error/a.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@rstest/core';
+
+test('passes even though the onConsoleLog hook throws', () => {
+  console.log('hello from a');
+  expect(1).toBe(1);
+});

--- a/e2e/log/fixtures/console-hook-error/rstest.config.ts
+++ b/e2e/log/fixtures/console-hook-error/rstest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  // A user `onConsoleLog` filter that throws. The worker forwards console output
+  // fire-and-forget (it never awaits the result), so this host-side error cannot
+  // travel back to the worker — the host must surface it as a diagnostic without
+  // failing the (passing) test.
+  onConsoleLog: () => {
+    throw new Error('onConsoleLog hook boom');
+  },
+});

--- a/e2e/log/fixtures/late-console/a.test.ts
+++ b/e2e/log/fixtures/late-console/a.test.ts
@@ -1,0 +1,17 @@
+import { test } from '@rstest/core';
+
+// A captured `console` reference, like a logger that grabs `console` once.
+const log = globalThis.console;
+
+test('schedules console calls that outlive the test file', () => {
+  // None of these are awaited, so they fire after this file's tests finish. With
+  // `isolate: false` the host disposes this file's birpc channel as soon as the
+  // file finishes, but the worker only closes it once the next file starts.
+  // Spread the logs across that handoff window so some fire while the channel is
+  // disposed-but-open and the later one fires after the worker has closed it.
+  // The forward rejects in both cases; neither may crash the run.
+  for (let delay = 0; delay <= 60; delay += 5) {
+    setTimeout(() => log.log('late log from a.test.ts'), delay);
+  }
+  setTimeout(() => log.log('late log from a.test.ts'), 250);
+});

--- a/e2e/log/fixtures/late-console/b.test.ts
+++ b/e2e/log/fixtures/late-console/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '@rstest/core';
+
+test('keeps the worker alive while a.test.ts logs late', async () => {
+  // Stay running long enough for a.test.ts's late `setTimeout` to fire.
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+});

--- a/e2e/log/fixtures/late-console/rstest.config.ts
+++ b/e2e/log/fixtures/late-console/rstest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  // `isolate` is driven per case by the test via `--isolate`. Run files
+  // sequentially on a single worker so that, under `isolate: false`, `a.test.ts`
+  // and `b.test.ts` share one process and exercise the closed-channel path.
+  pool: { maxWorkers: 1 },
+  // Suppress all console output. A late log that outlives its file must not only
+  // avoid crashing the run, it must also stay suppressed — forwarding it after
+  // teardown (or writing it to the raw stream) would bypass this filter.
+  onConsoleLog: () => false,
+});

--- a/e2e/log/late-console.test.ts
+++ b/e2e/log/late-console.test.ts
@@ -1,0 +1,46 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Regression test for https://github.com/web-infra-dev/rstest/issues/1367.
+// `a.test.ts` captures a `console` reference and flushes it from `setTimeout`s
+// that outlive the file. With `isolate: false` every file shares one worker, so
+// the late logs fire after the host has disposed a's birpc channel (and, later,
+// after the worker has closed it). Forwarding such a log used to leave a pending
+// birpc request that `$close()` rejected as `[birpc] rpc is closed`, failing the
+// run and misattributing it to `b.test.ts`.
+//
+// Forwarding is now best-effort: the worker never awaits the forward and
+// swallows the rejected send, so a late log can neither crash the run nor leak
+// past the `onConsoleLog: () => false` suppression filter. Assert this across
+// both pools and both isolate modes: with `isolate: true` each file gets a fresh
+// worker so the bug cannot occur, which guards against a regression that only
+// fixes one mode.
+describe('late console log (issue #1367)', () => {
+  for (const pool of ['forks', 'threads'] as const) {
+    for (const isolate of [true, false] as const) {
+      it(`should not fail the run when a console call outlives its test file (${pool} pool, isolate: ${isolate})`, async () => {
+        const { cli, expectExecSuccess } = await runRstestCli({
+          command: 'rstest',
+          args: ['run', '--pool', pool, '--isolate', String(isolate)],
+          options: {
+            nodeOptions: {
+              cwd: join(__dirname, 'fixtures/late-console'),
+            },
+          },
+        });
+
+        await expectExecSuccess();
+
+        // The late log must not crash the run via a closed/disposed channel...
+        expect(cli.log).not.toContain('rpc is closed');
+        // ...and it must stay suppressed, not leak to the raw worker stream.
+        expect(cli.log).not.toContain('late log from a.test.ts');
+      });
+    }
+  }
+});

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -22,6 +22,7 @@ import {
   color,
   getForceColorEnv,
   isDeno,
+  logger,
   needFlagExperimentalDetectModule,
   toError,
 } from '../utils';
@@ -311,13 +312,24 @@ export const createPool = async ({
     log: UserConsoleLog;
     projectConfig: ProjectContext['normalizedConfig'];
   }): Promise<void> => {
-    if (!shouldEmitUserConsoleLog({ log, projectConfig })) {
-      return;
-    }
+    // The worker forwards console output fire-and-forget (see `emitInterceptedLog`
+    // in runInPool): a delivery failure is dropped silently in the worker, and an
+    // error thrown here cannot travel back to fail the originating test — the
+    // worker's swallow would hide it. A user `onConsoleLog` filter or a reporter
+    // `onUserConsoleLog` that throws is a real defect, though, so surface it here
+    // on the host — where it occurs — rather than letting it vanish. This keeps
+    // console handling best-effort without hiding bugs.
+    try {
+      if (!shouldEmitUserConsoleLog({ log, projectConfig })) {
+        return;
+      }
 
-    await Promise.all(
-      reporters.map((reporter) => reporter.onUserConsoleLog?.(log)),
-    );
+      await Promise.all(
+        reporters.map((reporter) => reporter.onUserConsoleLog?.(log)),
+      );
+    } catch (error) {
+      logger.error(color.red('Failed to handle console log:'), toError(error));
+    }
   };
 
   // Propagate parent execArgv to workers, except flags known to cause issues

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -167,8 +167,20 @@ const preparePool = async (
       disableConsoleIntercept,
       silent,
     },
-    emitInterceptedLog: async (log) => {
-      await rpc.onConsoleLog(log);
+    emitInterceptedLog: (log) => {
+      // Forwarding console output to the host is best-effort, fire-and-forget:
+      // the result is never awaited. With `isolate: false` a captured console
+      // (e.g. a logger that flushes from a late `setTimeout`/microtask) can fire
+      // after this file's birpc channel has been closed or disposed by the host,
+      // so the call rejects — immediately once the channel is `$close()`d, or
+      // later when `$close()` rejects the still-pending request. Swallowing it
+      // drops such an orphan log instead of surfacing an `unhandledRejection`
+      // that fails the run and is misattributed to whichever file is currently
+      // running. A dropped late log also stays subject to the host's
+      // `onConsoleLog` policy, matching `isolate: true` where late logs are lost
+      // as the worker is torn down.
+      // See https://github.com/web-infra-dev/rstest/issues/1367.
+      void rpc.onConsoleLog(log).catch(() => {});
     },
     writeOriginalLog: createOriginalLogWriter(),
   });

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -84,6 +84,7 @@ menlo
 metafile
 microfrontend
 microfrontends
+misattributed
 mjsx
 modu
 modularly


### PR DESCRIPTION
## Summary

With `isolate: false`, all test files share one worker but each file owns its own birpc channel. The host disposes a file's channel as soon as the file finishes, while the worker only closes it when the next file starts. A console reference captured by a file (e.g. a logger that flushes from a late `setTimeout`/microtask) could fire in or after that window and forward the log over a disposed/closed channel.

The console interceptor does not await the forward, so the rejected send surfaced as an `unhandledRejection` (`[birpc] rpc is closed`) that **failed the run even though every assertion passed**, and **blamed the wrong file** — whichever happened to be running when the late log fired.

Console forwarding is best-effort, with two failure modes now handled at their own layer:

- **Delivery failures** (a disposed/closed channel, a teardown race) are an expected lifecycle artifact. The worker forwards the log fire-and-forget and swallows the rejected send, so the late log is dropped instead of crashing the run — matching `isolate: true` where such logs are lost as the worker is torn down.
- **Handler failures** (a user `onConsoleLog` filter or a reporter's `onUserConsoleLog` throwing) would otherwise be hidden by that swallow. The host now surfaces them where they occur, without failing the otherwise-passing run.

The change lives in the pool-agnostic worker/host paths, so it applies to both the `forks` and `threads` pools.

Originally surfaced while migrating Rsbuild's e2e runner to rstest (web-infra-dev/rsbuild#7776), then reduced to the minimal repro in #1367.

## Related Links

- Closes #1367
- Originally found in web-infra-dev/rsbuild#7776 — https://github.com/web-infra-dev/rsbuild/pull/7776

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
