### PR TITLE
docs: update agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ When working on code in a specific package, use the Read tool to load that packa
 
 If a package does not have its own `AGENTS.md`, follow this root file and copy the closest local patterns.
 
-## Monorepo Structure
+## Monorepo structure
 
 - `packages/core/` — @rstest/core: core testing framework (CLI, runtime, reporter, pool)
 - `packages/browser/` — @rstest/browser: browser mode support (Playwright, WebSocket RPC)
@@ -37,7 +37,7 @@ If a package does not have its own `AGENTS.md`, follow this root file and copy t
 - `website/` — documentation site (Rspress)
 - `scripts/` — build scripts and shared configs
 
-## Package Manager and Workspace
+## Package manager and workspace
 
 - Use `pnpm` (the repository currently pins `pnpm@11.5.2`).
 - The workspace includes `benchmarks`, `website`, `scripts/**`, `packages/**`, `examples/**`, and `e2e/**`.
@@ -74,7 +74,7 @@ pnpm prettier --write path/to/file.ts
 
 _Note_: E2E tests and examples consume built package output. Rebuild affected packages before running them (for example, `pnpm --filter @rstest/browser build`). For testing workflows, use the `testing` skill.
 
-## Development Workflow
+## Development workflow
 
 - Keep changes small and focused.
 - Before changing behavior, identify the affected package(s), public API/config impact, browser-mode impact, adapter impact, docs impact, and test scope.
@@ -84,7 +84,7 @@ _Note_: E2E tests and examples consume built package output. Rebuild affected pa
 - Do not make repo-wide rewrites unless explicitly asked.
 - Do not revert unrelated local changes.
 
-## Testing Guidance
+## Testing guidance
 
 - Prefer targeted tests first, then broader validation when needed.
 - For root-discovered unit tests, prefer `pnpm rstest <package-test-path>`.
@@ -93,7 +93,7 @@ _Note_: E2E tests and examples consume built package output. Rebuild affected pa
 - Do not overlap `pnpm build` and `pnpm e2e`; wait for builds to finish before e2e.
 - If e2e fails with missing built files, rebuild the affected package(s) before retrying.
 
-## Code Style
+## Code style
 
 - Use ESM-first: `.mjs` for runtime loaders, `.ts`/`.mts` for typed utilities.
 - Do not mix CommonJS and ESM in the same module unless the file is intentionally a compatibility fixture.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,80 +4,117 @@ Rstest is an Rsbuild-based testing framework for JavaScript/TypeScript projects.
 
 ## Sub-package Instructions
 
-When working on code in a specific package, use the Read tool to load that package's AGENTS.md file for package-specific guidelines:
+When working on code in a specific package, use the Read tool to load that package's `AGENTS.md` file for package-specific guidelines:
 
-- For @rstest/core: @packages/core/AGENTS.md
-- For @rstest/browser: @packages/browser/AGENTS.md
-- For @rstest/browser-ui: @packages/browser-ui/AGENTS.md
-- For @rstest/browser-react: @packages/browser-react/AGENTS.md
-- For @rstest/coverage-istanbul: @packages/coverage-istanbul/AGENTS.md
-- For @rstest/adapter-rslib: @packages/adapter-rslib/AGENTS.md
-- For @rstest/adapter-rsbuild: @packages/adapter-rsbuild/AGENTS.md
-- For rstest VS Code extension: @packages/vscode/AGENTS.md
-- For documentation site: @website/AGENTS.md
+- For @rstest/core: `packages/core/AGENTS.md`
+- For @rstest/browser: `packages/browser/AGENTS.md`
+- For @rstest/browser-ui: `packages/browser-ui/AGENTS.md`
+- For @rstest/browser-react: `packages/browser-react/AGENTS.md`
+- For @rstest/coverage-istanbul: `packages/coverage-istanbul/AGENTS.md`
+- For @rstest/adapter-rslib: `packages/adapter-rslib/AGENTS.md`
+- For @rstest/adapter-rsbuild: `packages/adapter-rsbuild/AGENTS.md`
+- For @rstest/adapter-rspack: `packages/adapter-rspack/AGENTS.md`
+- For rstest VS Code extension: `packages/vscode/AGENTS.md`
+- For documentation site: `website/AGENTS.md`
 
-## Monorepo structure
+If a package does not have its own `AGENTS.md`, follow this root file and copy the closest local patterns.
 
