### PR TITLE
refactor(core): single-source RSTEST_* env-var names

### DIFF
--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -1,3 +1,4 @@
+import { ENV } from '../utils/env';
 import { logger } from '../utils/logger';
 
 function initNodeEnv() {
@@ -13,7 +14,7 @@ function initNodeEnv() {
  */
 export function initRstestEnv(): void {
   initNodeEnv();
-  process.env.RSTEST = 'true';
+  process.env[ENV.RSTEST] = 'true';
 }
 
 export function prepareCli(): void {

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -28,6 +28,7 @@ import type {
 } from '../types';
 import {
   castArray,
+  ENV,
   getAbsolutePath,
   logger,
   normalizeBuildCache,
@@ -228,7 +229,7 @@ export class Rstest implements RstestContext {
             _globalSetups: false,
             outputModule:
               config.output?.module ??
-              process.env.RSTEST_OUTPUT_MODULE !== 'false',
+              process.env[ENV.OUTPUT_MODULE] !== 'false',
             environmentName,
             normalizedConfig: config,
           };
@@ -241,7 +242,7 @@ export class Rstest implements RstestContext {
             name: rstestConfig.name,
             outputModule:
               rstestConfig.output?.module ??
-              process.env.RSTEST_OUTPUT_MODULE !== 'false',
+              process.env[ENV.OUTPUT_MODULE] !== 'false',
             environmentName: formatEnvironmentName(rstestConfig.name),
             normalizedConfig: rstestConfig,
           },

--- a/packages/core/src/pool/memoryGate.ts
+++ b/packages/core/src/pool/memoryGate.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import os from 'node:os';
 import v8 from 'node:v8';
+import { ENV } from '../utils/env';
 import { isDebug, logger } from '../utils/logger';
 import { isWorkerResponseEnvelope } from './protocol';
 
@@ -238,7 +239,7 @@ export class MemoryGate {
 
 /** Honors `RSTEST_MEMORY_AWARE=0` (emergency kill switch). */
 export const createDefaultMemoryGate = (): MemoryGate | undefined => {
-  if (process.env.RSTEST_MEMORY_AWARE === '0') return undefined;
+  if (process.env[ENV.MEMORY_AWARE] === '0') return undefined;
   return new MemoryGate();
 };
 

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -7,6 +7,7 @@ import {
   type WorkerResponse,
   wrapWorkerResponse,
 } from '../../pool/protocol';
+import { ENV } from '../../utils/env';
 import { channel } from './channels';
 import { runInPool } from './runInPool';
 
@@ -82,7 +83,7 @@ process.on('uncaughtException', fatalExit);
 process.on('unhandledRejection', fatalExit);
 
 const handleStart = (request: Extract<WorkerRequest, { type: 'start' }>) => {
-  process.env.RSTEST_WORKER_ID = String(request.workerId);
+  process.env[ENV.WORKER_ID] = String(request.workerId);
   send({ type: 'started', pid: process.pid });
 };
 
@@ -98,7 +99,7 @@ const RESPONSE_TYPE: Record<TaskKind, 'runFinished' | 'collectFinished'> = {
 // bootstrap; toggling `RSTEST_MEMORY_AWARE` mid-run is not supported (host
 // samples it at pool construction too).
 const MEMORY_REPORTING_ENABLED =
-  isMainThread && process.env.RSTEST_MEMORY_AWARE !== '0';
+  isMainThread && process.env[ENV.MEMORY_AWARE] !== '0';
 
 const runTask = async (
   kind: TaskKind,

--- a/packages/core/src/utils/agent/detectAgent.ts
+++ b/packages/core/src/utils/agent/detectAgent.ts
@@ -1,4 +1,5 @@
 import { type AgentName, detectAgent as detectAgentFromStdEnv } from 'std-env';
+import { ENV } from '../env';
 
 type KnownAgentNames = AgentName;
 
@@ -17,7 +18,7 @@ type AgentResult =
     };
 
 export function determineAgent(): AgentResult {
-  if (process.env.RSTEST_NO_AGENT === '1') {
+  if (process.env[ENV.NO_AGENT] === '1') {
     return { isAgent: false, agent: undefined };
   }
 

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -1,0 +1,24 @@
+/**
+ * Single source of truth for Rstest's `process.env.*` variable names.
+ *
+ * Each of these is read and/or written from more than one module, so spelling
+ * the literal out at every site is a drift hazard — a typo or rename on one
+ * side silently breaks the producer/consumer pairing. Reference `ENV.*` instead
+ * so the name lives in exactly one place.
+ *
+ * Scope this to environment-variable *names* only. Internal `globalThis` keys
+ * and `import.meta` hook keys are a different surface and live with their own
+ * modules (e.g. `runtime/worker/runtimeHooks.ts`).
+ */
+export const ENV = {
+  /** Set to `'true'` while a test run is active (set in `cli/prepare.ts`). */
+  RSTEST: 'RSTEST',
+  /** User override for `output.module`; `'false'` disables ESM output. */
+  OUTPUT_MODULE: 'RSTEST_OUTPUT_MODULE',
+  /** Per-worker id exposed so user code can partition finite resources. */
+  WORKER_ID: 'RSTEST_WORKER_ID',
+  /** Emergency kill switch for the memory-aware pool gate (`'0'` disables). */
+  MEMORY_AWARE: 'RSTEST_MEMORY_AWARE',
+  /** Set to `'1'` to force-disable agent (CI assistant) detection. */
+  NO_AGENT: 'RSTEST_NO_AGENT',
+} as const;

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './agent';
 export * from './constants';
+export * from './env';
 export * from './helper';
 export * from './logger';
 export * from './process';


### PR DESCRIPTION
## Summary

The same `RSTEST_*` environment-variable name was spelled out as a string literal at every read/write site, with `RSTEST_MEMORY_AWARE` and `RSTEST_OUTPUT_MODULE` each appearing in two different modules. Nothing ties a producer to its consumer, so a typo or rename on one side would silently break the pairing at runtime with no error.

This centralizes the names in a single `ENV` const (`packages/core/src/utils/env.ts`) and has every site reference `process.env[ENV.*]`:

- A misspelled key is now a **compile error** (`as const` keys) instead of a runtime no-op.
- A rename happens in exactly one place; producer/consumer can no longer drift apart.
- No behavior change — the literal values (`'RSTEST'`, `'RSTEST_OUTPUT_MODULE'`, `'RSTEST_WORKER_ID'`, `'RSTEST_MEMORY_AWARE'`, `'RSTEST_NO_AGENT'`) are unchanged.

Scope is limited to env-var *names*; worker code imports the const directly (not via the utils barrel) to keep worker startup free of barrel bloat.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).