### PR TITLE
refactor(browser): deepen core↔browser seam and close browser-mode drift hazards

### DIFF
--- a/packages/browser-ui/src/components/TestFilesTree.tsx
+++ b/packages/browser-ui/src/components/TestFilesTree.tsx
@@ -3,6 +3,12 @@ import type { GlobalToken } from 'antd/es/theme/interface';
 import type { DataNode } from 'antd/es/tree';
 import { ChevronDown, ChevronRight, Package } from 'lucide-react';
 import React, { useCallback, useMemo } from 'react';
+import {
+  appendSuiteSegment,
+  caseKey,
+  emptyKey,
+  projectKey as toProjectKey,
+} from '../core/treeNodeKey';
 import type { BrowserProjectRuntime, TestFileInfo } from '../types';
 import { openInEditor, toRelativePath } from '../utils';
 import {
@@ -117,7 +123,7 @@ export const TestFilesTree: React.FC<TestFilesTreeProps> = ({
       if (cases.length === 0) {
         return [
           {
-            key: `${file}::__empty`,
+            key: emptyKey(file),
             title: (
               <span className="text-xs text-(--muted-foreground)">
                 No test cases reported yet
@@ -184,7 +190,7 @@ export const TestFilesTree: React.FC<TestFilesTreeProps> = ({
         for (const child of node.children.values()) {
           const suiteStatus = calcStatus(child);
           const suiteMeta = CASE_STATUS_META[suiteStatus];
-          const suiteKey = `${keyPrefix}::suite::${child.fullPath.join('::')}`;
+          const suiteKey = appendSuiteSegment(keyPrefix, child.fullPath);
           const suiteFullName = child.fullPath.join('  ');
 
           result.push({
@@ -214,7 +220,7 @@ export const TestFilesTree: React.FC<TestFilesTreeProps> = ({
         for (const testCase of node.cases) {
           const caseMeta = CASE_STATUS_META[testCase.status];
           result.push({
-            key: `${keyPrefix}::case::${testCase.id}`,
+            key: caseKey(keyPrefix, testCase.id),
             title: (
               <TestCaseTitle
                 icon={caseMeta.icon}
@@ -300,7 +306,7 @@ export const TestFilesTree: React.FC<TestFilesTreeProps> = ({
         const projectFiles = filteredTestFiles.filter(
           (f) => f.projectName === projectName,
         );
-        const projectKey = `__project__${projectName}`;
+        const projectKey = toProjectKey(projectName);
         const projectRoot = projectRootMap.get(projectName);
 
         // Calculate project status based on file statuses

--- a/packages/browser-ui/src/core/caseMap.test.ts
+++ b/packages/browser-ui/src/core/caseMap.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from '@rstest/core';
 import type { TestInfo } from '@rstest/core/internal/browser-runtime';
 import type { CaseInfo } from '../utils/constants';
-import { buildCollectedCaseMap, upsertRunningCase } from './caseMap';
+import {
+  buildCollectedCaseMap,
+  projectCaseInfo,
+  upsertRunningCase,
+} from './caseMap';
 
 type CollectedCaseInfo = Extract<TestInfo, { type: 'case' }>;
 
@@ -161,5 +165,84 @@ describe('buildCollectedCaseMap', () => {
         location: { line: 24, column: 5 },
       },
     });
+  });
+});
+
+describe('projectCaseInfo', () => {
+  it('falls back to the file path (two-tier) when no previousCase is given', () => {
+    const info = projectCaseInfo({
+      filePath: '/file.test.ts',
+      test: { testId: 'c1', name: 'n', testPath: '' },
+      status: 'pass',
+    });
+    // Empty testPath falls through to filePath, never to a previousCase tier.
+    expect(info.filePath).toBe('/file.test.ts');
+    expect(info.location).toBeUndefined();
+  });
+
+  it('uses previousCase filePath/location only when test omits them', () => {
+    const previousCase: CaseInfo = {
+      id: 'c1',
+      name: 'n',
+      parentNames: [],
+      fullName: 'n',
+      status: 'running',
+      filePath: '/prev.test.ts',
+      location: { line: 9, column: 1 },
+    };
+    const info = projectCaseInfo({
+      filePath: '/file.test.ts',
+      test: { testId: 'c1', name: 'n' },
+      status: 'pass',
+      previousCase,
+    });
+    expect(info.filePath).toBe('/prev.test.ts');
+    expect(info.location).toEqual({ line: 9, column: 1 });
+  });
+
+  it('takes location verbatim from the test when present', () => {
+    const info = projectCaseInfo({
+      filePath: '/file.test.ts',
+      test: {
+        testId: 'c1',
+        name: 'n',
+        testPath: '/file.test.ts',
+        location: { line: 3, column: 2 },
+      },
+      status: 'fail',
+    });
+    expect(info.location).toEqual({ line: 3, column: 2 });
+  });
+
+  it('joins parentNames into fullName with a double space, falling back to name', () => {
+    expect(
+      projectCaseInfo({
+        filePath: '/f.test.ts',
+        test: { testId: 'c1', name: 'renders' },
+        status: 'pass',
+      }).fullName,
+    ).toBe('renders');
+
+    expect(
+      projectCaseInfo({
+        filePath: '/f.test.ts',
+        test: { testId: 'c1', name: 'renders', parentNames: ['a', 'b'] },
+        status: 'pass',
+      }).fullName,
+    ).toBe('a  b  renders');
+  });
+
+  it('drops falsy parentNames entries', () => {
+    const info = projectCaseInfo({
+      filePath: '/f.test.ts',
+      test: {
+        testId: 'c1',
+        name: 'n',
+        parentNames: ['a', '', 'b'] as string[],
+      },
+      status: 'pass',
+    });
+    expect(info.parentNames).toEqual(['a', 'b']);
+    expect(info.fullName).toBe('a  b  n');
   });
 });

--- a/packages/browser-ui/src/core/caseMap.ts
+++ b/packages/browser-ui/src/core/caseMap.ts
@@ -3,7 +3,15 @@ import type { CaseInfo } from '../utils/constants';
 
 type CollectedCaseInfo = Extract<TestInfo, { type: 'case' }>;
 
-const createCaseInfo = ({
+/**
+ * Single owner of the inbound case → {@link CaseInfo} projection used by every
+ * protocol path that materializes a case (file-ready, case-start, case-result,
+ * file-complete). Callers that omit `previousCase` get exactly the two-tier
+ * `testPath || filePath` and bare-`location` behavior the case-result and
+ * file-complete handlers previously hand-rolled inline; passing `previousCase`
+ * additionally falls back to the prior case's `filePath`/`location`.
+ */
+export const projectCaseInfo = ({
   filePath,
   test,
   status,
@@ -55,7 +63,7 @@ export const buildCollectedCaseMap = ({
 
     const previous = previousCases[test.testId];
 
-    nextFile[test.testId] = createCaseInfo({
+    nextFile[test.testId] = projectCaseInfo({
       filePath,
       test,
       status: previous?.status ?? 'idle',
@@ -83,7 +91,7 @@ export const upsertRunningCase = ({
 
   return {
     ...previousCases,
-    [test.testId]: createCaseInfo({
+    [test.testId]: projectCaseInfo({
       filePath,
       test,
       status: 'running',

--- a/packages/browser-ui/src/core/treeNodeKey.test.ts
+++ b/packages/browser-ui/src/core/treeNodeKey.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  appendSuiteSegment,
+  caseKey,
+  emptyKey,
+  projectKey,
+  suiteKey,
+} from './treeNodeKey';
+
+describe('treeNodeKey grammar', () => {
+  it('builds a single-level suite key', () => {
+    expect(suiteKey('/f.test.ts', ['s1'])).toBe('/f.test.ts::suite::s1');
+  });
+
+  it('accumulates nested suite keys from ancestor prefixes', () => {
+    expect(suiteKey('/f.test.ts', ['s1', 's2'])).toBe(
+      '/f.test.ts::suite::s1::suite::s1::s2',
+    );
+  });
+
+  it('round-trips: the recursive producer fold equals the one-pass accumulation', () => {
+    // Producer fold: append one segment per recursion level.
+    const level1 = appendSuiteSegment('/f.test.ts', ['s1']);
+    const level2 = appendSuiteSegment(level1, ['s1', 's2']);
+    // Enumerator one-pass form.
+    expect(level2).toBe(suiteKey('/f.test.ts', ['s1', 's2']));
+  });
+
+  it('preserves a literal double-colon in a suite name (regression)', () => {
+    // Producer accumulation for fullPath ['a::b'] then ['a::b','c'].
+    const producer = appendSuiteSegment(
+      appendSuiteSegment('/f.test.ts', ['a::b']),
+      ['a::b', 'c'],
+    );
+    // The enumerator must reach the same key without a join→split round-trip.
+    expect(suiteKey('/f.test.ts', ['a::b', 'c'])).toBe(producer);
+    expect(suiteKey('/f.test.ts', ['a::b'])).toBe('/f.test.ts::suite::a::b');
+  });
+
+  it('builds project, case and empty keys', () => {
+    expect(projectKey('web')).toBe('__project__web');
+    expect(caseKey('/f.test.ts::suite::a', 'id-1')).toBe(
+      '/f.test.ts::suite::a::case::id-1',
+    );
+    expect(emptyKey('/f.test.ts')).toBe('/f.test.ts::__empty');
+  });
+});

--- a/packages/browser-ui/src/core/treeNodeKey.ts
+++ b/packages/browser-ui/src/core/treeNodeKey.ts
@@ -1,0 +1,53 @@
+/**
+ * Single owner of the Ant Design Tree node-key grammar for the browser-mode
+ * test tree.
+ *
+ * Two sites build these keys and MUST agree byte-for-byte: the producer
+ * (`TestFilesTree`) builds keys while recursing the tree, and the enumerator
+ * (`main.tsx` `allExpandableKeys`) rebuilds the same keys in one pass to drive
+ * "expand all". Ant Design requires `expandedKeys ⊆ treeData keys`, so any
+ * divergence makes expand-all silently skip a subtree with no error.
+ *
+ * Every helper builds keys ONLY from structured array inputs — never from a
+ * pre-joined string that is later split apart — so a suite or case name that
+ * contains a literal `::` can never be mis-parsed.
+ */
+
+export const PROJECT_KEY_PREFIX = '__project__';
+export const SUITE_KEY_SEGMENT = '::suite::';
+export const CASE_KEY_SEGMENT = '::case::';
+export const EMPTY_KEY_SUFFIX = '::__empty';
+
+export const projectKey = (projectName: string): string =>
+  `${PROJECT_KEY_PREFIX}${projectName}`;
+
+/**
+ * Single recursive producer step: append one suite segment whose label is the
+ * suite node's full ancestor path. `keyPrefix` is the parent suite's key (or the
+ * file key at the top level); `fullPath` is the suite's ancestor names, kept as
+ * an array so a literal `::` inside a name is preserved verbatim.
+ */
+export const appendSuiteSegment = (
+  keyPrefix: string,
+  fullPath: string[],
+): string => `${keyPrefix}${SUITE_KEY_SEGMENT}${fullPath.join('::')}`;
+
+/**
+ * Full one-pass accumulation of a suite key from the file key and the suite's
+ * ancestor names. Equals folding {@link appendSuiteSegment} over every ancestor
+ * prefix, so it reproduces the recursive producer output exactly — this is the
+ * form the enumerator uses.
+ */
+export const suiteKey = (fileKey: string, parentNames: string[]): string => {
+  let key = fileKey;
+  for (let i = 1; i <= parentNames.length; i++) {
+    key = appendSuiteSegment(key, parentNames.slice(0, i));
+  }
+  return key;
+};
+
+export const caseKey = (parentKey: string, caseId: string): string =>
+  `${parentKey}${CASE_KEY_SEGMENT}${caseId}`;
+
+export const emptyKey = (fileKey: string): string =>
+  `${fileKey}${EMPTY_KEY_SUFFIX}`;

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -20,7 +20,12 @@ import {
   isStaleBrowserRpcRequest,
   readBrowserRpcRequest,
 } from './core/browserRpc';
-import { buildCollectedCaseMap, upsertRunningCase } from './core/caseMap';
+import {
+  buildCollectedCaseMap,
+  projectCaseInfo,
+  upsertRunningCase,
+} from './core/caseMap';
+import { projectKey as toProjectKey, suiteKey } from './core/treeNodeKey';
 import { forwardDispatchRpcRequest, readDispatchMessage } from './core/channel';
 import { createRunId, createRunnerUrl } from './core/runtime';
 import { useRpc } from './hooks/useRpc';
@@ -42,7 +47,11 @@ import type {
   TestStatus,
 } from './utils/constants';
 import { logger } from './utils/logger';
-import { selectionFromConfig, type ViewportSelection } from './utils/viewport';
+import {
+  isPositiveFiniteSize,
+  selectionFromConfig,
+  type ViewportSelection,
+} from './utils/viewport';
 import { isDevicePreset } from './utils/viewportPresets';
 import './index.css';
 
@@ -137,15 +146,9 @@ const BrowserRunner: React.FC<{
         if (mode === 'responsive') {
           const width = Number((parsed as any).width);
           const height = Number((parsed as any).height);
-          if (
-            Number.isFinite(width) &&
-            width > 0 &&
-            Number.isFinite(height) &&
-            height > 0
-          ) {
-            return { mode: 'responsive', width, height };
-          }
-          return null;
+          return isPositiveFiniteSize(width, height)
+            ? { mode: 'responsive', width, height }
+            : null;
         }
         if (mode === 'preset') {
           const preset = (parsed as any).preset;
@@ -341,24 +344,21 @@ const BrowserRunner: React.FC<{
 
   const upsertCase = useCallback(
     (filePath: string, payload: BrowserClientTestResult) => {
-      const parentNames = (payload.parentNames ?? []).filter(Boolean);
-      const fullName =
-        [...parentNames, payload.name].join('  ') || payload.name;
+      // Project via the shared owner WITHOUT previousCase so the three-tier
+      // filePath / location?? fallback collapses to the two-tier
+      // `testPath || filePath` and bare `location` this path has always used.
+      const next = projectCaseInfo({
+        filePath,
+        test: payload,
+        status: mapCaseStatus(payload.status),
+      });
       setCaseMap((prev) => {
         const prevFile = prev[filePath] ?? {};
         return {
           ...prev,
           [filePath]: {
             ...prevFile,
-            [payload.testId]: {
-              id: payload.testId,
-              name: payload.name,
-              parentNames,
-              fullName,
-              status: mapCaseStatus(payload.status),
-              filePath: payload.testPath || filePath,
-              location: payload.location,
-            },
+            [payload.testId]: next,
           },
         };
       });
@@ -484,18 +484,14 @@ const BrowserRunner: React.FC<{
             const newCases: Record<string, CaseInfo> = {};
             for (const result of payload.results ?? []) {
               if (result?.testId) {
-                const parentNames = (result.parentNames ?? []).filter(Boolean);
-                const fullName =
-                  [...parentNames, result.name].join('  ') || result.name;
-                newCases[result.testId] = {
-                  id: result.testId,
-                  name: result.name,
-                  parentNames,
-                  fullName,
+                // Same shared projection, without previousCase: the file's
+                // `testPath` is the two-tier filePath fallback, location stays
+                // bare — byte-identical to the previous inline literal.
+                newCases[result.testId] = projectCaseInfo({
+                  filePath: testPath,
+                  test: result,
                   status: mapCaseStatus(result.status),
-                  filePath: result.testPath || testPath,
-                  location: result.location,
-                };
+                });
               }
             }
             return { ...prev, [testPath]: newCases };
@@ -616,7 +612,7 @@ const BrowserRunner: React.FC<{
     // Add project keys if multiple projects
     if (hasMultipleProjects) {
       for (const projectName of projectNames) {
-        keys.push(`__project__${projectName}`);
+        keys.push(toProjectKey(projectName));
       }
     }
 
@@ -625,31 +621,16 @@ const BrowserRunner: React.FC<{
       const filePath = file.testPath;
       keys.push(filePath);
 
-      // Collect all unique suite paths from cases
+      // Enumerate every ancestor suite key straight from each case's
+      // parentNames array — via the shared grammar, never a join→split
+      // round-trip — so the keys match the producer byte-for-byte even when a
+      // suite name itself contains a literal '::'.
       const cases = Object.values(caseMap[filePath] ?? {});
-      const suitePaths = new Set<string>();
-
       for (const testCase of cases) {
-        const parentNames = testCase.parentNames;
-        // Build all ancestor suite keys
+        const { parentNames } = testCase;
         for (let i = 1; i <= parentNames.length; i++) {
-          const suitePath = parentNames.slice(0, i).join('::');
-          suitePaths.add(suitePath);
+          keys.push(suiteKey(filePath, parentNames.slice(0, i)));
         }
-      }
-
-      // Add suite keys - need to match the key format in TestFilesTree
-      // Key format: ${keyPrefix}::suite::${fullPath.join('::')}
-      // where keyPrefix accumulates from parent suites
-      for (const suitePath of suitePaths) {
-        const parts = suitePath.split('::');
-        // Build the actual key by accumulating prefixes
-        let currentKey = filePath;
-        for (let i = 1; i <= parts.length; i++) {
-          const partialPath = parts.slice(0, i).join('::');
-          currentKey = `${currentKey}::suite::${partialPath}`;
-        }
-        keys.push(currentKey);
       }
     }
 

--- a/packages/browser-ui/src/utils/viewport.test.ts
+++ b/packages/browser-ui/src/utils/viewport.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from '@rstest/core';
+import { isPositiveFiniteSize, selectionFromConfig } from './viewport';
+
+describe('isPositiveFiniteSize', () => {
+  it('accepts two finite, strictly positive dimensions', () => {
+    expect(isPositiveFiniteSize(800, 600)).toBe(true);
+  });
+
+  it('rejects zero, negative, NaN and Infinity on either axis', () => {
+    expect(isPositiveFiniteSize(0, 600)).toBe(false);
+    expect(isPositiveFiniteSize(-1, 600)).toBe(false);
+    expect(isPositiveFiniteSize(Number.NaN, 600)).toBe(false);
+    expect(isPositiveFiniteSize(Number.POSITIVE_INFINITY, 600)).toBe(false);
+    expect(isPositiveFiniteSize(800, 0)).toBe(false);
+    expect(isPositiveFiniteSize(800, -1)).toBe(false);
+    expect(isPositiveFiniteSize(800, Number.NaN)).toBe(false);
+    expect(isPositiveFiniteSize(800, Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe('selectionFromConfig', () => {
+  it('defaults to full when no viewport is configured', () => {
+    expect(selectionFromConfig(undefined)).toEqual({ mode: 'full' });
+  });
+
+  it('decodes a valid responsive object', () => {
+    expect(selectionFromConfig({ width: 800, height: 600 })).toEqual({
+      mode: 'responsive',
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it('falls back to full for non-positive / non-finite dimensions', () => {
+    expect(selectionFromConfig({ width: 0, height: 600 })).toEqual({
+      mode: 'full',
+    });
+    expect(selectionFromConfig({ width: -1, height: 600 })).toEqual({
+      mode: 'full',
+    });
+    expect(selectionFromConfig({ width: Number.NaN, height: 600 })).toEqual({
+      mode: 'full',
+    });
+    expect(
+      selectionFromConfig({ width: Number.POSITIVE_INFINITY, height: 600 }),
+    ).toEqual({ mode: 'full' });
+  });
+});

--- a/packages/browser-ui/src/utils/viewport.ts
+++ b/packages/browser-ui/src/utils/viewport.ts
@@ -37,6 +37,16 @@ export const viewportSizeOf = (
     : { width: info.width, height: info.height };
 };
 
+/**
+ * Sole owner of the "valid responsive dimensions" rule: both axes must be
+ * finite and strictly positive. Shared by {@link selectionFromConfig} (decoding
+ * a config object) and `readStoredViewport` in main.tsx (decoding persisted
+ * localStorage state) so a future viewport field can never diverge between the
+ * two decoders.
+ */
+export const isPositiveFiniteSize = (width: number, height: number): boolean =>
+  Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0;
+
 export const selectionFromConfig = (
   viewport: BrowserViewport | undefined,
 ): ViewportSelection => {
@@ -56,12 +66,7 @@ export const selectionFromConfig = (
   if (typeof viewport === 'object') {
     const width = Number((viewport as any).width);
     const height = Number((viewport as any).height);
-    if (
-      Number.isFinite(width) &&
-      width > 0 &&
-      Number.isFinite(height) &&
-      height > 0
-    ) {
+    if (isPositiveFiniteSize(width, height)) {
       // In DevTools terms, this is a custom responsive viewport.
       return { mode: 'responsive', width, height };
     }

--- a/packages/browser/src/client/dispatchTransport.ts
+++ b/packages/browser/src/client/dispatchTransport.ts
@@ -4,10 +4,15 @@ import type {
 } from '../protocol';
 import {
   DISPATCH_MESSAGE_TYPE,
+  DISPATCH_NAMESPACE_RUNNER,
   DISPATCH_RESPONSE_TYPE,
+  DISPATCH_RPC_BRIDGE_NAME,
   DISPATCH_RPC_REQUEST_TYPE,
 } from '../protocol';
 
+// Coincidentally equal to the host-side RUNNER_FRAMES_READY_TIMEOUT_MS and the
+// runner's CONFIG_WAIT_TIMEOUT_MS (entry.ts), but a semantically distinct
+// default in a different runtime, so deliberately not shared with them.
 const DEFAULT_RPC_TIMEOUT_MS = 30_000;
 
 export const getRpcTimeout = (): number => {
@@ -35,6 +40,63 @@ export const createRequestId = (prefix: string): string => {
 
   requestIdCounter += 1;
   return `${prefix}-${Date.now().toString(36)}-${requestIdCounter.toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+/**
+ * Build a runner-lifecycle dispatch request.
+ *
+ * Lifecycle events (`file-ready`, `suite-start`, `suite-result`, `case-start`)
+ * share the dispatch-rpc envelope but are delivered fire-and-forget via
+ * {@link sendRunnerLifecycle}, so the request id only needs to be unique — it is
+ * produced by the shared {@link createRequestId} factory rather than a bespoke
+ * per-runner counter.
+ */
+export const createRunnerLifecycleRequest = (
+  method: string,
+  args: unknown,
+): BrowserDispatchRequest => ({
+  requestId: createRequestId('runner-lifecycle'),
+  namespace: DISPATCH_NAMESPACE_RUNNER,
+  method,
+  args,
+});
+
+/**
+ * Deliver a runner-lifecycle request fire-and-forget.
+ *
+ * Unlike {@link dispatchRpc}, this never awaits, unwraps, id-matches, or times
+ * out: the host echoes a response but the runner ignores it. Failures surface
+ * only through the optional `onError` hook (debug logging at the call site),
+ * keeping the hot test loop non-blocking.
+ */
+export const sendRunnerLifecycle = (
+  request: BrowserDispatchRequest,
+  onError?: (error: unknown) => void,
+): void => {
+  if (window.parent === window) {
+    const dispatchBridge = window[DISPATCH_RPC_BRIDGE_NAME];
+    if (!dispatchBridge) {
+      onError?.(
+        new Error('Dispatch RPC bridge is not available in top-level runner.'),
+      );
+      return;
+    }
+    void Promise.resolve(dispatchBridge(request)).catch((error: unknown) => {
+      onError?.(error);
+    });
+    return;
+  }
+
+  window.parent.postMessage(
+    {
+      type: DISPATCH_MESSAGE_TYPE,
+      payload: {
+        type: DISPATCH_RPC_REQUEST_TYPE,
+        payload: request,
+      },
+    },
+    '*',
+  );
 };
 
 const isDispatchResponse = (
@@ -116,7 +178,7 @@ export const dispatchRpc = <T>({
   staleMessage: string;
 }): Promise<T> => {
   if (window.parent === window) {
-    const dispatchBridge = window.__rstest_dispatch_rpc__;
+    const dispatchBridge = window[DISPATCH_RPC_BRIDGE_NAME];
     if (!dispatchBridge) {
       throw new Error(
         'Dispatch RPC bridge is not available in top-level runner.',

--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -17,21 +17,21 @@ import {
   createBrowserTaskContext,
   createRstestRuntime,
   globalApis,
+  RSTEST_ENV_SYMBOL_KEY,
   setRealTimers,
+  unwrapRegex,
 } from '@rstest/core/internal/browser-runtime';
 import { normalize } from 'pathe';
 import type {
   BrowserClientMessage,
-  BrowserDispatchRequest,
   BrowserProjectRuntime,
   RunnerLifecycleMethod,
 } from '../protocol';
+import { DISPATCH_MESSAGE_TYPE, RSTEST_CONFIG_MESSAGE_TYPE } from '../protocol';
 import {
-  DISPATCH_MESSAGE_TYPE,
-  DISPATCH_NAMESPACE_RUNNER,
-  DISPATCH_RPC_REQUEST_TYPE,
-  RSTEST_CONFIG_MESSAGE_TYPE,
-} from '../protocol';
+  createRunnerLifecycleRequest,
+  sendRunnerLifecycle,
+} from './dispatchTransport';
 import { BrowserSnapshotEnvironment } from './snapshot';
 import {
   findNewScriptUrl,
@@ -45,8 +45,6 @@ declare global {
   var __coverage__: Record<string, unknown> | undefined;
 }
 
-let runnerDispatchRequestId = 0;
-
 /**
  * Debug logger for browser client.
  * Only logs when debug mode is enabled (DEBUG=rstest on server side).
@@ -58,26 +56,12 @@ const debugLog = (...args: unknown[]): void => {
 };
 
 type RuntimeEnvStore = Record<string, string | undefined>;
-const RSTEST_ENV_SYMBOL = Symbol.for('rstest.env');
+const RSTEST_ENV_SYMBOL = Symbol.for(RSTEST_ENV_SYMBOL_KEY);
 
 type GlobalWithRuntimeEnv = typeof globalThis &
   Record<symbol, unknown> & {
     global?: typeof globalThis;
   };
-
-const REGEXP_FLAG_PREFIX = 'RSTEST_REGEXP:';
-
-const unwrapRegex = (value: string): string | RegExp => {
-  if (value.startsWith(REGEXP_FLAG_PREFIX)) {
-    const raw = value.slice(REGEXP_FLAG_PREFIX.length);
-    const match = raw.match(/^\/(.+)\/([gimuy]*)$/);
-    if (match) {
-      const [, pattern, flags] = match;
-      return new RegExp(pattern!, flags);
-    }
-  }
-  return value;
-};
 
 const restoreRuntimeConfig = (
   config: BrowserProjectRuntime['runtimeConfig'],
@@ -225,42 +209,30 @@ const send = (message: BrowserClientMessage): void => {
   }
   // Fallback: direct call if running outside iframe (not typical)
   // Note: This binding may not exist if not using Playwright
-  window.__rstest_dispatch__?.(message);
+  window[DISPATCH_MESSAGE_TYPE]?.(message);
 };
 
 const dispatchRunnerLifecycle = (
   method: RunnerLifecycleMethod,
   payload: unknown,
 ): void => {
-  const request: BrowserDispatchRequest = {
-    requestId: `runner-lifecycle-${++runnerDispatchRequestId}`,
-    namespace: DISPATCH_NAMESPACE_RUNNER,
-    method,
-    args: payload,
-  };
-
-  if (window.parent === window) {
-    const dispatchBridge = window.__rstest_dispatch_rpc__;
-    if (!dispatchBridge) {
-      debugLog(
-        '[Runner] Missing dispatch bridge for lifecycle method:',
-        method,
-      );
-      return;
-    }
-    void Promise.resolve(dispatchBridge(request)).catch((error: unknown) => {
+  sendRunnerLifecycle(
+    createRunnerLifecycleRequest(method, payload),
+    (error: unknown) => {
       debugLog('[Runner] Failed to dispatch lifecycle method:', method, error);
-    });
-    return;
-  }
-
-  send({
-    type: DISPATCH_RPC_REQUEST_TYPE,
-    payload: request,
-  });
+    },
+  );
 };
 
-/** Timeout for waiting for browser config from container (30 seconds) */
+/**
+ * Timeout for waiting for browser config from container (30 seconds).
+ *
+ * Coincidentally equal to the RPC default (client/dispatchTransport.ts) and the
+ * host's RUNNER_FRAMES_READY_TIMEOUT_MS (hostController.ts), but semantically
+ * distinct and in a different runtime, so deliberately not shared. Implicit
+ * invariant: this must not exceed the host's frames-ready timeout, or the host
+ * declares the runner un-ready before it can even receive its config.
+ */
 const CONFIG_WAIT_TIMEOUT_MS = 30_000;
 
 /**

--- a/packages/browser/src/dispatchCapabilities.ts
+++ b/packages/browser/src/dispatchCapabilities.ts
@@ -1,5 +1,9 @@
 import type { Reporter } from '@rstest/core/internal/browser';
 import { HostDispatchRouter } from './dispatchRouter';
+import {
+  DISPATCH_NAMESPACE_RUNNER,
+  DISPATCH_NAMESPACE_SNAPSHOT,
+} from './protocol';
 import type {
   BrowserClientMessage,
   BrowserDispatchHandler,
@@ -142,22 +146,28 @@ export const createHostDispatchRouter = ({
     fatal: (args) => runnerCallbacks.onFatal(args as RunnerPayload<'fatal'>),
   };
 
-  router.register('runner', async (request: BrowserDispatchRequest) => {
-    // `request.method` is untrusted wire data, so the lookup may miss. Unknown
-    // methods are ignored for forward-compatibility with newer runners, matching
-    // the previous `default: break`.
-    await runnerMethodHandlers[request.method as RunnerDispatchMethod]?.(
-      request.args,
-    );
-  });
+  router.register(
+    DISPATCH_NAMESPACE_RUNNER,
+    async (request: BrowserDispatchRequest) => {
+      // `request.method` is untrusted wire data, so the lookup may miss. Unknown
+      // methods are ignored for forward-compatibility with newer runners,
+      // matching the previous `default: break`.
+      await runnerMethodHandlers[request.method as RunnerDispatchMethod]?.(
+        request.args,
+      );
+    },
+  );
 
-  router.register('snapshot', async (request: BrowserDispatchRequest) => {
-    const snapshotRequest = toSnapshotRpcRequest(request);
-    if (!snapshotRequest) {
-      return undefined;
-    }
-    return runSnapshotRpc(snapshotRequest);
-  });
+  router.register(
+    DISPATCH_NAMESPACE_SNAPSHOT,
+    async (request: BrowserDispatchRequest) => {
+      const snapshotRequest = toSnapshotRpcRequest(request);
+      if (!snapshotRequest) {
+        return undefined;
+      }
+      return runSnapshotRpc(snapshotRequest);
+    },
+  );
 
   for (const [namespace, handler] of extensionHandlers ?? []) {
     if (router.has(namespace)) {

--- a/packages/browser/src/env.d.ts
+++ b/packages/browser/src/env.d.ts
@@ -1,3 +1,4 @@
+import { DISPATCH_MESSAGE_TYPE, DISPATCH_RPC_BRIDGE_NAME } from './protocol';
 import type {
   BrowserClientMessage,
   BrowserDispatchRequest,
@@ -38,8 +39,11 @@ declare global {
 
   interface Window {
     __RSTEST_BROWSER_OPTIONS__?: BrowserHostConfig;
-    __rstest_dispatch__?: (message: BrowserClientMessage) => void;
-    __rstest_dispatch_rpc__?: (
+    // Keyed by the sentinel constants so the declared global name and the
+    // constant are the same source — renaming a constant moves this key with it,
+    // and every `window[CONST]` access site stays in lockstep automatically.
+    [DISPATCH_MESSAGE_TYPE]?: (message: BrowserClientMessage) => void;
+    [DISPATCH_RPC_BRIDGE_NAME]?: (
       request: BrowserDispatchRequest,
     ) => Promise<unknown>;
     __rstest_container_dispatch__?: (data: unknown) => void;

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -25,6 +25,7 @@ import {
   type RstestContext,
   type RuntimeConfig,
   resolveProjectBuildCache,
+  RSTEST_ENV_SYMBOL_KEY,
   rsbuild,
   serializableConfig,
   type Test,
@@ -52,6 +53,7 @@ import type {
   BrowserDispatchRequest,
   BrowserDispatchResponse,
   BrowserHostConfig,
+  BrowserLogPayload,
   BrowserProjectRuntime,
   BrowserRpcRequest,
   BrowserViewport,
@@ -60,6 +62,7 @@ import type {
 } from './protocol';
 import {
   DISPATCH_MESSAGE_TYPE,
+  DISPATCH_NAMESPACE_BROWSER,
   DISPATCH_NAMESPACE_RUNNER,
   validateBrowserRpcRequest,
 } from './protocol';
@@ -96,6 +99,15 @@ type RsbuildInstance = rsbuild.RsbuildInstance;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OPTIONS_PLACEHOLDER = '__RSTEST_OPTIONS_PLACEHOLDER__';
+
+/**
+ * Extra time added on top of a file's `testTimeout` before the host gives up
+ * waiting for that file's RPC to settle. Covers fixed per-file overhead (page
+ * navigation, runner boot) that is not part of the user's test budget. The
+ * headless and headed scheduling paths both apply this same buffer, so it lives
+ * here as one constant to keep their per-file timeout semantics identical.
+ */
+const PER_FILE_TIMEOUT_BUFFER_MS = 30_000;
 
 /**
  * Monotonic counter for synthetic per-file Perfetto `pid` values in `--trace`
@@ -165,18 +177,8 @@ type TestFileStartPayload = {
   projectName: string;
 };
 
-/** Payload for log event */
-type LogPayload = {
-  level: 'log' | 'warn' | 'error' | 'info' | 'debug';
-  content: string;
-  taskId?: string;
-  taskName?: string;
-  taskParentNames?: string[];
-  taskType?: 'file' | 'suite' | 'case';
-  testPath: string;
-  type: 'stdout' | 'stderr';
-  trace?: string;
-};
+/** Payload for log event — single-sourced from the wire protocol. */
+type LogPayload = BrowserLogPayload;
 
 /** Payload for fatal error event */
 type FatalPayload = {
@@ -832,8 +834,9 @@ const getRuntimeConfigFromProject = (
   return {
     // Propagate NODE_ENV and the RSTEST flag from the host so
     // `process.env.NODE_ENV` / `process.env.RSTEST` (rewritten to the
-    // `rstest.env` symbol store) resolve in browser tests the same way they do
-    // in Node mode, where `prepare.ts` sets them on the real `process.env`.
+    // `RSTEST_ENV_SYMBOL_KEY` symbol store) resolve in browser tests the same
+    // way they do in Node mode, where `prepare.ts` sets them on the real
+    // `process.env`.
     // User-supplied `env` wins so explicit overrides still take effect.
     // See https://github.com/web-infra-dev/rstest/issues/1351
     env: {
@@ -1333,6 +1336,13 @@ const createBrowserRuntime = async ({
                 project.rootPath,
               ),
             );
+            // rspack `define` replaces `process.env` / `import.meta.env` with
+            // this literal expression. JSON.stringify reproduces the exact
+            // double-quoted `"rstest.env"` text, so the owned key can never
+            // drift from the runtime `Symbol.for(RSTEST_ENV_SYMBOL_KEY)` sites.
+            const rstestEnvDefine = `globalThis[Symbol.for(${JSON.stringify(
+              RSTEST_ENV_SYMBOL_KEY,
+            )})]`;
             // Merge order: current config -> userConfig -> rstest required config (highest priority)
             const merged = mergeEnvironmentConfig(
               config,
@@ -1351,8 +1361,8 @@ const createBrowserRuntime = async ({
                 },
                 source: {
                   define: {
-                    'process.env': 'globalThis[Symbol.for("rstest.env")]',
-                    'import.meta.env': 'globalThis[Symbol.for("rstest.env")]',
+                    'process.env': rstestEnvDefine,
+                    'import.meta.env': rstestEnvDefine,
                   },
                 },
                 output: {
@@ -2165,13 +2175,16 @@ export const runBrowserController = async (
     }
   };
 
-  runtime.dispatchHandlers.set('browser', async (dispatchRequest) => {
-    const request = validateBrowserRpcRequest(dispatchRequest.args);
-    return dispatchBrowserRpcRequest({
-      request,
-      target: dispatchRequest.target,
-    });
-  });
+  runtime.dispatchHandlers.set(
+    DISPATCH_NAMESPACE_BROWSER,
+    async (dispatchRequest) => {
+      const request = validateBrowserRpcRequest(dispatchRequest.args);
+      return dispatchBrowserRpcRequest({
+        request,
+        target: dispatchRequest.target,
+      });
+    },
+  );
 
   runtime.setContainerOptions(hostOptions);
 
@@ -2606,7 +2619,7 @@ export const runBrowserController = async (
       message: BrowserClientMessage,
     ): Promise<void> => {
       const response = await dispatchRouter.dispatch({
-        requestId: nextDispatchRequestId('runner'),
+        requestId: nextDispatchRequestId(DISPATCH_NAMESPACE_RUNNER),
         runToken: run.token,
         namespace: DISPATCH_NAMESPACE_RUNNER,
         method: message.type,
@@ -2663,7 +2676,7 @@ export const runBrowserController = async (
       );
       const perFileTimeoutMs =
         (projectRuntime?.runtimeConfig.testTimeout ?? maxTestTimeoutForRpc) +
-        30_000;
+        PER_FILE_TIMEOUT_BUFFER_MS;
 
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -3062,6 +3075,12 @@ export const runBrowserController = async (
   }
 
   let currentTestFiles = allTestFiles;
+  // Coincidentally equal to the runner-side CONFIG_WAIT_TIMEOUT_MS and
+  // DEFAULT_RPC_TIMEOUT_MS (client/entry.ts, client/dispatchTransport.ts) but
+  // semantically distinct and in a different runtime, so deliberately NOT shared
+  // with them. Invariant worth preserving: a runner must be able to receive its
+  // config (config-wait) before the host declares its frames un-ready, i.e.
+  // CONFIG_WAIT_TIMEOUT_MS <= RUNNER_FRAMES_READY_TIMEOUT_MS.
   const RUNNER_FRAMES_READY_TIMEOUT_MS = 30_000;
   let currentRunnerFramesSignature: string | null = null;
   const runnerFramesWaiters = new Map<string, Set<() => void>>();
@@ -3149,7 +3168,7 @@ export const runBrowserController = async (
     );
     return (
       (projectRuntime?.runtimeConfig.testTimeout ?? maxTestTimeoutForRpc) +
-      30_000
+      PER_FILE_TIMEOUT_BUFFER_MS
     );
   };
 

--- a/packages/browser/src/protocol.ts
+++ b/packages/browser/src/protocol.ts
@@ -1,4 +1,4 @@
-import type { DevicePreset } from '@rstest/core/internal/browser';
+import type { BrowserViewport } from '@rstest/core/internal/browser';
 import type {
   RuntimeConfig,
   TestFileResult,
@@ -30,12 +30,10 @@ export const DISPATCH_METHOD_RPC = 'rpc';
 
 export type SerializedRuntimeConfig = RuntimeConfig;
 
-export type BrowserViewport =
-  | {
-      width: number;
-      height: number;
-    }
-  | DevicePreset;
+// `BrowserViewport` is a core config type (`@rstest/core` owns the canonical
+// definition used by `NormalizedBrowserModeConfig`). Re-export it so the host
+// assigns the SAME type across the seam instead of a hand-copied duplicate.
+export type { BrowserViewport };
 
 export type BrowserProjectRuntime = {
   name: string;
@@ -60,6 +58,25 @@ export type TestFileInfo = {
  * - 'collect': Only collect test metadata without running
  */
 export type BrowserExecutionMode = 'run' | 'collect';
+
+/**
+ * Wire shape of a `log` client message payload. The host receives this and maps
+ * it onto core's {@link UserConsoleLog} (notably `level` → `name`); that mapper
+ * (`hostController.ts` `handleLog`) annotates its result as `UserConsoleLog`, so
+ * the map→core direction is compiler-checked. Owning the wire shape here as one
+ * named type keeps the host's input type from drifting away from the producer.
+ */
+export type BrowserLogPayload = {
+  level: 'log' | 'warn' | 'error' | 'info' | 'debug';
+  content: string;
+  taskId?: string;
+  taskName?: string;
+  taskParentNames?: string[];
+  taskType?: 'file' | 'suite' | 'case';
+  testPath: string;
+  type: 'stdout' | 'stderr';
+  trace?: string;
+};
 
 export type BrowserHostConfig = {
   rootPath: string;
@@ -104,20 +121,7 @@ export type BrowserClientMessage =
     }
   | { type: 'case-result'; payload: TestResult }
   | { type: 'file-complete'; payload: TestFileResult }
-  | {
-      type: 'log';
-      payload: {
-        level: 'log' | 'warn' | 'error' | 'info' | 'debug';
-        content: string;
-        taskId?: string;
-        taskName?: string;
-        taskParentNames?: string[];
-        taskType?: 'file' | 'suite' | 'case';
-        testPath: string;
-        type: 'stdout' | 'stderr';
-        trace?: string;
-      };
-    }
+  | { type: 'log'; payload: BrowserLogPayload }
   | {
       type: 'fatal';
       payload: { message: string; stack?: string };
@@ -182,6 +186,11 @@ export type BrowserDispatchRequest = {
   namespace: string;
   method: string;
   args?: unknown;
+  // Routing reads `namespace`, `method`, `runToken`, and `target.sessionId`
+  // (see dispatchRouter.ts / dispatchBrowserRpcRequest). `target.testFile` and
+  // `target.projectName` are carried for diagnostics / forward-compatibility and
+  // are NOT consulted for routing today — adding a routing-relevant field here
+  // means wiring a reader on the host side, which structural typing won't force.
   target?: {
     testFile?: string;
     sessionId?: string;

--- a/packages/browser/src/providers/index.ts
+++ b/packages/browser/src/providers/index.ts
@@ -1,3 +1,4 @@
+import type { BrowserProvider } from '@rstest/core/internal/browser';
 import type { BrowserRpcRequest } from '../rpcProtocol';
 import { playwrightProviderImplementation } from './playwright';
 
@@ -14,8 +15,14 @@ import { playwrightProviderImplementation } from './playwright';
  * - do not reference optional peer provider types from public declarations
  * - keep provider-specific behavior and config decoding inside provider implementations
  * - prefer direct passthrough to provider APIs over provider-specific translation
+ *
+ * The provider-name union is owned by `@rstest/core` (see `BROWSER_PROVIDERS`)
+ * because core's CLI `init` templates need it but cannot import this package
+ * (peer-dependency direction). `providerImplementations` below is keyed by the
+ * re-exported union, so a provider added in core without an implementation here
+ * is a compile error.
  */
-export type BrowserProvider = 'playwright';
+export type { BrowserProvider };
 
 /** Minimal console shape needed by host logging bridge. */
 export type BrowserConsoleMessage = {

--- a/packages/browser/tests/dispatchTransport.test.ts
+++ b/packages/browser/tests/dispatchTransport.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, rstest } from '@rstest/core';
+import {
+  DISPATCH_MESSAGE_TYPE,
+  DISPATCH_NAMESPACE_RUNNER,
+  DISPATCH_RPC_REQUEST_TYPE,
+} from '../src/protocol';
+
+const loadModule = () => import('../src/client/dispatchTransport');
+
+describe('runner-lifecycle dispatch transport', () => {
+  afterEach(() => {
+    rstest.unstubAllGlobals();
+    rstest.resetModules();
+  });
+
+  it('builds a runner-namespace envelope with a unique request id', async () => {
+    rstest.stubGlobal('window', { parent: {} });
+    const { createRunnerLifecycleRequest } = await loadModule();
+
+    const req = createRunnerLifecycleRequest('suite-start', { a: 1 });
+    expect(req.namespace).toBe(DISPATCH_NAMESPACE_RUNNER);
+    expect(req.method).toBe('suite-start');
+    expect(req.args).toEqual({ a: 1 });
+    expect(typeof req.requestId).toBe('string');
+    expect(req.requestId.length).toBeGreaterThan(0);
+
+    const req2 = createRunnerLifecycleRequest('case-start', undefined);
+    expect(req2.requestId).not.toBe(req.requestId);
+  });
+
+  it('delivers fire-and-forget to the top-level dispatch bridge', async () => {
+    const bridge = rstest.fn(() => Promise.resolve({ requestId: 'x' }));
+    const win: any = { __rstest_dispatch_rpc__: bridge };
+    win.parent = win;
+    rstest.stubGlobal('window', win);
+
+    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+      await loadModule();
+    const req = createRunnerLifecycleRequest('file-ready', { f: 1 });
+    const onError = rstest.fn();
+    sendRunnerLifecycle(req, onError);
+
+    expect(bridge).toHaveBeenCalledTimes(1);
+    expect(bridge).toHaveBeenCalledWith(req);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('routes a rejecting bridge to onError without throwing', async () => {
+    const failure = new Error('bridge boom');
+    const bridge = rstest.fn(() => Promise.reject(failure));
+    const win: any = { __rstest_dispatch_rpc__: bridge };
+    win.parent = win;
+    rstest.stubGlobal('window', win);
+
+    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+      await loadModule();
+    const onError = rstest.fn();
+    expect(() =>
+      sendRunnerLifecycle(
+        createRunnerLifecycleRequest('case-start', null),
+        onError,
+      ),
+    ).not.toThrow();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
+  it('reports a missing top-level bridge through onError', async () => {
+    const win: any = { __rstest_dispatch_rpc__: undefined };
+    win.parent = win;
+    rstest.stubGlobal('window', win);
+
+    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+      await loadModule();
+    const onError = rstest.fn();
+    sendRunnerLifecycle(
+      createRunnerLifecycleRequest('suite-result', null),
+      onError,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0]).toBeInstanceOf(Error);
+  });
+
+  it('posts the request to the parent window in the iframe path', async () => {
+    const postMessage = rstest.fn();
+    rstest.stubGlobal('window', { parent: { postMessage } });
+
+    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+      await loadModule();
+    const req = createRunnerLifecycleRequest('suite-start', { s: 1 });
+    sendRunnerLifecycle(req);
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: DISPATCH_MESSAGE_TYPE,
+        payload: { type: DISPATCH_RPC_REQUEST_TYPE, payload: req },
+      },
+      '*',
+    );
+  });
+});

--- a/packages/browser/tests/protocol.test.ts
+++ b/packages/browser/tests/protocol.test.ts
@@ -6,7 +6,25 @@ import type {
   BrowserHostConfig,
   BrowserProjectRuntime,
 } from '../src/protocol';
-import { validateBrowserRpcRequest } from '../src/protocol';
+import {
+  DISPATCH_METHOD_RPC,
+  DISPATCH_NAMESPACE_BROWSER,
+  DISPATCH_NAMESPACE_RUNNER,
+  DISPATCH_NAMESPACE_SNAPSHOT,
+  validateBrowserRpcRequest,
+} from '../src/protocol';
+
+describe('dispatch namespace wire values', () => {
+  // The host registrations (dispatchCapabilities, hostController), the router
+  // Map keys, and the client producers all reference these constants. Pin the
+  // wire values so a rename of any identifier cannot silently change the bytes.
+  it('pins the namespace and method wire strings', () => {
+    expect(DISPATCH_NAMESPACE_RUNNER).toBe('runner');
+    expect(DISPATCH_NAMESPACE_BROWSER).toBe('browser');
+    expect(DISPATCH_NAMESPACE_SNAPSHOT).toBe('snapshot');
+    expect(DISPATCH_METHOD_RPC).toBe('rpc');
+  });
+});
 
 describe('browser protocol types', () => {
   describe('BrowserProjectRuntime', () => {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -2,9 +2,27 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { defineConfig, rspack } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
-import { peerDependencies } from '../browser/package.json';
+import {
+  peerDependencies,
+  version as browserVersion,
+} from '../browser/package.json';
 import { licensePlugin } from './licensePlugin';
 import { version } from './package.json';
+
+// `RSTEST_VERSION` is build-injected into both @rstest/core and @rstest/browser
+// from each package's own package.json, and the browser-mode runtime gate
+// (core/src/core/browserLoader.ts) refuses to load a browser build whose version
+// differs from core's. Those two reads can only drift if the packages are
+// versioned independently — which a single build cannot otherwise detect — so
+// assert the peer pair is in lockstep here, surfacing a mismatch at build time
+// instead of as a runtime version-gate false negative for the user.
+if (version !== browserVersion) {
+  throw new Error(
+    `@rstest/core (${version}) and @rstest/browser (${browserVersion}) versions ` +
+      'are out of sync. They are published as a peer pair and must match; ' +
+      'bump packages/core/package.json and packages/browser/package.json together.',
+  );
+}
 
 const isBuildWatch = process.argv.includes('--watch');
 const isLibBuild = process.argv.includes('build');

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -20,6 +20,7 @@ export { PhaseTracker } from './runtime/worker/phaseTracker';
 export type {
   BrowserTestRunOptions,
   BrowserTestRunResult,
+  BrowserViewport,
   CoverageMapData,
   DevicePreset,
   FormattedError,
@@ -47,7 +48,12 @@ export {
 // Worker concurrency primitives shared with @rstest/browser
 export { getNumCpus, parseWorkers } from './utils/workers';
 // Constants
-export { resolveProjectBuildCache } from './utils/constants';
+export {
+  BROWSER_PROVIDERS,
+  resolveProjectBuildCache,
+  RSTEST_ENV_SYMBOL_KEY,
+} from './utils/constants';
+export type { BrowserProvider } from './utils/constants';
 export { getSetupFiles } from './utils/getSetupFiles';
 export { getTestEntries } from './utils/testFiles';
 export { rsbuild };

--- a/packages/core/src/browserRuntime.ts
+++ b/packages/core/src/browserRuntime.ts
@@ -28,4 +28,7 @@ export type {
   WorkerState,
 } from './types';
 // Constants needed by browser client
-export { globalApis } from './utils/constants';
+export { globalApis, RSTEST_ENV_SYMBOL_KEY } from './utils/constants';
+// Browser-safe regexp wire-format decoder (mirrors the host-side encoder used
+// by `serializableConfig`). Kept here so the client never re-declares it.
+export { unwrapRegex } from './utils/regexpWireFormat';

--- a/packages/core/src/cli/init/browser/templates.ts
+++ b/packages/core/src/cli/init/browser/templates.ts
@@ -1,8 +1,12 @@
 import type { Agent } from 'package-manager-detector';
 import { resolveCommand } from 'package-manager-detector/commands';
+import {
+  BROWSER_PROVIDERS,
+  type BrowserProvider,
+} from '../../../utils/constants';
 
 export type Framework = 'react' | 'vanilla';
-export type BrowserProvider = 'playwright';
+export type { BrowserProvider };
 
 /** Base name of the example component emitted by the init templates. */
 export const DEFAULT_COMPONENT_BASE_NAME = 'Counter';
@@ -69,7 +73,7 @@ export function getConfigTemplate(): string {
 export default defineConfig({
   browser: {
     enabled: true,
-    provider: 'playwright',
+    provider: '${BROWSER_PROVIDERS[0]}',
   },
 });
 `;

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -7,6 +7,7 @@ import type {
   WaitUntilOptions,
   WorkerState,
 } from '../../types';
+import { RSTEST_ENV_SYMBOL_KEY } from '../../utils/constants';
 import { getRealTimers } from '../util';
 import type { FakeTimerInstallOpts, FakeTimersSnapshot } from './fakeTimers';
 import { mockObject as mockObjectImpl } from './mockObject';
@@ -101,7 +102,7 @@ export const createRstestUtilities: (
   workerState: WorkerState,
 ) => Promise<RstestUtilities> = async (workerState) => {
   type RuntimeEnvStore = Record<string, string | undefined>;
-  const RSTEST_ENV_SYMBOL = Symbol.for('rstest.env');
+  const RSTEST_ENV_SYMBOL = Symbol.for(RSTEST_ENV_SYMBOL_KEY);
   type GlobalWithRuntimeEnv = typeof globalThis & Record<symbol, unknown>;
   type PropertyKey = string | symbol | number;
   type EnvStackEntry = { value: string | undefined };

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -8,6 +8,7 @@ import type {
   ReporterWithOptions,
 } from './reporter';
 import type { ConsoleStreamType, MaybePromise } from './utils';
+import type { BrowserProvider } from '../utils/constants';
 
 // TODO: chaiConfig.includeStack seems not used
 export type ChaiConfig = Partial<
@@ -168,7 +169,7 @@ export type BrowserModeConfig = {
    *
    * Currently only 'playwright' is supported.
    */
-  provider: 'playwright';
+  provider: BrowserProvider;
   /**
    * Which browser to use for testing.
    *
@@ -580,7 +581,7 @@ type OptionalKeys =
 
 export type NormalizedBrowserModeConfig = {
   enabled: boolean;
-  provider: 'playwright';
+  provider: BrowserProvider;
   browser: BrowserName;
   headless: boolean;
   port?: number;

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -15,6 +15,31 @@ export const POINTER = '➜';
 
 export const ROOT_SUITE_NAME = 'Rstest:_internal_root_suite';
 
+/**
+ * Description key of the well-known `Symbol.for(...)` under which Rstest stores
+ * the runtime env store on `globalThis`. Single owner of the string, shared by
+ * three contexts that must resolve the SAME registry symbol: the core worker
+ * runtime and the browser client both call `Symbol.for(RSTEST_ENV_SYMBOL_KEY)`,
+ * while the host bakes it into the rspack `define` text via
+ * `JSON.stringify(RSTEST_ENV_SYMBOL_KEY)`. Kept a plain string (not a Symbol) so
+ * it serves both the runtime and the build-define codegen path. Re-exported from
+ * both `./internal/browser-runtime` and `./internal/browser` barrels.
+ */
+export const RSTEST_ENV_SYMBOL_KEY = 'rstest.env';
+
+/**
+ * Single source of truth for the built-in browser provider identifiers.
+ *
+ * Core owns this list because the peer-dependency direction is one-way
+ * (`@rstest/browser` depends on `@rstest/core`, never the reverse), so the CLI
+ * `init` templates here cannot import the registry from `@rstest/browser`.
+ * `@rstest/browser` re-exports {@link BrowserProvider} and keys its provider
+ * registry by it (`Record<BrowserProvider, …>`), so adding a provider here
+ * forces a matching implementation there — a missing key is a compile error.
+ */
+export const BROWSER_PROVIDERS = ['playwright'] as const;
+export type BrowserProvider = (typeof BROWSER_PROVIDERS)[number];
+
 export const TEMP_RSTEST_OUTPUT_DIR = 'dist/.rstest-temp';
 const DEFAULT_BUILD_CACHE_PREFIX = 'node_modules/.cache/rstest';
 const DEFAULT_BUILD_CACHE_DIRECTORY_MARKER = Symbol(

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -10,6 +10,7 @@ import {
 import type { RuntimeConfig, TestResult } from '../types';
 import { TEST_DELIMITER } from './constants';
 import { color } from './logger';
+import { wrapRegex } from './regexpWireFormat';
 
 /**
  * Generate a stable hash for a file path.
@@ -158,11 +159,6 @@ export const getTaskNameWithPrefix = (
  * runtime internals across the provider-agnostic barrier).
  */
 export const getFileTaskId = (testPath: string): string => `file:${testPath}`;
-
-const REGEXP_FLAG_PREFIX = 'RSTEST_REGEXP:';
-
-const wrapRegex = (value: RegExp): string =>
-  `${REGEXP_FLAG_PREFIX}${value.toString()}`;
 
 /**
  * Makes some special types that are not supported for passing into the pool serializable.

--- a/packages/core/src/utils/regexpWireFormat.ts
+++ b/packages/core/src/utils/regexpWireFormat.ts
@@ -1,0 +1,31 @@
+/**
+ * Wire-format codec for serializing a `RegExp` `testNamePattern` across the
+ * pool / browser-host boundary.
+ *
+ * The encoder ({@link wrapRegex}) and decoder ({@link unwrapRegex}) are the
+ * single owner of the `RSTEST_REGEXP:` sentinel and its flag grammar, so the two
+ * ends can never drift. This module is intentionally free of Node-only imports
+ * so it can be re-exported from the browser-runtime surface
+ * (`@rstest/core/internal/browser-runtime`) and bundled into the browser client.
+ */
+const REGEXP_FLAG_PREFIX = 'RSTEST_REGEXP:';
+
+export const wrapRegex = (value: RegExp): string =>
+  `${REGEXP_FLAG_PREFIX}${value.toString()}`;
+
+export const unwrapRegex = (value: string): string | RegExp => {
+  if (!value.startsWith(REGEXP_FLAG_PREFIX)) {
+    return value;
+  }
+  const raw = value.slice(REGEXP_FLAG_PREFIX.length);
+  // Mirror `RegExp.prototype.toString`, which can emit any of `d g i m s u v y`.
+  // The previous `[gimuy]` charset silently failed to decode patterns carrying
+  // the `d`, `s`, or `v` flag, leaving the raw sentinel string in place (so the
+  // pattern matched nothing in browser mode).
+  const match = raw.match(/^\/(.+)\/([dgimsuvy]*)$/);
+  if (!match) {
+    return value;
+  }
+  const [, pattern, flags] = match;
+  return new RegExp(pattern!, flags);
+};

--- a/packages/core/tests/utils/constants.test.ts
+++ b/packages/core/tests/utils/constants.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from '@rstest/core';
+import { RSTEST_ENV_SYMBOL_KEY } from '../../src/utils/constants';
+
+describe('RSTEST_ENV_SYMBOL_KEY', () => {
+  // The core worker runtime, the browser client, and the host build-define text
+  // all resolve Symbol.for(RSTEST_ENV_SYMBOL_KEY). The cross-context env store
+  // only works if every context uses this exact description string — pin the
+  // value so a rename cannot silently break env propagation.
+  it('is the exact well-known env symbol description', () => {
+    expect(RSTEST_ENV_SYMBOL_KEY).toBe('rstest.env');
+  });
+
+  it('resolves to the same global-registry symbol as the literal', () => {
+    expect(Symbol.for(RSTEST_ENV_SYMBOL_KEY)).toBe(Symbol.for('rstest.env'));
+  });
+
+  it('reproduces the exact double-quoted host define text via JSON.stringify', () => {
+    expect(
+      `globalThis[Symbol.for(${JSON.stringify(RSTEST_ENV_SYMBOL_KEY)})]`,
+    ).toBe('globalThis[Symbol.for("rstest.env")]');
+  });
+});

--- a/packages/core/tests/utils/regexpWireFormat.test.ts
+++ b/packages/core/tests/utils/regexpWireFormat.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from '@rstest/core';
+import { unwrapRegex, wrapRegex } from '../../src/utils/regexpWireFormat';
+
+describe('regexp wire-format codec', () => {
+  it('round-trips a simple RegExp', () => {
+    const wrapped = wrapRegex(/foo/i);
+    expect(wrapped).toBe('RSTEST_REGEXP:/foo/i');
+
+    const unwrapped = unwrapRegex(wrapped);
+    expect(unwrapped).toBeInstanceOf(RegExp);
+    expect((unwrapped as RegExp).source).toBe('foo');
+    expect((unwrapped as RegExp).flags).toBe('i');
+  });
+
+  it('preserves d/s/v flags (regression: the old [gimuy] charset dropped them)', () => {
+    for (const re of [/foo/d, /foo/s, /foo/v, /my test foo/dsv]) {
+      const decoded = unwrapRegex(wrapRegex(re));
+      expect(decoded).toBeInstanceOf(RegExp);
+      expect((decoded as RegExp).flags).toBe(re.flags);
+      expect((decoded as RegExp).source).toBe(re.source);
+    }
+
+    const decoded = unwrapRegex(wrapRegex(/my test foo/dsv)) as RegExp;
+    expect(decoded.test('my test foo')).toBe(true);
+  });
+
+  it('passes through plain strings unchanged', () => {
+    expect(unwrapRegex('my test name')).toBe('my test name');
+  });
+
+  it('returns the raw value when the sentinel wraps a non-regexp payload', () => {
+    expect(unwrapRegex('RSTEST_REGEXP:not-a-regex')).toBe(
+      'RSTEST_REGEXP:not-a-regex',
+    );
+  });
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -39,6 +39,7 @@ dedupe
 deepmerge
 desync
 desynced
+dgimsuvy
 distpath
 DNSCHANNEL
 docgen


### PR DESCRIPTION
## Summary

Final PR of the core↔browser seam refactor series. It does two things:

**1. Deepen the core↔browser seam** — pull shared primitives behind named owners so the two sides cannot drift:
- `regexpWireFormat` owns `wrapRegex`/`unwrapRegex` (widened flag charset — fixes `d`/`s`/`v` flag decode); the browser client's lifecycle dispatch collapses into `dispatchTransport`.
- `RSTEST_ENV_SYMBOL_KEY` is the single owner of the env-store symbol description shared by the core worker runtime, the browser client, and the host rspack `define` text; `DISPATCH_NAMESPACE_*` constants own the dispatch wire strings.
- browser-ui: `treeNodeKey` owns the tree-node-key grammar — this also **fixes expand-all for suite names containing `::`** (the one intended behavior change); `projectCaseInfo` unifies case projection and `isPositiveFiniteSize` the viewport predicate.

**2. Close browser-mode drift hazards** — replace "two sites that must stay in sync but nothing enforces it" spots with single sources or compile-time checks, so divergence becomes structurally impossible or a type error instead of a silent runtime fault:
- Dispatch sentinel globals: bare `window.__rstest_dispatch*__` accesses now read `window[DISPATCH_*]`, and `env.d.ts` keys the `Window` interface by the same constants, so renaming a sentinel moves the declaration and every access site together.
- `BrowserViewport` and the browser log payload re-export / single-source their shapes from core instead of hand-copying them across the seam.
- `BrowserProvider`: core owns `BROWSER_PROVIDERS`; the CLI `init` templates and the browser provider registry (`Record<BrowserProvider, …>`) derive from it.
- The per-file timeout buffer is one constant across the headless/headed paths, and core↔browser version equality is asserted at build time (ahead of the runtime version gate). Three coincidentally-equal, cross-runtime RPC timeouts are documented as deliberately distinct rather than merged.

No public API changes. The only behavior change is the browser-ui expand-all fix for suite names containing `::`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
