### PR TITLE
chore: enable isolated dts builds

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -54,10 +54,6 @@
         "tests/**/*.ts",
         "tests/**/fixtures/**",
       ],
-      "ignoreDependencies": [
-        // Used by rslib for fast declaration file generation: https://rslib.dev/guide/advanced/dts#generate-declaration-files-with-tsgo
-        "@typescript/native-preview",
-      ],
     },
     "packages/browser": {
       "entry": [
@@ -70,8 +66,6 @@
         "tests/**/*.ts",
       ],
       "ignoreDependencies": [
-        // Used by rslib for fast declaration file generation: https://rslib.dev/guide/advanced/dts#generate-declaration-files-with-tsgo
-        "@typescript/native-preview",
         // Virtual module resolved at build time by rspack alias in hostController.ts
         "@rstest/browser-manifest",
       ],

--- a/packages/adapter-rsbuild/rslib.config.mts
+++ b/packages/adapter-rsbuild/rslib.config.mts
@@ -16,7 +16,7 @@ export default defineConfig({
     {
       format: 'esm',
       dts: {
-        tsgo: true,
+        isolated: true,
         bundle: true,
       },
       bundle: true,

--- a/packages/adapter-rslib/rslib.config.mts
+++ b/packages/adapter-rslib/rslib.config.mts
@@ -15,7 +15,9 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      dts: true,
+      dts: {
+        isolated: true,
+      },
       bundle: true,
       syntax: 'es2023',
       experiments: {

--- a/packages/adapter-rspack/rslib.config.mts
+++ b/packages/adapter-rspack/rslib.config.mts
@@ -15,7 +15,9 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      dts: true,
+      dts: {
+        isolated: true,
+      },
       bundle: true,
       syntax: 'es2023',
       experiments: {

--- a/packages/browser-react/rslib.config.ts
+++ b/packages/browser-react/rslib.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
     {
       format: 'esm',
       syntax: ['chrome 100'],
-      dts: true,
+      dts: {
+        isolated: true,
+      },
       redirect: {
         // Append `.js` to relative imports in emitted .d.ts so they resolve
         // under NodeNext/Node16 module resolution (ESM requires explicit ext).

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -60,7 +60,6 @@
     "@types/convert-source-map": "^2.0.3",
     "@types/picomatch": "^4.0.3",
     "@types/ws": "^8.18.1",
-    "@typescript/native-preview": "7.0.0-dev.20260608.1",
     "@vitest/snapshot": "^3.2.6",
     "birpc": "^4.0.0",
     "picomatch": "^4.0.4",

--- a/packages/browser/rslib.config.ts
+++ b/packages/browser/rslib.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        isolated: true,
         bundle: false,
       },
       redirect: {

--- a/packages/browser/src/browserRpcRegistry.ts
+++ b/packages/browser/src/browserRpcRegistry.ts
@@ -14,7 +14,7 @@
  * - Artifacts intentionally excluded for now: screenshot/toMatchScreenshot/
  *   trace/video
  */
-export const supportedLocatorActions = new Set<string>([
+export const supportedLocatorActions: Set<string> = new Set([
   'click',
   'dblclick',
   'fill',
@@ -32,7 +32,7 @@ export const supportedLocatorActions = new Set<string>([
   'setInputFiles',
 ]);
 
-export const supportedExpectElementMatchers = new Set<string>([
+export const supportedExpectElementMatchers: Set<string> = new Set([
   'toBeVisible',
   'toBeHidden',
   'toBeEnabled',

--- a/packages/browser/src/concurrency.ts
+++ b/packages/browser/src/concurrency.ts
@@ -19,7 +19,7 @@ type HeadlessConcurrencyContext = Pick<Rstest, 'command'> & {
 
 export const resolveDefaultHeadlessWorkers = (
   command: HeadlessConcurrencyContext['command'],
-  numCpus = getNumCpus(),
+  numCpus: number = getNumCpus(),
 ): number => {
   const baseWorkers = Math.max(
     Math.min(DEFAULT_MAX_HEADLESS_WORKERS, numCpus - 1),

--- a/packages/browser/src/headedSerialTaskQueue.ts
+++ b/packages/browser/src/headedSerialTaskQueue.ts
@@ -1,10 +1,14 @@
 type HeadedSerialTask = () => Promise<void>;
 
+type HeadedSerialTaskQueue = {
+  enqueue: (task: HeadedSerialTask) => Promise<void>;
+};
+
 /**
  * Serializes headed browser file execution so only one task runs at a time.
  * The queue keeps draining even if an earlier task rejects.
  */
-export const createHeadedSerialTaskQueue = () => {
+export const createHeadedSerialTaskQueue = (): HeadedSerialTaskQueue => {
   let queue: Promise<void> = Promise.resolve();
 
   const enqueue = (task: HeadedSerialTask): Promise<void> => {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -600,7 +600,15 @@ export const createBrowserLazyCompilationConfig = (
   };
 };
 
-export const createBrowserRsbuildDevConfig = (_isWatchMode: boolean) => {
+export const createBrowserRsbuildDevConfig = (
+  _isWatchMode: boolean,
+): {
+  writeToDisk: boolean;
+  hmr: boolean;
+  client: {
+    logLevel: 'error';
+  };
+} => {
   return {
     writeToDisk: isDebug(),
     // Keep HMR enabled in browser mode even for one-shot runs.

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "composite": true,
+    "isolatedDeclarations": true,
     "emitDeclarationOnly": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": ["node"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,7 +90,6 @@
     "@types/jsdom": "^21.1.7",
     "@types/picomatch": "^4.0.3",
     "@types/source-map-support": "^0.5.10",
-    "@typescript/native-preview": "7.0.0-dev.20260608.1",
     "@vitest/expect": "^3.2.6",
     "@vitest/pretty-format": "^3.2.6",
     "@vitest/snapshot": "^3.2.6",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         advancedEsm: true,
       },
       dts: {
-        tsgo: true,
+        isolated: true,
         bundle: process.env.SOURCEMAP
           ? false
           : {
@@ -159,7 +159,7 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2023',
       dts: {
-        tsgo: true,
+        isolated: true,
         bundle: true,
       },
       source: {

--- a/packages/coverage-istanbul/rslib.config.ts
+++ b/packages/coverage-istanbul/rslib.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
     {
       format: 'esm',
       syntax: 'es2023',
-      dts: true,
+      dts: {
+        isolated: true,
+      },
       redirect: {
         // Append `.js` to relative imports in emitted .d.ts so they resolve
         // under NodeNext/Node16 module resolution (ESM requires explicit ext).

--- a/packages/coverage-v8/rslib.config.ts
+++ b/packages/coverage-v8/rslib.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
     {
       format: 'esm',
       syntax: 'es2021',
-      dts: true,
+      dts: {
+        isolated: true,
+      },
     },
   ],
   tools: {

--- a/packages/coverage-v8/tsconfig.json
+++ b/packages/coverage-v8/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@rstest/tsconfig/base",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "composite": true,
+    "isolatedDeclarations": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/browser':
         specifier: workspace:*
         version: link:../packages/browser
@@ -898,7 +898,7 @@ importers:
         version: 2.0.11
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -910,7 +910,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -928,7 +928,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rspack/cli':
         specifier: ~2.0.6
         version: 2.0.6(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@rspack/dev-server@2.0.3(@rspack/core@2.0.6(@swc/helpers@0.5.23)))
@@ -965,7 +965,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/browser-ui':
         specifier: workspace:*
         version: link:../browser-ui
@@ -984,9 +984,6 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260608.1
-        version: 7.0.0-dev.20260608.1
       '@vitest/snapshot':
         specifier: ^3.2.6
         version: 3.2.6
@@ -1004,7 +1001,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1105,7 +1102,7 @@ importers:
         version: 1.5.3(@rsbuild/core@2.0.11)
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -1133,9 +1130,6 @@ importers:
       '@types/source-map-support':
         specifier: ^0.5.10
         version: 0.5.10
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260608.1
-        version: 7.0.0-dev.20260608.1
       '@vitest/expect':
         specifier: ^3.2.6
         version: 3.2.6
@@ -1234,7 +1228,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1289,7 +1283,7 @@ importers:
         version: 2.0.11
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1322,7 +1316,7 @@ importers:
         version: 2.0.11
       '@rslib/core':
         specifier: 0.22.0
-        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+        version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -3815,53 +3809,6 @@ packages:
 
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-ZGs+yhsPWFDkSHydJyF8I3d4witpXiD69auWZtSotNWG3gBR5Ne291m38rvxoLFDRlFHwAQpPT7q3yStp+cQSQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-cxmBCl1+fvGgom2vwPTbZ43bW68rfjDIU1ZDQGtjXvj1bpW9fEozskJqgZdNNHu8WQIl17zj4Ke+noENwgGu9w==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-/JPrQqa36CSMdXeEXhZ0mYUmufehIL8ujagXvU8z/3/b/CeWjgoZLJCuy76k9NLZCG7wGvcFWFK5kgOEKyDQdw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-tWFLuzAWg8XnOkN7f94MAW8qLTMG7Q74IXHSG18cVmftuBxwvn1Lov+0Rnd9rsH7VAuSIu00Co6G3/PbGvGrxA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-QfVLSH1NMAOa+N6Ey9cFHWppLFISOeCG3c0nJER3LXrDwkE4WtsVGHQ4IRDpIYT3Q2iC7QWUFWwrHayNKlrGYA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-DvpbX0aPCWCe4bJEP0cOky4cCwF+5QJZHsLoGV4gYd+0EFEkarTOxZG0CezP30E/iX6u1RUOrtTeMZOQthqDpQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-J9nQB87sU+YJE3fq3XKwQvgLNWVXiEWyOP1L/FuyOlHb77UkFXmpaUbFTJ1w7rfd91nlKb2EECfsdTxbELUT0Q==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-nJyuPQwFn/VlP7JvFA0jPHJMMHaDy5vWM5xRYUwjZZd3dcY7LldfZ1EkdPOLc+GW0trXcmvRemQ4XCsBkOGOUQ==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
 
   '@typespec/ts-http-runtime@0.3.0':
     resolution: {integrity: sha512-sOx1PKSuFwnIl7z4RN0Ls7N9AQawmR9r66eI5rFCzLDIs8HTIYrIpH9QjYWoX0lkgGrkLxXhi4QnK7MizPRrIg==}
@@ -9800,10 +9747,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)':
+  '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.11
-      rsbuild-plugin-dts: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.11)(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.11)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.8(@types/node@22.18.6)
       typescript: 6.0.3
@@ -10708,37 +10655,6 @@ snapshots:
   '@types/yargs@17.0.33':
     dependencies:
       '@types/yargs-parser': 21.0.3
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
-    optional: true
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260608.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260608.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260608.1':
-    optional: true
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260608.1':
-    optional: true
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260608.1':
-    optional: true
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260608.1':
-    optional: true
-
-  '@typescript/native-preview@7.0.0-dev.20260608.1':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260608.1
 
   '@typespec/ts-http-runtime@0.3.0':
     dependencies:
@@ -14518,13 +14434,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.11
 
-  rsbuild-plugin-dts@0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.11)(@typescript/native-preview@7.0.0-dev.20260608.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.11)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.11
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.8(@types/node@22.18.6)
-      '@typescript/native-preview': 7.0.0-dev.20260608.1
       typescript: 6.0.3
 
   rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.0.11):


### PR DESCRIPTION
## Summary

This PR switches Rstest's Rslib package builds to `dts.isolated` so declaration files are generated via Rspack's isolated declaration path instead of the previous tsgo/default DTS flows. It also enables TypeScript `isolatedDeclarations` where it was missing, adds the explicit type annotations required by isolated declaration emit in `@rstest/browser`, and removes the now-unused `@typescript/native-preview` dependency and knip ignores.

Performance data from local clean package builds (baseline strategy vs isolated):

| Package | Baseline | Isolated | Saved | Improvement |
| --- | ---: | ---: | ---: | ---: |
| `@rstest/core` | 6.50s | 5.65s | 0.85s | 13.1% |
| `@rstest/browser` | 2.33s | 2.02s | 0.31s | 13.3% |
| `@rstest/adapter-rsbuild` | 2.50s | 2.33s | 0.17s | 6.8% |
| `@rstest/adapter-rslib` | 2.27s | 1.63s | 0.64s | 28.2% |
| `@rstest/adapter-rspack` | 2.13s | 1.67s | 0.46s | 21.6% |
| `@rstest/browser-react` | 2.32s | 1.70s | 0.62s | 26.7% |
| `@rstest/coverage-istanbul` | 2.22s | 1.68s | 0.54s | 24.3% |
| `@rstest/coverage-v8` | 1.65s | 1.09s | 0.56s | 33.9% |

## Related Links

https://rslib.rs/config/lib/dts#dtsisolated

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).