### PR TITLE
ci: trim pre-merge PR workload, keep full coverage on main

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,37 @@
+name: 'Setup Playwright'
+description: 'Resolve the Playwright browser cache path + version, restore the browser cache, and install browsers (chromium + webkit). Run after dependencies are installed.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set Playwright cache path and version
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          echo "PLAYWRIGHT_BROWSERS_PATH=$USERPROFILE/AppData/Local/ms-playwright" >> "$GITHUB_ENV"
+        else
+          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_ENV"
+        fi
+        # Resolve the installed Playwright version so the browser cache key
+        # invalidates exactly when Playwright (and thus its browser builds)
+        # changes — not on every unrelated lockfile bump.
+        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('playwright/package.json').version)")" >> "$GITHUB_ENV"
+
+    - name: Cache Playwright Browsers
+      continue-on-error: true
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+        key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
+        # Keyed on the Playwright version (set in the step above): unrelated
+        # lockfile bumps no longer cold-miss, and a Playwright version bump
+        # invalidates correctly. restore-keys lets `playwright install` patch
+        # from the previous version's cache instead of a full cold download.
+        restore-keys: |
+          playwright-${{ runner.os }}-
+
+    - name: Install Playwright Browsers
+      shell: bash
+      # chromium + webkit: browser-mode e2e (e.g. browser-mode/webkit.test.ts,
+      # which runs under the default `test` script) needs both.
+      run: npx playwright install chromium webkit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
-        os: [macos-14, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -128,7 +128,7 @@ jobs:
         # tsc is OS-independent, so PR runs it on macOS only; the post-merge
         # FULL run still typechecks both OSes so push-to-main stays a literal
         # superset of PR coverage.
-        if: needs.prepare.outputs.is_full_run == 'true' || matrix.os == 'macos-14'
+        if: needs.prepare.outputs.is_full_run == 'true' || matrix.os == 'macos-latest'
         run: pnpm run typecheck
 
       - name: Run Test
@@ -147,7 +147,7 @@ jobs:
       fail-fast: false
       matrix:
         # run ut in macOS, as SWC cases will fail in Ubuntu CI
-        os: [macos-14, windows-latest]
+        os: [macos-latest, windows-latest]
         # Trigger-dependent axes (gated by prepare.outputs.is_full_run):
         #
         #   trigger      | node_version | test_script                           | exclude

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,11 @@ jobs:
 
   # ======== ut ========
   ut:
-    needs: prepare
+    # Gate behind lint so a lint failure skips the (billed-premium) macOS +
+    # Windows ut runners — and transitively e2e — before they start; e2e already
+    # needs lint. Trade-off: any lint nit (prettier/spell/dedupe/knip) now blocks
+    # ut+e2e too, instead of running them in parallel with lint.
+    needs: [prepare, lint]
     if: needs.prepare.outputs.changed == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -110,32 +114,21 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: pnpm fetch
-        run: pnpm fetch
-
       - name: Install Dependencies
+        # setup-node's `cache: pnpm` restores the store; `--prefer-offline`
+        # reuses it. A standalone `pnpm fetch` only re-warms an already-warm
+        # store (~26s/job of no gain). Install still runs the root `prepare`
+        # lifecycle (`pnpm run build`), so packages are built as before.
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Set Playwright cache path
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            echo "PLAYWRIGHT_BROWSERS_PATH=$USERPROFILE/AppData/Local/ms-playwright" >> "$GITHUB_ENV"
-          else
-            echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_ENV"
-          fi
-
-      - name: Cache Playwright Browsers
-        continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright Browsers
-        run: npx playwright install chromium webkit
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: Run Type Check
+        # tsc is OS-independent, so PR runs it on macOS only; the post-merge
+        # FULL run still typechecks both OSes so push-to-main stays a literal
+        # superset of PR coverage.
+        if: needs.prepare.outputs.is_full_run == 'true' || matrix.os == 'macos-14'
         run: pnpm run typecheck
 
       - name: Run Test
@@ -159,7 +152,7 @@ jobs:
         #
         #   trigger      | node_version | test_script                           | exclude
         #   -------------+--------------+---------------------------------------+-----------
-        #   PR (regular) | [20, 24]     | [test]                                | -
+        #   PR (regular) | [24]         | [test]                                | -
         #   push to main | [20, 22, 24] | [test, commonjs, no-isolate, threads] | test × 22
         #   release PR   | [20, 22, 24] | [test, commonjs, no-isolate, threads] | test × 22
         #
@@ -169,7 +162,7 @@ jobs:
           ${{ fromJson(
             needs.prepare.outputs.is_full_run == 'true'
               && '["20","22","24"]'
-            || '["20","24"]'
+            || '["24"]'
           ) }}
         test_script: >-
           ${{ fromJson(
@@ -200,36 +193,24 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: pnpm fetch
-        run: pnpm fetch
-
       - name: Install Dependencies
+        # setup-node's `cache: pnpm` restores the store; `--prefer-offline`
+        # reuses it. A standalone `pnpm fetch` only re-warms an already-warm
+        # store (~26s/job of no gain). Install still runs the root `prepare`
+        # lifecycle (`pnpm run build`), so packages are built as before.
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Set Playwright cache path
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            echo "PLAYWRIGHT_BROWSERS_PATH=$USERPROFILE/AppData/Local/ms-playwright" >> "$GITHUB_ENV"
-          else
-            echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_ENV"
-          fi
-
-      - name: Cache Playwright Browsers
-        continue-on-error: true
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright Browsers
-        run: npx playwright install chromium webkit
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: E2E Test (${{ matrix.test_script }})
         run: cd e2e && pnpm ${{ matrix.test_script }}
 
       - name: VS Code Extension Test
-        if: matrix.test_script == 'test'
+        # OS-sensitive (Extension Host) but node-insensitive: on PR, pin to a
+        # single combo (Windows + node 24) instead of every e2e row. FULL runs
+        # still exercise it on every 'test' row.
+        if: matrix.test_script == 'test' && (needs.prepare.outputs.is_full_run == 'true' || (matrix.os == 'windows-latest' && matrix.node_version == '24'))
         run: pnpm run test:vscode
 
   # ======== codspeed ========
@@ -255,6 +236,7 @@ jobs:
       - name: Check test requirement
         run: |
           for result in \
+            "${{ needs.prepare.result }}" \
             "${{ needs.lint.result }}" \
             "${{ needs.ut.result }}" \
             "${{ needs.e2e.result }}"; do

--- a/packages/core/tests/utils/helper.test.ts
+++ b/packages/core/tests/utils/helper.test.ts
@@ -1,6 +1,7 @@
 import { sep } from 'node:path';
 import {
   getWorkerSerialization,
+  needFlagExperimentalDetectModule,
   parsePosix,
   prettyTime,
 } from '../../src/utils/helper';
@@ -51,6 +52,55 @@ it('should use json serialization in Bun', () => {
       Reflect.deleteProperty(process.versions, 'bun');
     } else {
       process.versions.bun = originalBunVersion;
+    }
+  }
+});
+
+// `--experimental-detect-module` is injected into every worker (see
+// `getNodeExecArgv` in src/pool/index.ts) only on Node versions where it is
+// meaningful: 20.10+ (opt-in) and 22.x < 7 (before it became default-on). It
+// must NEVER be injected on Node 24+. Faking `process.versions.node` pins the
+// version gate so this default-on worker path keeps coverage even though PR CI
+// only runs Node 24 (the actual runtime behavior is covered by the post-merge
+// full run on Node 20).
+it('needFlagExperimentalDetectModule gates on the Node version', () => {
+  // `process.versions.node` is read-only (writable: false) but configurable,
+  // so override it via defineProperty and restore the original descriptor.
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    process.versions,
+    'node',
+  );
+  const evaluate = (version: string) => {
+    Object.defineProperty(process.versions, 'node', {
+      value: version,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+    return needFlagExperimentalDetectModule();
+  };
+
+  try {
+    expect({
+      '20.9.0': evaluate('20.9.0'),
+      '20.10.0': evaluate('20.10.0'),
+      '20.19.0': evaluate('20.19.0'),
+      '22.6.0': evaluate('22.6.0'),
+      '22.7.0': evaluate('22.7.0'),
+      '22.12.0': evaluate('22.12.0'),
+      '24.0.0': evaluate('24.0.0'),
+    }).toEqual({
+      '20.9.0': false, // before 20.10.0
+      '20.10.0': true, // introduced
+      '20.19.0': true, // engines floor (^20.19.0)
+      '22.6.0': true, // 22.x before default-on
+      '22.7.0': false, // default-on since 22.7.0
+      '22.12.0': false,
+      '24.0.0': false, // never injected on Node 24+
+    });
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(process.versions, 'node', originalDescriptor);
     }
   }
 });


### PR DESCRIPTION
## Summary

Pre-merge PR runs did redundant work: the VS Code Extension Test and typecheck ran on every e2e matrix cell regardless of OS/Node relevance, and the Playwright browser cache invalidated on every unrelated lockfile bump. This trims what a PR runs while keeping the post-merge **FULL** run (push to `main` / `release:` PR) a *literal superset* of PR coverage — anything dropped from a PR is still exercised on main, which is the intended safety net.

- **e2e matrix**: PR runs Node 24 only (FULL still runs 20/22/24), cutting PR e2e from 4 jobs to 2 and removing the slowest critical-path job.
- **VS Code Extension Test**: pinned to one combo (Windows + Node 24) on PR — it's Extension-Host/OS-sensitive but Node-insensitive; FULL still runs it on every `test` row.
- **typecheck**: macOS only on PR (`tsc` is OS-independent); FULL keeps both OSes.
- **fail-fast**: `ut` now needs `lint`, so a lint failure skips the (billed-premium) macOS/Windows runners — and transitively e2e — before they start.
- **caching**: drop the redundant `pnpm fetch` (setup-node's pnpm cache + `--prefer-offline` already cover it); key the Playwright browser cache on the Playwright version rather than the lockfile hash, so unrelated bumps no longer cold-miss; the shared Playwright setup is extracted into a `setup-playwright` composite action.
- **gate**: `test-gate` now also checks `prepare.result`, closing a false-green where a failed `prepare` would skip ut/e2e (a `skipped` result is neither `failure` nor `cancelled`).

The only default-on worker path Node 24 never exercises is the Node-version-gated `--experimental-detect-module` flag (injected only on Node 20.10+ / 22 < 7). A unit test mocks `process.versions.node` to pin that gate, so the branch keeps PR-time coverage without running Node 20 on PR.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).