### PR TITLE
chore: use rslint for typecheck

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,8 +6,7 @@
     "test": "rstest run",
     "test:commonjs": "cross-env RSTEST_OUTPUT_MODULE=false rstest run",
     "test:no-isolate": "cross-env ISOLATE=false rstest --isolate false",
-    "test:threads": "rstest run --pool.type threads",
-    "typecheck": "tsc --noEmit"
+    "test:threads": "rstest run --pool.type threads"
   },
   "devDependencies": {
     "@rsbuild/core": "~2.0.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "rstest",
     "test:examples": "pnpm --filter \"@examples/*\" test",
     "test:vscode": "pnpm --filter ./packages/vscode test",
-    "typecheck": "pnpm --filter \"!@examples/*\" run typecheck"
+    "typecheck": "rslint --type-check-only"
   },
   "devDependencies": {
     "@rsdoctor/rspack-plugin": "^1.5.12",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -32,8 +32,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "test": "rstest",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/adapter-rslib/tsconfig.json"
+    "test": "rstest"
   },
   "devDependencies": {
     "@rslib/core": "0.22.0",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -32,8 +32,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "test": "rstest",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/adapter-rspack/tsconfig.json"
+    "test": "rstest"
   },
   "devDependencies": {
     "@rslib/core": "0.22.0",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -40,8 +40,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "cross-env SOURCEMAP=true rslib build --watch",
-    "test": "rstest",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/browser-react/tsconfig.json"
+    "test": "rstest"
   },
   "devDependencies": {
     "@rslib/core": "0.22.0",

--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -23,8 +23,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "rsbuild build --config ./rsbuild.config.ts",
-    "dev": "rsbuild dev --config ./rsbuild.config.ts",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/browser-ui/tsconfig.json"
+    "dev": "rsbuild dev --config ./rsbuild.config.ts"
   },
   "dependencies": {
     "antd": "^6.4.3",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -41,8 +41,7 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "rslib build --watch",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/browser/tsconfig.json"
+    "dev": "rslib build --watch"
   },
   "dependencies": {
     "@jridgewell/trace-mapping": "0.3.31",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,8 +64,7 @@
   "scripts": {
     "build": "rslib build && npx prettier ./LICENSE.md --write",
     "dev": "cross-env SOURCEMAP=true rslib build --watch",
-    "test": "npx rstest --globals",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/core/tsconfig.json"
+    "test": "npx rstest --globals"
   },
   "dependencies": {
     "@rsbuild/core": "~2.0.11",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -30,8 +30,7 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "cross-env SOURCEMAP=true rslib build --watch",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/coverage-istanbul/tsconfig.json"
+    "dev": "cross-env SOURCEMAP=true rslib build --watch"
   },
   "dependencies": {
     "istanbul-lib-coverage": "^3.2.2",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -29,8 +29,7 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "test": "rstest",
-    "typecheck": "tsc --noEmit"
+    "test": "rstest"
   },
   "dependencies": {
     "acorn": "^8.16.0",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -24,7 +24,6 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:e2e": "cross-env FORCE_COLOR=1 tsc -p tsconfig.test.json && cross-env FORCE_COLOR=1 node ./tests-dist/runTest.js",
     "test:unit": "rstest",
-    "typecheck": "pnpm -w exec tsc --noEmit -p packages/vscode/tsconfig.json",
     "watch": "rslib build --watch",
     "watch:local": "cross-env SOURCEMAP=true rslib build --watch"
   },

--- a/rslint.config.mts
+++ b/rslint.config.mts
@@ -6,7 +6,7 @@ export default defineConfig([
   {
     languageOptions: {
       parserOptions: {
-        project: ['./packages/*/tsconfig.json'],
+        project: ['./e2e/tsconfig.json', './packages/*/tsconfig.json'],
       },
     },
     rules: {


### PR DESCRIPTION
## Summary

Replace the root typecheck workflow with `rslint --type-check-only` so type checking runs through Rslint's parallel checker instead of invoking package-level `tsc --noEmit` scripts one by one. The Rslint project list now includes both `e2e/tsconfig.json` and `packages/*/tsconfig.json`, and the redundant per-package `typecheck` scripts are removed.

Performance comparison on this workspace across 5 runs:
- Old sequential `tsc --noEmit -p ...`: avg 8.068s, median 7.800s
- New `rslint --type-check-only`: avg 1.030s, median 1.010s

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).