### PR TITLE
refactor(coverage): single-source provider contract and align collect error handling

### DIFF
--- a/packages/core/src/coverage/generate.ts
+++ b/packages/core/src/coverage/generate.ts
@@ -341,7 +341,7 @@ export async function generateCoverage(
 
     // Generate coverage reports
     await traceSpan('coverage:generate-reports', 'coverage', () =>
-      coverageProvider.generateReports(finalCoverageMap, coverage),
+      coverageProvider.generateReports(finalCoverageMap),
     );
 
     if (coverage.thresholds) {

--- a/packages/core/src/coverage/index.ts
+++ b/packages/core/src/coverage/index.ts
@@ -61,7 +61,7 @@ export function cleanCoverageReports(options: NormalizedCoverageOptions): void {
 }
 
 export async function createCoverageProvider(
-  options: CoverageOptions,
+  options: NormalizedCoverageOptions,
   root: string,
 ): Promise<CoverageProvider | null> {
   if (!options.enabled) {

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -159,7 +159,7 @@ export type NormalizedCoverageOptions = Required<
 };
 
 export declare class CoverageProvider {
-  constructor(options: CoverageOptions, root?: string);
+  constructor(options: NormalizedCoverageOptions, root?: string);
   /**
    * Initialize coverage collection
    */
@@ -188,12 +188,14 @@ export declare class CoverageProvider {
   }): Promise<FileCoverageData[]>;
 
   /**
-   * Generate coverage reports
+   * Generate coverage reports.
+   *
+   * Reporters and output directory come from the normalized options the
+   * provider received at construction — there is no per-call override, so a
+   * provider cannot silently ignore a second argument that drifts away from the
+   * constructor config.
    */
-  generateReports(
-    coverageMap: CoverageMap,
-    options: CoverageOptions,
-  ): Promise<void>;
+  generateReports(coverageMap: CoverageMap): Promise<void>;
 
   /**
    * Clean up coverage data

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -92,7 +92,11 @@ export class CoverageProvider implements RstestCoverageProvider {
 
       return this.coverageMap;
     } catch (error) {
-      console.warn('Failed to collect coverage data:', error);
+      // Surface collection failures the same way the v8 provider does: log to
+      // stderr and mark the run as failed, so a broken coverage map never
+      // passes silently with a zero exit code.
+      console.error('Failed to collect coverage data:', error);
+      process.exitCode = 1;
       return null;
     }
   }

--- a/packages/coverage-istanbul/tests/provider.test.ts
+++ b/packages/coverage-istanbul/tests/provider.test.ts
@@ -1,0 +1,62 @@
+import type { NormalizedCoverageOptions } from '@rstest/core';
+import type { CoverageMap } from 'istanbul-lib-coverage';
+import { CoverageProvider } from '../src/provider';
+
+const createOptions = (
+  overrides: Partial<NormalizedCoverageOptions> = {},
+): NormalizedCoverageOptions => ({
+  enabled: true,
+  exclude: [],
+  provider: 'istanbul',
+  reporters: [],
+  reportsDirectory: 'coverage',
+  clean: true,
+  reportOnFailure: false,
+  allowExternal: false,
+  ...overrides,
+});
+
+describe('coverage-istanbul provider', () => {
+  // Typed as optional so the `delete` below stays legal (the src-side
+  // `declare global var __coverage__: any` is non-optional).
+  const globalWithCoverage = globalThis as { __coverage__?: unknown };
+  const originalCoverage = globalWithCoverage.__coverage__;
+  const originalExitCode = process.exitCode;
+  const originalError = console.error;
+
+  afterEach(() => {
+    globalWithCoverage.__coverage__ = originalCoverage;
+    process.exitCode = originalExitCode;
+    console.error = originalError;
+  });
+
+  it('returns null without touching the exit code when there is no coverage data', () => {
+    delete globalWithCoverage.__coverage__;
+    const provider = new CoverageProvider(createOptions());
+
+    expect(provider.collect()).toBeNull();
+    expect(process.exitCode).toBe(originalExitCode);
+  });
+
+  it('marks the run as failed when collection throws (parity with the v8 provider)', () => {
+    globalWithCoverage.__coverage__ = {};
+    const provider = new CoverageProvider(createOptions());
+
+    // Force the merge step to fail so the catch branch runs.
+    provider.createCoverageMap = (): CoverageMap =>
+      ({
+        merge() {
+          throw new Error('boom');
+        },
+      }) as unknown as CoverageMap;
+
+    let loggedError = false;
+    console.error = () => {
+      loggedError = true;
+    };
+
+    expect(provider.collect()).toBeNull();
+    expect(loggedError).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -3,7 +3,6 @@ import inspector from 'node:inspector/promises';
 import { posix, win32 } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type {
-  CoverageOptions,
   NormalizedCoverageOptions,
   CoverageProvider as RstestCoverageProvider,
 } from '@rstest/core';
@@ -429,18 +428,13 @@ export class CoverageProvider implements RstestCoverageProvider {
     return results.filter((res): res is FileCoverageData => res !== null);
   }
 
-  async generateReports(
-    coverageMap: CoverageMap,
-    options?: CoverageOptions,
-  ): Promise<void> {
-    const opts = { ...this.options, ...(options || {}) };
-
+  async generateReports(coverageMap: CoverageMap): Promise<void> {
     const context = createContext({
-      dir: opts.reportsDirectory,
+      dir: this.options.reportsDirectory,
       coverageMap: coverageMap,
     });
 
-    const reportersList = opts.reporters || ['text', 'html', 'json'];
+    const reportersList = this.options.reporters;
     for (const reporter of reportersList) {
       if (typeof reporter === 'object' && 'execute' in reporter) {
         reporter.execute(context);


### PR DESCRIPTION
## Summary

The `CoverageProvider` contract carried two invitations for silent drift between the declaration and the istanbul/v8 implementations:

- The constructor was declared with the loose `CoverageOptions`, while every provider and every call site actually deals in `NormalizedCoverageOptions`.
- `generateReports(map, options)` had a second argument that both providers already ignored in favor of the options injected at construction — and TypeScript lets a method implement a wider interface with *fewer* params, so a provider could silently drop it.

This PR makes the contract honest and single-sourced, and aligns provider error handling:

- The contract constructor and `createCoverageProvider` now take `NormalizedCoverageOptions`, and `generateReports` drops the redundant `options` argument. Re-introducing either now fails to compile at the call site (verified: `TS2345` / `TS2554`).
- Removes the now-dead `options` merge and `['text','html','json']` fallback from the v8 `generateReports` (one fewer per-call allocation).
- Aligns the istanbul `collect()` error path with the v8 provider: log to stderr and set `process.exitCode = 1` instead of warning and exiting zero, so a broken coverage map never passes silently. Adds istanbul provider tests covering the parity.

No public API or user-facing behavior change beyond the istanbul collect-failure now surfacing a non-zero exit code (matching v8).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).