### PR TITLE
refactor(core): single-source reporter run-count derivation and CLI/init owners

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -220,45 +220,54 @@ const applyRuntimeCommandOptions = (command: Command): void => {
   applyOptions(command, poolOptionDefinitions);
 };
 
+/**
+ * Derives the set of option names that consume a following value-bearing
+ * argument, directly from the cac option definitions. cac treats an option as
+ * value-taking when its rawName carries a `<required>` or `[optional]` token,
+ * so any rawName containing a `<` or `[` is value-taking — the same way cac
+ * classifies each option when it parses the rawName. Every comma-separated
+ * alias before the first such token (e.g. both `-c` and `--config`) is
+ * registered.
+ *
+ * Single owner: previously this was a hand-maintained literal that had to be
+ * kept byte-for-byte in sync with the five option-definition arrays — adding a
+ * new value-taking flag silently desynced argument splitting in
+ * {@link getCliCommand}. Tokens stay RAW (no de-dashing/camelCasing) because
+ * they are matched against `arg.split('=', 1)[0]`.
+ */
+const valueTakingOptionNames = (
+  definitions: readonly OptionDefinition[][],
+): Set<string> => {
+  const names = new Set<string>();
+  for (const group of definitions) {
+    for (const [rawName] of group) {
+      // The aliases end at the first `<required>` / `[optional]` token; an
+      // option with neither token is a boolean flag, which is not value-taking.
+      const lt = rawName.indexOf('<');
+      const sq = rawName.indexOf('[');
+      if (lt < 0 && sq < 0) {
+        continue;
+      }
+      const tokenAt = lt < 0 ? sq : sq < 0 ? lt : Math.min(lt, sq);
+      for (const alias of rawName.slice(0, tokenAt).split(',')) {
+        const trimmed = alias.trim();
+        if (trimmed) {
+          names.add(trimmed);
+        }
+      }
+    }
+  }
+  return names;
+};
+
 const commands = new Set(['init', 'list', 'merge-reports', 'run', 'watch']);
 
