### PR TITLE
chore(deps): update @rsbuild/core to 2.0.14

### DIFF
--- a/e2e/dom/fixtures/package.json
+++ b/e2e/dom/fixtures/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-react": "^2.0.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "test:threads": "rstest run --pool.type threads"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rslib/core": "0.22.0",
     "@rstest/browser": "workspace:*",

--- a/e2e/projects/fixtures-shard/packages/client-vue/package.json
+++ b/e2e/projects/fixtures-shard/packages/client-vue/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-vue": "^1.2.9",
     "@rstest/core": "workspace:*",
     "@vue/compiler-dom": "^3.5.35",

--- a/e2e/projects/fixtures-shard/packages/client/package.json
+++ b/e2e/projects/fixtures-shard/packages/client/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-react": "^2.0.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/projects/fixtures/packages/client-vue/package.json
+++ b/e2e/projects/fixtures/packages/client-vue/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-vue": "^1.2.9",
     "@rstest/core": "workspace:*",
     "@vue/compiler-dom": "^3.5.35",

--- a/e2e/projects/fixtures/packages/client/package.json
+++ b/e2e/projects/fixtures/packages/client/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-react": "^2.0.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/vue/fixtures/package.json
+++ b/e2e/vue/fixtures/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-babel": "^1.2.1",
     "@rsbuild/plugin-vue": "^1.2.9",
     "@rsbuild/plugin-vue-jsx": "^2.0.1",

--- a/examples/react-rsbuild/package.json
+++ b/examples/react-rsbuild/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rstest/adapter-rsbuild": "workspace:*",
     "@testing-library/dom": "^10.4.1",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rstest/core": "workspace:*",
     "@testing-library/dom": "^10.4.1",

--- a/examples/svelte-rsbuild/package.json
+++ b/examples/svelte-rsbuild/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-svelte": "^2.0.0",
     "@rstest/adapter-rsbuild": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -13,7 +13,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-babel": "^1.2.1",
     "@rsbuild/plugin-vue": "^1.2.9",
     "@rsbuild/plugin-vue-jsx": "^2.0.1",

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -35,7 +35,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rslib/core": "0.22.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*"

