### PR TITLE
refactor(core): gate global setup once and co-locate run verdict

### DIFF
--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -1,7 +1,7 @@
 import { type ChildProcess, type ForkOptions, fork } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'pathe';
-import type { EntryInfo, FormattedError } from '../types';
+import type { EntryInfo, FormattedError, ProjectContext } from '../types';
 import {
   bgColor,
   color,
@@ -9,6 +9,35 @@ import {
   getWorkerSerialization,
   killAndWait,
 } from '../utils';
+
+/**
+ * Single owner of the once-per-project global-setup gate.
+ *
+ * Global setup runs at most once per project and only when the project has at
+ * least one running test. This collapses the read-check-and-set that was
+ * hand-copied across {@link runTests} and {@link listTests} into one named,
+ * test-covered operation, preserving the exact short-circuit order and the
+ * set-before-await semantics (a failed setup is not retried within the run).
+ *
+ * The `_globalSetups` marker lives on the per-project {@link ProjectContext} and
+ * is intentionally never reset between watch reruns — only re-seeded `false`
+ * when a fresh context is constructed — so this helper mutates the passed object
+ * by reference and never touches module-level state.
+ *
+ * @returns `true` when the caller should run global setup now (and the marker
+ * has been claimed); `false` otherwise.
+ */
+export function claimGlobalSetupOnce(
+  project: Pick<ProjectContext, '_globalSetups'>,
+  entriesLength: number,
+  globalSetupEntriesLength: number,
+): boolean {
+  if (!(entriesLength && globalSetupEntriesLength) || project._globalSetups) {
+    return false;
+  }
+  project._globalSetups = true;
+  return true;
+}
 
 const CLOSE_TIMEOUT_MS = 10_000;
 

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -21,7 +21,11 @@ import {
   ROOT_SUITE_NAME,
   resolveShardedEntries,
 } from '../utils';
-import { runGlobalSetup, runGlobalTeardown } from './globalSetup';
+import {
+  claimGlobalSetupOnce,
+  runGlobalSetup,
+  runGlobalTeardown,
+} from './globalSetup';
 import { createRsbuildServer, prepareRsbuild } from './rsbuild';
 
 type ListedTest = {
@@ -220,11 +224,8 @@ const collectNodeTests = async ({
       } = await getRsbuildStats({ environmentName: project.environmentName });
 
       if (
-        entries.length &&
-        globalSetupEntries.length &&
-        !project._globalSetups
+        claimGlobalSetupOnce(project, entries.length, globalSetupEntries.length)
       ) {
-        project._globalSetups = true;
         const files = globalSetupEntries.flatMap((e) => e.files!);
         const assetFilesPromise = getAssetFiles(files);
         const sourceMapsPromise = getSourceMaps(files);

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -28,7 +28,11 @@ import {
   loadBrowserModule,
 } from './browserLoader';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
-import { runGlobalSetup, runGlobalTeardown } from './globalSetup';
+import {
+  claimGlobalSetupOnce,
+  runGlobalSetup,
+  runGlobalTeardown,
+} from './globalSetup';
 import { createRsbuildServer, prepareRsbuild } from './rsbuild';
 import type { Rstest } from './rstest';
 
@@ -593,10 +597,11 @@ export async function runTests(context: Rstest): Promise<void> {
 
         testStart ??= Date.now();
 
-        // Global setup only run once per project
-        // Global setup runs only if there is at least one running test
-        if (entries.length && globalSetupEntries.length && !p._globalSetups) {
-          p._globalSetups = true;
+        // Global setup runs once per project, only if there is at least one
+        // running test.
+        if (
+          claimGlobalSetupOnce(p, entries.length, globalSetupEntries.length)
+        ) {
           const files = globalSetupEntries.flatMap((e) => e.files!);
           const globalSetupTraceArgs = {
             project: p.name,
@@ -725,6 +730,12 @@ export async function runTests(context: Rstest): Promise<void> {
         return sourceMap ? JSON.parse(sourceMap) : null;
       };
 
+      // Reduce the per-environment worker returns (and, when unifying reporter
+      // output, the browser result) into the run verdict. The only side effects
+      // are merging browser coverage into `mergedCoverageMap` and stripping it
+      // from the browser results to avoid reporter/state cache bloat (mirrors
+      // the node-side pool layer's `delete result.coverage`).
+
       // When unifying reporter output, combine browser and node durations
       const duration: Duration =
         shouldUnifyReporter && browserResult
@@ -765,12 +776,6 @@ export async function runTests(context: Rstest): Promise<void> {
         errors.push(...browserResult.unhandledErrors);
       }
 
-      context.updateReporterResultState(
-        results,
-        testResults,
-        currentDeletedEntries,
-      );
-
       // Check for failures including browser results when unified
       const nodeHasFailure =
         results.some((r) => r.status === 'fail') || errors.length;
@@ -779,11 +784,17 @@ export async function runTests(context: Rstest): Promise<void> {
 
       const noTestsDiscovered = results.length === 0 && !errors.length;
 
+      const isFailure = nodeHasFailure || browserHasFailure;
+
+      context.updateReporterResultState(
+        results,
+        testResults,
+        currentDeletedEntries,
+      );
+
       if (noTestsDiscovered) {
         reportNoTestFiles({ context, mode });
       }
-
-      const isFailure = nodeHasFailure || browserHasFailure;
 
       if (isFailure) {
         process.exitCode = 1;

--- a/packages/core/tests/core/globalSetup.test.ts
+++ b/packages/core/tests/core/globalSetup.test.ts
@@ -1,7 +1,38 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { describe, expect, it } from '@rstest/core';
-import { GlobalSetupWorker } from '../../src/core/globalSetup';
+import {
+  claimGlobalSetupOnce,
+  GlobalSetupWorker,
+} from '../../src/core/globalSetup';
+
+describe('claimGlobalSetupOnce', () => {
+  it('claims the gate once when there are running tests and setup entries', () => {
+    const project = { _globalSetups: false };
+    expect(claimGlobalSetupOnce(project, 3, 1)).toBe(true);
+    expect(project._globalSetups).toBe(true);
+    // Idempotent: a second call does not re-run setup.
+    expect(claimGlobalSetupOnce(project, 3, 1)).toBe(false);
+  });
+
+  it('does not claim when there are no running tests', () => {
+    const project = { _globalSetups: false };
+    expect(claimGlobalSetupOnce(project, 0, 1)).toBe(false);
+    expect(project._globalSetups).toBe(false);
+  });
+
+  it('does not claim when there are no global setup entries', () => {
+    const project = { _globalSetups: false };
+    expect(claimGlobalSetupOnce(project, 3, 0)).toBe(false);
+    expect(project._globalSetups).toBe(false);
+  });
+
+  it('does not re-claim when the marker is already set', () => {
+    const project = { _globalSetups: true };
+    expect(claimGlobalSetupOnce(project, 3, 1)).toBe(false);
+    expect(project._globalSetups).toBe(true);
+  });
+});
 
 class MockChildProcess extends EventEmitter {
   stdout = new EventEmitter();


### PR DESCRIPTION
## Summary

Internal refactor with no behavior or public API change.

- **Single-owner global-setup gate.** The once-per-project guard (`entries.length && globalSetupEntries.length && !project._globalSetups`, then claim the marker *before* awaiting setup) was hand-copied in both `runTests` and `listTests`. A drift in that read-check-set — e.g. losing the set-before-await ordering — would let global setup run twice or be retried after a failure. This collapses both copies into a named, test-covered `claimGlobalSetupOnce(project, entriesLength, globalSetupEntriesLength)` that owns the exact short-circuit order and set-before-await semantics. The `_globalSetups` marker still lives on `ProjectContext` and is still never reset between watch reruns.
- **Co-locate the run verdict.** In `runTests`, the failure flags (`nodeHasFailure` / `browserHasFailure` / `noTestsDiscovered` / `isFailure`) are now derived in the same place as the rest of the per-environment reduction (`results` / `testResults` / `errors` / `duration` and the browser coverage merge), so the whole run verdict is computed once, before the reporter state update — instead of being split across two points around `updateReporterResultState`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).