### PR TITLE
test(browser): stabilize basic interval fixture

### DIFF
--- a/e2e/browser-mode/fixtures/basic/tests/async.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/async.test.ts
@@ -59,12 +59,23 @@ describe('Async operations', () => {
   it('should handle setInterval', async () => {
     let count = 0;
 
-    const intervalId = globalThis.setInterval(() => {
-      count++;
-    }, 20);
+    await new Promise<void>((resolve, reject) => {
+      const intervalId = globalThis.setInterval(() => {
+        count++;
+        if (count >= 2) {
+          globalThis.clearTimeout(timeoutId);
+          globalThis.clearInterval(intervalId);
+          resolve();
+        }
+      }, 20);
 
-    await sleep(120);
-    globalThis.clearInterval(intervalId);
+      const timeoutId = globalThis.setTimeout(() => {
+        globalThis.clearInterval(intervalId);
+        reject(
+          new Error(`Expected interval to tick at least twice, got ${count}`),
+        );
+      }, 1000);
+    });
 
     expect(count).toBeGreaterThanOrEqual(2);
   });


### PR DESCRIPTION
## Summary

This PR stabilizes the browser-mode basic async fixture after the e2e optimization in #1408. The `setInterval` case now waits until the interval actually ticks twice instead of sleeping for a fixed 120ms window, which avoids flaky failures when browser scheduling is slower under the combined basic test run.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1408

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).