### PR TITLE
release: 0.10.4

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
## What's Changed
### New Features 🎉
* feat(core): support build CLI options (#1397)
* feat(coverage): support custom reporters (#1395)
* feat(core): support runtime test skip (#1392)
* feat(core): pass stdout/stderr stream type as second onConsoleLog argument (#1361)
* feat(core): emit agent-readable timing summary for --trace (#1355)
* feat(core): add host-side trace spans (#1344)
### Bug Fixes 🐞
* fix(core): validate required dot CLI option values (#1400)
* fix(core): exit browser mode when a sibling node project has no tests (#1386)
* fix(core): type runtime hook registration as sync (#1364)
* fix(core): prevent late console logs from failing the run (isolate: false) (#1368)
* fix(browser): expose process.env.RSTEST in browser mode (#1356)
### Refactor 🔨
* refactor(core): single-source RSTEST_* env-var names (#1387)
* refactor(core, adapters): single-source adapter cache-key & target→env logic (#1384)
* refactor(coverage): single-source provider contract and align collect error handling (#1385)
* refactor(core): single-source reporter map and GitHub Actions detection (#1383)
* refactor(core): single-source test-execution runtime contracts (#1381)
* refactor(browser): deepen core↔browser seam and close browser-mode drift hazards (#1382)
* refactor(core): consolidate runtime primitives (file task-id, env-loader registry, scoped-restore LIFO) (#1379)
* refactor(browser): single-source the runner dispatch method vocabulary (#1380)
* refactor(browser): single-source the snapshot RPC method/args contract (#1377)
* refactor(core): single-source reporter run-count derivation and CLI/init owners (#1374)
* refactor(core): gate global setup once and co-locate run verdict (#1371)
* refactor(core): derive hook registration signatures from RunnerAPI (#1370)
* refactor(core): own runtime-contract grammar for chunk names and worker import hooks (#1366)
* refactor(core, browser): deepen core↔browser seams and dedupe shared primitives (#1362)
* refactor(core): unify dynamic-import resolver across CJS/ESM worker loaders (#1359)
* refactor(browser): drop unused internal browser surface (#1360)
* refactor(core): move internal browser host subpaths under ./internal (#1358)
### Document 📖
* docs(website): correct config overview anchors (#1394)
* docs: fix broken documentation links (#1393)
* docs: note native addons can crash the threads pool (#1365)
* docs: normalize half/full-width punctuation across zh and en docs (#1353)
* docs: clarify relationship between output.bundleDependencies and output.externals (#1352)
* docs: fix $N positional placeholders in test.each / describe.for examples (#1350)
* docs: fix { spy: true } module example to assert on a directly-called export (#1349)
### Other Changes
* release: 0.10.4 (#1401)
* chore(deps): update all non-major dependencies (#1399)
* ci: install pnpm via pnpm/action-setup across all workflows (#1398)
* chore: use pnpm stage publish for release (#1375)
* ci: trim pre-merge PR workload, keep full coverage on main (#1378)
* chore(deps): update all non-major dependencies (#1346)
* chore(deps): update rstackjs/rstack-ecosystem-ci digest to 3cbb846 (#1343)

**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.10.3...v0.10.4