### PR TITLE
feat(coverage): support custom reporters

### DIFF
--- a/e2e/test-coverage/fixtures/custom-coverage-reporter.cjs
+++ b/e2e/test-coverage/fixtures/custom-coverage-reporter.cjs
@@ -1,0 +1,15 @@
+const fs = require('node:fs');
+
+module.exports = class CustomCoverageReporter {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  execute(context) {
+    const summary = context.getTree('flat').getRoot().getCoverageSummary();
+    fs.writeFileSync(
+      this.options.outputFile,
+      JSON.stringify({ lines: summary.lines.pct }),
+    );
+  }
+};

--- a/e2e/test-coverage/fixtures/custom-coverage-reporter.mjs
+++ b/e2e/test-coverage/fixtures/custom-coverage-reporter.mjs
@@ -1,6 +1,6 @@
-const fs = require('node:fs');
+import fs from 'node:fs';
 
-module.exports = class CustomCoverageReporter {
+export default class CustomCoverageReporter {
   constructor(options = {}) {
     this.options = options;
   }
@@ -12,4 +12,4 @@ module.exports = class CustomCoverageReporter {
       JSON.stringify({ lines: summary.lines.pct }),
     );
   }
-};
+}

--- a/e2e/test-coverage/fixtures/rstest.customReporter.config.ts
+++ b/e2e/test-coverage/fixtures/rstest.customReporter.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     provider: 'istanbul',
     reporters: [
       [
-        './custom-coverage-reporter.cjs',
+        './custom-coverage-reporter.mjs',
         { outputFile: 'custom-coverage-report.json' },
       ],
     ],

--- a/e2e/test-coverage/fixtures/rstest.customReporter.config.ts
+++ b/e2e/test-coverage/fixtures/rstest.customReporter.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  exclude: ['test/sourcemapMapping.test.ts', 'allow-external/**'],
+  coverage: {
+    enabled: true,
+    provider: 'istanbul',
+    reporters: [
+      [
+        './custom-coverage-reporter.cjs',
+        { outputFile: 'custom-coverage-report.json' },
+      ],
+    ],
+  },
+  setupFiles: ['./rstest.setup.ts'],
+});

--- a/e2e/test-coverage/index.test.ts
+++ b/e2e/test-coverage/index.test.ts
@@ -221,6 +221,30 @@ describe('test coverage-istanbul', () => {
     ).toBeTruthy();
   });
 
