### PR TITLE
fix(core): validate required dot CLI option values

### DIFF
--- a/e2e/cli/index.test.ts
+++ b/e2e/cli/index.test.ts
@@ -94,6 +94,24 @@ describe.concurrent('test exit code', () => {
     await expectExecSuccess();
   });
 
+  it('should return code 1 when required dot-notation option value is missing', async ({
+    onTestFinished,
+  }) => {
+    const { expectExecFailed, expectStderrLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'success.test.ts', '--pool.type'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecFailed();
+    expectStderrLog(/option `--pool\.type <type>` value is missing/);
+  });
+
   it('should support browser shorthand with nested browser options', async ({
     onTestFinished,
   }) => {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -271,6 +271,27 @@ const valueTakingOptionNames = (
   return names;
 };
 
+const requiredDotOptionNames = (
+  definitions: readonly OptionDefinition[][],
+): Set<string> => {
+  const names = new Set<string>();
+  for (const group of definitions) {
+    for (const [rawName] of group) {
+      const tokenAt = rawName.indexOf('<');
+      if (tokenAt < 0) {
+        continue;
+      }
+      for (const alias of rawName.slice(0, tokenAt).split(',')) {
+        const trimmed = alias.trim();
+        if (trimmed.includes('.')) {
+          names.add(trimmed);
+        }
+      }
+    }
+  }
+  return names;
+};
+
 const commands = new Set(['init', 'list', 'merge-reports', 'run', 'watch']);
 
 export const valueTakingOptions: Set<string> = valueTakingOptionNames([
@@ -280,6 +301,40 @@ export const valueTakingOptions: Set<string> = valueTakingOptionNames([
   hiddenPassthroughOptionDefinitions,
   listCommandOptionDefinitions,
 ]);
+
+export const requiredDotOptions: Set<string> = requiredDotOptionNames([
+  runtimeOptionDefinitions,
+  poolOptionDefinitions,
+  mergeReportsOptionDefinitions,
+  hiddenPassthroughOptionDefinitions,
+  listCommandOptionDefinitions,
+]);
+
+const validateRequiredDotOptionValues = (cli: CAC): void => {
+  for (const option of [
+    ...cli.globalCommand.options,
+    ...(cli.matchedCommand?.options ?? []),
+  ]) {
+    if (!option.required || !requiredDotOptions.has(`--${option.name}`)) {
+      continue;
+    }
+
+    const [root, ...path] = option.name.split('.');
+    if (!root) {
+      continue;
+    }
+    const value = path.reduce<unknown>((target, key) => {
+      if (typeof target !== 'object' || target === null) {
+        return undefined;
+      }
+      return (target as Record<string, unknown>)[key];
+    }, cli.options[root]);
+
+    if (value === true || value === false) {
+      throw new Error(`option \`${option.rawName}\` value is missing`);
+    }
+  }
+};
 
 const getCliCommand = (argv: string[]): string | undefined => {
   for (let index = 2; index < argv.length; index++) {
@@ -424,11 +479,16 @@ const normalizeMixedCliOptions = (cli: CAC): void => {
   const originalParse = cli.parse.bind(cli);
 
   cli.parse = ((argv, options) => {
-    const parsed = originalParse(
-      normalizeCliArgs(argv ?? process.argv),
-      options,
-    );
+    const run = options?.run !== false;
+    const parsed = originalParse(normalizeCliArgs(argv ?? process.argv), {
+      ...options,
+      run: false,
+    });
     validateWildcardOptions(parsed.options as Record<string, unknown>);
+    validateRequiredDotOptionValues(cli);
+    if (run) {
+      cli.runMatchedCommand();
+    }
     return parsed;
   }) as CAC['parse'];
 };

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -310,6 +310,11 @@ export const requiredDotOptions: Set<string> = requiredDotOptionNames([
   listCommandOptionDefinitions,
 ]);
 
+const hasMissingRequiredOptionValue = (value: unknown): boolean =>
+  value === true ||
+  value === false ||
+  (Array.isArray(value) && value.some(hasMissingRequiredOptionValue));
+
 const validateRequiredDotOptionValues = (cli: CAC): void => {
   for (const option of [
     ...cli.globalCommand.options,
@@ -330,7 +335,7 @@ const validateRequiredDotOptionValues = (cli: CAC): void => {
       return (target as Record<string, unknown>)[key];
     }, cli.options[root]);
 
-    if (value === true || value === false) {
+    if (hasMissingRequiredOptionValue(value)) {
       throw new Error(`option \`${option.rawName}\` value is missing`);
     }
   }

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -9,6 +9,7 @@ import {
   getForceRerunTriggers,
   hasForceRerunTrigger,
   normalizeCliFilters,
+  requiredDotOptions,
   resolveChangedFiles,
   validateRelatedCliOptions,
   valueTakingOptions,
@@ -81,6 +82,34 @@ describe('valueTakingOptions (derived from option definitions)', () => {
     expect(valueTakingOptions.has('--coverage')).toBe(false);
     expect(valueTakingOptions.has('--output.emitAssets')).toBe(false);
     expect(valueTakingOptions.has('--output.cssModules')).toBe(false);
+  });
+});
+
+describe('requiredDotOptions (derived from option definitions)', () => {
+  it('derives the required dot-notation option names', () => {
+    expect([...requiredDotOptions].sort()).toEqual(
+      [
+        '--browser.name',
+        '--browser.port',
+        '--coverage.exclude',
+        '--coverage.include',
+        '--coverage.provider',
+        '--coverage.reporters',
+        '--coverage.reportsDirectory',
+        '--pool.execArgv',
+        '--pool.maxWorkers',
+        '--pool.minWorkers',
+        '--pool.type',
+        '--source.tsconfigPath',
+      ].sort(),
+    );
+  });
+
+  it('excludes optional and boolean dot-notation flags', () => {
+    expect(requiredDotOptions.has('--coverage.changed')).toBe(false);
+    expect(requiredDotOptions.has('--coverage.enabled')).toBe(false);
+    expect(requiredDotOptions.has('--browser.enabled')).toBe(false);
+    expect(requiredDotOptions.has('--output.emitAssets')).toBe(false);
   });
 });
 
@@ -246,6 +275,48 @@ describe('CLI help output', () => {
     });
   });
 
+  it('rejects missing values for required pool dot-notation options', () => {
+    const cli = createCli();
+
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--pool.type'], { run: false }),
+    ).toThrow('option `--pool.type <type>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--pool.maxWorkers'], {
+        run: false,
+      }),
+    ).toThrow('option `--pool.maxWorkers <value>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--pool.minWorkers'], {
+        run: false,
+      }),
+    ).toThrow('option `--pool.minWorkers <value>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--pool.execArgv'], { run: false }),
+    ).toThrow('option `--pool.execArgv <arg>` value is missing');
+  });
+
+  it('accepts required pool dot-notation option values', () => {
+    const parsed = createCli().parse(
+      [
+        'node',
+        'rstest',
+        'run',
+        '--pool.type=forks',
+        '--pool.maxWorkers',
+        '2',
+        '--pool.execArgv=--no-warnings',
+      ],
+      { run: false },
+    );
+
+    expect(parsed.options.pool).toEqual({
+      type: 'forks',
+      maxWorkers: 2,
+      execArgv: '--no-warnings',
+    });
+  });
+
   it('allows --browser shorthand to be mixed with nested browser options', () => {
     const parsed = createCli().parse(
       ['node', 'rstest', 'run', '--browser', '--browser.name', 'chromium'],
@@ -280,6 +351,17 @@ describe('CLI help output', () => {
       enabled: false,
       name: 'chromium',
     });
+  });
+
+  it('rejects missing values for required browser dot-notation options', () => {
+    const cli = createCli();
+
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--browser.name'], { run: false }),
+    ).toThrow('option `--browser.name <name>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--browser.port'], { run: false }),
+    ).toThrow('option `--browser.port <port>` value is missing');
   });
 
   it('accepts --reporters and populates options.reporters', () => {
@@ -327,6 +409,16 @@ describe('CLI help output', () => {
       cleanDistPath: true,
       module: false,
     });
+  });
+
+  it('rejects missing values for required source dot-notation options', () => {
+    const cli = createCli();
+
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--source.tsconfigPath'], {
+        run: false,
+      }),
+    ).toThrow('option `--source.tsconfigPath <path>` value is missing');
   });
 
   it('hides internal parser helper options from command help', () => {
@@ -425,6 +517,47 @@ describe('CLI help output', () => {
       reportOnFailure: true,
       clean: false,
       allowExternal: true,
+    });
+  });
+
+  it('rejects missing values for required coverage dot-notation options', () => {
+    const cli = createCli();
+
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--coverage.provider'], {
+        run: false,
+      }),
+    ).toThrow('option `--coverage.provider <provider>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--coverage.include'], {
+        run: false,
+      }),
+    ).toThrow('option `--coverage.include <pattern>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--coverage.exclude'], {
+        run: false,
+      }),
+    ).toThrow('option `--coverage.exclude <pattern>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--coverage.reporters'], {
+        run: false,
+      }),
+    ).toThrow('option `--coverage.reporters <reporter>` value is missing');
+    expect(() =>
+      cli.parse(['node', 'rstest', 'run', '--coverage.reportsDirectory'], {
+        run: false,
+      }),
+    ).toThrow('option `--coverage.reportsDirectory <dir>` value is missing');
+  });
+
+  it('accepts optional coverage dot-notation options without a value', () => {
+    const parsed = createCli().parse(
+      ['node', 'rstest', 'run', '--coverage.changed'],
+      { run: false },
+    );
+
+    expect(parsed.options.coverage).toEqual({
+      changed: true,
     });
   });
 });

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -317,6 +317,23 @@ describe('CLI help output', () => {
     });
   });
 
