### PR TITLE
fix(types): narrow chai config options

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -10,9 +10,8 @@ import type {
 import type { ConsoleStreamType, MaybePromise } from './utils';
 import type { BrowserProvider } from '../utils/constants';
 
-// TODO: chaiConfig.includeStack seems not used
 export type ChaiConfig = Partial<
-  Omit<typeof config, 'useProxy' | 'proxyExcludedKeys' | 'deepEqual'>
+  Pick<typeof config, 'showDiff' | 'truncateThreshold'>
 >;
 
 export type RstestPoolType = 'forks' | 'threads';


### PR DESCRIPTION
## Summary

This PR narrows the public `ChaiConfig` type to the supported options documented by Rstest. It replaces the previous broad `Omit`-based type with an explicit `Pick` for `showDiff` and `truncateThreshold`, avoiding accidental exposure of unsupported Chai internals such as `includeStack`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).