+  it('coverage-istanbul with custom reporter', async () => {
+    const reportFile = join(__dirname, 'fixtures/custom-coverage-report.json');
+    fs.removeSync(reportFile);
+
+    const { expectExecSuccess, expectLog, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', 'rstest.customReporter.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const logs = cli.stdout.split('\n').filter(Boolean);
+
+    expectLog('Coverage enabled with istanbul', logs);
+    expect(fs.readJsonSync(reportFile)).toEqual({ lines: 94.64 });
+
+    fs.removeSync(reportFile);
+  });
+
   it('should keep coverage report when no test files match with --passWithNoTests (regression #1212)', async () => {
     const reportsDir = join(__dirname, 'fixtures/test-temp-no-tests-coverage');
     const staleFile = join(reportsDir, 'stale-from-previous-run.txt');

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import type {
   NormalizedCoverageOptions,
   CoverageProvider as RstestCoverageProvider,
@@ -25,7 +26,10 @@ export class CoverageProvider implements RstestCoverageProvider {
   // Cache to avoid redundant readFile calls in generateCoverageForUntestedFiles and generateReports.
   private sourcemapUrlCache = new Map<string, string | undefined>();
 
-  constructor(private options: NormalizedCoverageOptions) {}
+  constructor(
+    private options: NormalizedCoverageOptions,
+    private root?: string,
+  ) {}
 
   init(): void {
     // Initialize global coverage object
@@ -115,13 +119,23 @@ export class CoverageProvider implements RstestCoverageProvider {
           ? reporter
           : [reporter, {}];
         const report = reports.create(
-          reporterName as Parameters<typeof reports.create>[0],
+          this.resolveReporterName(reporterName) as Parameters<
+            typeof reports.create
+          >[0],
           reporterOptions,
         );
         //NOTE: https://github.com/vitest-dev/vitest/blob/41a111c35b6605dbe8a536a6e03b35e9bc0ce770/packages/coverage-istanbul/src/provider.ts#L145
         report.execute(context);
       }
     }
+  }
+
+  private resolveReporterName(reporterName: string): string {
+    if (reporterName.startsWith('.')) {
+      return resolve(this.root ?? process.cwd(), reporterName);
+    }
+
+    return reporterName;
   }
 
   cleanup(): void {

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -1,9 +1,11 @@
-import { resolve } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type {
   NormalizedCoverageOptions,
   CoverageProvider as RstestCoverageProvider,
 } from '@rstest/core';
 import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage';
+import type { ReportBase } from 'istanbul-lib-report';
 import { createContext } from 'istanbul-lib-report';
 import reports from 'istanbul-reports';
 import {
@@ -15,6 +17,10 @@ import {
 } from './utils';
 
 const UNTESTED_FILES_CONCURRENCY = 4;
+
+type CoverageReporterConstructor = new (
+  options: Record<string, unknown>,
+) => ReportBase;
 
 // Global type declaration for coverage
 declare global {
@@ -118,16 +124,45 @@ export class CoverageProvider implements RstestCoverageProvider {
         const [reporterName, reporterOptions] = Array.isArray(reporter)
           ? reporter
           : [reporter, {}];
-        const report = reports.create(
-          this.resolveReporterName(reporterName) as Parameters<
-            typeof reports.create
-          >[0],
-          reporterOptions,
-        );
+        const report = await this.createReport(reporterName, reporterOptions);
         //NOTE: https://github.com/vitest-dev/vitest/blob/41a111c35b6605dbe8a536a6e03b35e9bc0ce770/packages/coverage-istanbul/src/provider.ts#L145
         report.execute(context);
       }
     }
+  }
+
+  private async createReport(
+    reporterName: string,
+    reporterOptions: Record<string, unknown>,
+  ): Promise<ReportBase> {
+    const resolvedReporterName = this.resolveReporterName(reporterName);
+
+    if (resolvedReporterName.endsWith('.mjs')) {
+      const reporterModule = await import(
+        this.toImportSpecifier(resolvedReporterName)
+      );
+      const Reporter = reporterModule.default as CoverageReporterConstructor;
+
+      return new Reporter(reporterOptions);
+    }
+
+    try {
+      return reports.create(
+        resolvedReporterName as Parameters<typeof reports.create>[0],
+        reporterOptions,
+      );
+    } catch (error) {
+      if (!this.isRequireEsmError(error)) {
+        throw error;
+      }
+    }
+
+    const reporterModule = await import(
+      this.toImportSpecifier(resolvedReporterName)
+    );
+    const Reporter = reporterModule.default as CoverageReporterConstructor;
+
+    return new Reporter(reporterOptions);
   }
 
   private resolveReporterName(reporterName: string): string {
@@ -136,6 +171,22 @@ export class CoverageProvider implements RstestCoverageProvider {
     }
 
     return reporterName;
+  }
+
+  private toImportSpecifier(reporterName: string): string {
+    if (isAbsolute(reporterName)) {
+      return pathToFileURL(reporterName).toString();
+    }
+
+    return reporterName;
+  }
+
+  private isRequireEsmError(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null || !('code' in error)) {
+      return false;
+    }
+
+    return error.code === 'ERR_REQUIRE_ESM';
   }
 
   cleanup(): void {

--- a/packages/coverage-istanbul/tests/provider.test.ts
+++ b/packages/coverage-istanbul/tests/provider.test.ts
@@ -69,9 +69,10 @@ describe('coverage-istanbul provider', () => {
 
     try {
       writeFileSync(
-        join(root, 'custom-coverage-reporter.cjs'),
-        `const fs = require('node:fs');
-module.exports = class CustomCoverageReporter {
+        join(root, 'custom-coverage-reporter.mjs'),
+        `import fs from 'node:fs';
+
+export default class CustomCoverageReporter {
   constructor(options = {}) {
     this.options = options;
   }
@@ -79,13 +80,13 @@ module.exports = class CustomCoverageReporter {
   execute() {
     fs.writeFileSync(this.options.outputFile, JSON.stringify({ ok: true }));
   }
-};
+}
 `,
       );
 
       const provider = new CoverageProvider(
         createOptions({
-          reporters: [['./custom-coverage-reporter.cjs', { outputFile }]],
+          reporters: [['./custom-coverage-reporter.mjs', { outputFile }]],
           reportsDirectory: join(root, 'coverage'),
         }),
         root,

--- a/packages/coverage-istanbul/tests/provider.test.ts
+++ b/packages/coverage-istanbul/tests/provider.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { NormalizedCoverageOptions } from '@rstest/core';
 import type { CoverageMap } from 'istanbul-lib-coverage';
 import { CoverageProvider } from '../src/provider';
@@ -58,5 +61,41 @@ describe('coverage-istanbul provider', () => {
     expect(provider.collect()).toBeNull();
     expect(loggedError).toBe(true);
     expect(process.exitCode).toBe(1);
+  });
+
+  it('loads custom coverage reporters from relative config paths', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rstest-coverage-reporter-'));
+    const outputFile = join(root, 'custom-reporter-output.json');
+
+    try {
+      writeFileSync(
+        join(root, 'custom-coverage-reporter.cjs'),
+        `const fs = require('node:fs');
+module.exports = class CustomCoverageReporter {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  execute() {
+    fs.writeFileSync(this.options.outputFile, JSON.stringify({ ok: true }));
+  }
+};
+`,
+      );
+
+      const provider = new CoverageProvider(
+        createOptions({
+          reporters: [['./custom-coverage-reporter.cjs', { outputFile }]],
+          reportsDirectory: join(root, 'coverage'),
+        }),
+        root,
+      );
+
+      await provider.generateReports(provider.createCoverageMap());
+
+      expect(existsSync(outputFile)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import inspector from 'node:inspector/promises';
-import { posix, resolve, win32 } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isAbsolute, posix, resolve, win32 } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type {
   NormalizedCoverageOptions,
   CoverageProvider as RstestCoverageProvider,
@@ -9,6 +9,7 @@ import type {
 import astV8ToIstanbul from 'ast-v8-to-istanbul';
 import { Parser } from 'acorn';
 import { type CoverageMap, type FileCoverageData } from 'istanbul-lib-coverage';
+import type { ReportBase } from 'istanbul-lib-report';
 import { createContext } from 'istanbul-lib-report';
 import reports from 'istanbul-reports';
 import picomatch from 'picomatch';
@@ -24,6 +25,10 @@ type SourceMapLike = {
   sourceRoot?: string;
   sourcesContent?: (string | null)[];
 };
+
+type CoverageReporterConstructor = new (
+  options: Record<string, unknown>,
+) => ReportBase;
 
 export class CoverageProvider implements RstestCoverageProvider {
   private session: inspector.Session | null = null;
@@ -442,15 +447,44 @@ export class CoverageProvider implements RstestCoverageProvider {
         const [reporterName, reporterOptions] = Array.isArray(reporter)
           ? reporter
           : [reporter, {}];
-        const report = reports.create(
-          this.resolveReporterName(reporterName) as Parameters<
-            typeof reports.create
-          >[0],
-          reporterOptions,
-        );
+        const report = await this.createReport(reporterName, reporterOptions);
         report.execute(context);
       }
     }
+  }
+
+  private async createReport(
+    reporterName: string,
+    reporterOptions: Record<string, unknown>,
+  ): Promise<ReportBase> {
+    const resolvedReporterName = this.resolveReporterName(reporterName);
+
+    if (resolvedReporterName.endsWith('.mjs')) {
+      const reporterModule = await import(
+        this.toImportSpecifier(resolvedReporterName)
+      );
+      const Reporter = reporterModule.default as CoverageReporterConstructor;
+
+      return new Reporter(reporterOptions);
+    }
+
+    try {
+      return reports.create(
+        resolvedReporterName as Parameters<typeof reports.create>[0],
+        reporterOptions,
+      );
+    } catch (error) {
+      if (!this.isRequireEsmError(error)) {
+        throw error;
+      }
+    }
+
+    const reporterModule = await import(
+      this.toImportSpecifier(resolvedReporterName)
+    );
+    const Reporter = reporterModule.default as CoverageReporterConstructor;
+
+    return new Reporter(reporterOptions);
   }
 
   private resolveReporterName(reporterName: string): string {
@@ -459,6 +493,22 @@ export class CoverageProvider implements RstestCoverageProvider {
     }
 
     return reporterName;
+  }
+
+  private toImportSpecifier(reporterName: string): string {
+    if (isAbsolute(reporterName)) {
+      return pathToFileURL(reporterName).toString();
+    }
+
+    return reporterName;
+  }
+
+  private isRequireEsmError(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null || !('code' in error)) {
+      return false;
+    }
+
+    return error.code === 'ERR_REQUIRE_ESM';
   }
 
   cleanup(): void {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import inspector from 'node:inspector/promises';
-import { posix, win32 } from 'node:path';
+import { posix, resolve, win32 } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type {
   NormalizedCoverageOptions,
@@ -442,10 +442,23 @@ export class CoverageProvider implements RstestCoverageProvider {
         const [reporterName, reporterOptions] = Array.isArray(reporter)
           ? reporter
           : [reporter, {}];
-        const report = reports.create(reporterName as any, reporterOptions);
+        const report = reports.create(
+          this.resolveReporterName(reporterName) as Parameters<
+            typeof reports.create
+          >[0],
+          reporterOptions,
+        );
         report.execute(context);
       }
     }
+  }
+
+  private resolveReporterName(reporterName: string): string {
+    if (reporterName.startsWith('.')) {
+      return resolve(this.root ?? process.cwd(), reporterName);
+    }
+
+    return reporterName;
   }
 
   cleanup(): void {

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -113,9 +113,10 @@ describe('coverage-v8 provider', () => {
 
     try {
       writeFileSync(
-        join(root, 'custom-coverage-reporter.cjs'),
-        `const fs = require('node:fs');
-module.exports = class CustomCoverageReporter {
+        join(root, 'custom-coverage-reporter.mjs'),
+        `import fs from 'node:fs';
+
+export default class CustomCoverageReporter {
   constructor(options = {}) {
     this.options = options;
   }
@@ -123,13 +124,13 @@ module.exports = class CustomCoverageReporter {
   execute() {
     fs.writeFileSync(this.options.outputFile, JSON.stringify({ ok: true }));
   }
-};
+}
 `,
       );
 
       const provider = new CoverageProvider(
         createOptions({
-          reporters: [['./custom-coverage-reporter.cjs', { outputFile }]],
+          reporters: [['./custom-coverage-reporter.mjs', { outputFile }]],
           reportsDirectory: join(root, 'coverage'),
         }),
         root,

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
@@ -101,6 +107,42 @@ function getProviderInternals(provider: CoverageProvider): ProviderInternals {
 }
 
 describe('coverage-v8 provider', () => {
+  it('loads custom coverage reporters from relative config paths', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rstest-coverage-reporter-'));
+    const outputFile = join(root, 'custom-reporter-output.json');
+
+    try {
+      writeFileSync(
+        join(root, 'custom-coverage-reporter.cjs'),
+        `const fs = require('node:fs');
+module.exports = class CustomCoverageReporter {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  execute() {
+    fs.writeFileSync(this.options.outputFile, JSON.stringify({ ok: true }));
+  }
+};
+`,
+      );
+
+      const provider = new CoverageProvider(
+        createOptions({
+          reporters: [['./custom-coverage-reporter.cjs', { outputFile }]],
+          reportsDirectory: join(root, 'coverage'),
+        }),
+        root,
+      );
+
+      await provider.generateReports(provider.createCoverageMap());
+
+      expect(existsSync(outputFile)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('fast merges duplicate converted coverage shapes', () => {
     const file = '/project/src/index.ts';
     const provider = new CoverageProvider(createOptions());

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -285,7 +285,7 @@ export default defineConfig({
 
 Custom coverage reporters should follow the Istanbul reporter contract. A reporter package or file is loaded by Rstest's coverage provider (using [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports) when possible), constructed with the options from `coverage.reporters`, and then called with an Istanbul report context.
 
-For example, an ESM reporter can export a class with an `execute` method:
+For example, an ESM reporter can export a class with an `execute` method. The `context` parameter is Istanbul's `Context` type from `istanbul-lib-report`:
 
 ```js title='custom-coverage-reporter.mjs'
 export default class CustomCoverageReporter {
@@ -293,6 +293,7 @@ export default class CustomCoverageReporter {
     this.options = options;
   }
 
+  /** @param {import('istanbul-lib-report').Context} context */
   execute(context) {
     // Use the standard Istanbul report context.
     const summary = context.getTree('flat').getRoot().getCoverageSummary();

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -17,13 +17,20 @@ type CoverageOptions = {
   include?: string[];
   changed?: boolean | string;
   exclude?: string[];
-  reporters?: (keyof ReportOptions | ReportWithOptions)[];
+  reporters?: CoverageReporter[];
   reportsDirectory?: string;
   reportOnFailure?: boolean;
   clean?: boolean;
   allowExternal?: boolean;
   thresholds?: CoverageThresholds;
 };
+
+type CoverageReporter =
+  | keyof ReportOptions
+  | [keyof ReportOptions, ReporterOptions]
+  | string
+  | [string, Record<string, unknown>]
+  | ReportBase;
 ```
 
 - **Default:** `undefined`
@@ -247,11 +254,13 @@ export default defineConfig({
 
 ### reporters
 
-- **Type:** `(ReporterName | [ReporterName, ReporterOptions>])[]`
+- **Type:** `CoverageReporter[]`
 - **Default:** `['text', 'html', 'clover', 'json']`
 - **CLI:** `--coverage.reporters <reporter>`
 
-The reporters to use for coverage collection. Each reporter can be either a string (the reporter name) or a tuple with the reporter name and its options.
+The reporters to use for coverage collection. Rstest uses the standard [Istanbul reporter API](https://istanbul.js.org/docs/advanced/alternative-reporters/) instead of a Rstest-specific coverage reporter API.
+
+Each reporter can be either a string (the reporter name), a tuple with the reporter name and its options, or an Istanbul-compatible reporter object with an `execute(context)` method.
 
 The CLI supports reporter names only. Repeat the flag to specify multiple reporters:
 
@@ -260,7 +269,7 @@ npx rstest run --coverage.reporters text --coverage.reporters=json
 ```
 
 - See [Istanbul Reporters](https://istanbul.js.org/docs/advanced/alternative-reporters/) for available reporters.
-- See [@types/istanbul-reporter](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/istanbul-reports/index.d.ts) for details about reporter specific options.
+- See [@types/istanbul-reports](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/istanbul-reports/index.d.ts) for details about reporter specific options.
 
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
@@ -272,6 +281,67 @@ export default defineConfig({
       'html',
       ['text', { skipFull: true }],
       ['json', { file: 'coverage-final.json' }],
+    ],
+  },
+});
+```
+
+#### Custom coverage reporters
+
+Custom coverage reporters should follow the Istanbul reporter contract. A reporter package or file is loaded by [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports), constructed with the options from `coverage.reporters`, and then called with an Istanbul report context.
+
+For example, a CommonJS reporter can export a class with an `execute` method:
+
+```js title='custom-coverage-reporter.cjs'
+class CustomCoverageReporter {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  execute(context) {
+    // Use the standard Istanbul report context.
+    const summary = context.getTree('flat').getRoot().getCoverageSummary();
+    console.log('Coverage summary:', summary.toJSON());
+  }
+}
+
+module.exports = CustomCoverageReporter;
+```
+
+Then reference the reporter by package name or file path in `rstest.config.ts`:
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    reporters: [
+      'text',
+      ['./custom-coverage-reporter.cjs', { outputFile: 'summary.json' }],
+    ],
+  },
+});
+```
+
+You can also pass an Istanbul-compatible reporter object directly when the reporter is created in config:
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    reporters: [
+      {
+        execute(context) {
+          const summary = context
+            .getTree('flat')
+            .getRoot()
+            .getCoverageSummary();
+          console.log(summary.toJSON());
+        },
+      },
     ],
   },
 });

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -26,8 +26,6 @@ type CoverageOptions = {
 };
 
 type CoverageReporter =
-  | keyof ReportOptions
-  | [keyof ReportOptions, ReporterOptions]
   | string
   | [string, Record<string, unknown>]
   | ReportBase;

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -290,10 +290,10 @@ export default defineConfig({
 
 Custom coverage reporters should follow the Istanbul reporter contract. A reporter package or file is loaded by [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports), constructed with the options from `coverage.reporters`, and then called with an Istanbul report context.
 
-For example, a CommonJS reporter can export a class with an `execute` method:
+For example, an ESM reporter can export a class with an `execute` method:
 
-```js title='custom-coverage-reporter.cjs'
-class CustomCoverageReporter {
+```js title='custom-coverage-reporter.mjs'
+export default class CustomCoverageReporter {
   constructor(options = {}) {
     this.options = options;
   }
@@ -304,8 +304,6 @@ class CustomCoverageReporter {
     console.log('Coverage summary:', summary.toJSON());
   }
 }
-
-module.exports = CustomCoverageReporter;
 ```
 
 Then reference the reporter by package name or file path in `rstest.config.ts`:
@@ -318,7 +316,7 @@ export default defineConfig({
     enabled: true,
     reporters: [
       'text',
-      ['./custom-coverage-reporter.cjs', { outputFile: 'summary.json' }],
+      ['./custom-coverage-reporter.mjs', { outputFile: 'summary.json' }],
     ],
   },
 });

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -25,10 +25,7 @@ type CoverageOptions = {
   thresholds?: CoverageThresholds;
 };
 
-type CoverageReporter =
-  | string
-  | [string, Record<string, unknown>]
-  | ReportBase;
+type CoverageReporter = string | [string, Record<string, unknown>] | ReportBase;
 ```
 
 - **Default:** `undefined`

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -286,7 +286,7 @@ export default defineConfig({
 
 #### Custom coverage reporters
 
-Custom coverage reporters should follow the Istanbul reporter contract. A reporter package or file is loaded by [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports), constructed with the options from `coverage.reporters`, and then called with an Istanbul report context.
+Custom coverage reporters should follow the Istanbul reporter contract. A reporter package or file is loaded by Rstest's coverage provider (using [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports) when possible), constructed with the options from `coverage.reporters`, and then called with an Istanbul report context.
 
 For example, an ESM reporter can export a class with an `execute` method:
 

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -283,7 +283,7 @@ export default defineConfig({
 
 自定义 coverage reporter 应遵循 Istanbul reporter 约定。reporter 包或文件会由 Rstest 的 coverage provider 加载（在可能的情况下会通过 [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports) 创建），使用 `coverage.reporters` 中传入的选项创建实例，然后用 Istanbul report context 调用。
 
-例如，一个 ESM reporter 可以导出带有 `execute` 方法的 class：
+例如，一个 ESM reporter 可以导出带有 `execute` 方法的 class。`context` 参数对应 `istanbul-lib-report` 中的 Istanbul `Context` 类型：
 
 ```js title='custom-coverage-reporter.mjs'
 export default class CustomCoverageReporter {
@@ -291,6 +291,7 @@ export default class CustomCoverageReporter {
     this.options = options;
   }
 
+  /** @param {import('istanbul-lib-report').Context} context */
   execute(context) {
     // Use the standard Istanbul report context.
     const summary = context.getTree('flat').getRoot().getCoverageSummary();

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -25,10 +25,7 @@ type CoverageOptions = {
   thresholds?: CoverageThresholds;
 };
 
-type CoverageReporter =
-  | string
-  | [string, Record<string, unknown>]
-  | ReportBase;
+type CoverageReporter = string | [string, Record<string, unknown>] | ReportBase;
 ```
 
 - **默认值：** `undefined`

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -288,10 +288,10 @@ export default defineConfig({
 
 自定义 coverage reporter 应遵循 Istanbul reporter 约定。reporter 包或文件会由 [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports) 加载，使用 `coverage.reporters` 中传入的选项创建实例，然后用 Istanbul report context 调用。
 
-例如，一个 CommonJS reporter 可以导出带有 `execute` 方法的 class：
+例如，一个 ESM reporter 可以导出带有 `execute` 方法的 class：
 
-```js title='custom-coverage-reporter.cjs'
-class CustomCoverageReporter {
+```js title='custom-coverage-reporter.mjs'
+export default class CustomCoverageReporter {
   constructor(options = {}) {
     this.options = options;
   }
@@ -302,8 +302,6 @@ class CustomCoverageReporter {
     console.log('Coverage summary:', summary.toJSON());
   }
 }
-
-module.exports = CustomCoverageReporter;
 ```
 
 然后在 `rstest.config.ts` 中通过包名或文件路径引用该 reporter：
@@ -316,7 +314,7 @@ export default defineConfig({
     enabled: true,
     reporters: [
       'text',
-      ['./custom-coverage-reporter.cjs', { outputFile: 'summary.json' }],
+      ['./custom-coverage-reporter.mjs', { outputFile: 'summary.json' }],
     ],
   },
 });

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -26,8 +26,6 @@ type CoverageOptions = {
 };
 
 type CoverageReporter =
-  | keyof ReportOptions
-  | [keyof ReportOptions, ReporterOptions]
   | string
   | [string, Record<string, unknown>]
   | ReportBase;

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -284,7 +284,7 @@ export default defineConfig({
 
 #### 自定义 coverage reporter
 
-自定义 coverage reporter 应遵循 Istanbul reporter 约定。reporter 包或文件会由 [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports) 加载，使用 `coverage.reporters` 中传入的选项创建实例，然后用 Istanbul report context 调用。
+自定义 coverage reporter 应遵循 Istanbul reporter 约定。reporter 包或文件会由 Rstest 的 coverage provider 加载（在可能的情况下会通过 [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports) 创建），使用 `coverage.reporters` 中传入的选项创建实例，然后用 Istanbul report context 调用。
 
 例如，一个 ESM reporter 可以导出带有 `execute` 方法的 class：
 

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -17,13 +17,20 @@ type CoverageOptions = {
   include?: string[];
   changed?: boolean | string;
   exclude?: string[];
-  reporters?: (keyof ReportOptions | ReportWithOptions)[];
+  reporters?: CoverageReporter[];
   reportsDirectory?: string;
   reportOnFailure?: boolean;
   clean?: boolean;
   allowExternal?: boolean;
   thresholds?: CoverageThresholds;
 };
+
+type CoverageReporter =
+  | keyof ReportOptions
+  | [keyof ReportOptions, ReporterOptions]
+  | string
+  | [string, Record<string, unknown>]
+  | ReportBase;
 ```
 
 - **默认值：** `undefined`
@@ -245,11 +252,13 @@ export default defineConfig({
 
 ### reporters
 
-- **类型：** `(ReporterName | [ReporterName, ReporterOptions>])[]`
+- **类型：** `CoverageReporter[]`
 - **默认值：** `['text', 'html', 'clover', 'json']`
 - **CLI：** `--coverage.reporters <reporter>`
 
-用于覆盖率收集的报告器。每个报告器可以是字符串（报告器名称）或包含报告器名称及其选项的元组。
+用于覆盖率收集的报告器。Rstest 使用标准 [Istanbul reporter API](https://istanbul.js.org/docs/advanced/alternative-reporters/)，而不是 Rstest 专属的 coverage reporter API。
+
+每个 reporter 可以是字符串（reporter 名称）、包含 reporter 名称及其选项的元组，也可以是带有 `execute(context)` 方法且兼容 Istanbul 的 reporter 对象。
 
 CLI 仅支持传入报告器名称。如需指定多个报告器，可以重复使用该参数：
 
@@ -258,7 +267,7 @@ npx rstest run --coverage.reporters text --coverage.reporters=json
 ```
 
 - 有关可用报告器，可参考 [Istanbul Reporters](https://istanbul.js.org/docs/advanced/alternative-reporters/)。
-- 有关报告器选项的详细信息，可参考 [@types/istanbul-reporter](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/istanbul-reports/index.d.ts)。
+- 有关报告器选项的详细信息，可参考 [@types/istanbul-reports](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/istanbul-reports/index.d.ts)。
 
 ```ts title='rstest.config.ts'
 import { defineConfig } from '@rstest/core';
@@ -270,6 +279,67 @@ export default defineConfig({
       'html',
       ['text', { skipFull: true }],
       ['json', { file: 'coverage-final.json' }],
+    ],
+  },
+});
+```
+
+#### 自定义 coverage reporter
+
+自定义 coverage reporter 应遵循 Istanbul reporter 约定。reporter 包或文件会由 [`istanbul-reports`](https://github.com/istanbuljs/istanbuljs/tree/main/packages/istanbul-reports) 加载，使用 `coverage.reporters` 中传入的选项创建实例，然后用 Istanbul report context 调用。
+
+例如，一个 CommonJS reporter 可以导出带有 `execute` 方法的 class：
+
+```js title='custom-coverage-reporter.cjs'
+class CustomCoverageReporter {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  execute(context) {
+    // Use the standard Istanbul report context.
+    const summary = context.getTree('flat').getRoot().getCoverageSummary();
+    console.log('Coverage summary:', summary.toJSON());
+  }
+}
+
+module.exports = CustomCoverageReporter;
+```
+
+然后在 `rstest.config.ts` 中通过包名或文件路径引用该 reporter：
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    reporters: [
+      'text',
+      ['./custom-coverage-reporter.cjs', { outputFile: 'summary.json' }],
+    ],
+  },
+});
+```
+
+如果在配置中直接创建 reporter，也可以传入兼容 Istanbul 的 reporter 对象：
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    reporters: [
+      {
+        execute(context) {
+          const summary = context
+            .getTree('flat')
+            .getRoot()
+            .getCoverageSummary();
+          console.log(summary.toJSON());
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
## Summary

This PR documents that Rstest coverage reporters follow the standard Istanbul reporter API and ensures custom Istanbul-compatible reporters can be loaded from project-relative paths. It adds unit coverage for both Istanbul and V8 coverage providers, plus an e2e test for the CLI flow with a custom reporter file.

Browser mode is unaffected because this only changes Node-side coverage report generation after coverage data is collected. Adapter changes are not required because no Rsbuild/Rslib config transform is introduced.

## Related Links

https://github.com/web-infra-dev/rstest/issues/1332#issuecomment-4562479490

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).