### PR TITLE
refactor(browser): single-source the runner dispatch method vocabulary

### DIFF
--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -24,6 +24,7 @@ import type {
   BrowserClientMessage,
   BrowserDispatchRequest,
   BrowserProjectRuntime,
+  RunnerLifecycleMethod,
 } from '../protocol';
 import {
   DISPATCH_MESSAGE_TYPE,
@@ -43,12 +44,6 @@ declare global {
   // eslint-disable-next-line no-var
   var __coverage__: Record<string, unknown> | undefined;
 }
-
-type RunnerLifecycleMethod =
-  | 'file-ready'
-  | 'suite-start'
-  | 'suite-result'
-  | 'case-start';
 
 let runnerDispatchRequestId = 0;
 

--- a/packages/browser/src/dispatchCapabilities.ts
+++ b/packages/browser/src/dispatchCapabilities.ts
@@ -4,6 +4,7 @@ import type {
   BrowserClientMessage,
   BrowserDispatchHandler,
   BrowserDispatchRequest,
+  RunnerDispatchMethod,
   SnapshotRpcMethod,
   SnapshotRpcMethodArgs,
   SnapshotRpcRequest,
@@ -109,52 +110,45 @@ export const createHostDispatchRouter = ({
 }: CreateHostDispatchRouterOptions): HostDispatchRouter => {
   const router = new HostDispatchRouter(routerOptions);
 
+  // Keyed by RunnerDispatchMethod so adding a runner method to that union forces
+  // a handler entry here (a missing key is a compile error) — the previous
+  // `switch` with `default: break` silently dropped unhandled methods. The
+  // `args` casts are checked against each callback's parameter type, so a wrong
+  // payload type also fails to compile.
+  const runnerMethodHandlers: {
+    [M in RunnerDispatchMethod]: (
+      args: BrowserDispatchRequest['args'],
+    ) => Promise<void>;
+  } = {
+    'file-start': (args) =>
+      runnerCallbacks.onTestFileStart(args as RunnerPayload<'file-start'>),
+    'file-ready': (args) =>
+      runnerCallbacks.onTestFileReady(args as RunnerDispatchFileReadyPayload),
+    'suite-start': (args) =>
+      runnerCallbacks.onTestSuiteStart(args as RunnerDispatchSuiteStartPayload),
+    'suite-result': (args) =>
+      runnerCallbacks.onTestSuiteResult(
+        args as RunnerDispatchSuiteResultPayload,
+      ),
+    'case-start': (args) =>
+      runnerCallbacks.onTestCaseStart(args as RunnerDispatchCaseStartPayload),
+    'case-result': (args) =>
+      runnerCallbacks.onTestCaseResult(args as RunnerPayload<'case-result'>),
+    'file-complete': (args) =>
+      runnerCallbacks.onTestFileComplete(
+        args as RunnerPayload<'file-complete'>,
+      ),
+    log: (args) => runnerCallbacks.onLog(args as RunnerPayload<'log'>),
+    fatal: (args) => runnerCallbacks.onFatal(args as RunnerPayload<'fatal'>),
+  };
+
   router.register('runner', async (request: BrowserDispatchRequest) => {
-    switch (request.method) {
-      case 'file-start':
-        await runnerCallbacks.onTestFileStart(
-          request.args as RunnerPayload<'file-start'>,
-        );
-        break;
-      case 'file-ready':
-        await runnerCallbacks.onTestFileReady(
-          request.args as RunnerDispatchFileReadyPayload,
-        );
-        break;
-      case 'suite-start':
-        await runnerCallbacks.onTestSuiteStart(
-          request.args as RunnerDispatchSuiteStartPayload,
-        );
-        break;
-      case 'suite-result':
-        await runnerCallbacks.onTestSuiteResult(
-          request.args as RunnerDispatchSuiteResultPayload,
-        );
-        break;
-      case 'case-start':
-        await runnerCallbacks.onTestCaseStart(
-          request.args as RunnerDispatchCaseStartPayload,
-        );
-        break;
-      case 'case-result':
-        await runnerCallbacks.onTestCaseResult(
-          request.args as RunnerPayload<'case-result'>,
-        );
-        break;
-      case 'file-complete':
-        await runnerCallbacks.onTestFileComplete(
-          request.args as RunnerPayload<'file-complete'>,
-        );
-        break;
-      case 'log':
-        await runnerCallbacks.onLog(request.args as RunnerPayload<'log'>);
-        break;
-      case 'fatal':
-        await runnerCallbacks.onFatal(request.args as RunnerPayload<'fatal'>);
-        break;
-      default:
-        break;
-    }
+    // `request.method` is untrusted wire data, so the lookup may miss. Unknown
+    // methods are ignored for forward-compatibility with newer runners, matching
+    // the previous `default: break`.
+    await runnerMethodHandlers[request.method as RunnerDispatchMethod]?.(
+      request.args,
+    );
   });
 
   router.register('snapshot', async (request: BrowserDispatchRequest) => {

--- a/packages/browser/src/protocol.ts
+++ b/packages/browser/src/protocol.ts
@@ -138,6 +138,38 @@ export type BrowserClientMessage =
     };
 
 /**
+ * Lifecycle methods the runner emits via `dispatchRunnerLifecycle()` as
+ * dispatch-rpc-requests on the `runner` namespace (as opposed to the
+ * {@link BrowserClientMessage} types it `send()`s). The runner client imports
+ * this instead of redeclaring the list, so the emit site cannot drift from the
+ * host router.
+ */
+export type RunnerLifecycleMethod =
+  | 'file-ready'
+  | 'suite-start'
+  | 'suite-result'
+  | 'case-start';
+
+/**
+ * {@link BrowserClientMessage} types that are forwarded to the `runner`
+ * namespace (by message `type`) rather than handled at the transport layer.
+ * `Extract` keeps this a checked subset of the message union — renaming a
+ * message type drops it here, surfacing as a missing handler downstream.
+ */
+type RunnerMessageMethod = Extract<
+  BrowserClientMessage['type'],
+  'file-start' | 'case-result' | 'file-complete' | 'log' | 'fatal'
+>;
+
+/**
+ * Single source of truth for every method handled by the `runner` dispatch
+ * namespace. The host handler table is keyed by this union (a missing key is a
+ * compile error), so adding a runner method here forces a matching handler and
+ * cannot silently no-op at runtime.
+ */
+export type RunnerDispatchMethod = RunnerLifecycleMethod | RunnerMessageMethod;
+
+/**
  * Transport-agnostic envelope used by host routing.
  * `namespace + method + args + target` describes an operation independent of
  * the underlying message channel, and `runToken` provides run-level isolation.


### PR DESCRIPTION
## Summary

The `runner` dispatch namespace handled inbound methods with a `switch` over `request.method: string` whose `default: break` **silently dropped** any unhandled method, and the runner client redeclared its own `RunnerLifecycleMethod` union. Adding a runner lifecycle method, or renaming a forwarded `BrowserClientMessage` type, could drift the client emit site from the host router with no compile-time signal — the message would just no-op at runtime.

This is the same single-source-of-truth treatment as #1377 (snapshot RPC), applied to the runner namespace:

- New `RunnerDispatchMethod` in `protocol.ts` = `RunnerLifecycleMethod` (lifecycle methods emitted via `dispatchRunnerLifecycle`) plus the `BrowserClientMessage` types forwarded to the namespace. The latter is pinned via `Extract<BrowserClientMessage['type'], …>`, so renaming a forwarded message type surfaces as an error instead of drifting.
- The host handler is now a `Record` keyed by `RunnerDispatchMethod`, so a missing method is a compile error (`TS2741`) rather than a silent no-op. Unknown wire methods are still ignored for forward-compatibility, matching the previous `default: break`.
- The runner client imports `RunnerLifecycleMethod` instead of redeclaring it, binding the emit site to the same source.

No runtime behavior change — wire payloads and dispatch flow are identical.

Verified: `@rstest/browser` typecheck passes; injecting a 5th lifecycle method makes the handler table fail (`TS2741`); renaming a forwarded message type errors at the client emit (`TS2820`), the `Extract` constraint (`TS2344`), and the handler table (`TS2353`) simultaneously; browser-mode e2e for the runner dispatch path — basic / reporter / console / error / list (15 cases) — all pass.

> Out of scope (adjacent, left for follow-up): the headed birpc `onTest*` callback path and the list-collect inline switch in `hostController.ts` use separate mechanisms over different subsets of the message union; folding them into one checked subset assertion is a larger change with behavior risk.

## Related Links

Follows #1377.

## Checklist

- [x] Tests updated (or not required). _(no behavior change; covered by existing browser-mode e2e)_
- [x] Documentation updated (or not required).