### PR TITLE
refactor(core): consolidate runtime primitives (file task-id, env-loader registry, scoped-restore LIFO)

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import type { SnapshotUpdateState } from '@vitest/snapshot';
 import { basename, dirname, join, resolve } from 'pathe';
-import { getFileTaskId } from '../runtime/runner';
 import type {
   CoverageMapData,
   EntryInfo,
@@ -20,6 +19,7 @@ import type {
 } from '../types';
 import {
   color,
+  getFileTaskId,
   getForceColorEnv,
   isDeno,
   logger,

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -46,6 +46,57 @@ const normalizeWaitOptions = (
   ),
 });
 
+/**
+ * Shared LIFO index-lifecycle for the three scoped-restore stacks behind
+ * `stubEnv`, `stubGlobal`, and `useFakeTimers`. Each stub pushes an entry and
+ * hands back a disposer; the disposer calls this to unwind. The three stacks
+ * keep identical bookkeeping but distinct restore actions, so this primitive
+ * owns ONLY the index management and delegates the restore itself:
+ *
+ *  - entry already removed (out-of-order dispose): no-op.
+ *  - entry shadowed by a newer stub: forward this entry's saved payload onto
+ *    the newer entry via `onSupersede` and drop this one — the live binding is
+ *    left untouched because the newer stub still owns it.
+ *  - entry is the newest (LIFO tail): pop it, re-apply its saved value via
+ *    `onTail`, then, only when the stack has fully drained, run `onEmpty`
+ *    (the two Map-backed stacks delete their now-empty key here; the bare
+ *    timer array passes none).
+ *
+ * The per-stack supersede payload (env value vs global descriptor vs the timer
+ * triple) and tail-restore action stay in the caller closures, so the
+ * behavioral split between the three stacks is preserved exactly.
+ */
+export const restoreScopedEntry = <E>(
+  stack: E[] | undefined,
+  entry: E,
+  handlers: {
+    onSupersede: (laterEntry: E) => void;
+    onTail: () => void;
+    onEmpty?: () => void;
+  },
+): void => {
+  if (!stack) {
+    return;
+  }
+  const index = stack.lastIndexOf(entry);
+  if (index === -1) {
+    return;
+  }
+
+  if (index !== stack.length - 1) {
+    // `index` is not the tail, so `index + 1` is always in-bounds.
+    handlers.onSupersede(stack[index + 1]!);
+    stack.splice(index, 1);
+    return;
+  }
+
+  stack.pop();
+  handlers.onTail();
+  if (stack.length === 0) {
+    handlers.onEmpty?.();
+  }
+};
+
 export const createRstestUtilities: (
   workerState: WorkerState,
 ) => Promise<RstestUtilities> = async (workerState) => {
@@ -141,89 +192,57 @@ export const createRstestUtilities: (
 
   const restoreEnvValue = (name: string, entry: EnvStackEntry) => {
     const runtimeEnv = resolveRuntimeEnv();
-    const envStack = originalEnvValues.get(name);
-    const index = envStack?.lastIndexOf(entry) ?? -1;
-    if (!envStack || index === -1) {
-      return;
-    }
-
-    if (index !== envStack.length - 1) {
-      const nextEntry = envStack[index + 1];
-      if (nextEntry) {
-        nextEntry.value = entry.value;
-      }
-      envStack.splice(index, 1);
-      return;
-    }
-
-    envStack.pop();
-    if (entry.value === undefined) {
-      Reflect.deleteProperty(runtimeEnv, name);
-    } else {
-      runtimeEnv[name] = entry.value;
-    }
-
-    if (envStack.length === 0) {
-      originalEnvValues.delete(name);
-    }
+    restoreScopedEntry(originalEnvValues.get(name), entry, {
+      onSupersede: (laterEntry) => {
+        laterEntry.value = entry.value;
+      },
+      onTail: () => {
+        if (entry.value === undefined) {
+          Reflect.deleteProperty(runtimeEnv, name);
+        } else {
+          runtimeEnv[name] = entry.value;
+        }
+      },
+      onEmpty: () => originalEnvValues.delete(name),
+    });
   };
 
   const restoreGlobalValue = (name: PropertyKey, entry: GlobalStackEntry) => {
-    const descriptorStack = originalGlobalValues.get(name);
-    const index = descriptorStack?.lastIndexOf(entry) ?? -1;
-    if (!descriptorStack || index === -1) {
-      return;
-    }
-
-    if (index !== descriptorStack.length - 1) {
-      const nextEntry = descriptorStack[index + 1];
-      if (nextEntry) {
-        nextEntry.descriptor = entry.descriptor;
-      }
-      descriptorStack.splice(index, 1);
-      return;
-    }
-
-    descriptorStack.pop();
-    if (!entry.descriptor) {
-      Reflect.deleteProperty(globalThis, name);
-    } else {
-      Object.defineProperty(globalThis, name, entry.descriptor);
-    }
-
-    if (descriptorStack.length === 0) {
-      originalGlobalValues.delete(name);
-    }
+    restoreScopedEntry(originalGlobalValues.get(name), entry, {
+      onSupersede: (laterEntry) => {
+        laterEntry.descriptor = entry.descriptor;
+      },
+      onTail: () => {
+        if (!entry.descriptor) {
+          Reflect.deleteProperty(globalThis, name);
+        } else {
+          Object.defineProperty(globalThis, name, entry.descriptor);
+        }
+      },
+      onEmpty: () => originalGlobalValues.delete(name),
+    });
   };
 
   const restoreFakeTimers = (entry: TimerStackEntry) => {
-    const index = timerStack.lastIndexOf(entry);
-    if (index === -1) {
-      return;
-    }
-
-    if (index !== timerStack.length - 1) {
-      const nextEntry = timerStack[index + 1];
-      if (nextEntry) {
-        nextEntry.config = entry.config;
-        nextEntry.snapshot = entry.snapshot;
-        nextEntry.wasFakeTimers = entry.wasFakeTimers;
-      }
-      timerStack.splice(index, 1);
-      return;
-    }
-
-    timerStack.pop();
-    if (entry.wasFakeTimers) {
-      timers().useFakeTimers(entry.config);
-      if (entry.snapshot) {
-        timers().restore(entry.snapshot);
-      }
-      currentFakeTimersConfig = entry.config;
-    } else {
-      timers().useRealTimers();
-      currentFakeTimersConfig = undefined;
-    }
+    restoreScopedEntry(timerStack, entry, {
+      onSupersede: (laterEntry) => {
+        laterEntry.config = entry.config;
+        laterEntry.snapshot = entry.snapshot;
+        laterEntry.wasFakeTimers = entry.wasFakeTimers;
+      },
+      onTail: () => {
+        if (entry.wasFakeTimers) {
+          timers().useFakeTimers(entry.config);
+          if (entry.snapshot) {
+            timers().restore(entry.snapshot);
+          }
+          currentFakeTimersConfig = entry.config;
+        } else {
+          timers().useRealTimers();
+          currentFakeTimersConfig = undefined;
+        }
+      },
+    });
   };
 
   const { fn, spyOn, isMockFunction, mocks, createMockInstance } = initSpy();

--- a/packages/core/src/runtime/runner/index.ts
+++ b/packages/core/src/runtime/runner/index.ts
@@ -7,14 +7,11 @@ import type {
   TestInfo,
   WorkerState,
 } from '../../types';
+import { getFileTaskId } from '../../utils/helper';
 import type { TaskContext } from '../worker/taskContext';
 import { TestRunner } from './runner';
 import { createRuntimeAPI } from './runtime';
 import { traverseUpdateTest } from './task';
-
-export const getFileTaskId = (testPath: string): string => {
-  return `file:${testPath}`;
-};
 
 export function createRunner({
   workerState,

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -20,12 +20,11 @@ import type {
   TestResultStatus,
   WorkerState,
 } from '../../types';
-import { getTaskNameWithPrefix } from '../../utils/helper';
+import { getFileTaskId, getTaskNameWithPrefix } from '../../utils/helper';
 import { createExpect } from '../api/expect';
 import { formatTestError } from '../util';
 import type { TaskContext } from '../worker/taskContext';
 import { handleFixtures } from './fixtures';
-import { getFileTaskId } from './index';
 import {
   getTestStatus,
   limitConcurrency,

--- a/packages/core/src/runtime/worker/env/registry.ts
+++ b/packages/core/src/runtime/worker/env/registry.ts
@@ -1,0 +1,18 @@
+import type { EnvironmentName, TestEnvironment } from '../../../types';
+
+/**
+ * Lazy loaders for the non-`node` test environments, keyed by environment name.
+ *
+ * `node` is the no-op fast path handled directly by the dispatcher in
+ * `runInPool.ts`, so it is intentionally absent here. The exhaustive `Record`
+ * keeps the dispatcher closed: adding a name to {@link EnvironmentName} forces a
+ * matching loader entry. Dynamic `import()` preserves the lazy-load behavior of
+ * the previous hand-written switch.
+ */
+export const environmentLoaders: Record<
+  Exclude<EnvironmentName, 'node'>,
+  () => Promise<{ environment: TestEnvironment<typeof globalThis> }>
+> = {
+  jsdom: () => import('./jsdom'),
+  'happy-dom': () => import('./happyDom'),
+};

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -10,9 +10,11 @@ import type {
   WorkerState,
 } from '../../types';
 import { globalApis } from '../../utils/constants';
+import { getFileTaskId } from '../../utils/helper';
 import { color } from '../../utils/logger';
 import { formatTestError, getRealTimers, setRealTimers } from '../util';
 import { createAsyncLeakDetector } from './asyncLeaks';
+import { environmentLoaders } from './env/registry';
 import { PhaseTracker } from './phaseTracker';
 import { createRuntimeRpc, createWorkerRpcOptions } from './rpc';
 import { createSilentConsoleController } from './silentConsole';
@@ -88,10 +90,6 @@ const setupEnv = (env?: Partial<NodeJS.ProcessEnv>) => {
       }
     });
   }
-};
-
-const getFileTaskId = (testPath: string): string => {
-  return `file:${testPath}`;
 };
 
 const createOriginalLogWriter = () => {
@@ -256,29 +254,22 @@ const preparePool = async (
   });
 
   tracker?.transition('envSetup');
-  switch (testEnvironment.name) {
-    case 'node':
-      break;
-    case 'jsdom': {
-      const { environment } = await import('./env/jsdom');
-      const { teardown } = await environment.setup(
-        global,
-        testEnvironment.options || {},
-      );
-      cleanupFns.push(() => teardown(global));
-      break;
-    }
-    case 'happy-dom': {
-      const { environment } = await import('./env/happyDom');
-      const { teardown } = await environment.setup(
-        global,
-        testEnvironment.options || {},
-      );
-      cleanupFns.push(async () => teardown(global));
-      break;
-    }
-    default:
+  // `node` is the no-op fast path; every other environment is resolved through
+  // the registry so adding one is a single entry instead of a new switch arm.
+  // teardown is `MaybePromise<void>` and is awaited via `Promise.all` in
+  // `cleanup`, so a single uniform wrapper preserves both the sync (jsdom) and
+  // async (happy-dom) teardown shapes.
+  if (testEnvironment.name !== 'node') {
+    const loadEnvironment = environmentLoaders[testEnvironment.name];
+    if (!loadEnvironment) {
       throw new Error(`Unknown test environment: ${testEnvironment.name}`);
+    }
+    const { environment } = await loadEnvironment();
+    const { teardown } = await environment.setup(
+      global,
+      testEnvironment.options || {},
+    );
+    cleanupFns.push(() => teardown(global));
   }
   tracker?.transition('prepare');
 

--- a/packages/core/src/runtime/worker/silentConsole.ts
+++ b/packages/core/src/runtime/worker/silentConsole.ts
@@ -1,4 +1,5 @@
 import type { RuntimeConfig, UserConsoleLog } from '../../types';
+import { getFileTaskId } from '../../utils/helper';
 
 type ConsoleWriter = (payload: {
   content: string;
@@ -10,11 +11,7 @@ const getBufferedLogTaskId = (log: UserConsoleLog): string => {
     return log.taskId;
   }
 
-  return `file:${log.testPath}`;
-};
-
-const getFileTaskId = (testPath: string): string => {
-  return `file:${testPath}`;
+  return getFileTaskId(log.testPath);
 };
 
 const getSuiteChainKey = (names: string[]): string => {

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -148,6 +148,17 @@ export const getTaskNameWithPrefix = (
   delimiter: string = TEST_DELIMITER,
 ): string => getTaskNames(test).join(delimiter ? ` ${delimiter} ` : ' ');
 
+/**
+ * Single source of truth for the `file:` task-id grammar. The value is an
+ * opaque pass-through label (never equality-checked across processes), so the
+ * grammar only needs to stay self-consistent — owning it here keeps the worker,
+ * pool, and runner copies from drifting.
+ *
+ * The browser package keeps its own copy on purpose (it must not import core
+ * runtime internals across the provider-agnostic barrier).
+ */
+export const getFileTaskId = (testPath: string): string => `file:${testPath}`;
+
 const REGEXP_FLAG_PREFIX = 'RSTEST_REGEXP:';
 
 const wrapRegex = (value: RegExp): string =>

--- a/packages/core/tests/pool/fixtures/testWorker.mjs
+++ b/packages/core/tests/pool/fixtures/testWorker.mjs
@@ -62,6 +62,10 @@ let assignedWorkerId = null;
 
 let runCount = 0;
 
+// This worker entry runs as a real .mjs and cannot import core .ts source, so
+// it keeps a literal copy. MUST match getFileTaskId in
+// packages/core/src/utils/helper.ts (the grammar is pinned by
+// tests/utils/helper.test.ts).
 const getFileTaskId = (testPath) => `file:${testPath}`;
 
 const makeRunResult = (request, extra) => ({

--- a/packages/core/tests/runtime/api/mockObject.test.ts
+++ b/packages/core/tests/runtime/api/mockObject.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from '@rstest/core';
+import { mockObject } from '../../../src/runtime/api/mockObject';
+import { initSpy } from '../../../src/runtime/api/spy';
+
+type Key = string | symbol;
+
+const globalConstructors = { Object, Function, Array, Map, RegExp };
+
+const make = (type: 'automock' | 'autospy') => {
+  const { createMockInstance, isMockFunction } = initSpy();
+  return {
+    isMockFunction,
+    run: <T extends Record<Key, any>>(object: T): T =>
+      mockObject({ createMockInstance, globalConstructors, type }, object, {}),
+  };
+};
+
+describe('mockObject automock', () => {
+  it('empties arrays', () => {
+    const { run } = make('automock');
+    expect(run({ list: [1, 2, 3] }).list).toEqual([]);
+  });
+
+  it('makes getters return undefined', () => {
+    const { run } = make('automock');
+    const source = {};
+    Object.defineProperty(source, 'value', {
+      enumerable: true,
+      configurable: true,
+      get: () => 42,
+    });
+    expect((run(source) as { value: unknown }).value).toBeUndefined();
+  });
+
+  it('replaces functions with empty mocks', () => {
+    const { run, isMockFunction } = make('automock');
+    const result = run({ doThing: () => 'real' });
+    expect(isMockFunction(result.doThing)).toBe(true);
+    expect(result.doThing()).toBeUndefined();
+  });
+
+  it('passes primitives through unchanged', () => {
+    const { run } = make('automock');
+    const result = run({ n: 1, s: 'x', b: true, nil: null });
+    expect(result.n).toBe(1);
+    expect(result.s).toBe('x');
+    expect(result.b).toBe(true);
+    expect(result.nil).toBeNull();
+  });
+
+  it('returns Date/RegExp/Map values by reference', () => {
+    const { run } = make('automock');
+    const date = new Date(0);
+    const regexp = /abc/;
+    const map = new Map([['k', 'v']]);
+    const result = run({ date, regexp, map });
+    expect(result.date).toBe(date);
+    expect(result.regexp).toBe(regexp);
+    expect(result.map).toBe(map);
+  });
+
+  it('resolves circular references without infinite recursion', () => {
+    const { run } = make('automock');
+    const source: Record<string, any> = { name: 'a' };
+    source.self = source;
+    const result = run(source);
+    expect(result.name).toBe('a');
+    expect(result.self).toBe(result);
+  });
+
+  it('collects only own properties for __esModule objects', () => {
+    const { run, isMockFunction } = make('automock');
+    const proto = { inherited: () => 'p' };
+    const mod = Object.create(proto);
+    mod.__esModule = true;
+    mod.own = () => 'o';
+    const result = run(mod);
+    expect(isMockFunction(result.own)).toBe(true);
+    expect('inherited' in result).toBe(false);
+  });
+});
+
+describe('mockObject autospy', () => {
+  it('wraps functions preserving the original implementation', () => {
+    const { run, isMockFunction } = make('autospy');
+    const result = run({ doThing: (x: number) => x + 1 });
+    expect(isMockFunction(result.doThing)).toBe(true);
+    expect(result.doThing(2)).toBe(3);
+    expect(result.doThing.mock.calls).toEqual([[2]]);
+  });
+
+  it('deep-clones arrays into a new identity', () => {
+    const { run } = make('autospy');
+    const source = { list: [1, 2, 3] };
+    const result = run(source);
+    expect(result.list).toEqual([1, 2, 3]);
+    expect(result.list).not.toBe(source.list);
+  });
+
+  it('preserves getters via their descriptor', () => {
+    const { run } = make('autospy');
+    const source = {};
+    Object.defineProperty(source, 'value', {
+      enumerable: true,
+      configurable: true,
+      get: () => 7,
+    });
+    expect((run(source) as { value: unknown }).value).toBe(7);
+  });
+
+  it('instantiates class constructors with prototype-method spies', () => {
+    const { run, isMockFunction } = make('autospy');
+    class Foo {
+      greet(): string {
+        return 'hi';
+      }
+    }
+    const result = run({ Foo });
+    expect(isMockFunction(result.Foo)).toBe(true);
+
+    const instance = new result.Foo();
+    expect(isMockFunction(instance.greet)).toBe(true);
+    expect(instance.greet()).toBe('hi');
+    expect(instance.greet.mock.calls).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/runtime/api/spy.test.ts
+++ b/packages/core/tests/runtime/api/spy.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from '@rstest/core';
+import { initSpy } from '../../../src/runtime/api/spy';
+
+describe('initSpy fn()', () => {
+  it('tracks calls, results and invocationCallOrder', () => {
+    const { fn } = initSpy();
+    const spy = fn((x: number) => x * 2);
+
+    expect(spy(2)).toBe(4);
+    expect(spy(3)).toBe(6);
+
+    expect(spy.mock.calls).toEqual([[2], [3]]);
+    expect(spy.mock.results).toEqual([
+      { type: 'return', value: 4 },
+      { type: 'return', value: 6 },
+    ]);
+    expect(spy.mock.invocationCallOrder).toHaveLength(2);
+    expect(spy.mock.invocationCallOrder[0]!).toBeLessThan(
+      spy.mock.invocationCallOrder[1]!,
+    );
+  });
+
+  it('records throwing results', () => {
+    const { fn } = initSpy();
+    const spy = fn(() => {
+      throw new Error('boom');
+    });
+
+    expect(() => spy()).toThrow('boom');
+    expect(spy.mock.results[0]!.type).toBe('throw');
+  });
+
+  it('isMockFunction distinguishes mocks from plain values', () => {
+    const { fn, isMockFunction } = initSpy();
+    expect(isMockFunction(fn())).toBe(true);
+    expect(isMockFunction(() => {})).toBe(false);
+    expect(isMockFunction(null)).toBe(false);
+  });
+});
+
+describe('initSpy once-implementation queue (LIFO-peek vs FIFO-consume)', () => {
+  it('pins the intentional divergence between getMockImplementation and dispatch', () => {
+    const { fn } = initSpy();
+    const baseImpl = () => 'base';
+    const spy = fn(baseImpl);
+    const onceA = () => 'A';
+    const onceB = () => 'B';
+
+    spy.mockImplementationOnce(onceA);
+    spy.mockImplementationOnce(onceB);
+
+    // getMockImplementation peeks the LAST queued once-impl (LIFO, spy.ts:62)...
+    expect(spy.getMockImplementation()).toBe(onceB);
+    // ...but actual dispatch consumes the FIRST queued once-impl (FIFO, spy.ts:143).
+    // The two intentionally disagree — this is pinned, not a bug to "fix".
+    expect(spy()).toBe('A');
+
+    // After A is consumed, B is both peeked and dispatched.
+    expect(spy.getMockImplementation()).toBe(onceB);
+    expect(spy()).toBe('B');
+
+    // Queue drained → falls back to the base implementation.
+    expect(spy.getMockImplementation()).toBe(baseImpl);
+    expect(spy()).toBe('base');
+  });
+});
+
+describe('initSpy reset semantics', () => {
+  it('mockClear resets call state but keeps the implementation', () => {
+    const { fn } = initSpy();
+    const spy = fn(() => 'impl');
+
+    expect(spy()).toBe('impl');
+    expect(spy.mock.calls).toHaveLength(1);
+
+    spy.mockClear();
+    expect(spy.mock.calls).toHaveLength(0);
+    expect(spy()).toBe('impl');
+  });
+
+  it('mockReset clears the once-queue and restores the base implementation', () => {
+    const { fn } = initSpy();
+    const spy = fn(() => 'base');
+
+    spy.mockImplementation(() => 'override');
+    spy.mockImplementationOnce(() => 'once');
+    expect(spy()).toBe('once');
+
+    spy.mockReset();
+    expect(spy()).toBe('base');
+  });
+
+  it('registers every created mock in the shared mocks set', () => {
+    const { fn, spyOn, mocks } = initSpy();
+    const a = fn();
+    const obj = { method: () => 'real' };
+    const b = spyOn(obj, 'method');
+
+    expect(mocks.has(a)).toBe(true);
+    expect(mocks.has(b)).toBe(true);
+
+    a();
+    obj.method();
+    // Mirror clearAllMocks: iterate the returned set.
+    for (const mock of mocks) {
+      mock.mockClear();
+    }
+    expect(a.mock.calls).toHaveLength(0);
+    expect(b.mock.calls).toHaveLength(0);
+  });
+});
+
+describe('initSpy spyOn', () => {
+  it('replaces a method while preserving original behavior and restores it', () => {
+    const { spyOn } = initSpy();
+    const obj = { greet: () => 'hi' };
+    const original = obj.greet;
+
+    const spy = spyOn(obj, 'greet');
+    expect(obj.greet).not.toBe(original);
+    expect(obj.greet()).toBe('hi');
+    expect(spy.mock.calls).toHaveLength(1);
+
+    spy.mockRestore();
+    expect(obj.greet).toBe(original);
+  });
+
+  it('returns the existing mock when the method is already mocked', () => {
+    const { spyOn } = initSpy();
+    const obj = { greet: () => 'hi' };
+    const spy1 = spyOn(obj, 'greet');
+    const spy2 = spyOn(obj, 'greet');
+    expect(spy2).toBe(spy1);
+  });
+
+  it('spies on a getter accessor', () => {
+    const { spyOn } = initSpy();
+    let backing = 1;
+    const obj = {};
+    Object.defineProperty(obj, 'val', {
+      configurable: true,
+      get() {
+        return backing;
+      },
+      set(next: number) {
+        backing = next;
+      },
+    });
+
+    const getSpy = spyOn(obj, 'val', 'get');
+    void (obj as { val: number }).val;
+    expect(getSpy.mock.calls).toHaveLength(1);
+  });
+
+  it('restores the spy via Symbol.dispose', () => {
+    if (!Symbol.dispose) return;
+    const { spyOn } = initSpy();
+    const obj = { greet: () => 'hi' };
+    const original = obj.greet;
+
+    const spy = spyOn(obj, 'greet');
+    expect(obj.greet).not.toBe(original);
+    (spy as unknown as Record<symbol, () => void>)[Symbol.dispose]!();
+    expect(obj.greet).toBe(original);
+  });
+});

--- a/packages/core/tests/runtime/api/utilities.test.ts
+++ b/packages/core/tests/runtime/api/utilities.test.ts
@@ -1,4 +1,7 @@
-import { createRstestUtilities } from '../../../src/runtime/api/utilities';
+import {
+  createRstestUtilities,
+  restoreScopedEntry,
+} from '../../../src/runtime/api/utilities';
 import { setRealTimers } from '../../../src/runtime/util';
 import type { WorkerState } from '../../../src/types';
 
@@ -224,5 +227,74 @@ describe('rstest utility scoped cleanup', () => {
     expect(callback).toHaveBeenCalledTimes(1);
 
     rs.useRealTimers();
+  });
+});
+
+describe('restoreScopedEntry', () => {
+  it('runs onTail and onEmpty when the newest (tail) entry is restored', () => {
+    const stack = [{ value: 1 }];
+    const entry = stack[0]!;
+    const events: string[] = [];
+
+    restoreScopedEntry(stack, entry, {
+      onSupersede: () => events.push('supersede'),
+      onTail: () => events.push('tail'),
+      onEmpty: () => events.push('empty'),
+    });
+
+    expect(events).toEqual(['tail', 'empty']);
+    expect(stack).toHaveLength(0);
+  });
+
+  it('forwards the saved payload onto the next entry without touching the live binding', () => {
+    const first = { value: 'first' };
+    const second = { value: 'second' };
+    const stack = [first, second];
+    const events: string[] = [];
+
+    // Disposing the shadowed (non-tail) entry: its payload supersedes the next
+    // entry and it is spliced out; no tail/empty restore runs.
+    restoreScopedEntry(stack, first, {
+      onSupersede: (later) => {
+        events.push('supersede');
+        later.value = first.value;
+      },
+      onTail: () => events.push('tail'),
+      onEmpty: () => events.push('empty'),
+    });
+
+    expect(events).toEqual(['supersede']);
+    expect(stack).toEqual([{ value: 'first' }]);
+    expect(stack[0]).toBe(second);
+  });
+
+  it('does not run onEmpty while older entries remain after the tail pop', () => {
+    const older = { value: 'older' };
+    const newest = { value: 'newest' };
+    const stack = [older, newest];
+    const events: string[] = [];
+
+    restoreScopedEntry(stack, newest, {
+      onSupersede: () => events.push('supersede'),
+      onTail: () => events.push('tail'),
+      onEmpty: () => events.push('empty'),
+    });
+
+    expect(events).toEqual(['tail']);
+    expect(stack).toEqual([older]);
+  });
+
+  it('is a no-op when the stack is missing or the entry was already removed', () => {
+    const events: string[] = [];
+    const handlers = {
+      onSupersede: () => events.push('supersede'),
+      onTail: () => events.push('tail'),
+      onEmpty: () => events.push('empty'),
+    };
+
+    restoreScopedEntry(undefined, { value: 1 }, handlers);
+    restoreScopedEntry([{ value: 1 }], { value: 2 }, handlers);
+
+    expect(events).toEqual([]);
   });
 });

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  handleFixtures,
+  normalizeFixtures,
+} from '../../../src/runtime/runner/fixtures';
+
+describe('normalizeFixtures', () => {
+  it('treats a single-function tuple as a fixture function', () => {
+    const fixtureFn = () => {};
+    const result = normalizeFixtures({ a: [fixtureFn] } as any);
+    expect(result.a).toMatchObject({ isFn: true, value: fixtureFn });
+  });
+
+  it('parses the [value, options] tuple form', () => {
+    const result = normalizeFixtures({ a: ['x', { auto: true }] } as any);
+    expect(result.a).toMatchObject({
+      isFn: false,
+      value: 'x',
+      options: { auto: true },
+    });
+  });
+
+  it('wraps a plain value as a non-function fixture', () => {
+    const result = normalizeFixtures({ a: 42 } as any);
+    expect(result.a).toMatchObject({ isFn: false, value: 42 });
+  });
+
+  it('computes deps only for fixtures that exist in the set', () => {
+    const aFn = ({ b }: any) => b;
+    const result = normalizeFixtures({ a: [aFn], b: 1, c: 2 } as any);
+    expect(result.a.deps).toEqual(['b']);
+  });
+
+  it('merges extendFixtures with local fixtures taking precedence', () => {
+    const extend = { base: { isFn: false, value: 'base' } } as any;
+    const result = normalizeFixtures({ a: 1 } as any, extend);
+    expect(result.base).toEqual({ isFn: false, value: 'base' });
+    expect(result.a).toMatchObject({ isFn: false, value: 1 });
+  });
+});
+
+describe('normalizeFixtures param parsing (getFixtureUsedProps)', () => {
+  it('skips dependency detection for an _-prefixed first param', () => {
+    const fixtureFn = (_ctx: any) => {};
+    const result = normalizeFixtures({ a: [fixtureFn] } as any);
+    expect(result.a.deps).toEqual([]);
+  });
+
+  it('throws when the first param is not destructured', () => {
+    const fixtureFn = (ctx: any) => ctx;
+    expect(() => normalizeFixtures({ a: [fixtureFn] } as any)).toThrow(
+      /object destructuring pattern/,
+    );
+  });
+
+  it('throws when a rest property is used', () => {
+    const fixtureFn = ({ ...rest }: any) => rest;
+    expect(() => normalizeFixtures({ a: [fixtureFn] } as any)).toThrow(
+      /Rest property/,
+    );
+  });
+
+  it('strips comments before parsing the destructured params', () => {
+    const useFn = ({ foo /* inline */, bar }: any) => [foo, bar];
+    const result = normalizeFixtures({
+      used: [useFn],
+      foo: 1,
+      bar: 2,
+    } as any);
+    expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
+  });
+});
+
+describe('handleFixtures', () => {
+  it('activates auto fixtures and on-demand fixtures used by the test fn', async () => {
+    const order: string[] = [];
+    const fixtures = normalizeFixtures({
+      autoFix: [
+        async (_ctx: any, use: any) => {
+          order.push('auto');
+          await use('A');
+        },
+        { auto: true },
+      ],
+      usedFix: [
+        async (_ctx: any, use: any) => {
+          order.push('used');
+          await use('U');
+        },
+      ],
+      unusedFix: [
+        async (_ctx: any, use: any) => {
+          order.push('unused');
+          await use('X');
+        },
+      ],
+    } as any);
+
+    const context: Record<string, any> = {};
+    const test = {
+      fixtures,
+      originalFn: ({ usedFix }: any) => usedFix,
+    } as any;
+
+    const { cleanups } = await handleFixtures(test, context);
+
+    expect(context.autoFix).toBe('A');
+    expect(context.usedFix).toBe('U');
+    expect('unusedFix' in context).toBe(false);
+    expect(order).toEqual(['auto', 'used']);
+    expect(cleanups).toHaveLength(2);
+  });
+
+  it('throws on circular fixture dependencies', async () => {
+    const fixtures = normalizeFixtures({
+      x: [async ({ y }: any, use: any) => use(y)],
+      y: [async ({ x }: any, use: any) => use(x)],
+    } as any);
+
+    const test = {
+      fixtures,
+      originalFn: ({ x }: any) => x,
+    } as any;
+
+    await expect(handleFixtures(test, {})).rejects.toThrow(
+      /Circular fixture dependency/,
+    );
+  });
+
+  it('registers cleanups in reverse (unshift) order', async () => {
+    const cleaned: string[] = [];
+    const fixtures = normalizeFixtures({
+      first: [
+        async (_c: any, use: any) => {
+          await use(1);
+          cleaned.push('first');
+        },
+        { auto: true },
+      ],
+      second: [
+        async (_c: any, use: any) => {
+          await use(2);
+          cleaned.push('second');
+        },
+        { auto: true },
+      ],
+    } as any);
+
+    const test = {
+      fixtures,
+      originalFn: () => {},
+    } as any;
+
+    const { cleanups } = await handleFixtures(test, {});
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+    expect(cleaned).toEqual(['second', 'first']);
+  });
+});

--- a/packages/core/tests/runtime/worker/env/registry.test.ts
+++ b/packages/core/tests/runtime/worker/env/registry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from '@rstest/core';
+import { environmentLoaders } from '../../../../src/runtime/worker/env/registry';
+
+describe('test environment registry', () => {
+  it('exposes loaders for exactly the non-node environments', () => {
+    expect(Object.keys(environmentLoaders).sort()).toEqual([
+      'happy-dom',
+      'jsdom',
+    ]);
+    // `node` is the no-op fast path, never a loader entry.
+    expect('node' in environmentLoaders).toBe(false);
+  });
+
+  it('each loader resolves to an adapter whose name matches its registry key', async () => {
+    for (const key of Object.keys(environmentLoaders) as Array<
+      keyof typeof environmentLoaders
+    >) {
+      const { environment } = await environmentLoaders[key]();
+      expect(environment.name).toBe(key);
+      expect(typeof environment.setup).toBe('function');
+    }
+  });
+});

--- a/packages/core/tests/utils/helper.test.ts
+++ b/packages/core/tests/utils/helper.test.ts
@@ -1,10 +1,17 @@
 import { sep } from 'node:path';
 import {
+  getFileTaskId,
   getWorkerSerialization,
   needFlagExperimentalDetectModule,
   parsePosix,
   prettyTime,
 } from '../../src/utils/helper';
+
+it('getFileTaskId builds the file: task-id grammar', () => {
+  // Locks the single source of truth so the worker/pool/runner consumers and
+  // the tests/pool/fixtures/testWorker.mjs literal copy cannot drift.
+  expect(getFileTaskId('/abs/foo.test.ts')).toBe('file:/abs/foo.test.ts');
+});
 
 it('parsePosix correctly', () => {
   const splitPaths = ['packages', 'core', 'tests', 'index.test.ts'];


### PR DESCRIPTION
## Summary

Internal refactor with no behavior or public API change. It folds three sets of hand-copied runtime primitives into single owners so the duplicated copies can no longer drift.

- **`getFileTaskId`** becomes the single owner of the `file:` task-id grammar, replacing the duplicated `` `file:${path}` `` copies in the runner, pool, worker, and console paths.
- **`environmentLoaders` registry** replaces the per-environment `switch`, so adding a test environment is a single registry entry instead of another branch.
- **`restoreScopedEntry`** unifies the LIFO restore bookkeeping shared by the env, global, and fake-timer stub stacks; each stack keeps its own restore action via small handler closures, so their distinct behavior is preserved exactly.

Note for review ordering: this touches `helper.ts` and `runtime/api/utilities.ts` in regions also edited by the upcoming browser-seam PR (regexp wire-format import / env-symbol key). The overlap is small and resolved when both land; this PR should merge first.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).