### PR TITLE
docs(website): correct config overview anchors

### DIFF
--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -108,7 +108,7 @@ export default function Overview() {
       items: item.items?.map((item) => {
         const [page, anchor] = item.split('.');
         const target = page ?? item;
-        const hash = anchor ? `#${camelToKebab(anchor)}` : '';
+        const hash = anchor ? `#${anchor.toLowerCase()}` : '';
 
         return {
           link: tUrl(`/config/test/${camelToKebab(target)}${hash}`),


### PR DESCRIPTION
## Summary

This PR fixes the Config Overview links for nested test config options such as `browser.providerOptions`. The overview entry is meant to jump to the `### providerOptions` config option heading, whose generated anchor is `#provideroptions` in both English and Chinese. Previously `ConfigOverview.tsx` converted the option name to kebab-case and generated `/zh/config/test/browser#provider-options`, but the Chinese browser config page only has `#provideroptions` for the option heading and `#provider-选项` for the separate `## Provider 选项` section.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).