### PR TITLE
test: speed up timeout e2e tests

### DIFF
--- a/e2e/test-api/fixtures/timeout.test.ts
+++ b/e2e/test-api/fixtures/timeout.test.ts
@@ -9,7 +9,7 @@ describe('level A', () => {
 
   it('it in level B', async ({ expect }) => {
     expect(1 + 1).toBe(2);
-    await sleep(5100);
+    await sleep(100);
     expect(1 + 1).toBe(2);
   });
 });

--- a/e2e/test-api/timeout.test.ts
+++ b/e2e/test-api/timeout.test.ts
@@ -5,7 +5,7 @@ describe('Test timeout', () => {
   it('should throw timeout error when test timeout', async () => {
     const { cli, expectLog, expectStderrLog } = await runRstestCli({
       command: 'rstest',
-      args: ['run', 'fixtures/timeout.test'],
+      args: ['run', 'fixtures/timeout.test', '--testTimeout=50'],
       options: {
         nodeOptions: {
           cwd: __dirname,
@@ -24,11 +24,11 @@ describe('Test timeout', () => {
     expectStderrLog(/timeout.test.ts:5:3/);
 
     expectStderrLog(
-      /Error: test timed out in 5000ms.*completed 1 expect assertion[^s]/,
+      /Error: test timed out in 50ms.*completed 1 expect assertion[^s]/,
     );
 
     expectStderrLog(/timeout.test.ts:10:3/);
 
     expectLog(/Tests 2 failed/, logs);
-  }, 10000);
+  });
 });

--- a/e2e/test-api/timeoutConfig.test.ts
+++ b/e2e/test-api/timeoutConfig.test.ts
@@ -6,7 +6,7 @@ describe('Test timeout configuration', () => {
     const { expectExecFailed, expectLog, expectStderrLog } = await runRstestCli(
       {
         command: 'rstest',
-        args: ['run', 'fixtures/timeout.test', '--testTimeout=10000'],
+        args: ['run', 'fixtures/timeout.test', '--testTimeout=150'],
         options: {
           nodeOptions: {
             cwd: __dirname,
@@ -21,5 +21,5 @@ describe('Test timeout configuration', () => {
     expectStderrLog('Error: test timed out in 50ms');
     expectStderrLog('timeout.test.ts:5:3');
     expectLog('Tests 1 failed | 1 passed');
-  }, 12000);
+  });
 });


### PR DESCRIPTION
## Summary

This PR speeds up the timeout e2e tests by avoiding waits against the default 5s timeout. The fixture now uses short sleeps with explicit timeout values, and the outer test timeouts are no longer extended to 10-12s.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).