-- `packages/core/` — @rstest/core: Core testing framework (CLI, runtime, reporter, pool)
-- `packages/browser/` — @rstest/browser: Browser mode support (Playwright, WebSocket RPC)
-- `packages/browser-ui/` — @rstest/browser-ui: Browser test UI (React + Tailwind + Ant Design)
-- `packages/browser-react/` — @rstest/browser-react: React component testing utilities
+## Monorepo Structure
+
+- `packages/core/` — @rstest/core: core testing framework (CLI, runtime, reporter, pool)
+- `packages/browser/` — @rstest/browser: browser mode support (Playwright, WebSocket RPC)
+- `packages/browser-ui/` — @rstest/browser-ui: prebuilt browser container UI (React + Tailwind + Ant Design)
+- `packages/browser-react/` — @rstest/browser-react: React component testing utilities for browser mode
 - `packages/coverage-istanbul/` — @rstest/coverage-istanbul: Istanbul coverage provider
+- `packages/coverage-v8/` — @rstest/coverage-v8: V8 coverage provider
 - `packages/adapter-rslib/` — @rstest/adapter-rslib: Rslib configuration adapter
 - `packages/adapter-rsbuild/` — @rstest/adapter-rsbuild: Rsbuild configuration adapter
+- `packages/adapter-rspack/` — @rstest/adapter-rspack: Rspack configuration adapter
 - `packages/vscode/` — rstest: VS Code extension
-- `e2e/` — End-to-end integration tests
-- `examples/` — Example projects (node, react, browser)
-- `website/` — Documentation site (Rspress)
-- `scripts/` — Build scripts and shared configs
+- `benchmarks/` — benchmark projects and runners
+- `e2e/` — end-to-end integration tests
+- `examples/` — example projects (node, react, browser)
+- `website/` — documentation site (Rspress)
+- `scripts/` — build scripts and shared configs
+
+## Package Manager and Workspace
+
+- Use `pnpm` (the repository currently pins `pnpm@11.5.2`).
+- The workspace includes `benchmarks`, `website`, `scripts/**`, `packages/**`, `examples/**`, and `e2e/**`.
+- Dependency installs use pnpm's stricter settings (`minimumReleaseAge`, `strictDepBuilds`, and explicit build-script approvals). Do not loosen these settings or add heavy dependencies without discussion.
 
 ## Commands
 
 ```bash
 # Root commands
 pnpm install                  # Install all workspace dependencies
-pnpm build                    # Build all packages (excludes examples)
+pnpm build                    # Build all packages under packages/*
 pnpm test                     # Run unit tests via rstest
 pnpm e2e                      # Run e2e tests
 pnpm lint                     # Prettier check + spell check + type lint
-pnpm format                   # Prettier format
-pnpm typecheck                # Type check all packages
+pnpm lint:type                # Run rslint
+pnpm typecheck                # Run rslint --type-check-only
+pnpm format                   # Prettier format + heading-case --write
+pnpm check-unused             # Run knip
+pnpm test:examples            # Run example tests
+pnpm test:vscode              # Run VS Code extension tests
+pnpm bench:cpu                # Run CPU benchmarks
+pnpm bench:memory             # Run memory benchmarks
 
-# Package-specific
+# Package-specific examples
 pnpm --filter @rstest/core build
 pnpm --filter @rstest/core dev
 pnpm --filter @rstest/core test
-pnpm --filter @rstest/core test -- tests/core/rsbuild.test.ts  # Single file
+pnpm --filter @rstest/core test -- tests/core/rsbuild.test.ts
 
-# File-scoped (faster feedback)
-pnpm prettier --write path/to/file.ts       # Format
-pnpm tsc --noEmit path/to/file.ts           # Type check
+# File-scoped / faster feedback
+pnpm rstest packages/core/tests/core/rsbuild.test.ts
+pnpm prettier --write path/to/file.ts
 ```
 
-_Note_: E2E tests and examples consume built package output — rebuild affected packages before running them (e.g., `pnpm --filter @rstest/browser build`). For testing workflows, see the testing skill.
+_Note_: E2E tests and examples consume built package output. Rebuild affected packages before running them (for example, `pnpm --filter @rstest/browser build`). For testing workflows, use the `testing` skill.
 
-## Do
+## Development Workflow
 
