### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -142,7 +142,7 @@ test.each<{ a: number; b: number; expected: number }>`
 });
 ```
 
-You can inject parameters with [printf formatting](https://nodejs.org/api/util.html#util_util_format_format_args) in the test name in the order of the test function parameters.
+You can inject parameters with [printf formatting](https://nodejs.org/api/util.html#utilformatformat-args) in the test name in the order of the test function parameters.
 
 - `%s`: String
 - `%d`: Number

--- a/website/docs/en/guide/basic/configure-rstest.mdx
+++ b/website/docs/en/guide/basic/configure-rstest.mdx
@@ -49,7 +49,7 @@ rstest -c scripts/rstest.config.mjs
 
 Rstest's build configuration inherits from Rsbuild. Therefore, in Rstest, you can use most of the Rsbuild configurations, such as:
 
-- Using Rsbuild plugins through [plugins](/config/#plugins);
+- Using Rsbuild plugins through [plugins](/config/build/plugins);
 - Configuring module resolution behavior through [resolve](/config/build/resolve);
 - Configuring Rspack through [tools.rspack](/config/build/tools#toolsrspack);
 - Configuring builtin:swc-loader through [tools.swc](/config/build/tools#toolsswc).

--- a/website/docs/en/guide/basic/projects.mdx
+++ b/website/docs/en/guide/basic/projects.mdx
@@ -16,7 +16,7 @@ Rstest supports running multiple test projects simultaneously within a single Rs
 
 Define each sub-project in a monorepo as a project through the [projects](/config/test/projects) field, where each sub-project has its own test configuration.
 
-Rstest will automatically recognize each subdirectory under the `packages` directory as an independent test project and run tests according to the [rstest.config.ts](/guide/basic/configure-rstest#configuration-files) file (if present) in the subdirectory.
+Rstest will automatically recognize each subdirectory under the `packages` directory as an independent test project and run tests according to the [rstest.config.ts](/guide/basic/configure-rstest#configuration-file) file (if present) in the subdirectory.
 
 ```ts name='rstest.config.ts'
 import { defineConfig, defineInlineProject } from '@rstest/core';

--- a/website/docs/en/guide/integration/rspack.mdx
+++ b/website/docs/en/guide/integration/rspack.mdx
@@ -78,7 +78,7 @@ Path to rspack config file.
 - **Type:** `string`
 - **Default:** `undefined`
 
-Select a named configuration when using [multi-config](https://rspack.dev/config/index#configuration-type) in your Rspack config file. Set to a string to use the config with a matching `name` field.
+Select a named configuration when using [multi-config](https://rspack.rs/config/other-options#name) in your Rspack config file. Set to a string to use the config with a matching `name` field.
 
 If your Rspack config exports an array of configurations:
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -142,7 +142,7 @@ test.each<{ a: number; b: number; expected: number }>`
 });
 ```
 
-你可以使用 [printf formatting](https://nodejs.org/api/util.html#util_util_format_format_args) 来格式化测试名称中的参数。
+你可以使用 [printf formatting](https://nodejs.org/api/util.html#utilformatformat-args) 来格式化测试名称中的参数。
 
 - `%s`: String
 - `%d`: Number

--- a/website/docs/zh/blog/announcing-0-10.mdx
+++ b/website/docs/zh/blog/announcing-0-10.mdx
@@ -90,7 +90,7 @@ npx rstest list --changed --filesOnly
 npx rstest list --related src/button.ts --filesOnly
 ```
 
-请参考 [Run related tests](/guide/basic/cli#run-related-tests) 与 [Run changed tests](/guide/basic/cli#run-changed-tests) 了解更多。
+请参考 [Run related tests](/guide/basic/cli#运行相关测试) 与 [Run changed tests](/guide/basic/cli#运行变更相关测试) 了解更多。
 
 ## 支持持久化构建缓存 \{#build-cache}
 

--- a/website/docs/zh/guide/basic/configure-rstest.mdx
+++ b/website/docs/zh/guide/basic/configure-rstest.mdx
@@ -49,7 +49,7 @@ rstest -c scripts/rstest.config.mjs
 
 Rstest 的构建配置继承自 Rsbuild。因此，在 Rstest 中，你可以使用绝大部分的 Rsbuild 配置。如：
 
-- 通过 [plugins](/config/#plugins) 使用 Rsbuild 插件；
+- 通过 [plugins](/config/build/plugins) 使用 Rsbuild 插件；
 - 通过 [resolve](/config/build/resolve) 对模块解析行为进行配置；
 - 通过 [tools.rspack](/config/build/tools#toolsrspack) 配置 Rspack；
 - 通过 [tools.swc](/config/build/tools#toolsswc) 对 builtin:swc-loader 进行配置。

--- a/website/docs/zh/guide/integration/rspack.mdx
+++ b/website/docs/zh/guide/integration/rspack.mdx
@@ -78,7 +78,7 @@ Rspack 配置文件的路径。
 - **类型：** `string`
 - **默认值：** `undefined`
 
-当 Rspack 配置文件使用[多配置](https://rspack.dev/config/index#configuration-type)时，选择指定名称的配置。设置为字符串以使用具有匹配 `name` 字段的配置。
+当 Rspack 配置文件使用[多配置](https://rspack.rs/config/other-options#name)时，选择指定名称的配置。设置为字符串以使用具有匹配 `name` 字段的配置。
 
 如果你的 Rspack 配置导出了一个配置数组：
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -29,7 +29,7 @@ import { Prompt } from '@rspress/core/theme';
 node -v
 ```
 
-如果你的环境中尚未安装 Node.js，或是版本太低，可以通过 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https:///github.com/Schniz/fnm) 安装。
+如果你的环境中尚未安装 Node.js，或是版本太低，可以通过 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https://github.com/Schniz/fnm) 安装。
 
 下面是通过 nvm 安装的例子：
 


### PR DESCRIPTION
## Summary

This PR fixes broken documentation links and anchors found in the docs, including outdated internal config anchors, malformed external URLs, and stale external anchors in English and Chinese pages.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).