### PR TITLE
chore: sync create draft release notes skill

### DIFF
--- a/.agents/skills/create-draft-release-notes/SKILL.md
+++ b/.agents/skills/create-draft-release-notes/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: create-draft-release-notes
-description: Create or update draft GitHub releases for the current project's main GitHub repository, then organize GitHub-generated release notes into user-friendly sections without rewriting release note items. Use for preparing, formatting, categorizing, creating, or updating GitHub release notes or draft releases.
+description: Create or update draft GitHub releases for the current project's main GitHub repository, then organize GitHub-generated release notes into user-friendly sections without rewriting release note items. Use for preparing, formatting, categorizing, creating, or updating GitHub release notes or draft releases, including optional highlights when the user asks for them.
 ---
 
 # Create Draft Release Notes
 
 ## Overview
 
-Create a GitHub draft release, organize the generated notes by conventional commit type, and save the organized body back to the draft. Preserve each release note item exactly; only split accidentally joined bullets, move bullets into sections, and adjust headings.
+Create a GitHub draft release, organize the generated notes by conventional commit type, and save the organized body back to the draft. Preserve each release note item exactly; only split accidentally joined bullets, move bullets into sections, and adjust headings. Add a top `## Highlights` section only when the user explicitly asks for highlights.
 
 ## Security Notes
 
@@ -57,20 +57,25 @@ Input: a release tag/title such as `v2.0.6`. If title and tag differ, ask for th
 
    Add `--verify-tag` when the release must use an existing remote tag.
 