-- Use ESM-first: `.mjs` for runtime loaders, `.ts` for typed utilities
-- Use 2-space indentation, LF line endings
-- Use camelCase for locals, PascalCase for types/components, SCREAMING_SNAKE_CASE for constants
-- Keep changes small and focused
-- Place tests mirroring source structure
+- Keep changes small and focused.
+- Before changing behavior, identify the affected package(s), public API/config impact, browser-mode impact, adapter impact, docs impact, and test scope.
+- Public API or config changes usually require docs updates.
+- Behavioral changes require corresponding e2e coverage unless there is a clear reason existing coverage is sufficient.
+- If a config option is shared with Rsbuild/Rslib/Rspack, check whether the adapters need to transform or pass it through consistently.
+- Do not make repo-wide rewrites unless explicitly asked.
+- Do not revert unrelated local changes.
 
-## Don't
+## Testing Guidance
 
-- Don't mix CommonJS and ESM in the same module
-- Don't add heavy dependencies without discussion
-- Don't use namespace imports like `import * as foo from 'foo'` unless the module shape requires it
-- Don't make repo-wide rewrites unless explicitly asked
+- Prefer targeted tests first, then broader validation when needed.
+- For root-discovered unit tests, prefer `pnpm rstest <package-test-path>`.
+- Do not pass `e2e/...` paths to the root `pnpm rstest` command.
+- Run e2e tests from the `e2e/` directory; when passing a path, strip the `e2e/` prefix.
+- Do not overlap `pnpm build` and `pnpm e2e`; wait for builds to finish before e2e.
+- If e2e fails with missing built files, rebuild the affected package(s) before retrying.
+
+## Code Style
+
+- Use ESM-first: `.mjs` for runtime loaders, `.ts`/`.mts` for typed utilities.
+- Do not mix CommonJS and ESM in the same module unless the file is intentionally a compatibility fixture.
+- Use 2-space indentation and LF line endings.
+- Use camelCase for locals, PascalCase for types/components, and SCREAMING_SNAKE_CASE for constants.
+- Avoid namespace imports like `import * as foo from 'foo'` unless the module shape requires it.
+- Prefer existing local patterns over introducing new abstractions.
+- Do not add comments that restate the code; comment only non-obvious intent or constraints.
+- Avoid unnecessary defensive runtime checks when TypeScript already guarantees the type.
+- Minimize `as` casts and `any`; never let `any` leak into exported APIs, config types, or cross-package contracts.
+- Avoid one-use abstractions unless they materially improve readability.
 
 ## Skills
 
 Available workflow skills in `.agents/skills/`:
 
-| Skill       | Description                                                                       |
-| ----------- | --------------------------------------------------------------------------------- |
-| development | Feature / bug-fix checklist for scope review and workflow routing                 |
-| pr-creator  | Create a PR for the current branch (from rstackjs/agent-skills)                   |
-| testing     | Testing workflow for the rstest monorepo (run tests, write tests, debug failures) |
-| typescript  | TypeScript anti-slop guardrails for .ts, .tsx, and .mts files                     |
+| Skill                      | Description                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| development                | Feature / bug-fix checklist for scope review and workflow routing                 |
+| testing                    | Testing workflow for the rstest monorepo (run tests, write tests, debug failures) |
+| typescript                 | TypeScript anti-slop guardrails for `.ts`, `.tsx`, and `.mts` files               |
+| pr-creator                 | Create a PR for the current branch                                                |
+| create-draft-release-notes | Create or update draft GitHub releases and organize generated release notes       |
+| create-release-blog        | Draft bilingual release blog posts from a version range                           |

--- a/website/docs/en/shared/agent-migrate.md
+++ b/website/docs/en/shared/agent-migrate.md
@@ -77,6 +77,18 @@ stop and provide:
 
 - Run the test suite and fix failures iteratively.
 - Fix configuration and resolver errors first, then address mocks/timers/snapshots, and touch test logic last.
+- If a third-party package fails because of ESM/CJS interop differences, prefer a config-level fix first by overriding its external module type in the test/build config, for example:
+
+```ts
+output: {
+   externals: {
+      'fs-extra': 'commonjs fs-extra',
+   },
+},
+```
+
+Use this when a dependency is being interpreted as the wrong module format under Rstest/Rspack.
+
 - If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3` (fixed in 0.9.3 — upgrade before debugging mock behavior further).
 
 ## Summarize changes


### PR DESCRIPTION
## Summary

This PR updates the repository agent instructions to match the current workspace layout, available package-level agents, root scripts, and installed workflow skills. It also refreshes the website migration agent snippet via `build:agent-install` so migration guidance includes the ESM/CJS interop config-level workaround.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).