--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rsbuild/plugin-svgr": "^2.0.3",
     "@tailwindcss/postcss": "^4.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "test": "npx rstest --globals"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@types/chai": "^5.2.3"
   },
   "devDependencies": {

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -41,7 +41,7 @@
     "v8-to-istanbul": "^9.3.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rslib/core": "0.22.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -104,7 +104,7 @@
     "workspaceContains:**/*rstest.{workspace,projects}*.{ts,js,mjs,cjs,cts,mts,json}"
   ],
   "devDependencies": {
-    "@rsbuild/core": "~2.0.12",
+    "@rsbuild/core": "~2.0.14",
     "@rslib/core": "0.22.0",
     "@rstest/core": "workspace:*",
     "@swc/core": "^1.15.40",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.12
-        version: 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
+        version: 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
       '@rslint/core':
         specifier: ^0.5.3
         version: 0.5.3(jiti@2.7.0)
@@ -60,10 +60,10 @@ importers:
         version: 3.0.2(prettier@3.8.3)
       rsbuild-plugin-arethetypeswrong:
         specifier: ^0.3.1
-        version: 0.3.1(@rsbuild/core@2.0.12)(typescript@6.0.3)
+        version: 0.3.1(@rsbuild/core@2.0.14)(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.12)
+        version: 0.3.4(@rsbuild/core@2.0.14)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -95,11 +95,11 @@ importers:
   e2e:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.22.0
         version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
@@ -219,11 +219,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -312,7 +312,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -366,11 +366,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -400,11 +400,11 @@ importers:
         version: 3.5.35(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
+        version: 1.2.9(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -428,11 +428,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -462,11 +462,11 @@ importers:
         version: 3.5.35(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
+        version: 1.2.9(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -516,7 +516,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -570,17 +570,17 @@ importers:
         version: 3.5.35(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-babel':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@2.0.12)
+        version: 1.2.1(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
+        version: 1.2.9(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.0)(@rsbuild/core@2.0.12)
+        version: 2.0.1(@babel/core@7.29.0)(@rsbuild/core@2.0.14)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -611,7 +611,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -659,11 +659,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -699,11 +699,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -740,7 +740,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rspack/cli':
         specifier: ~2.0.8
         version: 2.0.8(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@rspack/dev-server@2.0.3(@rspack/core@2.0.8(@swc/helpers@0.5.23)))
@@ -833,11 +833,11 @@ importers:
   examples/svelte-rsbuild:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-svelte':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.12)(less@4.6.4)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@6.0.3)
+        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(less@4.6.4)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@6.0.3)
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -861,17 +861,17 @@ importers:
         version: 3.5.35(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-babel':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@2.0.12)
+        version: 1.2.1(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
+        version: 1.2.9(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.0)(@rsbuild/core@2.0.12)
+        version: 2.0.1(@babel/core@7.29.0)(@rsbuild/core@2.0.14)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -894,8 +894,8 @@ importers:
   packages/adapter-rsbuild:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rslib/core':
         specifier: 0.22.0
         version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
@@ -1043,14 +1043,14 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.0.3(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -1070,8 +1070,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@types/chai':
         specifier: ^5.2.3
         version: 5.2.3
@@ -1093,13 +1093,13 @@ importers:
         version: 7.58.8(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
+        version: 1.6.4(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.12)
+        version: 1.4.6(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.12)
+        version: 1.5.3(@rsbuild/core@2.0.14)
       '@rslib/core':
         specifier: 0.22.0
         version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
@@ -1279,8 +1279,8 @@ importers:
         version: 9.3.0
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rslib/core':
         specifier: 0.22.0
         version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
@@ -1312,8 +1312,8 @@ importers:
   packages/vscode:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.12
-        version: 2.0.12
+        specifier: ~2.0.14
+        version: 2.0.14
       '@rslib/core':
         specifier: 0.22.0
         version: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)
@@ -1384,7 +1384,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.12)
+        version: 1.5.3(@rsbuild/core@2.0.14)
       '@rspress/core':
         specifier: 2.0.14
         version: 2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
@@ -1414,10 +1414,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@2.0.12)
+        version: 1.0.6(@rsbuild/core@2.0.14)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.0.12)
+        version: 1.1.3(@rsbuild/core@2.0.14)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
         version: 1.0.4(@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
@@ -2819,8 +2819,8 @@ packages:
     resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
-  '@rsbuild/core@2.0.12':
-    resolution: {integrity: sha512-6f0M9TO4pAeM/VAshg9PajYK4IbfUB21Xun2kT0q3/SbBQ607KzkQZ6fmReuKUKCLbo26tGnbgg5P77eDDcfaA==}
+  '@rsbuild/core@2.0.14':
+    resolution: {integrity: sha512-SSPer6vM+v82CV6JXIOzyyT++A1ECgsVvvUuveD5rfGxX/W58vWGnB+zWcYbMfYOjTntD+9ve6QGGh6kBjPx6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -9501,14 +9501,14 @@ snapshots:
 
   '@remix-run/router@1.23.3': {}
 
-  '@rsbuild/core@2.0.12':
+  '@rsbuild/core@2.0.14':
     dependencies:
       '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.0.12)':
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.0.14)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -9517,11 +9517,11 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.12)':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.14)':
     dependencies:
       acorn: 8.16.0
       browserslist-to-es-version: 1.2.0
@@ -9529,21 +9529,21 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
       less-loader: 12.3.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(less@4.6.4)(webpack@5.107.2)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.0.12)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.0.14)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9569,18 +9569,18 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.8(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.12)':
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.14)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9588,15 +9588,15 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
 
-  '@rsbuild/plugin-svelte@2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.12)(less@4.6.4)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@6.0.3)':
+  '@rsbuild/plugin-svelte@2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(less@4.6.4)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@6.0.3)':
     dependencies:
       svelte: 5.56.3
       svelte-loader: 3.2.4(svelte@5.56.3)
       svelte-preprocess: 6.0.5(@babel/core@7.29.0)(less@4.6.4)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -9609,37 +9609,37 @@ snapshots:
       - sugarss
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-vue-jsx@2.0.1(@babel/core@7.29.0)(@rsbuild/core@2.0.12)':
+  '@rsbuild/plugin-vue-jsx@2.0.1(@babel/core@7.29.0)(@rsbuild/core@2.0.14)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.0.12)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.0.14)
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       babel-plugin-vue-jsx-hmr: 1.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))':
+  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       rspack-vue-loader: 17.5.0(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.5.35(typescript@6.0.3))
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -9647,9 +9647,9 @@ snapshots:
 
   '@rsdoctor/client@1.5.12': {}
 
-  '@rsdoctor/core@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)':
+  '@rsdoctor/core@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.12)
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.14)
       '@rsdoctor/graph': 1.5.12(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
       '@rsdoctor/sdk': 1.5.12(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
       '@rsdoctor/types': 1.5.12(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
@@ -9682,9 +9682,9 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)':
+  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)':
     dependencies:
-      '@rsdoctor/core': 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
+      '@rsdoctor/core': 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
       '@rsdoctor/graph': 1.5.12(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
       '@rsdoctor/sdk': 1.5.12(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
       '@rsdoctor/types': 1.5.12(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.107.2)
@@ -9750,8 +9750,8 @@ snapshots:
 
   '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.12
-      rsbuild-plugin-dts: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.12)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.14
+      rsbuild-plugin-dts: 0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.14)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.8(@types/node@22.18.6)
       typescript: 6.0.3
@@ -9928,8 +9928,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.0.12
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.12)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.0.14
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.14)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.14
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -9989,7 +9989,7 @@ snapshots:
 
   '@rspress/shared@2.0.14':
     dependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
       '@shikijs/rehype': 4.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -14429,34 +14429,34 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.0.12)(typescript@6.0.3):
+  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.0.14)(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
 
-  rsbuild-plugin-dts@0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.12)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.22.0(@microsoft/api-extractor@7.58.8(@types/node@22.18.6))(@rsbuild/core@2.0.14)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.8(@types/node@22.18.6)
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.0.12):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.0.14):
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.0.12):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.0.14):
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.12):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.14):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.0.12
+      '@rsbuild/core': 2.0.14
 
   rslog@2.1.3: {}
 


### PR DESCRIPTION
## Summary

- Update workspace `@rsbuild/core` dependencies from `~2.0.12` to `~2.0.14` and refresh the pnpm lockfile.
- Confirm `@rspack/core` is already on the latest `2.0.8`, so no manifest change is needed for it.
- No runtime code changes are included.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.14

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).