### PR TITLE
fix(core): report untransformed mock API calls

### DIFF
--- a/e2e/mock/fixtures/aliasRuntimeError/index.test.ts
+++ b/e2e/mock/fixtures/aliasRuntimeError/index.test.ts
@@ -1,0 +1,10 @@
+import { expect, rstest as vi, test } from '@rstest/core';
+import { increment } from '../../src/increment';
+
+vi.mock('../../src/increment', () => ({
+  increment: (num: number) => num + 10,
+}));
+
+test('alias mock should not be silent', () => {
+  expect(increment(1)).toBe(11);
+});

--- a/e2e/mock/tests/aliasRuntimeError.test.ts
+++ b/e2e/mock/tests/aliasRuntimeError.test.ts
@@ -1,0 +1,28 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import { runRstestCli } from '../../scripts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('mock API aliases', () => {
+  it('reports an error when module mock APIs are called through an alias', async () => {
+    const { expectExecFailed, expectStderrLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, '../fixtures/aliasRuntimeError'),
+        },
+      },
+    });
+
+    await expectExecFailed();
+
+    expectStderrLog(
+      'rs.mock() must be called as rstest.mock() or rs.mock() so Rstest can transform it',
+    );
+    expectStderrLog('Import aliases are not supported for module mock APIs');
+  });
+});

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -47,6 +47,15 @@ const normalizeWaitOptions = (
   ),
 });
 
+const createUntransformedRuntimeApiError = (apiName: string) =>
+  new Error(
+    `[Rstest] rs.${apiName}() must be called as rstest.${apiName}() or rs.${apiName}() so Rstest can transform it. Import aliases are not supported for module mock APIs.`,
+  );
+
+const createPluginManagedApi = (apiName: string) => () => {
+  throw createUntransformedRuntimeApiError(apiName);
+};
+
 /**
  * Shared LIFO index-lifecycle for the three scoped-restore stacks behind
  * `stubEnv`, `stubGlobal`, and `useFakeTimers`. Each stub pushes an entry and
@@ -293,40 +302,20 @@ export const createRstestUtilities: (
       }
       return rstest;
     },
-    // The below methods are not implemented in the core package.
-    // The actual implementation is managed by the built-in Rstest plugin.
-    mock: () => undefined,
-    mockRequire: () => undefined,
-    doMock: () => undefined,
-    doMockRequire: () => undefined,
-    unmock: () => undefined,
-    doUnmock: () => undefined,
-    unmockRequire: () => undefined,
-    doUnmockRequire: () => undefined,
-    importMock: () => {
-      // The actual implementation is managed by the built-in Rstest plugin.
-      return Promise.resolve({} as any);
-    },
-    requireMock: () => {
-      // The actual implementation is managed by the built-in Rstest plugin.
-      return {} as any;
-    },
-    importActual: () => {
-      // The actual implementation is managed by the built-in Rstest plugin.
-      return Promise.resolve({} as any);
-    },
-    requireActual: () => {
-      // The actual implementation is managed by the built-in Rstest plugin.
-      return {} as any;
-    },
-    resetModules: () => {
-      // The actual implementation is managed by the built-in Rstest plugin.
-      return {} as any;
-    },
-    hoisted: () => {
-      // The actual implementation is managed by the built-in Rstest plugin.
-      return {} as any;
-    },
+    mock: createPluginManagedApi('mock'),
+    mockRequire: createPluginManagedApi('mockRequire'),
+    doMock: createPluginManagedApi('doMock'),
+    doMockRequire: createPluginManagedApi('doMockRequire'),
+    unmock: createPluginManagedApi('unmock'),
+    doUnmock: createPluginManagedApi('doUnmock'),
+    unmockRequire: createPluginManagedApi('unmockRequire'),
+    doUnmockRequire: createPluginManagedApi('doUnmockRequire'),
+    importMock: createPluginManagedApi('importMock'),
+    requireMock: createPluginManagedApi('requireMock'),
+    importActual: createPluginManagedApi('importActual'),
+    requireActual: createPluginManagedApi('requireActual'),
+    resetModules: createPluginManagedApi('resetModules'),
+    hoisted: createPluginManagedApi('hoisted'),
 
     setConfig: (config) => {
       if (!originalConfig) {

--- a/packages/core/tests/runtime/api/utilities.test.ts
+++ b/packages/core/tests/runtime/api/utilities.test.ts
@@ -136,6 +136,36 @@ describe('rstest utilities wait APIs', () => {
   });
 });
 
+describe('rstest utilities plugin-managed APIs', () => {
+  it('throws when module mock APIs are not transformed by the Rstest plugin', async () => {
+    const rs = await createRstestUtilities(createWorkerState());
+
+    expect(() => rs.mock('./module')).toThrow(
+      'rs.mock() must be called as rstest.mock() or rs.mock() so Rstest can transform it',
+    );
+    expect(() => rs.doMock('./module')).toThrow(
+      'Import aliases are not supported for module mock APIs',
+    );
+    expect(() => rs.unmock('./module')).toThrow(
+      'Import aliases are not supported for module mock APIs',
+    );
+  });
+
+  it('throws when module loader APIs are not transformed by the Rstest plugin', async () => {
+    const rs = await createRstestUtilities(createWorkerState());
+
+    expect(() => rs.importActual('./module')).toThrow(
+      'rs.importActual() must be called as rstest.importActual() or rs.importActual() so Rstest can transform it',
+    );
+    expect(() => rs.requireActual('./module')).toThrow(
+      'Import aliases are not supported for module mock APIs',
+    );
+    expect(() => rs.hoisted(() => ({}))).toThrow(
+      'Import aliases are not supported for module mock APIs',
+    );
+  });
+});
+
 describe('rstest utility scoped cleanup', () => {
   const envName = 'RSTEST_SCOPED_ENV';
 


### PR DESCRIPTION
## Summary

This PR fixes a silent failure mode for module mock APIs when calls are not transformed by the built-in Rstest plugin, such as when `rstest` is imported through an alias. Instead of returning placeholder values, plugin-managed APIs now throw a runtime error that explains the required `rstest.*` / `rs.*` call shape and notes that import aliases are not supported for module mock APIs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).