### PR TITLE
refactor(core): single-source reporter map and GitHub Actions detection

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -7,6 +7,7 @@ import {
 import { dirname, isAbsolute, join, resolve } from 'pathe';
 import { isCI } from 'std-env';
 import type {
+  BuiltInReporterNames,
   ExtendConfig,
   NormalizedConfig,
   ProjectConfig,
@@ -193,6 +194,26 @@ export const mergeRstestConfig = (...configs: RstestConfig[]): RstestConfig => {
   }, {});
 };
 
+/**
+ * Whether the process is running inside GitHub Actions. Single source for the
+ * `GITHUB_ACTIONS` runtime signal so every consumer interprets it identically.
+ * Reads `process.env` directly so the build-time `process.env.GITHUB_ACTIONS`
+ * define keeps controlling it (e.g. forced off in this package's own tests).
+ */
+export const isGithubActions = (): boolean =>
+  process.env.GITHUB_ACTIONS === 'true';
+
+/**
+ * Reporters enabled by default. Under GitHub Actions the `github-actions`
+ * reporter is added so failures surface as CI annotations. Takes the flag as a
+ * parameter (pure) so the selection is unit-testable without mutating env or
+ * fighting the build-time `GITHUB_ACTIONS` define.
+ */
+export const getDefaultReporters = (
+  githubActions: boolean = isGithubActions(),
+): BuiltInReporterNames[] =>
+  githubActions ? ['default', 'github-actions'] : ['default'];
+
 const createDefaultConfig = (): NormalizedConfig => ({
   root: process.cwd(),
   name: 'rstest',
@@ -227,10 +248,7 @@ const createDefaultConfig = (): NormalizedConfig => ({
     },
   },
   retry: 0,
-  reporters:
-    process.env.GITHUB_ACTIONS === 'true'
-      ? ['default', 'github-actions']
-      : ['default'],
+  reporters: getDefaultReporters(),
   clearMocks: false,
   resetMocks: false,
   restoreMocks: false,

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -12,6 +12,7 @@ import { JUnitReporter } from '../reporter/junit';
 import { MdReporter } from '../reporter/md';
 import { VerboseReporter } from '../reporter/verbose';
 import type {
+  BuiltInReporterNames,
   FileFilterMode,
   NormalizedConfig,
   NormalizedProjectConfig,
@@ -312,16 +313,14 @@ export class Rstest implements RstestContext {
   }
 }
 
-const reportersMap: {
-  default: typeof DefaultReporter;
-  dot: typeof DotReporter;
-  verbose: typeof VerboseReporter;
-  'github-actions': typeof GithubActionsReporter;
-  junit: typeof JUnitReporter;
-  json: typeof JsonReporter;
-  md: typeof MdReporter;
-  blob: typeof BlobReporter;
-} = {
+// `satisfies Record<BuiltInReporterNames, …>` keeps this map in lockstep with
+// the BuiltInReporterNames union (the single source of truth): a name added to
+// the union without a class here is a missing-key compile error, and a class
+// added here without a union entry is an excess-key error. The previous explicit
+// object-type annotation duplicated the key list and let the two drift, surfacing
+// only as a runtime "Reporter X not found". `satisfies` (not `:`) preserves each
+// value's concrete constructor type for the `new reportersMap[name](…)` call.
+const reportersMap = {
   default: DefaultReporter,
   dot: DotReporter,
   verbose: VerboseReporter,
@@ -330,7 +329,7 @@ const reportersMap: {
   json: JsonReporter,
   md: MdReporter,
   blob: BlobReporter,
-};
+} satisfies Record<BuiltInReporterNames, new (...args: any[]) => unknown>;
 
 function createReporters(
   reporters: RstestConfig['reporters'],

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -1,5 +1,7 @@
 import { resolve } from 'pathe';
 import {
+  getDefaultReporters,
+  isGithubActions,
   mergeRstestConfig,
   resolveExtends,
   withDefaultConfig,
@@ -520,5 +522,26 @@ describe('withDefaultConfig browser normalization', () => {
     const config: RstestConfig = {};
 
     expect(() => withDefaultConfig(config)).not.toThrow();
+  });
+});
+
+describe('default reporter selection', () => {
+  // `getDefaultReporters` takes the GitHub Actions flag as a parameter so both
+  // branches can be asserted directly — the build-time `GITHUB_ACTIONS` define
+  // (forced to 'false' for this package's own tests) makes the inline runtime
+  // check otherwise impossible to exercise for the `true` branch here.
+  it('adds the github-actions reporter under GitHub Actions', () => {
+    expect(getDefaultReporters(true)).toEqual(['default', 'github-actions']);
+  });
+
+  it('uses only the default reporter outside GitHub Actions', () => {
+    expect(getDefaultReporters(false)).toEqual(['default']);
+  });
+
+  it('defaults to the GITHUB_ACTIONS env signal', () => {
+    // In this package's test build the define pins GITHUB_ACTIONS off, so the
+    // env-driven default must match the non-CI branch and `isGithubActions()`.
+    expect(isGithubActions()).toBe(false);
+    expect(getDefaultReporters()).toEqual(['default']);
   });
 });


### PR DESCRIPTION
## Summary

Two small drift-prone spots in the core config/reporter layer had duplicated source-of-truth, both of which only surface as runtime errors when they fall out of sync. This PR makes each compiler-enforced or single-sourced:

- **Reporter map**: `reportersMap` previously carried an explicit object-type annotation that re-listed every reporter key. Adding a name to the `BuiltInReporterNames` union without a matching class (or vice versa) drifted silently and only failed at runtime with "Reporter X not found". It now uses `satisfies Record<BuiltInReporterNames, …>`, so any mismatch is a compile error while still preserving each value's concrete constructor type for `new reportersMap[name](…)`.
- **GitHub Actions detection**: the `GITHUB_ACTIONS` env check and the default-reporters ternary were inlined in `createDefaultConfig`. They are now extracted into `isGithubActions()` and a pure `getDefaultReporters(githubActions = isGithubActions())`, giving the CI signal one named interpretation and making the default-reporter selection unit-testable without fighting the build-time `GITHUB_ACTIONS` define.

No behavior change. Adds unit tests covering both branches of the default-reporter selection.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).