### PR TITLE
ci: install pnpm via pnpm/action-setup across all workflows

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,16 +30,15 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Install pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,14 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Setup Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.22.1 # pin to avoid bug in 22.22.2
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       # Update npm to the latest version to enable OIDC
       - name: Update npm
@@ -109,15 +108,14 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Setup Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,16 +54,15 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install Dependencies
         run: pnpm install --ignore-scripts


### PR DESCRIPTION
## Summary

Some workflows installed pnpm via corepack (`npm install -g corepack@latest --force` + `corepack enable`), while `ut`/`e2e` already used `pnpm/action-setup`. corepack install time is unstable on CI runners (notably Windows, ~15–40s); `pnpm/action-setup` is steadier (~10–15s) and drops the extra `run` step.

This unifies pnpm installation across every workflow to `pnpm/action-setup@v6.0.8` and aligns the `setup-node` config (`cache-dependency-path: pnpm-lock.yaml`):

- `test.yml` → `lint` job (ubuntu)
- `release.yml` → `release` job (ubuntu) and `release_vscode_extension` job (matrix includes Windows/macOS runners, where the install-time win actually applies)
- `preview.yml` → `preview` job (ubuntu)

The ubuntu-only jobs benefit mainly from consistency and one fewer step; the Windows install-time improvement applies to `ut`/`e2e` and `release_vscode_extension`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).