-7. Organize and save the draft body:
+7. Organize the draft body:
 
    ```bash
    tmp_dir="$(mktemp -d)"
    gh release view "$release_tag" -R "$repo" --json body --jq '.body' > "$tmp_dir/generated.md"
    node .agents/skills/create-draft-release-notes/scripts/create-draft-release-notes.mjs "$tmp_dir/generated.md" > "$tmp_dir/organized.md"
+   ```
+
+8. Select the final notes file. Use `$tmp_dir/organized.md` by default. If the user asked for highlights, run the [Optional Highlights Workflow](#optional-highlights-workflow), write the result to `$tmp_dir/final.md`, and use that file instead.
+
+9. Save the final body:
+
+   ```bash
    gh release edit "$release_tag" -R "$repo" --draft --title "$release_title" --notes-file "$tmp_dir/organized.md"
    ```
 
-8. Return the draft URL:
+   Replace `$tmp_dir/organized.md` with `$tmp_dir/final.md` when highlights were generated.
 
-   ```bash
-   gh release view "$release_tag" -R "$repo" --json url --jq '.url'
-   ```
+10. Return the draft URL with `gh release view "$release_tag" -R "$repo" --json url --jq '.url'`.
 
 ## Markdown-Only Workflow
 
@@ -81,6 +86,43 @@ node .agents/skills/create-draft-release-notes/scripts/create-draft-release-note
 ```
 
 Omit the file path to read from stdin. Review that every original item still appears once and non-item sections remain.
+
+## Optional Highlights Workflow
+
+Use only when the user asks for highlights. Use user-specified topics when provided; otherwise infer the most valuable 1-3 user-facing changes from the generated notes and release range. Ask one concise question only if the scope is unclear.
+
+Prioritize breaking changes, features, performance wins. Avoid chores, tests, internal refactors, and routine dependency updates unless they have clear user value.
+
+Use local docs/source only when needed for accurate wording or examples.
+
+Write highlights before `## What's Changed`:
+
+- Use `## Highlights`.
+- Use one `###` heading per highlight.
+- Keep each highlight to a short paragraph plus an optional fenced code example.
+- Include examples only when the API/configuration is clear.
+- Do not rewrite or reorder changelog items below `## What's Changed`.
+- Replace an existing top `## Highlights` block instead of adding another one.
+
+Example shape:
+
+````markdown
+## Highlights
+
+### Feature Title
+
+Briefly explain the user-facing value.
+
+```ts
+export default {
+  output: {
+    example: true,
+  },
+};
+```
+
+## What's Changed
+````
 
 ## Categories
 
@@ -110,7 +152,7 @@ Keep each category in generated top-to-bottom order.
 
 - Do not rewrite bullet text, authors, URLs, PR numbers, package names, scopes, punctuation, or casing.
 - Do not drop comments, `**Full Changelog**`, or other non-item sections.
-- Do not add commentary to the release note itself.
+- Do not add commentary to the release note itself, except for a requested `## Highlights` section.
 - Do not emit empty category sections.
 
 ## Resources

--- a/.agents/skills/create-draft-release-notes/SKILL.md
+++ b/.agents/skills/create-draft-release-notes/SKILL.md
@@ -65,15 +65,19 @@ Input: a release tag/title such as `v2.0.6`. If title and tag differ, ask for th
    node .agents/skills/create-draft-release-notes/scripts/create-draft-release-notes.mjs "$tmp_dir/generated.md" > "$tmp_dir/organized.md"
    ```
 
-8. Select the final notes file. Use `$tmp_dir/organized.md` by default. If the user asked for highlights, run the [Optional Highlights Workflow](#optional-highlights-workflow), write the result to `$tmp_dir/final.md`, and use that file instead.
+8. Select the final notes file:
+
+   ```bash
+   final_notes_file="$tmp_dir/organized.md"
+   ```
+
+   If the user asked for highlights, run the [Optional Highlights Workflow](#optional-highlights-workflow), write the result to `$tmp_dir/final.md`, and then set `final_notes_file="$tmp_dir/final.md"`.
 
 9. Save the final body:
 
    ```bash
-   gh release edit "$release_tag" -R "$repo" --draft --title "$release_title" --notes-file "$tmp_dir/organized.md"
+   gh release edit "$release_tag" -R "$repo" --draft --title "$release_title" --notes-file "$final_notes_file"
    ```
-
-   Replace `$tmp_dir/organized.md` with `$tmp_dir/final.md` when highlights were generated.
 
 10. Return the draft URL with `gh release view "$release_tag" -R "$repo" --json url --jq '.url'`.
 

--- a/.agents/skills/create-draft-release-notes/scripts/create-draft-release-notes.mjs
+++ b/.agents/skills/create-draft-release-notes/scripts/create-draft-release-notes.mjs
@@ -102,9 +102,7 @@ function organize(markdown) {
   const prefix = markdown.slice(0, bodyStart).trimEnd();
   const suffix = markdown.slice(bodyEnd).replace(/^\n+/, '');
 
-  return suffix
-    ? `${prefix}\n${lines.join('\n')}\n\n${suffix}`
-    : `${prefix}\n${lines.join('\n')}\n`;
+  return suffix ? `${prefix}\n${lines.join('\n')}\n\n${suffix}` : `${prefix}\n${lines.join('\n')}\n`;
 }
 
 try {

--- a/.agents/skills/create-draft-release-notes/scripts/create-draft-release-notes.mjs
+++ b/.agents/skills/create-draft-release-notes/scripts/create-draft-release-notes.mjs
@@ -102,7 +102,9 @@ function organize(markdown) {
   const prefix = markdown.slice(0, bodyStart).trimEnd();
   const suffix = markdown.slice(bodyEnd).replace(/^\n+/, '');
 
-  return suffix ? `${prefix}\n${lines.join('\n')}\n\n${suffix}` : `${prefix}\n${lines.join('\n')}\n`;
+  return suffix
+    ? `${prefix}\n${lines.join('\n')}\n\n${suffix}`
+    : `${prefix}\n${lines.join('\n')}\n`;
 }
 
 try {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/create-draft-release-notes/SKILL.md",
-      "computedHash": "976322727110f876a069fbd2a3f8ee23fa2cd4b6bd5fa454e309062b0c9da608"
+      "computedHash": "ac0fd0bc0eb7abde798501f8915a87905125c67a52cee37fb1913f178dbe517d"
     },
     "pr-creator": {
       "source": "rstackjs/agent-skills",


### PR DESCRIPTION
## Summary

Sync the `create-draft-release-notes` skill to support optional release highlights while preserving the default generated release note organization flow.

## Related Links

https://github.com/rstackjs/agent-skills#create-draft-release-notes
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).