### PR TITLE
refactor(browser): single-source the snapshot RPC method/args contract

### DIFF
--- a/packages/browser/src/client/snapshot.ts
+++ b/packages/browser/src/client/snapshot.ts
@@ -1,4 +1,4 @@
-import type { BrowserDispatchRequest, SnapshotRpcRequest } from '../protocol';
+import type { BrowserDispatchRequest, SnapshotRpcCall } from '../protocol';
 import { DISPATCH_NAMESPACE_SNAPSHOT } from '../protocol';
 import {
   createRequestId,
@@ -11,41 +11,36 @@ const SNAPSHOT_HEADER = '// Rstest Snapshot';
 
 const createSnapshotDispatchRequest = (
   requestId: string,
-  method: SnapshotRpcRequest['method'],
-  args: SnapshotRpcRequest['args'],
+  call: SnapshotRpcCall,
 ): BrowserDispatchRequest => {
   // Snapshot is just one namespace on the shared dispatch RPC channel.
   // Keep this mapping explicit so new runner-side RPC clients can mirror it.
   return {
     requestId,
     namespace: DISPATCH_NAMESPACE_SNAPSHOT,
-    method,
-    args,
+    method: call.method,
+    args: call.args,
   };
 };
 
 /**
  * Send a snapshot RPC request to the container (parent window).
  * The container will forward it to the host via WebSocket RPC.
+ *
+ * `call` is a {@link SnapshotRpcCall}, so `method` and `args` are validated as a
+ * pair — a mismatched argument shape fails to compile at the call site.
  */
-const sendRpcRequest = <T>(
-  method: SnapshotRpcRequest['method'],
-  args: SnapshotRpcRequest['args'],
-): Promise<T> => {
+const sendRpcRequest = <T>(call: SnapshotRpcCall): Promise<T> => {
   const requestId = createRequestId('snapshot-rpc');
   const rpcTimeout = getRpcTimeout();
-  const dispatchRequest = createSnapshotDispatchRequest(
-    requestId,
-    method,
-    args,
-  );
+  const dispatchRequest = createSnapshotDispatchRequest(requestId, call);
 
   return dispatchRpc<T>({
     requestId,
     request: dispatchRequest,
     timeoutMs: rpcTimeout,
     staleMessage: 'Stale snapshot RPC request ignored.',
-    timeoutMessage: `Snapshot RPC timeout after ${rpcTimeout / 1000}s: ${method}`,
+    timeoutMessage: `Snapshot RPC timeout after ${rpcTimeout / 1000}s: ${call.method}`,
   });
 };
 
@@ -67,8 +62,9 @@ export class BrowserSnapshotEnvironment {
   }
 
   async resolvePath(filepath: string): Promise<string> {
-    return sendRpcRequest<string>('resolveSnapshotPath', {
-      testPath: filepath,
+    return sendRpcRequest<string>({
+      method: 'resolveSnapshotPath',
+      args: { testPath: filepath },
     });
   }
 
@@ -77,18 +73,24 @@ export class BrowserSnapshotEnvironment {
   }
 
   async saveSnapshotFile(filepath: string, snapshot: string): Promise<void> {
-    await sendRpcRequest<void>('saveSnapshotFile', {
-      filepath,
-      content: snapshot,
+    await sendRpcRequest<void>({
+      method: 'saveSnapshotFile',
+      args: { filepath, content: snapshot },
     });
   }
 
   async readSnapshotFile(filepath: string): Promise<string | null> {
-    return sendRpcRequest<string | null>('readSnapshotFile', { filepath });
+    return sendRpcRequest<string | null>({
+      method: 'readSnapshotFile',
+      args: { filepath },
+    });
   }
 
   async removeSnapshotFile(filepath: string): Promise<void> {
-    await sendRpcRequest<void>('removeSnapshotFile', { filepath });
+    await sendRpcRequest<void>({
+      method: 'removeSnapshotFile',
+      args: { filepath },
+    });
   }
 
   /**

--- a/packages/browser/src/dispatchCapabilities.ts
+++ b/packages/browser/src/dispatchCapabilities.ts
@@ -4,6 +4,8 @@ import type {
   BrowserClientMessage,
   BrowserDispatchHandler,
   BrowserDispatchRequest,
+  SnapshotRpcMethod,
+  SnapshotRpcMethodArgs,
   SnapshotRpcRequest,
 } from './protocol';
 
@@ -52,37 +54,50 @@ type CreateHostDispatchRouterOptions = {
   onDuplicateNamespace?: (namespace: string) => void;
 };
 
+/**
+ * Builds a typed {@link SnapshotRpcRequest} from the untrusted wire envelope,
+ * one builder per method. Keyed by {@link SnapshotRpcMethod}, so adding or
+ * renaming a method in the union forces a matching entry here — a stale name
+ * becomes a compile error instead of silently falling through to `null`. The
+ * `args` casts are the unavoidable trust boundary for inbound wire data.
+ */
+const snapshotRequestBuilders: {
+  [M in SnapshotRpcMethod]: (
+    id: string,
+    args: BrowserDispatchRequest['args'],
+  ) => Extract<SnapshotRpcRequest, { method: M }>;
+} = {
+  resolveSnapshotPath: (id, args) => ({
+    id,
+    method: 'resolveSnapshotPath',
+    args: args as SnapshotRpcMethodArgs['resolveSnapshotPath'],
+  }),
+  readSnapshotFile: (id, args) => ({
+    id,
+    method: 'readSnapshotFile',
+    args: args as SnapshotRpcMethodArgs['readSnapshotFile'],
+  }),
+  saveSnapshotFile: (id, args) => ({
+    id,
+    method: 'saveSnapshotFile',
+    args: args as SnapshotRpcMethodArgs['saveSnapshotFile'],
+  }),
+  removeSnapshotFile: (id, args) => ({
+    id,
+    method: 'removeSnapshotFile',
+    args: args as SnapshotRpcMethodArgs['removeSnapshotFile'],
+  }),
+};
+
 const toSnapshotRpcRequest = (
   request: BrowserDispatchRequest,
 ): SnapshotRpcRequest | null => {
-  switch (request.method) {
-    case 'resolveSnapshotPath':
-      return {
-        id: request.requestId,
-        method: 'resolveSnapshotPath',
-        args: request.args as { testPath: string },
-      };
-    case 'readSnapshotFile':
-      return {
-        id: request.requestId,
-        method: 'readSnapshotFile',
-        args: request.args as { filepath: string },
-      };
-    case 'saveSnapshotFile':
-      return {
-        id: request.requestId,
-        method: 'saveSnapshotFile',
-        args: request.args as { filepath: string; content: string },
-      };
-    case 'removeSnapshotFile':
-      return {
-        id: request.requestId,
-        method: 'removeSnapshotFile',
-        args: request.args as { filepath: string },
-      };
-    default:
-      return null;
-  }
+  const builder = snapshotRequestBuilders[
+    request.method as SnapshotRpcMethod
+  ] as
+    | ((id: string, args: BrowserDispatchRequest['args']) => SnapshotRpcRequest)
+    | undefined;
+  return builder ? builder(request.requestId, request.args) : null;
 };
 
 export const createHostDispatchRouter = ({

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -2511,8 +2511,12 @@ export const runBrowserController = async (
         );
       case 'removeSnapshotFile':
         return snapshotRpcMethods.removeSnapshotFile(request.args.filepath);
-      default:
-        return undefined;
+      default: {
+        // Exhaustiveness guard: a new SnapshotRpcRequest method without a case
+        // here fails to compile rather than silently returning undefined.
+        const _exhaustive: never = request;
+        return _exhaustive;
+      }
     }
   };
 

--- a/packages/browser/src/protocol.ts
+++ b/packages/browser/src/protocol.ts
@@ -10,6 +10,9 @@ import type { SnapshotUpdateState } from '@vitest/snapshot';
 export type {
   BrowserLocatorIR,
   BrowserRpcRequest,
+  SnapshotRpcCall,
+  SnapshotRpcMethod,
+  SnapshotRpcMethodArgs,
   SnapshotRpcRequest,
 } from './rpcProtocol';
 export { validateBrowserRpcRequest } from './rpcProtocol';

--- a/packages/browser/src/rpcProtocol.ts
+++ b/packages/browser/src/rpcProtocol.ts
@@ -179,27 +179,40 @@ export const validateBrowserRpcRequest = (
 };
 
 /**
+ * Single source of truth for snapshot RPC methods and their argument shapes.
+ * The request union, the client sender, both host-side mappers, and every
+ * exhaustiveness check derive from this map — adding or renaming a method here
+ * forces a compile error at every site that has not been updated.
+ */
+export type SnapshotRpcMethodArgs = {
+  resolveSnapshotPath: { testPath: string };
+  readSnapshotFile: { filepath: string };
+  saveSnapshotFile: { filepath: string; content: string };
+  removeSnapshotFile: { filepath: string };
+};
+
+export type SnapshotRpcMethod = keyof SnapshotRpcMethodArgs;
+
+/**
  * Snapshot RPC request from runner iframe.
  * The container will forward these to the host via WebSocket RPC.
  */
-export type SnapshotRpcRequest =
-  | {
-      id: string;
-      method: 'resolveSnapshotPath';
-      args: { testPath: string };
-    }
-  | {
-      id: string;
-      method: 'readSnapshotFile';
-      args: { filepath: string };
-    }
-  | {
-      id: string;
-      method: 'saveSnapshotFile';
-      args: { filepath: string; content: string };
-    }
-  | {
-      id: string;
-      method: 'removeSnapshotFile';
-      args: { filepath: string };
-    };
+export type SnapshotRpcRequest = {
+  [M in SnapshotRpcMethod]: {
+    id: string;
+    method: M;
+    args: SnapshotRpcMethodArgs[M];
+  };
+}[SnapshotRpcMethod];
+
+/**
+ * Client-side snapshot RPC call (request without the transport `id`).
+ * Distributive over {@link SnapshotRpcMethod} so `method` and `args` stay paired
+ * at the call site — a mismatched pair fails to compile.
+ */
+export type SnapshotRpcCall = {
+  [M in SnapshotRpcMethod]: {
+    method: M;
+    args: SnapshotRpcMethodArgs[M];
+  };
+}[SnapshotRpcMethod];


### PR DESCRIPTION
## Summary

The snapshot RPC method names and their argument shapes were hardcoded in **four** places — the `SnapshotRpcRequest` union, the runner-side client sender, the host-side `toSnapshotRpcRequest` mapper, and the host `runSnapshotRpc` switch. A method rename or args-shape change at one site silently drifted from the others: the mapper degraded to a no-op (`default: return null`) and the host switch returned `undefined` (`default`) **at runtime** instead of failing to compile.

This collapses all four sites onto a single source of truth, so adding or renaming a method forces a compile error at every unupdated site:

- New `SnapshotRpcMethodArgs` map (method → args shape) is the only place names/shapes live; the `SnapshotRpcRequest` union and the new client `SnapshotRpcCall` are mapped types over it.
- The client `sendRpcRequest` now takes one discriminated `call` payload, so `method` and `args` stay paired at the call site (a mismatched pair fails to compile).
- The host-side builder is a `Record` keyed by `SnapshotRpcMethod` (a missing key is a compile error), and the host switch closes with a `never` exhaustiveness guard.

No runtime behavior change — the wire payloads and dispatch flow are identical.

Verified: `@rstest/browser` typecheck passes; injecting a 5th method confirms both guards bite (`TS2741` at the builder map, `TS2322` at the host switch); all 10 `e2e/browser-mode/snapshot.test.ts` cases pass (create / read / match-fail / update / obsolete / multiple / error / file / inline), exercising the full client→dispatch→host contract chain.

## Checklist

- [x] Tests updated (or not required). _(no behavior change; covered by existing browser-mode snapshot e2e)_
- [x] Documentation updated (or not required).