-const valueTakingOptions = new Set([
-  '-c',
-  '-r',
-  '-t',
-  '--bail',
-  '--browser.name',
-  '--browser.port',
-  '--changed',
-  '--config',
-  '--config-loader',
-  '--coverage.changed',
-  '--coverage.exclude',
-  '--coverage.include',
-  '--coverage.provider',
-  '--coverage.reporters',
-  '--coverage.reportsDirectory',
-  '--exclude',
-  '--hookTimeout',
-  '--include',
-  '--json',
-  '--maxConcurrency',
-  '--pool',
-  '--pool.execArgv',
-  '--pool.maxWorkers',
-  '--pool.minWorkers',
-  '--pool.type',
-  '--project',
-  '--reporter',
-  '--reporters',
-  '--retry',
-  '--root',
-  '--shard',
-  '--silent',
-  '--slowTestThreshold',
-  '--testEnvironment',
-  '--testNamePattern',
-  '--testTimeout',
+export const valueTakingOptions: Set<string> = valueTakingOptionNames([
+  runtimeOptionDefinitions,
+  poolOptionDefinitions,
+  mergeReportsOptionDefinitions,
+  hiddenPassthroughOptionDefinitions,
+  listCommandOptionDefinitions,
 ]);
 
 const getCliCommand = (argv: string[]): string | undefined => {

--- a/packages/core/src/cli/init/browser/create.ts
+++ b/packages/core/src/cli/init/browser/create.ts
@@ -14,9 +14,13 @@ import { color, determineAgent } from '../../../utils';
 import { detectProject } from './detect';
 import type { BrowserProvider, Framework } from './templates';
 import {
+  BROWSER_TEST_SCRIPT_KEY,
+  DEFAULT_COMPONENT_BASE_NAME,
+  getBrowserTestScript,
   getConfigFileName,
   getConfigTemplate,
   getDependenciesWithVersions,
+  getFileExtensions,
   getInstallCommand,
   getPlaywrightInstallCommand,
   getReactComponentTemplate,
@@ -24,6 +28,8 @@ import {
   getRunCommand,
   getVanillaComponentTemplate,
   getVanillaTestTemplate,
+  resolveEffectiveFramework,
+  rewriteComponentImport,
 } from './templates';
 import {
   ensureDir,
@@ -78,25 +84,21 @@ function computeFilePreview(
   projectInfo: ProjectInfo,
 ): FilePreview {
   const { language, testDir, framework } = projectInfo;
-  const effectiveFramework: Framework =
-    framework === 'react' ? 'react' : 'vanilla';
+  const effectiveFramework = resolveEffectiveFramework(framework);
 
   const configFile = getConfigFileName();
 
-  // Determine file extensions based on framework and language
-  let componentExt: string;
-  let testExt: string;
-
-  if (effectiveFramework === 'react') {
-    componentExt = language === 'ts' ? '.tsx' : '.jsx';
-    testExt = language === 'ts' ? '.test.tsx' : '.test.jsx';
-  } else {
-    componentExt = language === 'ts' ? '.ts' : '.js';
-    testExt = language === 'ts' ? '.test.ts' : '.test.js';
-  }
+  const { componentExt, testExt } = getFileExtensions(
+    effectiveFramework,
+    language,
+  );
 
   const testDirPath = path.join(cwd, testDir);
-  const baseName = getUniqueBaseName(testDirPath, 'Counter', componentExt);
+  const baseName = getUniqueBaseName(
+    testDirPath,
+    DEFAULT_COMPONENT_BASE_NAME,
+    componentExt,
+  );
 
   return {
     configFile,
@@ -166,8 +168,7 @@ async function createInteractive(
   isAgent: boolean,
 ): Promise<void> {
   const { agent, language, testDir, framework, reactVersion } = projectInfo;
-  const effectiveFramework: Framework =
-    framework === 'react' ? 'react' : 'vanilla';
+  const effectiveFramework = resolveEffectiveFramework(framework);
 
   intro(color.bold(color.magenta('Set up Rstest browser mode')));
 
@@ -287,8 +288,7 @@ async function generateFiles(
   provider: BrowserProvider,
 ): Promise<string[]> {
   const { language, testDir, framework } = projectInfo;
-  const effectiveFramework: Framework =
-    framework === 'react' ? 'react' : 'vanilla';
+  const effectiveFramework = resolveEffectiveFramework(framework);
   const createdFiles: string[] = [];
 
   // 1. Create config file
@@ -302,19 +302,17 @@ async function generateFiles(
   ensureDir(testDirPath);
 
   // 3. Create example files based on framework
-  let componentExt: string;
-  let testExt: string;
-
-  if (effectiveFramework === 'react') {
-    componentExt = language === 'ts' ? '.tsx' : '.jsx';
-    testExt = language === 'ts' ? '.test.tsx' : '.test.jsx';
-  } else {
-    componentExt = language === 'ts' ? '.ts' : '.js';
-    testExt = language === 'ts' ? '.test.ts' : '.test.js';
-  }
+  const { componentExt, testExt } = getFileExtensions(
+    effectiveFramework,
+    language,
+  );
 
   // Get unique base name to avoid conflicts
-  const baseName = getUniqueBaseName(testDirPath, 'Counter', componentExt);
+  const baseName = getUniqueBaseName(
+    testDirPath,
+    DEFAULT_COMPONENT_BASE_NAME,
+    componentExt,
+  );
 
   // Create component file
   const componentFileName = `${baseName}${componentExt}`;
@@ -331,32 +329,18 @@ async function generateFiles(
   const testFileName = `${baseName}${testExt}`;
   const testPath = path.join(testDirPath, testFileName);
 
-  let testContent: string;
-  if (effectiveFramework === 'react') {
-    testContent = getReactTestTemplate(language);
-    // Update import path if using non-default name
-    if (baseName !== 'Counter') {
-      testContent = testContent.replace(
-        /from '\.\/Counter\.(tsx|jsx)'/,
-        `from './${baseName}.$1'`,
-      );
-    }
-  } else {
-    testContent = getVanillaTestTemplate(language);
-    // Update import path if using non-default name
-    if (baseName !== 'Counter') {
-      testContent = testContent.replace(
-        /from '\.\/Counter\.(ts|js)'/,
-        `from './${baseName}.$1'`,
-      );
-    }
-  }
+  const baseTestContent =
+    effectiveFramework === 'react'
+      ? getReactTestTemplate(language)
+      : getVanillaTestTemplate(language);
+  // Point the example-component import at the deduplicated base name.
+  const testContent = rewriteComponentImport(baseTestContent, baseName);
   writeFile(testPath, testContent);
   createdFiles.push(`${testDir}/${testFileName}`);
 
   // 4. Update package.json scripts
   updatePackageJsonScripts(cwd, {
-    'test:browser': 'rstest --config=rstest.browser.config.mts',
+    [BROWSER_TEST_SCRIPT_KEY]: getBrowserTestScript(),
   });
 
   // 5. Add devDependencies to package.json

--- a/packages/core/src/cli/init/browser/templates.ts
+++ b/packages/core/src/cli/init/browser/templates.ts
@@ -4,6 +4,62 @@ import { resolveCommand } from 'package-manager-detector/commands';
 export type Framework = 'react' | 'vanilla';
 export type BrowserProvider = 'playwright';
 
+/** Base name of the example component emitted by the init templates. */
+export const DEFAULT_COMPONENT_BASE_NAME = 'Counter';
+
+/**
+ * Collapses a detected framework (which may be undetected/`null`) into the
+ * concrete template family. Single owner of the `react ? react : vanilla`
+ * decision that the interactive, non-interactive, preview, and generate paths
+ * previously each re-encoded.
+ */
+export function resolveEffectiveFramework(
+  framework: 'react' | null,
+): Framework {
+  return framework === 'react' ? 'react' : 'vanilla';
+}
+
+/**
+ * Owns the framework + language → file-extension matrix shared by the file
+ * preview and the file generation step (previously duplicated verbatim in both).
+ */
+export function getFileExtensions(
+  framework: Framework,
+  language: 'ts' | 'js',
+): { componentExt: string; testExt: string } {
+  if (framework === 'react') {
+    return {
+      componentExt: language === 'ts' ? '.tsx' : '.jsx',
+      testExt: language === 'ts' ? '.test.tsx' : '.test.jsx',
+    };
+  }
+  return {
+    componentExt: language === 'ts' ? '.ts' : '.js',
+    testExt: language === 'ts' ? '.test.ts' : '.test.js',
+  };
+}
+
+/**
+ * Rewrites the example-component import in a generated test file to follow a
+ * deduplicated base name. The test templates always import from
+ * `./Counter.<ext>`; when the component is written under a non-default name
+ * (e.g. `Counter_1`), the import must track it. Owns the `Counter` literal and
+ * the extension-agnostic import grammar so {@link getReactTestTemplate} /
+ * {@link getVanillaTestTemplate} and the caller no longer re-encode either.
+ */
+export function rewriteComponentImport(
+  content: string,
+  baseName: string,
+): string {
+  if (baseName === DEFAULT_COMPONENT_BASE_NAME) {
+    return content;
+  }
+  return content.replace(
+    /from '\.\/Counter\.(tsx|jsx|ts|js)'/,
+    `from './${baseName}.$1'`,
+  );
+}
+
 /**
  * Get rstest.config.mts template content.
  */
@@ -218,13 +274,16 @@ export function getPlaywrightInstallCommand(
   return [resolved.command, ...resolved.args].join(' ');
 }
 
+/** package.json script key registered by the browser-mode init flow. */
+export const BROWSER_TEST_SCRIPT_KEY = 'test:browser';
+
 /**
  * Get run command for the package manager.
  */
 export function getRunCommand(agent: Agent): string {
-  const resolved = resolveCommand(agent, 'run', ['test:browser']);
+  const resolved = resolveCommand(agent, 'run', [BROWSER_TEST_SCRIPT_KEY]);
   if (!resolved) {
-    return 'npm run test:browser';
+    return `npm run ${BROWSER_TEST_SCRIPT_KEY}`;
   }
   return [resolved.command, ...resolved.args].join(' ');
 }
@@ -234,4 +293,13 @@ export function getRunCommand(agent: Agent): string {
  */
 export function getConfigFileName(): string {
   return 'rstest.browser.config.mts';
+}
+
+/**
+ * The `test:browser` package.json script command. Composed from
+ * {@link getConfigFileName} at call time so the config filename has exactly one
+ * owner — the script value can never drift from the file actually written.
+ */
+export function getBrowserTestScript(): string {
+  return `rstest --config=${getConfigFileName()}`;
 }

--- a/packages/core/src/core/mergeReports.ts
+++ b/packages/core/src/core/mergeReports.ts
@@ -4,7 +4,7 @@ import {
   createCoverageProvider,
   ensureCoverageProviderInstalled,
 } from '../coverage';
-import type { BlobData } from '../reporter/blob';
+import { type BlobData, isBlobFile } from '../reporter/blob';
 import type {
   CoverageMapData,
   Duration,
@@ -26,9 +26,7 @@ function loadBlobFiles(blobDir: string): BlobData[] {
     );
   }
 
-  const files = readdirSync(blobDir)
-    .filter((f) => /^blob(-\d+-\d+)?\.json$/.test(f))
-    .sort();
+  const files = readdirSync(blobDir).filter(isBlobFile).sort();
 
   if (files.length === 0) {
     throw new Error(

--- a/packages/core/src/reporter/blob.ts
+++ b/packages/core/src/reporter/blob.ts
@@ -26,6 +26,21 @@ export type BlobData = {
 
 const DEFAULT_OUTPUT_DIR = '.rstest-reports';
 
+/**
+ * Single owner of the on-disk blob filename grammar. The writer (this module)
+ * and the merge reader (`mergeReports.ts`) previously encoded the
+ * `blob[-index-count].json` shape independently — a string template here and a
+ * hand-written regexp there — so a rename would silently desync the two sides.
+ */
+export const blobFileName = (shard?: {
+  index: number;
+  count: number;
+}): string => (shard ? `blob-${shard.index}-${shard.count}.json` : 'blob.json');
+
+export const BLOB_FILE_RE: RegExp = /^blob(-\d+-\d+)?\.json$/;
+
+export const isBlobFile = (name: string): boolean => BLOB_FILE_RE.test(name);
+
 export class BlobReporter implements Reporter {
   private readonly config: NormalizedConfig;
   private readonly outputDir: string;
@@ -66,9 +81,7 @@ export class BlobReporter implements Reporter {
     unhandledErrors?: Error[];
   }): Promise<void> {
     const shard = this.config.shard;
-    const fileName = shard
-      ? `blob-${shard.index}-${shard.count}.json`
-      : 'blob.json';
+    const fileName = blobFileName(shard);
 
     const blobData: BlobData = {
       version: RSTEST_VERSION,

--- a/packages/core/src/reporter/json.ts
+++ b/packages/core/src/reporter/json.ts
@@ -12,6 +12,7 @@ import type {
   UserConsoleLog,
 } from '../types';
 import { getTaskNameWithPrefix, logger } from '../utils';
+import { deriveRunCounts } from './utils';
 
 type JsonReport = {
   tool: 'rstest';
@@ -99,17 +100,10 @@ export class JsonReporter implements Reporter {
     snapshotSummary: SnapshotSummary;
     unhandledErrors?: Error[];
   }): JsonReport {
-    const failedTests = testResults.filter(
-      (result) => result.status === 'fail',
-    );
-    const passedTests = testResults.filter(
-      (result) => result.status === 'pass',
-    );
-    const skippedTests = testResults.filter(
-      (result) => result.status === 'skip',
-    );
-    const todoTests = testResults.filter((result) => result.status === 'todo');
-    const failedFiles = results.filter((result) => result.status === 'fail');
+    const { failedTests, failedFiles, counts } = deriveRunCounts({
+      results,
+      testResults,
+    });
     const noTestsDiscovered = results.length === 0 && testResults.length === 0;
     const hasFailedStatus =
       failedTests.length > 0 ||
@@ -121,15 +115,7 @@ export class JsonReporter implements Reporter {
       tool: 'rstest',
       version: RSTEST_VERSION,
       status: hasFailedStatus ? 'fail' : 'pass',
-      summary: {
-        testFiles: results.length,
-        failedFiles: failedFiles.length,
-        tests: testResults.length,
-        failedTests: failedTests.length,
-        passedTests: passedTests.length,
-        skippedTests: skippedTests.length,
-        todoTests: todoTests.length,
-      },
+      summary: counts,
       durationMs: {
         total: duration.totalTime,
         build: duration.buildTime,

--- a/packages/core/src/reporter/md.ts
+++ b/packages/core/src/reporter/md.ts
@@ -100,6 +100,7 @@ import type {
 import {
   buildPackageManagerReproCommand,
   collectFailures,
+  deriveRunCounts,
   detectPackageManagerAgent,
   ensureSingleBlankLine,
   type FailureItem,
@@ -909,17 +910,14 @@ export class MdReporter implements Reporter {
       ? await detectPackageManagerAgent(rootPath)
       : 'npm';
 
-    const failedTests = testResults.filter(
-      (result) => result.status === 'fail',
-    );
-    const passedTests = testResults.filter(
-      (result) => result.status === 'pass',
-    );
-    const skippedTests = testResults.filter(
-      (result) => result.status === 'skip',
-    );
-    const todoTests = testResults.filter((result) => result.status === 'todo');
-    const failedFiles = results.filter((result) => result.status === 'fail');
+    const {
+      failedTests,
+      passedTests,
+      skippedTests,
+      todoTests,
+      failedFiles,
+      counts,
+    } = deriveRunCounts({ results, testResults });
     const status =
       failedTests.length || failedFiles.length || unhandledErrors?.length
         ? 'fail'
@@ -929,15 +927,7 @@ export class MdReporter implements Reporter {
 
     const summaryPayload: Record<string, unknown> = {
       status,
-      counts: {
-        testFiles: results.length,
-        failedFiles: failedFiles.length,
-        tests: testResults.length,
-        failedTests: failedTests.length,
-        passedTests: passedTests.length,
-        skippedTests: skippedTests.length,
-        todoTests: todoTests.length,
-      },
+      counts,
       durationMs: {
         total: duration.totalTime,
         build: duration.buildTime,

--- a/packages/core/src/reporter/utils.ts
+++ b/packages/core/src/reporter/utils.ts
@@ -17,6 +17,58 @@ import {
   prettyTime,
 } from '../utils';
 
+/**
+ * Single owner of the run-end per-status partition and the 7-field counts
+ * struct shared by the md and json reporters (previously hand-copied,
+ * byte-identical, in both). Only the count derivation is shared — the pass/fail
+ * verdict deliberately stays per-reporter because md and json disagree on the
+ * empty-run case.
+ */
+export const deriveRunCounts = ({
+  results,
+  testResults,
+}: {
+  results: TestFileResult[];
+  testResults: TestResult[];
+}): {
+  failedTests: TestResult[];
+  passedTests: TestResult[];
+  skippedTests: TestResult[];
+  todoTests: TestResult[];
+  failedFiles: TestFileResult[];
+  counts: {
+    testFiles: number;
+    failedFiles: number;
+    tests: number;
+    failedTests: number;
+    passedTests: number;
+    skippedTests: number;
+    todoTests: number;
+  };
+} => {
+  const failedTests = testResults.filter((result) => result.status === 'fail');
+  const passedTests = testResults.filter((result) => result.status === 'pass');
+  const skippedTests = testResults.filter((result) => result.status === 'skip');
+  const todoTests = testResults.filter((result) => result.status === 'todo');
+  const failedFiles = results.filter((result) => result.status === 'fail');
+  return {
+    failedTests,
+    passedTests,
+    skippedTests,
+    todoTests,
+    failedFiles,
+    counts: {
+      testFiles: results.length,
+      failedFiles: failedFiles.length,
+      tests: testResults.length,
+      failedTests: failedTests.length,
+      passedTests: passedTests.length,
+      skippedTests: skippedTests.length,
+      todoTests: todoTests.length,
+    },
+  };
+};
+
 const statusStr = {
   fail: '✗',
   pass: '✓',

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeCliFilters,
   resolveChangedFiles,
   validateRelatedCliOptions,
+  valueTakingOptions,
 } from '../../src/cli/commands';
 
 const renderHelp = (argv: string[]): string => {
@@ -28,6 +29,57 @@ const renderHelp = (argv: string[]): string => {
 
   return logs.join('\n');
 };
+
+describe('valueTakingOptions (derived from option definitions)', () => {
+  it('derives exactly the value-taking option names across all definition groups', () => {
+    expect([...valueTakingOptions].sort()).toEqual(
+      [
+        '-c',
+        '-r',
+        '-t',
+        '--bail',
+        '--browser.name',
+        '--browser.port',
+        '--changed',
+        '--config',
+        '--config-loader',
+        '--coverage.changed',
+        '--coverage.exclude',
+        '--coverage.include',
+        '--coverage.provider',
+        '--coverage.reporters',
+        '--coverage.reportsDirectory',
+        '--exclude',
+        '--hookTimeout',
+        '--include',
+        '--json',
+        '--maxConcurrency',
+        '--pool',
+        '--pool.execArgv',
+        '--pool.maxWorkers',
+        '--pool.minWorkers',
+        '--pool.type',
+        '--project',
+        '--reporter',
+        '--reporters',
+        '--retry',
+        '--root',
+        '--shard',
+        '--silent',
+        '--slowTestThreshold',
+        '--testEnvironment',
+        '--testNamePattern',
+        '--testTimeout',
+      ].sort(),
+    );
+  });
+
+  it('excludes boolean flags that take no value', () => {
+    expect(valueTakingOptions.has('--globals')).toBe(false);
+    expect(valueTakingOptions.has('--isolate')).toBe(false);
+    expect(valueTakingOptions.has('--coverage')).toBe(false);
+  });
+});
 
 describe('CLI help output', () => {
   it('shows list-specific options for list help', () => {

--- a/packages/core/tests/cli/initBrowserTemplates.test.ts
+++ b/packages/core/tests/cli/initBrowserTemplates.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  BROWSER_TEST_SCRIPT_KEY,
+  DEFAULT_COMPONENT_BASE_NAME,
+  getBrowserTestScript,
+  getConfigFileName,
+  getFileExtensions,
+  getReactTestTemplate,
+  getVanillaTestTemplate,
+  resolveEffectiveFramework,
+  rewriteComponentImport,
+} from '../../src/cli/init/browser/templates';
+
+describe('browser init layout owners', () => {
+  it('composes the test:browser script from the owned config filename', () => {
+    expect(getBrowserTestScript()).toBe(
+      `rstest --config=${getConfigFileName()}`,
+    );
+    expect(BROWSER_TEST_SCRIPT_KEY).toBe('test:browser');
+  });
+
+  it('collapses a detected framework into a concrete template family', () => {
+    expect(resolveEffectiveFramework('react')).toBe('react');
+    expect(resolveEffectiveFramework(null)).toBe('vanilla');
+  });
+
+  it('derives the framework + language extension matrix', () => {
+    expect(getFileExtensions('react', 'ts')).toEqual({
+      componentExt: '.tsx',
+      testExt: '.test.tsx',
+    });
+    expect(getFileExtensions('react', 'js')).toEqual({
+      componentExt: '.jsx',
+      testExt: '.test.jsx',
+    });
+    expect(getFileExtensions('vanilla', 'ts')).toEqual({
+      componentExt: '.ts',
+      testExt: '.test.ts',
+    });
+    expect(getFileExtensions('vanilla', 'js')).toEqual({
+      componentExt: '.js',
+      testExt: '.test.js',
+    });
+  });
+});
+
+describe('rewriteComponentImport', () => {
+  it('leaves the default base name untouched', () => {
+    const content = getReactTestTemplate('ts');
+    expect(rewriteComponentImport(content, DEFAULT_COMPONENT_BASE_NAME)).toBe(
+      content,
+    );
+  });
+
+  it('rewrites the React test import to a deduplicated base name', () => {
+    const content = getReactTestTemplate('ts');
+    const rewritten = rewriteComponentImport(content, 'Counter_1');
+    expect(rewritten).toContain("from './Counter_1.tsx'");
+    expect(rewritten).not.toContain("from './Counter.tsx'");
+  });
+
+  it('rewrites the vanilla test import preserving the extension', () => {
+    const content = getVanillaTestTemplate('js');
+    const rewritten = rewriteComponentImport(content, 'Widget');
+    expect(rewritten).toContain("from './Widget.js'");
+    expect(rewritten).not.toContain("from './Counter.js'");
+  });
+});

--- a/packages/core/tests/reporter/blob.test.ts
+++ b/packages/core/tests/reporter/blob.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from '@rstest/core';
+import { blobFileName, isBlobFile } from '../../src/reporter/blob';
+
+describe('blob wire-format', () => {
+  it('names the unsharded blob deterministically', () => {
+    expect(blobFileName()).toBe('blob.json');
+    expect(blobFileName(undefined)).toBe('blob.json');
+  });
+
+  it('encodes the shard index/count into the filename', () => {
+    expect(blobFileName({ index: 1, count: 4 })).toBe('blob-1-4.json');
+    expect(blobFileName({ index: 12, count: 30 })).toBe('blob-12-30.json');
+  });
+
+  it('round-trips: every name the writer emits is recognized by the reader', () => {
+    expect(isBlobFile(blobFileName())).toBe(true);
+    expect(isBlobFile(blobFileName({ index: 2, count: 3 }))).toBe(true);
+  });
+
+  it('rejects unrelated and malformed filenames', () => {
+    expect(isBlobFile('blob.txt')).toBe(false);
+    expect(isBlobFile('report.json')).toBe(false);
+    expect(isBlobFile('blob-1.json')).toBe(false);
+    expect(isBlobFile('blob-1-2-3.json')).toBe(false);
+    expect(isBlobFile('prefix-blob.json')).toBe(false);
+    expect(isBlobFile('blob-a-b.json')).toBe(false);
+  });
+});

--- a/packages/core/tests/reporter/utils.test.ts
+++ b/packages/core/tests/reporter/utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@rstest/core';
+import { deriveRunCounts } from '../../src/reporter/utils';
+import type { TestFileResult, TestResult } from '../../src/types';
+
+const test = (status: TestResult['status'], id: string): TestResult =>
+  ({
+    status,
+    name: `test-${id}`,
+    testPath: '/root/file.test.ts',
+    project: 'default',
+    testId: id,
+  }) as TestResult;
+
+const file = (status: TestFileResult['status'], id: string): TestFileResult =>
+  ({
+    status,
+    name: `file-${id}`,
+    testPath: `/root/file-${id}.test.ts`,
+    results: [],
+    project: 'default',
+    testId: id,
+  }) as TestFileResult;
+
+describe('deriveRunCounts', () => {
+  it('partitions test results by status and derives the 7-field counts struct', () => {
+    const testResults = [
+      test('pass', '1'),
+      test('pass', '2'),
+      test('fail', '3'),
+      test('skip', '4'),
+      test('todo', '5'),
+    ];
+    const results = [file('pass', 'a'), file('fail', 'b')];
+
+    const derived = deriveRunCounts({ results, testResults });
+
+    expect(derived.passedTests.map((t) => t.testId)).toEqual(['1', '2']);
+    expect(derived.failedTests.map((t) => t.testId)).toEqual(['3']);
+    expect(derived.skippedTests.map((t) => t.testId)).toEqual(['4']);
+    expect(derived.todoTests.map((t) => t.testId)).toEqual(['5']);
+    expect(derived.failedFiles.map((f) => f.testId)).toEqual(['b']);
+
+    expect(derived.counts).toEqual({
+      testFiles: 2,
+      failedFiles: 1,
+      tests: 5,
+      failedTests: 1,
+      passedTests: 2,
+      skippedTests: 1,
+      todoTests: 1,
+    });
+  });
+
+  it('returns zeroed counts for an empty run', () => {
+    const derived = deriveRunCounts({ results: [], testResults: [] });
+
+    expect(derived.failedTests).toEqual([]);
+    expect(derived.failedFiles).toEqual([]);
+    expect(derived.counts).toEqual({
+      testFiles: 0,
+      failedFiles: 0,
+      tests: 0,
+      failedTests: 0,
+      passedTests: 0,
+      skippedTests: 0,
+      todoTests: 0,
+    });
+  });
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -37,6 +37,8 @@ ctsx
 datauri
 dedupe
 deepmerge
+desync
+desynced
 distpath
 DNSCHANNEL
 docgen
@@ -179,6 +181,7 @@ unocss
 unpatch
 unplugin
 unpredictibly
+unsharded
 unshift
 unstub
 upath


### PR DESCRIPTION
## Summary

Internal refactor with no behavior or public API change. It collapses several copy-pasted blocks into single owners so the writer/reader (or reporter/reporter) pairs can no longer silently drift apart.

- **Reporter run-count derivation.** `deriveRunCounts` becomes the single owner of the pass/fail/skip count derivation that was hand-copied byte-for-byte in the markdown and JSON reporters. Each reporter keeps its own empty-run verdict (md and json intentionally differ), only the counting is shared.
- **Blob file-name grammar.** `blobFileName` / `isBlobFile` (+ `BLOB_FILE_RE`) own the `blob[-index-count].json` naming so the blob reporter (writer) and `mergeReports` (reader) share one definition instead of two hand-written regexps that could diverge.
- **CLI value-taking option set.** `valueTakingOptionNames` derives the set of options that consume a following argument directly from the command definitions, replacing a hand-maintained literal that had to be kept in sync by hand (a missed entry silently broke argv splitting in `getCliCommand`). A test pins the derived set so any drift fails CI.
- **Browser-init layout owners.** The config filename, `test:browser` script, framework resolution, extension matrix, and component import-rewrite each get a single owner in `templates.ts`, replacing literals scattered across `create.ts`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).