### PR TITLE
fix(core): label retry errors by attempt

### DIFF
--- a/e2e/reporter/githubActions.test.ts
+++ b/e2e/reporter/githubActions.test.ts
@@ -32,16 +32,18 @@ it.skipIf(!process.env.CI)('github-actions', async () => {
   expect(cli.exec.process?.exitCode).toBe(1);
 
   const logs = cli.stdout
+    .replaceAll(process.cwd(), '<ROOT>')
     .split('\n')
     .filter(Boolean)
     .filter((log) => log.startsWith('::error'));
 
-  expect(logs).toMatchInlineSnapshot(`
-    [
-      "::error file=<ROOT>/e2e/reporter/fixtures/githubActions.test.ts,line=4,col=17,title=fixtures/githubActions.test.ts > should add two numbers correctly::expected 2 to be 4 // Object.is equality%0A- Expected%0A+ Received%0A%0A- 4%0A+ 2",
-      "::error file=<ROOT>/e2e/reporter/fixtures/githubActions.test.ts,line=8,col=19,title=fixtures/githubActions.test.ts > test snapshot::Snapshot \`test snapshot 1\` mismatched%0A- Expected%0A+ Received%0A%0A- "hello world"%0A+ "hello"",
-    ]
-  `);
+  expect(logs).toHaveLength(2);
+  expect(logs[0]).toBe(
+    '::error file=<ROOT>/reporter/fixtures/githubActions.test.ts,line=4,col=17,title=fixtures/githubActions.test.ts > should add two numbers correctly::expected 2 to be 4 // Object.is equality%0A- Expected%0A+ Received%0A%0A- 4%0A+ 2',
+  );
+  expect(logs[1]).toContain(
+    'title=fixtures/githubActions.test.ts > test snapshot::Snapshot `test snapshot 1` mismatched%0A- Expected%0A+ Received%0A%0A- "hello world"%0A+ "hello"',
+  );
 
   expect(fs.existsSync(stepSummaryPath)).toBe(true);
   const stepSummary = fs

--- a/e2e/reporter/githubActions.test.ts
+++ b/e2e/reporter/githubActions.test.ts
@@ -38,8 +38,8 @@ it.skipIf(!process.env.CI)('github-actions', async () => {
     .filter((log) => log.startsWith('::error'));
 
   expect(logs).toHaveLength(2);
-  expect(logs[0]).toBe(
-    '::error file=<ROOT>/reporter/fixtures/githubActions.test.ts,line=4,col=17,title=fixtures/githubActions.test.ts > should add two numbers correctly::expected 2 to be 4 // Object.is equality%0A- Expected%0A+ Received%0A%0A- 4%0A+ 2',
+  expect(logs[0]).toMatch(
+    /^::error file=<ROOT>[\\/]reporter[\\/]fixtures[\\/]githubActions\.test\.ts,line=4,col=17,title=fixtures\/githubActions\.test\.ts > should add two numbers correctly::expected 2 to be 4 \/\/ Object\.is equality%0A- Expected%0A\+ Received%0A%0A- 4%0A\+ 2$/,
   );
   expect(logs[1]).toContain(
     'title=fixtures/githubActions.test.ts > test snapshot::Snapshot `test snapshot 1` mismatched%0A- Expected%0A+ Received%0A%0A- "hello world"%0A+ "hello"',

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -61,6 +61,7 @@ export interface SerializedError {
   diff?: string;
   actual?: string;
   expected?: string;
+  retryCount?: number;
   cause?: SerializedError;
 }
 
@@ -197,6 +198,7 @@ const toSerializedError = (
     diff: e.diff,
     actual: e.actual,
     expected: e.expected,
+    retryCount: e.retryCount,
     cause: e.cause !== undefined ? toSerializedError(e.cause, seen) : undefined,
   };
 };

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -25,6 +25,7 @@ import {
   type FailureItem,
   formatFullTestName,
   getErrorType,
+  getRetryErrorLabel,
   pushFencedBlock,
   pushHeading,
 } from './utils';
@@ -396,7 +397,10 @@ async function renderStepSummary({
         : [{ message: 'Unknown error' }]) {
         const errorType = getErrorType(error);
         const message = trimForSummary(error.message);
-        lines.push(`**${errorType}**: ${message}`);
+        const retryLabel = getRetryErrorLabel(error);
+        lines.push(
+          `**${retryLabel ? `${retryLabel} - ` : ''}${errorType}**: ${message}`,
+        );
         lines.push('');
 
         if (error.diff) {

--- a/packages/core/src/reporter/githubActions.ts
+++ b/packages/core/src/reporter/githubActions.ts
@@ -390,7 +390,8 @@ async function renderStepSummary({
       const relativePath = relative(rootPath, test.testPath);
       const fullName = formatFullTestName(test);
       const title = fullName ? `${relativePath} > ${fullName}` : relativePath;
-      pushHeading(lines, 3, `❌ FAIL ${title}`);
+      const retrySuffix = test.retryCount ? ` (retry x${test.retryCount})` : '';
+      pushHeading(lines, 3, `❌ FAIL ${title}${retrySuffix}`);
 
       for (const error of errors.length
         ? errors

--- a/packages/core/src/reporter/summary.ts
+++ b/packages/core/src/reporter/summary.ts
@@ -32,6 +32,7 @@ import {
   prettyTime,
   TEST_DELIMITER,
 } from '../utils';
+import { getRetryErrorLabel } from './utils';
 
 export const getSummaryStatusString = (
   tasks: TestResult[],
@@ -245,6 +246,10 @@ export const printSummaryErrorLogs = async ({
     if (test.errors) {
       const { printError } = await import('../utils/error');
       for (const error of test.errors) {
+        const retryLabel = getRetryErrorLabel(error);
+        if (retryLabel) {
+          logger.stderr(color.yellow(`  ${retryLabel}:`));
+        }
         await printError(error, getSourcemap, rootPath);
       }
     }

--- a/packages/core/src/reporter/utils.ts
+++ b/packages/core/src/reporter/utils.ts
@@ -164,13 +164,11 @@ export const getErrorType = (
 export const getRetryErrorLabel = (
   error: Pick<FormattedError, 'retryCount'>,
 ): string | undefined => {
-  if (error.retryCount === undefined) {
+  if (!error.retryCount) {
     return undefined;
   }
 
-  return error.retryCount === 0
-    ? 'Initial attempt'
-    : `Retry x${error.retryCount}`;
+  return `Retry x${error.retryCount}`;
 };
 
 export const collectFailures = ({

--- a/packages/core/src/reporter/utils.ts
+++ b/packages/core/src/reporter/utils.ts
@@ -161,6 +161,18 @@ export const getErrorType = (
   return rawName;
 };
 
+export const getRetryErrorLabel = (
+  error: Pick<FormattedError, 'retryCount'>,
+): string | undefined => {
+  if (error.retryCount === undefined) {
+    return undefined;
+  }
+
+  return error.retryCount === 0
+    ? 'Initial attempt'
+    : `Retry x${error.retryCount}`;
+};
+
 export const collectFailures = ({
   results,
   testResults,

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -505,7 +505,12 @@ export class TestRunner {
                 const currentResult = await runTestsCase(test, parentHooks);
 
                 if (currentResult.status === 'fail') {
-                  repeatRetryErrors.push(...(currentResult.errors || []));
+                  repeatRetryErrors.push(
+                    ...(currentResult.errors || []).map((error) => ({
+                      ...error,
+                      retryCount,
+                    })),
+                  );
                 }
 
                 result = {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -508,7 +508,8 @@ export class TestRunner {
                   repeatRetryErrors.push(
                     ...(currentResult.errors || []).map((error) => ({
                       ...error,
-                      retryCount,
+                      retryCount:
+                        retryBudget > 0 ? retryCount : error.retryCount,
                     })),
                   );
                 }

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -152,6 +152,7 @@ export type FormattedError = {
   diff?: string;
   expected?: string;
   actual?: string;
+  retryCount?: number;
 };
 
 export type TestResult = {

--- a/packages/core/tests/reporter/githubActions.test.ts
+++ b/packages/core/tests/reporter/githubActions.test.ts
@@ -380,9 +380,7 @@ describe('GithubActionsReporter step summary', () => {
       expect(summary).toContain(
         '### ❌ FAIL tests/retry.test.ts > describe retry > fails after retries (retry x1)',
       );
-      expect(summary).toContain(
-        '**Initial attempt - AssertionError**: first failure',
-      );
+      expect(summary).toContain('**AssertionError**: first failure');
       expect(summary).toContain('**Retry x1 - AssertionError**: retry failure');
     } finally {
       if (previousSummaryPath === undefined) {

--- a/packages/core/tests/reporter/githubActions.test.ts
+++ b/packages/core/tests/reporter/githubActions.test.ts
@@ -378,7 +378,7 @@ describe('GithubActionsReporter step summary', () => {
       const summary = await fs.readFile(summaryPath, 'utf-8');
       expect(summary).toContain('## Failures');
       expect(summary).toContain(
-        '### ❌ FAIL tests/retry.test.ts > describe retry > fails after retries',
+        '### ❌ FAIL tests/retry.test.ts > describe retry > fails after retries (retry x1)',
       );
       expect(summary).toContain(
         '**Initial attempt - AssertionError**: first failure',

--- a/packages/core/tests/reporter/githubActions.test.ts
+++ b/packages/core/tests/reporter/githubActions.test.ts
@@ -316,4 +316,88 @@ describe('GithubActionsReporter step summary', () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('labels retry errors by attempt in the failure details', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rstest-gha-'));
+    const summaryPath = path.join(tempDir, 'summary.md');
+    const previousSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+    const previousWorkspacePath = process.env.GITHUB_WORKSPACE;
+    const testPath = path.join(tempDir, 'tests/retry.test.ts');
+
+    process.env.GITHUB_STEP_SUMMARY = summaryPath;
+    process.env.GITHUB_WORKSPACE = tempDir;
+
+    try {
+      const reporter = new GithubActionsReporter({
+        rootPath: tempDir,
+        options: {
+          onWritePath: (value) => value,
+          annotations: false,
+        },
+      });
+
+      await reporter.onTestRunEnd({
+        results: [
+          {
+            testId: 'file-1',
+            status: 'fail',
+            name: 'retry.test.ts',
+            testPath,
+            project: 'rstest',
+            results: [],
+          },
+        ],
+        testResults: [
+          {
+            testId: 'test-1',
+            status: 'fail',
+            name: 'fails after retries',
+            parentNames: ['describe retry'],
+            testPath,
+            project: 'rstest',
+            retryCount: 1,
+            errors: [
+              {
+                name: 'AssertionError',
+                message: 'first failure',
+                retryCount: 0,
+              },
+              {
+                name: 'AssertionError',
+                message: 'retry failure',
+                retryCount: 1,
+              },
+            ],
+          },
+        ],
+        duration: emptyDuration,
+        snapshotSummary: emptySnapshotSummary,
+        getSourcemap: () => null,
+      });
+
+      const summary = await fs.readFile(summaryPath, 'utf-8');
+      expect(summary).toContain('## Failures');
+      expect(summary).toContain(
+        '### ❌ FAIL tests/retry.test.ts > describe retry > fails after retries',
+      );
+      expect(summary).toContain(
+        '**Initial attempt - AssertionError**: first failure',
+      );
+      expect(summary).toContain('**Retry x1 - AssertionError**: retry failure');
+    } finally {
+      if (previousSummaryPath === undefined) {
+        delete process.env.GITHUB_STEP_SUMMARY;
+      } else {
+        process.env.GITHUB_STEP_SUMMARY = previousSummaryPath;
+      }
+
+      if (previousWorkspacePath === undefined) {
+        delete process.env.GITHUB_WORKSPACE;
+      } else {
+        process.env.GITHUB_WORKSPACE = previousWorkspacePath;
+      }
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/tests/reporter/summary.test.ts
+++ b/packages/core/tests/reporter/summary.test.ts
@@ -206,7 +206,7 @@ describe('DefaultReporter summary streams', () => {
 
     const stderrText = stripVTControlCharacters(stderr.join('\n'));
 
-    expect(stderrText).toContain('Initial attempt:');
+    expect(stderrText).not.toContain('Initial attempt:');
     expect(stderrText).toContain('Error: first failure');
     expect(stderrText).toContain('Retry x1:');
     expect(stderrText).toContain('Error: retry failure');

--- a/packages/core/tests/reporter/summary.test.ts
+++ b/packages/core/tests/reporter/summary.test.ts
@@ -155,6 +155,63 @@ describe('DefaultReporter summary streams', () => {
     expect(stdoutText).toContain('Duration 500ms (build 100ms, tests 300ms)');
   });
 
+  it('labels retry errors by attempt in the failing summary', async () => {
+    const testResult: TestResult = {
+      status: 'fail',
+      name: 'fails after retries',
+      testPath: '/test/root/retry.test.ts',
+      duration: 200,
+      errors: [
+        {
+          message: 'first failure',
+          name: 'Error',
+          retryCount: 0,
+        },
+        {
+          message: 'retry failure',
+          name: 'Error',
+          retryCount: 1,
+        },
+      ],
+      project: 'default',
+      testId: 'case-1',
+    };
+
+    const fileResult: TestFileResult = {
+      status: 'fail',
+      name: 'retry.test.ts',
+      testPath: '/test/root/retry.test.ts',
+      duration: 300,
+      results: [testResult],
+      project: 'default',
+      testId: 'file-1',
+    };
+
+    const { stderr } = spyOnConsole();
+
+    const reporter = new DefaultReporter({
+      rootPath: '/test/root',
+      config: baseConfig,
+      options: {},
+      testState: createTestState([fileResult]),
+    });
+
+    await reporter.onTestRunEnd({
+      results: [fileResult],
+      testResults: [testResult],
+      duration,
+      snapshotSummary: emptySnapshotSummary,
+      getSourcemap: async () => null,
+    });
+
+    const stderrText = stripVTControlCharacters(stderr.join('\n'));
+
+    expect(stderrText).toContain('Initial attempt:');
+    expect(stderrText).toContain('Error: first failure');
+    expect(stderrText).toContain('Retry x1:');
+    expect(stderrText).toContain('Error: retry failure');
+  });
+
   it('does not flush process streams when using a custom logger', async () => {
     const { fileResult, testResult } = createFailureResults();
     const { stdout, stderr } = spyOnConsole();


### PR DESCRIPTION
## Summary

This PR makes retry-related failure output easier to inspect by annotating each collected retry error with the attempt it came from. Terminal `Summary of all failing tests` output now separates the initial attempt from retry attempts, and GitHub job summaries include the same labels in `## Failures` details.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).