### PR TITLE
fix(core): exit browser mode when a sibling node project has no tests

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -74,10 +74,10 @@ Important:
 
 ## Fixture strategy
 
-- **Prefer reusing** an existing fixture when the scenario can be expressed by extending it
-- Add a new fixture only when the scenario truly needs different config, dependencies, or file layout
-- Keep fixtures minimal and representative of the behavior under test
-- Don't create near-duplicate fixtures just to add one extra test case
+Before adding a fixture, list existing ones in the same area (`ls e2e/<area>/fixtures`) and name the closest match. Prefer extending it:
+
+- Adding a project, config flag, or test file is additive reuse — "different config" alone does not justify a new fixture. **After extending, re-run every test using that fixture** to confirm none broke.
+- A new fixture is right when reuse would force an **incompatible** change to config other tests depend on, or contort the fixture's intent.
 
 ## E2E rstest spawns with persistent `dist/.rstest-temp/`
 

--- a/e2e/browser-mode/fixtures/multi-project-config/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/multi-project-config/rstest.config.mts
@@ -1,5 +1,13 @@
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  projects: ['./project-b/rstest.config.mts', './project-a/rstest.config.mts'],
+  projects: [
+    './project-b/rstest.config.mts',
+    './project-a/rstest.config.mts',
+    // Empty node project (#1363): configured but matches zero test files, forcing
+    // the mixed browser+node "no node tests to run" path that previously hung the
+    // CLI (the deferred browser teardown never fired because node `run()` was
+    // skipped). Keep it here so the multi-project browser tests also guard it.
+    { name: 'node-empty', include: ['node-tests/**/*.test.ts'] },
+  ],
 });

--- a/e2e/browser-mode/multiProjectExit.test.ts
+++ b/e2e/browser-mode/multiProjectExit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@rstest/core';
+import { runBrowserCli } from './utils';
+
+/**
+ * Regression test for https://github.com/web-infra-dev/rstest/issues/1363.
+ * The `multi-project-config` fixture carries an empty node project alongside its
+ * browser projects; filtering to a single browser test leaves the node project
+ * with zero tests, which is the mixed "no node tests to run" shape that hung.
+ *
+ * `expectExecSuccess()` awaits process exit, so a regression here surfaces as a
+ * test timeout rather than a wrong assertion.
+ */
+describe('browser mode - multi project exit', () => {
+  it('exits when a node project has no tests but a browser project does', async () => {
+    const { expectExecSuccess, cli } = await runBrowserCli(
+      'multi-project-config',
+      { args: ['project-b/tests/smoke.test.ts'] },
+    );
+
+    await expectExecSuccess();
+    expect(cli.stdout).toContain('smoke.test.ts');
+    expect(cli.stdout).toMatch(/Tests.*passed/);
+  });
+});

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -414,7 +414,12 @@ export async function runTests(context: Rstest): Promise<void> {
       }
     }
     browserResultPromise = runBrowserModeTests(context, browserProjectsToRun, {
-      skipOnTestRunEnd: shouldUnifyReporter,
+      // Defer browser teardown + reporting to the unified node run only when
+      // node tests will actually run. If node projects resolve to zero files,
+      // the `!hasNodeTestsToRun` early return below skips `run()` entirely, so a
+      // deferred browser would never be torn down and the CLI hangs. Otherwise
+      // let the browser self-finalize like the browser-only path. See #1363.
+      skipOnTestRunEnd: shouldUnifyReporter && hasNodeTestsToRun,
       shardedEntries: shard ? browserEntries : undefined,
       allowEmptyWatchRun: isWatchMode && context.relatedResolutionEmpty,
       onTraceEvents: forwardBrowserTraceEvents,


### PR DESCRIPTION
## Summary

`rstest run` (non-watch) hung forever for multi-project configs that mix a browser project with one or more non-browser (node) projects, when the node projects resolved to **zero test files** — e.g. a config with `node` / `happy-dom` / `browser` projects where only browser test files exist. The browser stayed up serving its dev server and the CLI never exited. Filtering to the single browser project (`--project browser`) exited correctly, which is what made it look intermittent.

Root cause: in mixed mode the browser runs with `skipOnTestRunEnd: shouldUnifyReporter` (true whenever node projects are *configured*), which defers the browser's teardown (dev server / WebSocket server / browser process) and reporting to the node-side `run()`. But when no node *tests* resolve, the `!hasNodeTestsToRun` early return fires before `run()` is ever called, so the deferred teardown never happens and the process keeps live handles open.

Fix: gate the deferral on `hasNodeTestsToRun` (`skipOnTestRunEnd: shouldUnifyReporter && hasNodeTestsToRun`). When no node tests will run, the browser self-finalizes (reports + closes) exactly like the browser-only fast path. Also covers the equivalent case where a file filter excludes all node tests.

## Out of scope

Coverage for this empty-node path is intentionally **not** addressed here. The browser project's coverage report is still skipped in that configuration, because generating it would require another out-of-`run()` coverage branch that entrenches a browser-specific anti-pattern. Tracked in #1388, to be resolved when browser mode flows through the unified `run()` as a pool type.

## Related Links

- Closes #1363
- Follow-up: #1388

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
