### PR TITLE
refactor(core): single-source test-execution runtime contracts

### DIFF
--- a/e2e/test-api/chain.test.ts
+++ b/e2e/test-api/chain.test.ts
@@ -5,11 +5,11 @@ describe('Test Chain', () => {
     expect(Object.keys(it)).toMatchInlineSnapshot(`
       [
         "fails",
+        "only",
+        "todo",
+        "skip",
         "concurrent",
         "sequential",
-        "skip",
-        "todo",
-        "only",
         "runIf",
         "skipIf",
         "each",
@@ -20,11 +20,11 @@ describe('Test Chain', () => {
     expect(Object.keys(it.only)).toMatchInlineSnapshot(`
       [
         "fails",
+        "only",
+        "todo",
+        "skip",
         "concurrent",
         "sequential",
-        "skip",
-        "todo",
-        "only",
         "runIf",
         "skipIf",
         "each",

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -11,6 +11,7 @@ import {
   type CoverageMapData,
   color,
   createCoverageProvider,
+  DEFAULT_TEST_TIMEOUT,
   type FormattedError,
   getNoTestFilesMessage,
   getSetupFiles,
@@ -2087,7 +2088,9 @@ export const runBrowserController = async (
 
   // Get max testTimeout from all browser projects for RPC timeout
   const maxTestTimeoutForRpc = Math.max(
-    ...browserProjects.map((p) => p.normalizedConfig.testTimeout ?? 5000),
+    ...browserProjects.map(
+      (p) => p.normalizedConfig.testTimeout ?? DEFAULT_TEST_TIMEOUT,
+    ),
   );
 
   const hostOptions: BrowserHostConfig = {
@@ -3710,7 +3713,9 @@ export const listBrowserTests = async (
 
   // Get max testTimeout from all browser projects for RPC timeout
   const maxTestTimeoutForRpc = Math.max(
-    ...browserProjects.map((p) => p.normalizedConfig.testTimeout ?? 5000),
+    ...browserProjects.map(
+      (p) => p.normalizedConfig.testTimeout ?? DEFAULT_TEST_TIMEOUT,
+    ),
   );
 
   const hostOptions: BrowserHostConfig = {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -50,6 +50,7 @@ export { getNumCpus, parseWorkers } from './utils/workers';
 // Constants
 export {
   BROWSER_PROVIDERS,
+  DEFAULT_TEST_TIMEOUT,
   resolveProjectBuildCache,
   RSTEST_ENV_SYMBOL_KEY,
 } from './utils/constants';

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -17,6 +17,7 @@ import {
   color,
   DEFAULT_CONFIG_EXTENSIONS,
   DEFAULT_CONFIG_NAME,
+  DEFAULT_TEST_TIMEOUT,
   formatRootStr,
   getOutputDistPathRoot,
   getTempRstestOutputDirGlob,
@@ -216,7 +217,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
   globals: false,
   passWithNoTests: false,
   update: false,
-  testTimeout: 5_000,
+  testTimeout: DEFAULT_TEST_TIMEOUT,
   hookTimeout: 10_000,
   testEnvironment: {
     name: 'node',

--- a/packages/core/src/runtime/api/poll.ts
+++ b/packages/core/src/runtime/api/poll.ts
@@ -19,6 +19,7 @@
 import type { Assertion } from '@vitest/expect';
 import { Assertion as ChaiAssertion, util } from 'chai';
 import type { RstestExpect, TestCase } from '../../types';
+import { SYNTHETIC_STACK_ERROR_MESSAGE } from '../../utils/constants';
 import { getRealTimers } from '../util';
 
 // these matchers are not supported because they don't make sense with poll
@@ -77,7 +78,7 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
         }
 
         return function (this: any, ...args: any[]) {
-          const STACK_TRACE_ERROR = new Error('STACK_TRACE_ERROR');
+          const STACK_TRACE_ERROR = new Error(SYNTHETIC_STACK_ERROR_MESSAGE);
           const promise = () =>
             new Promise<void>((resolve, reject) => {
               let intervalId: any;

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -20,6 +20,7 @@ import type {
   TestResultStatus,
   WorkerState,
 } from '../../types';
+import { SYNTHETIC_STACK_ERROR_MESSAGE } from '../../utils/constants';
 import { getFileTaskId, getTaskNameWithPrefix } from '../../utils/helper';
 import { createExpect } from '../api/expect';
 import { formatTestError } from '../util';
@@ -664,7 +665,7 @@ export class TestRunner {
         name: 'onTestFinished hook',
         fn,
         timeout: timeout || this.workerState!.runtimeConfig.hookTimeout,
-        stackTraceError: new Error('STACK_TRACE_ERROR'),
+        stackTraceError: new Error(SYNTHETIC_STACK_ERROR_MESSAGE),
       }),
     );
   }
@@ -682,7 +683,7 @@ export class TestRunner {
         name: 'onTestFailed hook',
         fn,
         timeout: timeout || this.workerState!.runtimeConfig.hookTimeout,
-        stackTraceError: new Error('STACK_TRACE_ERROR'),
+        stackTraceError: new Error(SYNTHETIC_STACK_ERROR_MESSAGE),
       }),
     );
   }

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -26,7 +26,10 @@ import type {
   TestRunMode,
   TestSuite,
 } from '../../types';
-import { ROOT_SUITE_NAME } from '../../utils/constants';
+import {
+  ROOT_SUITE_NAME,
+  SYNTHETIC_STACK_ERROR_MESSAGE,
+} from '../../utils/constants';
 import { castArray, generateFilePathHash } from '../../utils/helper';
 import {
   formatName,
@@ -39,6 +42,21 @@ import { normalizeFixtures } from './fixtures';
 import { registerTestSuiteListener, wrapTimeout } from './task';
 
 type CollectStatus = 'lazy' | 'running';
+
+/**
+ * Run-mode / concurrency modifiers shared by the `test` and `describe` APIs.
+ * Both factories install these as chainable getters (`test.skip`,
+ * `describe.only`, …), so listing them once here keeps the two installs from
+ * drifting — a new shared modifier is added in a single place. API-specific
+ * modifiers (e.g. `test.fails`) stay inline at their call site.
+ */
+const SHARED_RUN_MODIFIERS = [
+  { name: 'only', overrides: { runMode: 'only' } },
+  { name: 'todo', overrides: { runMode: 'todo' } },
+  { name: 'skip', overrides: { runMode: 'skip' } },
+  { name: 'concurrent', overrides: { concurrent: true } },
+  { name: 'sequential', overrides: { sequential: true } },
+] as const;
 
 class RunnerRuntime {
   /** all test cases */
@@ -109,7 +127,7 @@ class RunnerRuntime {
         name: `${key} hook`,
         fn,
         timeout,
-        stackTraceError: new Error('STACK_TRACE_ERROR'),
+        stackTraceError: new Error(SYNTHETIC_STACK_ERROR_MESSAGE),
       }),
     );
   }
@@ -343,7 +361,7 @@ class RunnerRuntime {
       name,
       originalFn,
       fn,
-      stackTraceError: new Error('STACK_TRACE_ERROR'),
+      stackTraceError: new Error(SYNTHETIC_STACK_ERROR_MESSAGE),
       runMode,
       type: 'case',
       timeout,
@@ -555,11 +573,7 @@ export const createRuntimeAPI = ({
 
     for (const { name, overrides } of [
       { name: 'fails', overrides: { fails: true } },
-      { name: 'concurrent', overrides: { concurrent: true } },
-      { name: 'sequential', overrides: { sequential: true } },
-      { name: 'skip', overrides: { runMode: 'skip' as const } },
-      { name: 'todo', overrides: { runMode: 'todo' as const } },
-      { name: 'only', overrides: { runMode: 'only' as const } },
+      ...SHARED_RUN_MODIFIERS,
     ]) {
       Object.defineProperty(testFn, name, {
         get: () => {
@@ -636,13 +650,7 @@ export const createRuntimeAPI = ({
         location: options.location ?? getLocation(),
       })) as DescribeAPI;
 
-    for (const { name, overrides } of [
-      { name: 'only', overrides: { runMode: 'only' as const } },
-      { name: 'todo', overrides: { runMode: 'todo' as const } },
-      { name: 'skip', overrides: { runMode: 'skip' as const } },
-      { name: 'concurrent', overrides: { concurrent: true } },
-      { name: 'sequential', overrides: { sequential: true } },
-    ]) {
+    for (const { name, overrides } of SHARED_RUN_MODIFIERS) {
       Object.defineProperty(describeFn, name, {
         get: () => {
           return createDescribeAPI({ ...options, ...overrides });

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -254,7 +254,10 @@ export const DEFAULT_CONFIG_EXTENSIONS = [
   '.cts',
 ] as const;
 
-export const globalApis: (keyof Rstest)[] = [
+// Literal tuple kept private so `(typeof globalApiList)[number]` is the exact
+// key union (the exported alias below is widened for consumers); `satisfies`
+// rejects a *wrong* key here.
+const globalApiList = [
   'test',
   'describe',
   'it',
@@ -268,6 +271,31 @@ export const globalApis: (keyof Rstest)[] = [
   'assert',
   'onTestFinished',
   'onTestFailed',
-];
+] as const satisfies readonly (keyof Rstest)[];
+
+export const globalApis: readonly (keyof Rstest)[] = globalApiList;
+
+/**
+ * Exhaustiveness guard for {@link globalApis}. `satisfies` above rejects a
+ * *wrong* key, but a short array still compiles — a new {@link Rstest} API
+ * silently missing here is never registered onto `globalThis` under
+ * `globals: true`. This alias resolves to a descriptive tuple (not `true`) when
+ * any `Rstest` key is absent, failing the assignment below at compile time.
+ */
+type MissingGlobalApis = Exclude<keyof Rstest, (typeof globalApiList)[number]>;
+type GlobalApisAreExhaustive = [MissingGlobalApis] extends [never]
+  ? true
+  : ['globalApis is missing keys of Rstest:', MissingGlobalApis];
+const _globalApisAreExhaustive: GlobalApisAreExhaustive = true;
+void _globalApisAreExhaustive;
+
+/** Shared marker message for synthetic errors used only to capture a stack
+ * trace. The value is a placeholder: the runner reads it back via
+ * `error.message`, so every synthetic-stack site must use this same constant. */
+export const SYNTHETIC_STACK_ERROR_MESSAGE = 'STACK_TRACE_ERROR';
+
+/** Default per-test timeout (ms). Single source for the config default and any
+ * downstream fallback. */
+export const DEFAULT_TEST_TIMEOUT = 5_000;
 
 export const TS_CONFIG_FILE = 'tsconfig.json';

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -14,7 +14,7 @@ const isHttpLikeFile = (file: string): boolean => /^https?:\/\//.test(file);
 const hintNotDefinedError = (message: string): string => {
   const [, varName] = /(\w+) is not defined/.exec(message) || [];
   if (varName) {
-    if ((globalApis as string[]).includes(varName)) {
+    if ((globalApis as readonly string[]).includes(varName)) {
       return message.replace(
         `${varName} is not defined`,
         `${varName} is not defined. Did you forget to enable "globals" configuration?`,


### PR DESCRIPTION
## Summary

Several test-execution-runtime contracts were spread across multiple sites where a change to one could silently drift from the others, with no compile-time signal. This applies the same single-source-of-truth treatment as the recent browser RPC refactors (#1377, #1380) to the core runtime:

- **`globalApis` exhaustiveness (was unguarded).** The list was typed `(keyof Rstest)[]`, so `keyof` rejects a *wrong* key but a *short* array still compiles — a new `Rstest` API missing from the list is never registered onto `globalThis` under `globals: true`, leaving it import-only. Added a compile-time exhaustiveness guard that fails (and names the missing key) when any `Rstest` key is absent.
- **Shared test/describe modifiers (was duplicated).** The `only`/`todo`/`skip`/`concurrent`/`sequential` modifiers were declared inline in both the `test` and `describe` factories; adding one to a single site would silently diverge the two APIs. Hoisted into one `SHARED_RUN_MODIFIERS` list driving both installs. `test.fails` stays inline as a test-only modifier.
- **Synthetic stack marker (was a magic string).** `'STACK_TRACE_ERROR'` was repeated across the runner, runtime, and poll modules. Centralized as `SYNTHETIC_STACK_ERROR_MESSAGE`.
- **Default test timeout (was a magic number).** The literal `5000` appeared in the config default and two browser-host fallbacks. Centralized as `DEFAULT_TEST_TIMEOUT`, exported through the `@rstest/core/internal/browser` entry.

No runtime behavior change. The unified modifier order matches the previously-pinned `describe` enumerable snapshot; the `test` API's (unsnapshotted) key order changes harmlessly.

> Note: the related `EnvironmentName` ↔ environment-switch hazard is already closed — the worker now resolves environments via an exhaustive `Record` registry (#1379), so no change was needed there.

## Related Links

Follows #1377 and #1380 (same single-source-of-truth treatment for the browser dispatch/RPC contracts).

## Checklist

- [x] Tests updated (or not required). _(no behavior change; covered by existing core unit + describe/runner/globals/lifecycle e2e — 373 unit + 72 e2e pass)_
- [x] Documentation updated (or not required).