### PR TITLE
refactor(core, adapters): single-source adapter cache-key & target→env logic

### DIFF
--- a/packages/adapter-rsbuild/rslib.config.mts
+++ b/packages/adapter-rsbuild/rslib.config.mts
@@ -4,6 +4,14 @@ import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
   plugins: publishCheckPlugins(),
+  output: {
+    // Bundle the shared config helpers into the adapter's dist so it carries no
+    // runtime dependency on a core subpath; `false` opts this exact subpath out
+    // of autoExternal.
+    externals: {
+      '@rstest/core/internal/adapter': false,
+    },
+  },
   lib: [
     {
       format: 'esm',

--- a/packages/adapter-rsbuild/src/toRstestConfig.ts
+++ b/packages/adapter-rsbuild/src/toRstestConfig.ts
@@ -1,77 +1,10 @@
-import { dirname, isAbsolute, join, normalize } from 'node:path';
+import { normalize } from 'node:path';
 import { mergeRsbuildConfig, type RsbuildConfig } from '@rsbuild/core';
 import type { ExtendConfig } from '@rstest/core';
-
-type BuildCacheConfig = NonNullable<
-  NonNullable<RsbuildConfig['performance']>['buildCache']
->;
-type BuildCacheOutput =
-  | boolean
-  | {
-      cacheDirectory?: string;
-      cacheDigest?: Array<string | undefined>;
-      buildDependencies?: string[];
-    }
-  | undefined;
-
-const getCacheDependency = ({
-  dependency,
-  configPath,
-  root,
-}: {
-  dependency: string;
-  configPath?: string;
-  root?: string;
-}): string => {
-  if (isAbsolute(dependency)) {
-    return normalize(dependency);
-  }
-
-  if (configPath) {
-    return normalize(join(dirname(configPath), dependency));
-  }
-
-  return root ? normalize(join(root, dependency)) : dependency;
-};
-
-const updateCacheConfig = ({
-  buildCache,
-  configPath,
-  root,
-}: {
-  buildCache?: BuildCacheConfig;
-  configPath?: string;
-  root?: string;
-}): BuildCacheOutput => {
-  if (buildCache === undefined) {
-    return undefined;
-  }
-
-  if (buildCache === false) {
-    return false;
-  }
-
-  if (buildCache === true) {
-    return configPath ? { buildDependencies: [normalize(configPath)] } : true;
-  }
-
-  const buildDependencies = buildCache.buildDependencies?.map((dependency) =>
-    getCacheDependency({
-      dependency,
-      configPath,
-      root,
-    }),
-  );
-  const nextBuildDependencies = configPath
-    ? Array.from(new Set([...(buildDependencies || []), normalize(configPath)]))
-    : buildDependencies;
-
-  return {
-    cacheDirectory: buildCache.cacheDirectory,
-    cacheDigest: buildCache.cacheDigest,
-    buildDependencies: nextBuildDependencies,
-  };
-};
+import {
+  resolveBuildCache,
+  resolveTestEnvironmentFromTarget,
+} from '@rstest/core/internal/adapter';
 
 /**
  * Convert rsbuild config to rstest config
@@ -147,7 +80,7 @@ export function toRstestConfig({
       module,
     },
     performance: {
-      buildCache: updateCacheConfig({
+      buildCache: resolveBuildCache({
         buildCache,
         configPath,
         root: finalBuildConfig.root,
@@ -158,7 +91,7 @@ export function toRstestConfig({
       swc,
       bundlerChain,
     } as ExtendConfig['tools'],
-    testEnvironment: target === 'node' ? 'node' : 'happy-dom',
+    testEnvironment: resolveTestEnvironmentFromTarget(target),
   } as ExtendConfig;
 
   return rstestConfig;

--- a/packages/adapter-rsbuild/tests/toRstestConfig.test.ts
+++ b/packages/adapter-rsbuild/tests/toRstestConfig.test.ts
@@ -1,4 +1,4 @@
-import { normalize } from 'node:path';
+import { normalize, resolve } from 'node:path';
 import { defineConfig, type RsbuildConfig } from '@rsbuild/core';
 import { describe, expect, it } from '@rstest/core';
 import { toRstestConfig } from '../src';
@@ -139,7 +139,9 @@ describe('toRstestConfig', () => {
       cacheDirectory: '.cache/from-rsbuild',
       cacheDigest: ['rsbuild-digest'],
       buildDependencies: [
-        normalize('/repo/configs/rsbuild-extra.ts'),
+        // relative dep is resolved (drive-aware on Windows); the config file
+        // itself is appended via normalize() — mirror both exactly.
+        normalize(resolve('/repo/configs/rsbuild-extra.ts')),
         normalize('/repo/configs/rsbuild.config.ts'),
       ],
     });
@@ -159,7 +161,7 @@ describe('toRstestConfig', () => {
     expect(config.performance?.buildCache).toEqual({
       cacheDirectory: '.cache/from-rsbuild',
       cacheDigest: ['rsbuild-digest'],
-      buildDependencies: [normalize('/repo/project/rsbuild-extra.ts')],
+      buildDependencies: [normalize(resolve('/repo/project/rsbuild-extra.ts'))],
     });
   });
 });

--- a/packages/adapter-rslib/rslib.config.mts
+++ b/packages/adapter-rslib/rslib.config.mts
@@ -4,6 +4,14 @@ import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
   plugins: publishCheckPlugins(),
+  output: {
+    // Bundle the shared config helpers into the adapter's dist so it carries no
+    // runtime dependency on a core subpath; `false` opts this exact subpath out
+    // of autoExternal.
+    externals: {
+      '@rstest/core/internal/adapter': false,
+    },
+  },
   lib: [
     {
       format: 'esm',

--- a/packages/adapter-rslib/src/index.ts
+++ b/packages/adapter-rslib/src/index.ts
@@ -1,6 +1,7 @@
-import { dirname, isAbsolute, normalize, resolve } from 'node:path';
+import { normalize } from 'node:path';
 import { loadConfig, type RslibConfig, mergeRslibConfig } from '@rslib/core';
 import type { ExtendConfig, ExtendConfigFn } from '@rstest/core';
+import { resolveBuildCache } from '@rstest/core/internal/adapter';
 
 export interface WithRslibConfigOptions {
   /**
@@ -24,77 +25,6 @@ export interface WithRslibConfigOptions {
    */
   modifyLibConfig?: (libConfig: RslibConfig) => RslibConfig;
 }
-
-type BuildCacheConfig = NonNullable<
-  NonNullable<RslibConfig['performance']>['buildCache']
->;
-type BuildCacheOutput =
-  | boolean
-  | {
-      cacheDirectory?: string;
-      cacheDigest?: Array<string | undefined>;
-      buildDependencies?: string[];
-    }
-  | undefined;
-
-const getCacheDependency = ({
-  dependency,
-  configPath,
-  root,
-}: {
-  dependency: string;
-  configPath?: string;
-  root?: string;
-}): string => {
-  if (isAbsolute(dependency)) {
-    return dependency;
-  }
-
-  if (configPath) {
-    return resolve(dirname(configPath), dependency);
-  }
-
-  return root ? resolve(root, dependency) : dependency;
-};
-
-const updateCacheConfig = ({
-  buildCache,
-  configPath,
-  root,
-}: {
-  buildCache?: BuildCacheConfig;
-  configPath?: string;
-  root?: string;
-}): BuildCacheOutput => {
-  if (buildCache === undefined) {
-    return undefined;
-  }
-
-  if (buildCache === false) {
-    return false;
-  }
-
-  if (buildCache === true) {
-    return configPath ? { buildDependencies: [configPath] } : true;
-  }
-
-  const buildDependencies = buildCache.buildDependencies?.map((dependency) =>
-    getCacheDependency({
-      dependency,
-      configPath,
-      root,
-    }),
-  );
-  const nextBuildDependencies = configPath
-    ? Array.from(new Set([...(buildDependencies || []), configPath]))
-    : buildDependencies;
-
-  return {
-    cacheDirectory: buildCache.cacheDirectory,
-    cacheDigest: buildCache.cacheDigest,
-    buildDependencies: nextBuildDependencies,
-  };
-};
 
 export function withRslibConfig(
   options: WithRslibConfigOptions = {},
@@ -195,7 +125,7 @@ export function withRslibConfig(
         module: finalLibConfig.output?.module ?? libConfig.format !== 'cjs',
       },
       performance: {
-        buildCache: updateCacheConfig({
+        buildCache: resolveBuildCache({
           buildCache,
           configPath: filePath,
           root: finalLibConfig.root,
@@ -207,6 +137,10 @@ export function withRslibConfig(
         bundlerChain,
       } as ExtendConfig['tools'],
 
+      // rslib builds libraries, which are Node-first: only an explicit `web`
+      // target maps to a browser env, everything else (including no target)
+      // defaults to `node`. This is the inverse of the rsbuild/rspack adapters'
+      // `resolveTestEnvironmentFromTarget` default, so this rule stays local.
       testEnvironment: target === 'web' ? 'happy-dom' : 'node',
     } as ExtendConfig;
 

--- a/packages/adapter-rspack/rslib.config.mts
+++ b/packages/adapter-rspack/rslib.config.mts
@@ -4,6 +4,14 @@ import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
   plugins: publishCheckPlugins(),
+  output: {
+    // Bundle the shared config helpers into the adapter's dist so it carries no
+    // runtime dependency on a core subpath; `false` opts this exact subpath out
+    // of autoExternal.
+    externals: {
+      '@rstest/core/internal/adapter': false,
+    },
+  },
   lib: [
     {
       format: 'esm',

--- a/packages/adapter-rspack/src/index.ts
+++ b/packages/adapter-rspack/src/index.ts
@@ -7,6 +7,10 @@ import type {
   RspackOptions,
 } from '@rspack/core';
 import type { ExtendConfig, ExtendConfigFn } from '@rstest/core';
+import {
+  resolveCacheDependency,
+  resolveTestEnvironmentFromTarget,
+} from '@rstest/core/internal/adapter';
 
 type RspackConfig = RspackOptions | MultiRspackOptions;
 
@@ -68,24 +72,6 @@ const findDefaultConfig = (cwd: string): string | null => {
   return null;
 };
 
-const normalizeTargets = (target: RspackOptions['target']): string[] => {
-  if (!target) {
-    return [];
-  }
-  if (Array.isArray(target)) {
-    return target.filter(Boolean) as string[];
-  }
-  if (typeof target === 'string') {
-    return [target];
-  }
-  return [];
-};
-
-const isNodeTarget = (targets: string[]): boolean =>
-  targets.some(
-    (target) => target === 'async-node' || target.startsWith('node'),
-  );
-
 const isHtmlRspackPlugin = (plugin: unknown): boolean =>
   plugin && (plugin as { constructor?: { name?: string } }).constructor
     ? (plugin as { constructor: { name?: string } }).constructor.name ===
@@ -96,20 +82,6 @@ const isPersistentCacheConfig = (
   cache: RspackOptions['cache'],
 ): cache is PersistentRspackCacheConfig =>
   typeof cache === 'object' && cache?.type === 'persistent';
-
-const getCachePath = ({
-  cachePath,
-  root,
-}: {
-  cachePath: string;
-  root?: string;
-}): string => {
-  if (path.isAbsolute(cachePath)) {
-    return path.normalize(cachePath);
-  }
-
-  return root ? path.normalize(path.resolve(root, cachePath)) : cachePath;
-};
 
 const getCacheRoot = (
   rspackConfig: RspackOptions,
@@ -150,9 +122,12 @@ const updateCacheConfig = ({
     return undefined;
   }
 
+  // Rspack resolves cache paths relative to the build `context` (root), so only
+  // `root` is passed — never `configPath` — to keep the shared resolver's
+  // context-based behavior.
   const buildDependencies = cache.buildDependencies?.map((dependency) =>
-    getCachePath({
-      cachePath: dependency,
+    resolveCacheDependency({
+      dependency,
       root,
     }),
   );
@@ -164,8 +139,8 @@ const updateCacheConfig = ({
 
   return {
     cacheDirectory: cache.storage?.directory
-      ? getCachePath({
-          cachePath: cache.storage.directory,
+      ? resolveCacheDependency({
+          dependency: cache.storage.directory,
           root,
         })
       : undefined,
@@ -341,8 +316,7 @@ export function toRstestConfig({
     ? modifyRspackConfig(rspackConfig)
     : rspackConfig;
 
-  const targets = normalizeTargets(finalConfig.target);
-  const testEnvironment = isNodeTarget(targets) ? 'node' : 'happy-dom';
+  const testEnvironment = resolveTestEnvironmentFromTarget(finalConfig.target);
 
   // Extract resolve config — rspack's ResolveOptions is mostly compatible
   // with rsbuild's resolve type, cast to align minor differences (e.g. alias: false)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,10 @@
       "types": "./dist/api/index.d.ts",
       "default": "./dist/api/index.js"
     },
+    "./internal/adapter": {
+      "types": "./dist/adapter.d.ts",
+      "default": "./dist/adapter.js"
+    },
     "./internal/browser": {
       "types": "./dist/browser.d.ts",
       "default": "./dist/browser.js"

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
         entry: {
           index: './src/index.ts',
           'api/index': './src/api/index.ts',
+          adapter: './src/adapter.ts',
           browser: './src/browser.ts',
           worker: './src/runtime/worker/index.ts',
           globalSetupWorker: './src/runtime/worker/globalSetupWorker.ts',

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -1,0 +1,133 @@
+// TODO(internal/adapter): this module ships as the `@rstest/core/internal/adapter`
+// subpath export, but the first-party adapters bundle it into their own dist
+// (`externals: { '@rstest/core/internal/adapter': false }`), so they keep no
+// runtime dependency on a core subpath. The shipped `dist/adapter.{js,d.ts}`
+// (~1.6KB JS) is therefore only a build-time resolution target — kept as an
+// extension point for external adapter authors (who can consume it at runtime
+// like `@rstest/browser` does with `internal/browser`). If that shipped copy is
+// ever deemed unwanted, relocate this module to a private (unpublished)
+// workspace package the adapters depend on, instead of core.
+import { dirname, isAbsolute, normalize, resolve } from 'node:path';
+
+/**
+ * Build target shape(s) accepted across adapters: a single target string
+ * (rsbuild / rslib `output.target`) or Rspack's `string | string[] | false`.
+ */
+export type AdapterBuildTarget = string | string[] | false | undefined;
+
+/**
+ * Resolve one `buildDependencies` entry to a stable, normalized path so every
+ * adapter computes the same cache key for the same inputs. Single source for
+ * the per-entry resolution that previously diverged across the three adapters
+ * (e.g. rslib skipped `normalize()`).
+ *
+ * Relative entries resolve against the config file's directory when a
+ * `configPath` is given, else against `root`. Callers choose the base by which
+ * argument they pass: the rsbuild and rslib adapters pass `configPath` (build
+ * deps are relative to the config file); the rspack adapter passes only `root`
+ * (Rspack resolves deps relative to the build `context`).
+ */
+export const resolveCacheDependency = ({
+  dependency,
+  configPath,
+  root,
+}: {
+  dependency: string;
+  configPath?: string;
+  root?: string;
+}): string => {
+  if (isAbsolute(dependency)) {
+    return normalize(dependency);
+  }
+  if (configPath) {
+    return normalize(resolve(dirname(configPath), dependency));
+  }
+  return root ? normalize(resolve(root, dependency)) : dependency;
+};
+
+/**
+ * Structural shape of a bundler's `performance.buildCache`, kept structural so
+ * core need not import each bundler's config type — the rsbuild and rslib
+ * adapters pass their own (compatible) `buildCache` value.
+ */
+type AdapterBuildCache =
+  | boolean
+  | {
+      buildDependencies?: string[];
+      cacheDirectory?: string;
+      cacheDigest?: Array<string | undefined>;
+    };
+
+/**
+ * Normalized `performance.buildCache` that an adapter feeds to rstest.
+ */
+export type BuildCacheOutput =
+  | boolean
+  | {
+      cacheDirectory?: string;
+      cacheDigest?: Array<string | undefined>;
+      buildDependencies?: string[];
+    }
+  | undefined;
+
+/**
+ * Map a bundler's `performance.buildCache` to rstest's, resolving every
+ * `buildDependencies` entry through {@link resolveCacheDependency} and adding
+ * the config file itself as a dependency. Single source shared by the rsbuild
+ * and rslib adapters, whose mappings are otherwise identical (the rspack
+ * adapter has its own, persistent-cache-shaped variant).
+ */
+export const resolveBuildCache = ({
+  buildCache,
+  configPath,
+  root,
+}: {
+  buildCache?: AdapterBuildCache;
+  configPath?: string;
+  root?: string;
+}): BuildCacheOutput => {
+  if (buildCache === undefined) {
+    return undefined;
+  }
+  if (buildCache === false) {
+    return false;
+  }
+  if (buildCache === true) {
+    return configPath ? { buildDependencies: [normalize(configPath)] } : true;
+  }
+  const buildDependencies = buildCache.buildDependencies?.map((dependency) =>
+    resolveCacheDependency({ dependency, configPath, root }),
+  );
+  const nextBuildDependencies = configPath
+    ? Array.from(new Set([...(buildDependencies || []), normalize(configPath)]))
+    : buildDependencies;
+  return {
+    cacheDirectory: buildCache.cacheDirectory,
+    cacheDigest: buildCache.cacheDigest,
+    buildDependencies: nextBuildDependencies,
+  };
+};
+
+/**
+ * Whether a build target runs in Node (vs the browser). Recognizes Rspack's
+ * `async-node` and any `node*` target, across single-string and array shapes.
+ * Single source so adapters cannot drift on which targets count as Node.
+ */
+export const isNodeTarget = (target: AdapterBuildTarget): boolean => {
+  const targets = Array.isArray(target)
+    ? (target.filter(Boolean) as string[])
+    : typeof target === 'string'
+      ? [target]
+      : [];
+  return targets.some((t) => t === 'async-node' || t.startsWith('node'));
+};
+
+/**
+ * Default `testEnvironment` derived from a build target: Node targets map to
+ * `'node'`, everything else (including no target) to `'happy-dom'`. Shared by
+ * the rsbuild and rspack adapters; rslib keeps its own inverse rule (see its
+ * call site) because libraries are Node-first, so an absent target → `'node'`.
+ */
+export const resolveTestEnvironmentFromTarget = (
+  target: AdapterBuildTarget,
+): 'node' | 'happy-dom' => (isNodeTarget(target) ? 'node' : 'happy-dom');

--- a/packages/core/tests/adapter.test.ts
+++ b/packages/core/tests/adapter.test.ts
@@ -1,0 +1,80 @@
+import { normalize, resolve } from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import {
+  isNodeTarget,
+  resolveCacheDependency,
+  resolveTestEnvironmentFromTarget,
+} from '../src/adapter';
+
+describe('resolveCacheDependency', () => {
+  it('normalizes an absolute dependency', () => {
+    expect(
+      resolveCacheDependency({ dependency: resolve('/repo/a/../b/dep.ts') }),
+    ).toBe(normalize(resolve('/repo/b/dep.ts')));
+  });
+
+  it('resolves a relative dependency against the config file directory', () => {
+    expect(
+      resolveCacheDependency({
+        dependency: './dep.ts',
+        configPath: resolve('/repo/configs/app.config.ts'),
+        // `root` is ignored when `configPath` is present
+        root: resolve('/repo/project'),
+      }),
+    ).toBe(normalize(resolve('/repo/configs/dep.ts')));
+  });
+
+  it('resolves a relative dependency against root when no config path', () => {
+    expect(
+      resolveCacheDependency({
+        dependency: './dep.ts',
+        root: resolve('/repo/project'),
+      }),
+    ).toBe(normalize(resolve('/repo/project/dep.ts')));
+  });
+
+  it('returns a bare relative dependency unchanged when no base is given', () => {
+    expect(resolveCacheDependency({ dependency: './dep.ts' })).toBe('./dep.ts');
+  });
+
+  it('produces identical keys for identical inputs (no cross-adapter drift)', () => {
+    const input = {
+      dependency: './shared/dep.ts',
+      configPath: resolve('/repo/configs/app.config.ts'),
+    };
+    // Whichever adapter computes this, the cache key must match.
+    expect(resolveCacheDependency(input)).toBe(
+      normalize(resolve('/repo/configs/shared/dep.ts')),
+    );
+  });
+});
+
+describe('isNodeTarget', () => {
+  it('recognizes node-like single-string targets', () => {
+    expect(isNodeTarget('node')).toBe(true);
+    expect(isNodeTarget('async-node')).toBe(true);
+    expect(isNodeTarget('node18.0')).toBe(true);
+  });
+
+  it('treats web / undefined / false as non-node', () => {
+    expect(isNodeTarget('web')).toBe(false);
+    expect(isNodeTarget('web-worker')).toBe(false);
+    expect(isNodeTarget(undefined)).toBe(false);
+    expect(isNodeTarget(false)).toBe(false);
+    expect(isNodeTarget([])).toBe(false);
+  });
+
+  it('detects a node target inside an array (rspack multi-target)', () => {
+    expect(isNodeTarget(['web', 'async-node'])).toBe(true);
+    expect(isNodeTarget(['web', 'web-worker'])).toBe(false);
+  });
+});
+
+describe('resolveTestEnvironmentFromTarget', () => {
+  it('maps node targets to node and everything else to happy-dom', () => {
+    expect(resolveTestEnvironmentFromTarget('node')).toBe('node');
+    expect(resolveTestEnvironmentFromTarget('async-node')).toBe('node');
+    expect(resolveTestEnvironmentFromTarget('web')).toBe('happy-dom');
+    expect(resolveTestEnvironmentFromTarget(undefined)).toBe('happy-dom');
+  });
+});


### PR DESCRIPTION
## Summary

The three config adapters (`@rstest/adapter-rsbuild`, `@rstest/adapter-rslib`, `@rstest/adapter-rspack`) had each grown their own copy of the same config-mapping logic, and the copies had silently drifted:

- **Cache-key resolution** — resolving `buildDependencies` entries to normalized paths. rslib skipped `normalize()`, so the same dependency could yield a different cache key depending on which adapter ran.
- **`target` → `testEnvironment` mapping** — deciding whether a build target runs in Node, duplicated three ways.

This PR moves the shared logic into a single source, `packages/core/src/adapter.ts`, exposed via `@rstest/core/internal/adapter`:

- `resolveCacheDependency` — per-entry path resolution (absolute → normalize; relative → resolve against the config dir or root, then normalize).
- `resolveBuildCache` — the full `performance.buildCache` mapping shared by the rsbuild and rslib adapters (the rspack adapter keeps its own persistent-cache variant).
- `isNodeTarget` / `resolveTestEnvironmentFromTarget` — one definition of which targets count as Node, across single-string and array (rspack multi-target) shapes.

**No new runtime coupling.** The adapters previously imported `@rstest/core` only as types (erased at build time). To preserve that, each adapter's `rslib.config.mts` sets `externals: { '@rstest/core/internal/adapter': false }`, so these pure helpers are **bundled into the adapter's own dist** instead of left as a runtime import of a core subpath. The source stays single-sourced in core, but the shipped adapter carries its own copy — so a published adapter needs no particular core version to resolve the export. (This differs from `@rstest/browser`, which consumes its `internal/*` import at runtime and keeps it external.)

The rslib adapter intentionally keeps its own inverse target→env rule (libraries are Node-first, so an absent target defaults to `node` rather than `happy-dom`); only the shared "which targets are Node" predicate is reused.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).