+  it('rejects missing values in repeated required pool dot-notation options', () => {
+    const cli = createCli();
+
+    expect(() =>
+      cli.parse(
+        [
+          'node',
+          'rstest',
+          'run',
+          '--pool.execArgv=--inspect',
+          '--pool.execArgv',
+        ],
+        { run: false },
+      ),
+    ).toThrow('option `--pool.execArgv <arg>` value is missing');
+  });
+
   it('allows --browser shorthand to be mixed with nested browser options', () => {
     const parsed = createCli().parse(
       ['node', 'rstest', 'run', '--browser', '--browser.name', 'chromium'],
@@ -548,6 +565,23 @@ describe('CLI help output', () => {
         run: false,
       }),
     ).toThrow('option `--coverage.reportsDirectory <dir>` value is missing');
+  });
+
+  it('rejects missing values in repeated required coverage dot-notation options', () => {
+    const cli = createCli();
+
+    expect(() =>
+      cli.parse(
+        [
+          'node',
+          'rstest',
+          'run',
+          '--coverage.include=src/**',
+          '--coverage.include',
+        ],
+        { run: false },
+      ),
+    ).toThrow('option `--coverage.include <pattern>` value is missing');
   });
 
   it('accepts optional coverage dot-notation options without a value', () => {


### PR DESCRIPTION
## Summary

Fixes required dot-notation CLI flags being silently accepted without values, such as `--pool.type` and `--pool.maxWorkers`. The CLI now validates parsed nested options before command execution so required dot options report the same missing-value error style as regular required options, while optional dot options such as `--coverage.changed` remain valid without a value.

## Related Links

close: https://github.com/web-infra-dev/rstest/issues/1059

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).