### PR TITLE
feat(core): support runtime test skip

### DIFF
--- a/e2e/test-api/fixtures/contextSkip.test.ts
+++ b/e2e/test-api/fixtures/contextSkip.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, expect, it } from '@rstest/core';
 
 const extended = it.extend({
+  fixtureCleanup: [
+    async ({}, use) => {
+      await use(undefined);
+      calls++;
+    },
+    { auto: true },
+  ],
   skipFixture: async ({ skip }, use) => {
     skip();
     await use('unreachable');
@@ -38,14 +45,14 @@ it('can skip from beforeEach', () => {
   expect(1 + 1).toBe(3);
 });
 
-it('continues running later tests', () => {
-  calls++;
-  expect(calls).toBe(2);
-  expect(beforeEachCalls).toBe(3);
-  expect(afterEachCalls).toBe(2);
-});
-
 extended('can skip from fixture', ({ skipFixture }) => {
   calls++;
   expect(skipFixture).toBe('unreachable');
+});
+
+it('continues running later tests', () => {
+  calls++;
+  expect(calls).toBe(3);
+  expect(beforeEachCalls).toBe(3);
+  expect(afterEachCalls).toBe(3);
 });

--- a/e2e/test-api/fixtures/contextSkip.test.ts
+++ b/e2e/test-api/fixtures/contextSkip.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, it } from '@rstest/core';
 
 const extended = it.extend({
   fixtureCleanup: [
-    async ({}, use) => {
+    async (_, use) => {
       await use(undefined);
       calls++;
     },

--- a/e2e/test-api/fixtures/contextSkip.test.ts
+++ b/e2e/test-api/fixtures/contextSkip.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, expect, it } from '@rstest/core';
+
+const extended = it.extend({
+  skipFixture: async ({ skip }, use) => {
+    skip();
+    await use('unreachable');
+  },
+});
+
+let calls = 0;
+let beforeEachCalls = 0;
+let afterEachCalls = 0;
+
+beforeEach((context) => {
+  beforeEachCalls++;
+
+  if (context.task.name === 'can skip from beforeEach') {
+    context.skip();
+  }
+});
+
+afterEach((context) => {
+  afterEachCalls++;
+
+  if (context.task.name === 'skips the current test body') {
+    expect(context.task.result?.status).toBe('skip');
+  }
+});
+
+it('skips the current test body', (context) => {
+  calls++;
+  context.skip();
+  expect(1 + 1).toBe(3);
+});
+
+it('can skip from beforeEach', () => {
+  calls++;
+  expect(1 + 1).toBe(3);
+});
+
+it('continues running later tests', () => {
+  calls++;
+  expect(calls).toBe(2);
+  expect(beforeEachCalls).toBe(3);
+  expect(afterEachCalls).toBe(2);
+});
+
+extended('can skip from fixture', ({ skipFixture }) => {
+  calls++;
+  expect(skipFixture).toBe('unreachable');
+});

--- a/e2e/test-api/index.test.ts
+++ b/e2e/test-api/index.test.ts
@@ -42,9 +42,9 @@ describe('Test API', () => {
       args: ['run', 'fixtures/contextSkip.test.ts'],
       options: {
         nodeOptions: {
-          cwd: __dirname,
+          cwd: dirname(fileURLToPath(import.meta.url)),
         },
-      },
+      }
     });
     await expectExecSuccess();
 

--- a/e2e/test-api/index.test.ts
+++ b/e2e/test-api/index.test.ts
@@ -35,4 +35,23 @@ describe('Test API', () => {
   it('`rs` should be identical to `rstest`', () => {
     expect(rs).toBe(rstest);
   });
+
+  it('context.skip skips the current test at runtime', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/contextSkip.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecSuccess();
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expect(
+      logs.find((log) => log.includes('Tests 1 passed | 3 skipped')),
+    ).toBeTruthy();
+  });
 });

--- a/e2e/test-api/index.test.ts
+++ b/e2e/test-api/index.test.ts
@@ -44,7 +44,7 @@ describe('Test API', () => {
         nodeOptions: {
           cwd: dirname(fileURLToPath(import.meta.url)),
         },
-      }
+      },
     });
     await expectExecSuccess();
 

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -105,15 +105,18 @@ export const handleFixtures = async (
 
     // This API behavior follows Vitest & Playwright
     // but why not return cleanup function?
-    await new Promise<void>((fixtureResolve) => {
+    await new Promise<void>((fixtureResolve, fixtureReject) => {
       let useDone: (() => void) | undefined;
-      const block = fixtureValue(context, async (value: any) => {
-        context[name] = value;
-        fixtureResolve();
-        return new Promise<void>((useFnResolve) => {
-          useDone = useFnResolve;
-        });
-      });
+      const block = Promise.resolve().then(() =>
+        fixtureValue(context, async (value: any) => {
+          context[name] = value;
+          fixtureResolve();
+          return new Promise<void>((useFnResolve) => {
+            useDone = useFnResolve;
+          });
+        }),
+      );
+      block.catch(fixtureReject);
 
       cleanups.unshift(() => {
         useDone?.();

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -61,11 +61,10 @@ export const normalizeFixtures = (
 export const handleFixtures = async (
   test: TestCase,
   context: Record<string, any>,
+  cleanups: (() => Promise<void>)[] = [],
 ): Promise<{
   cleanups: (() => Promise<void>)[];
 }> => {
-  const cleanups: (() => Promise<void>)[] = [];
-
   if (!test.fixtures) {
     return { cleanups };
   }
@@ -110,6 +109,10 @@ export const handleFixtures = async (
       const block = Promise.resolve().then(() =>
         fixtureValue(context, async (value: any) => {
           context[name] = value;
+          cleanups.unshift(() => {
+            useDone?.();
+            return block;
+          });
           fixtureResolve();
           return new Promise<void>((useFnResolve) => {
             useDone = useFnResolve;
@@ -117,11 +120,6 @@ export const handleFixtures = async (
         }),
       );
       block.catch(fixtureReject);
-
-      cleanups.unshift(() => {
-        useDone?.();
-        return block;
-      });
     });
 
     doneMap.add(name);

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -111,6 +111,7 @@ export class TestRunner {
       this.beforeEach(test, state, api);
 
       const cleanups: AfterEachListener[] = [];
+      const fixtureCleanups: (() => Promise<void>)[] = [];
 
       let skipped = false;
 
@@ -124,11 +125,11 @@ export class TestRunner {
       });
 
       try {
-        const fixtureCleanups = await this.beforeRunTest(
+        await this.beforeRunTest(
           test,
           snapshotClient.getSnapshotState(testPath),
+          fixtureCleanups,
         );
-        cleanups.push(...fixtureCleanups);
       } catch (error) {
         if (error instanceof TestSkipError) {
           skipped = true;
@@ -254,6 +255,7 @@ export class TestRunner {
       const afterEachFns = [...(parentHooks.afterEachListeners || [])]
         .reverse()
         .concat(cleanups)
+        .concat(fixtureCleanups)
         .concat(test.onFinished);
 
       test.context.task.result = result;
@@ -746,7 +748,8 @@ export class TestRunner {
   private async beforeRunTest(
     test: TestCase,
     snapshotState: SnapshotState,
-  ): Promise<(() => Promise<void>)[]> {
+    fixtureCleanups: (() => Promise<void>)[],
+  ): Promise<void> {
     setState<MatcherState>(
       {
         assertionCalls: 0,
@@ -769,9 +772,7 @@ export class TestRunner {
       enumerable: false,
     });
 
-    const { cleanups } = await handleFixtures(test, context);
-
-    return cleanups;
+    await handleFixtures(test, context, fixtureCleanups);
   }
 
   private afterRunTest(test: TestCase): void {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -23,7 +23,7 @@ import type {
 import { SYNTHETIC_STACK_ERROR_MESSAGE } from '../../utils/constants';
 import { getFileTaskId, getTaskNameWithPrefix } from '../../utils/helper';
 import { createExpect } from '../api/expect';
-import { formatTestError } from '../util';
+import { formatTestError, TestSkipError } from '../util';
 import type { TaskContext } from '../worker/taskContext';
 import { handleFixtures } from './fixtures';
 import {
@@ -112,30 +112,65 @@ export class TestRunner {
 
       const cleanups: AfterEachListener[] = [];
 
-      const fixtureCleanups = await this.beforeRunTest(
-        test,
-        snapshotClient.getSnapshotState(testPath),
-      );
-      cleanups.push(...fixtureCleanups);
+      let skipped = false;
+
+      const skipResult = (): TestResult => ({
+        testId: test.testId,
+        status: 'skip' as const,
+        parentNames: test.parentNames,
+        name: test.name,
+        testPath,
+        project,
+      });
 
       try {
-        for (const fn of parentHooks.beforeEachListeners) {
-          const cleanupFn = await fn(test.context);
-          if (cleanupFn) cleanups.push(cleanupFn);
-        }
+        const fixtureCleanups = await this.beforeRunTest(
+          test,
+          snapshotClient.getSnapshotState(testPath),
+        );
+        cleanups.push(...fixtureCleanups);
       } catch (error) {
-        result = {
-          testId: test.testId,
-          status: 'fail' as const,
-          parentNames: test.parentNames,
-          name: test.name,
-          errors: await formatTestError(error, test),
-          testPath,
-          project,
-        };
+        if (error instanceof TestSkipError) {
+          skipped = true;
+          result = skipResult();
+        } else {
+          result = {
+            testId: test.testId,
+            status: 'fail' as const,
+            parentNames: test.parentNames,
+            name: test.name,
+            errors: await formatTestError(error, test),
+            testPath,
+            project,
+          };
+        }
       }
 
-      if (result?.status !== 'fail') {
+      if (!result) {
+        try {
+          for (const fn of parentHooks.beforeEachListeners) {
+            const cleanupFn = await fn(test.context);
+            if (cleanupFn) cleanups.push(cleanupFn);
+          }
+        } catch (error) {
+          if (error instanceof TestSkipError) {
+            skipped = true;
+            result = skipResult();
+          } else {
+            result = {
+              testId: test.testId,
+              status: 'fail' as const,
+              parentNames: test.parentNames,
+              name: test.name,
+              errors: await formatTestError(error, test),
+              testPath,
+              project,
+            };
+          }
+        }
+      }
+
+      if (!result) {
         if (test.fails) {
           try {
             await test.fn?.(test.context);
@@ -154,15 +189,20 @@ export class TestRunner {
                 },
               ],
             };
-          } catch {
-            result = {
-              testId: test.testId,
-              project,
-              status: 'pass' as const,
-              parentNames: test.parentNames,
-              name: test.name,
-              testPath,
-            };
+          } catch (error) {
+            if (error instanceof TestSkipError) {
+              skipped = true;
+              result = skipResult();
+            } else {
+              result = {
+                testId: test.testId,
+                project,
+                status: 'pass' as const,
+                parentNames: test.parentNames,
+                name: test.name,
+                testPath,
+              };
+            }
           }
         } else {
           try {
@@ -193,15 +233,20 @@ export class TestRunner {
               testPath,
             };
           } catch (error) {
-            result = {
-              testId: test.testId,
-              project,
-              status: 'fail' as const,
-              parentNames: test.parentNames,
-              name: test.name,
-              errors: await formatTestError(error, test),
-              testPath,
-            };
+            if (error instanceof TestSkipError) {
+              skipped = true;
+              result = skipResult();
+            } else {
+              result = {
+                testId: test.testId,
+                project,
+                status: 'fail' as const,
+                parentNames: test.parentNames,
+                name: test.name,
+                errors: await formatTestError(error, test),
+                testPath,
+              };
+            }
           }
         }
       }
@@ -220,6 +265,10 @@ export class TestRunner {
         result.status = 'fail';
         result.errors ??= [];
         result.errors.push(...(await formatTestError(error)));
+      }
+
+      if (skipped) {
+        snapshotClient.skipTest(testPath, getTaskNameWithPrefix(test));
       }
 
       if (result.status === 'fail') {
@@ -627,6 +676,12 @@ export class TestRunner {
       },
     });
 
+    Object.defineProperty(context, 'skip', {
+      value: () => {
+        throw new TestSkipError('Test skipped');
+      },
+    });
+
     Object.defineProperty(context, '_useLocalExpect', {
       get() {
         return _expect != null;
@@ -708,13 +763,13 @@ export class TestRunner {
 
     const context = this.createTestContext(test);
 
-    const { cleanups } = await handleFixtures(test, context);
-
     // create test context
     Object.defineProperty(test, 'context', {
       value: context,
       enumerable: false,
     });
+
+    const { cleanups } = await handleFixtures(test, context);
 
     return cleanups;
   }

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -228,6 +228,8 @@ export function parseTemplateTable(
 
 export class TestRegisterError extends Error {}
 
+export class TestSkipError extends Error {}
+
 class RstestError extends Error {
   public fullStack?: boolean;
 }

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -23,6 +23,8 @@ export interface TestContext {
     result?: TestResult;
   };
   expect: RstestExpect;
+  /** Skip the current test during execution. */
+  skip: () => never;
   onTestFinished: RunnerAPI['onTestFinished'];
   onTestFailed: RunnerAPI['onTestFailed'];
 }

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -93,6 +93,17 @@ test.skip('skip this test', () => {
 });
 ```
 
+Use `test.skip` when you know at definition time that a test should be skipped. If the decision can only be made while the test is running, call `context.skip()` from the test context instead. `context.skip()` stops executing the current test immediately, so code after it will not run, and the test is reported as skipped.
+
+```ts
+test('skip at runtime', (context) => {
+  context.skip();
+
+  // This assertion is not executed.
+  expect(1 + 1).toBe(3);
+});
+```
+
 ## test.todo
 
 Marks certain tests as todo.
@@ -489,11 +500,26 @@ export interface TestContext {
   };
   /** The `expect` API bound to the current test */
   expect: Expect;
+  /** Skip the current test during execution */
+  skip: () => never;
   /** The `onTestFinished` hook bound to the current test */
   onTestFinished: OnTestFinished;
   /** The `onTestFailed` hook bound to the current test */
   onTestFailed: OnTestFailed;
 }
+```
+
+Use `context.skip()` to skip a test while it is running. Code after
+`context.skip()` will not execute, and the test is reported as skipped:
+
+```ts
+import { expect, test } from '@rstest/core';
+
+test('skipped test', (context) => {
+  context.skip();
+
+  expect(1 + 1).toBe(3);
+});
 ```
 
 You can also extend `TestContext` with custom fixtures using `test.extend`.

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -93,6 +93,17 @@ test.skip('skip this test', () => {
 });
 ```
 
+当你在定义测试时就确定要跳过它，可以使用 `test.skip`。如果只能在测试运行过程中决定是否跳过，请从测试上下文中调用 `context.skip()`。`context.skip()` 会立即停止执行当前测试，因此它后面的代码不会继续执行，并且该测试会被报告为 skipped。
+
+```ts
+test('skip at runtime', (context) => {
+  context.skip();
+
+  // 这个断言不会被执行。
+  expect(1 + 1).toBe(3);
+});
+```
+
 ## test.todo
 
 将某些测试标记为待办。
@@ -478,11 +489,25 @@ export interface TestContext {
   };
   /** The `expect` API bound to the current test */
   expect: Expect;
+  /** Skip the current test during execution */
+  skip: () => never;
   /** The `onTestFinished` hook bound to the current test */
   onTestFinished: OnTestFinished;
   /** The `onTestFailed` hook bound to the current test */
   onTestFailed: OnTestFailed;
 }
+```
+
+你可以使用 `context.skip()` 在测试运行过程中跳过当前测试。`context.skip()` 之后的代码不会继续执行，测试结果会被标记为 skipped：
+
+```ts
+import { expect, test } from '@rstest/core';
+
+test('skipped test', (context) => {
+  context.skip();
+
+  expect(1 + 1).toBe(3);
+});
 ```
 
 你也可以通过 `test.extend` 方法通过自定义 fixture 的方式来扩展测试上下文。


### PR DESCRIPTION
## Summary

This PR adds `context.skip()` so tests can be skipped dynamically while they are running. Calling `context.skip()` immediately stops executing the current test, reports it as skipped, and still runs cleanup hooks such as `afterEach` / `onTestFinished`. It also documents the runtime skip behavior alongside both `TestContext` and `test.skip`.

## Related Links

Closes https://github.com/web-infra-dev/rstest/issues/1391

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).