### PR TITLE
fix(browser): preserve dot dirs in context exclude globs

### DIFF
--- a/e2e/browser-mode/config.test.ts
+++ b/e2e/browser-mode/config.test.ts
@@ -12,6 +12,7 @@ describe('browser mode - config options', () => {
     const { expectExecSuccess, cli } = await runBrowserCli('config');
     await expectExecSuccess();
     expect(cli.stdout).toMatch(/Tests.*passed/);
+    expect(cli.stdout).toContain('git/source-dir.test.ts');
   });
 
   it('should respect customized output.distPath.root', async () => {

--- a/e2e/browser-mode/fixtures/config/git/source-dir.test.ts
+++ b/e2e/browser-mode/fixtures/config/git/source-dir.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('browser context exclude glob', () => {
+  it('does not exclude bare git source directories', () => {
+    expect(location.href).toContain('localhost');
+  });
+});

--- a/e2e/browser-mode/fixtures/config/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/config/rstest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
     headless: true,
     port: BROWSER_PORTS.config,
   },
-  include: ['./*.test.ts'],
+  include: ['./*.test.ts', './git/*.test.ts'],
   testTimeout: BROWSER_TEST_TIMEOUT,
   globals: true,
   source: {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -629,6 +629,7 @@ const globToRegexp = (glob: string): RegExp => {
     fastpaths: false,
     noglobstar: false,
     bash: false,
+    dot: true,
   });
 
   if (!regex) {
@@ -721,7 +722,11 @@ export const createBrowserContextExcludeRegExp = (
     return null;
   }
 
-  const projectRootSource = escapeRegExp(normalizePathForRegExp(projectRoot));
+  const normalizedProjectRoot = normalizePathForRegExp(projectRoot).replace(
+    /[\\/]$/,
+    '',
+  );
+  const projectRootSource = escapeRegExp(normalizedProjectRoot);
   let source = excludeRegExp.source;
   if (source.startsWith('^')) {
     source = source.substring(1);
@@ -730,9 +735,12 @@ export const createBrowserContextExcludeRegExp = (
     source = source.substring(0, source.length - 1);
   }
 
-  const relativeSource = `(?:\\.)?(?:${source})`;
+  const relativeSource = `(?:(?:${source})|\\.(?:${source}))`;
+  const absoluteSource = normalizedProjectRoot
+    ? `${projectRootSource}(?=[\\/])(?:${source})`
+    : `(?:${source})`;
   return new RegExp(
-    `^(?:(?![A-Za-z]:[\\/]|[\\/])${relativeSource}|${projectRootSource}(?:${source}))$`,
+    `^(?:(?![A-Za-z]:[\\/]|[\\/])${relativeSource}|${absoluteSource})$`,
   );
 };
 

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -730,8 +730,9 @@ export const createBrowserContextExcludeRegExp = (
     source = source.substring(0, source.length - 1);
   }
 
+  const relativeSource = `(?:\\.)?(?:${source})`;
   return new RegExp(
-    `^(?:(?![A-Za-z]:[\\/]|[\\/])(?:${source})|${projectRootSource}(?:${source}))$`,
+    `^(?:(?![A-Za-z]:[\\/]|[\\/])${relativeSource}|${projectRootSource}(?:${source}))$`,
   );
 };
 

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -730,7 +730,9 @@ export const createBrowserContextExcludeRegExp = (
     source = source.substring(0, source.length - 1);
   }
 
-  return new RegExp(`^(?:${projectRootSource}[\\\\/])?(?:${source})$`);
+  return new RegExp(
+    `^(?:(?![A-Za-z]:[\\/]|[\\/])(?:${source})|${projectRootSource}(?:${source}))$`,
+  );
 };
 
 type StatsModule = {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -687,6 +687,54 @@ const escapeRegExp = (value: string): string =>
 const normalizePathForRegExp = (value: string): string =>
   normalize(value).replaceAll('\\', '/');
 
+const normalizeExcludePatternForRegExp = (value: string): string =>
+  value.startsWith('./')
+    ? `./${normalizePathForRegExp(value.substring(2))}`
+    : normalizePathForRegExp(value);
+
+const isEscapedRegExpCharacter = (source: string, index: number): boolean => {
+  let backslashCount = 0;
+  for (
+    let current = index - 1;
+    current >= 0 && source[current] === '\\';
+    current--
+  ) {
+    backslashCount++;
+  }
+  return backslashCount % 2 === 1;
+};
+
+const replacePathSeparatorsInRegExpSource = (source: string): string => {
+  let result = '';
+  let inCharacterClass = false;
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index];
+    const isEscaped = isEscapedRegExpCharacter(source, index);
+
+    if (character === '[' && !isEscaped) {
+      inCharacterClass = true;
+    }
+
+    if (!inCharacterClass && character === '\\' && source[index + 1] === '/') {
+      result += PATH_SEPARATOR_SOURCE;
+      index++;
+      continue;
+    }
+
+    result += character;
+
+    if (character === ']' && !isEscaped) {
+      inCharacterClass = false;
+    }
+  }
+
+  return result;
+};
+
+const normalizeRegExpPathSeparators = (regex: RegExp): RegExp =>
+  new RegExp(replacePathSeparatorsInRegExpSource(regex.source));
+
 /**
  * Convert exclude patterns to a RegExp for import.meta.webpackContext's exclude option
  * This is used at compile time to filter out files during bundling
@@ -697,7 +745,9 @@ const normalizePathForRegExp = (value: string): string =>
  */
 const excludePatternsToRegExp = (patterns: string[]): RegExp | null => {
   const sources = patterns.map((pattern) => {
-    const regex = globToRegexp(normalizePathForRegExp(pattern));
+    const regex = normalizeRegExpPathSeparators(
+      globToRegexp(normalizeExcludePatternForRegExp(pattern)),
+    );
     let source = regex.source;
     if (source.startsWith('^')) {
       source = source.substring(1);
@@ -705,7 +755,7 @@ const excludePatternsToRegExp = (patterns: string[]): RegExp | null => {
     if (source.endsWith('$')) {
       source = source.substring(0, source.length - 1);
     }
-    return source.replaceAll('\\/', PATH_SEPARATOR_SOURCE);
+    return replacePathSeparatorsInRegExpSource(source);
   });
 
   if (sources.length === 0) {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -741,6 +741,27 @@ type BrowserContextExcludeSource = {
   isAbsolute: boolean;
 };
 
+const createRelativeContextExcludeSource = (
+  source: string,
+  normalizedPattern: string,
+): string => {
+  if (normalizedPattern.startsWith('./')) {
+    return source;
+  }
+
+  return normalizedPattern.startsWith('**/')
+    ? `(?:(?:${source})|\\.(?:${source}))`
+    : `(?:(?:${source})|\\.${PATH_SEPARATOR_SOURCE}(?:${source}))`;
+};
+
+const createProjectAbsoluteExcludeSource = (
+  source: string,
+  normalizedPattern: string,
+): string =>
+  normalizedPattern.startsWith('./') || normalizedPattern.startsWith('**/')
+    ? source
+    : `${PATH_SEPARATOR_SOURCE}(?:${source})`;
+
 /**
  * Convert exclude patterns to a RegExp for import.meta.webpackContext's exclude option
  * This is used at compile time to filter out files during bundling
@@ -764,12 +785,19 @@ const excludePatternsToRegExpSources = (
     }
 
     source = replacePathSeparatorsInRegExpSource(source);
+    const isAbsolute = isAbsolutePatternForRegExp(normalizedPattern);
+    const absolute = normalizedPattern.startsWith('./')
+      ? source.substring(2)
+      : source;
+
     return {
-      relative: source,
-      absolute: normalizedPattern.startsWith('./')
-        ? source.substring(2)
-        : source,
-      isAbsolute: isAbsolutePatternForRegExp(normalizedPattern),
+      relative: isAbsolute
+        ? source
+        : createRelativeContextExcludeSource(source, normalizedPattern),
+      absolute: isAbsolute
+        ? absolute
+        : createProjectAbsoluteExcludeSource(absolute, normalizedPattern),
+      isAbsolute,
     };
   });
 
@@ -812,7 +840,7 @@ export const createBrowserContextExcludeRegExp = (
     const absolutePatternSource = `(?:${relativeExcludeSources
       .map((source) => source.absolute)
       .join('|')})`;
-    const relativeSource = `(?:(?:${relativePatternSource})|\\.(?:${relativePatternSource}))`;
+    const relativeSource = `(?:${relativePatternSource})`;
     const absoluteSource = normalizedProjectRoot
       ? `${projectRootSource}(?=${PATH_SEPARATOR_SOURCE})(?:${absolutePatternSource})`
       : `(?:${absolutePatternSource})`;

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -676,44 +676,61 @@ const globPatternsToRegExp = (patterns: string[]): RegExp => {
   return new RegExp(`(?:${regexParts.join('|')})$`);
 };
 
+const REGEXP_SPECIAL_CHARACTERS = /[|\\{}()[\]^$+*?.]/g;
+
+const escapeRegExp = (value: string): string =>
+  value.replace(REGEXP_SPECIAL_CHARACTERS, '\\$&');
+
+const normalizePathForRegExp = (value: string): string =>
+  normalize(value).replaceAll('\\', '/');
+
 /**
  * Convert exclude patterns to a RegExp for import.meta.webpackContext's exclude option
  * This is used at compile time to filter out files during bundling
  *
  * Example:
  *   Input: ['**\/node_modules\/**', '**\/dist\/**']
- *   Output: /[\\/](node_modules|dist)[\\/]/
+ *   Output: a regexp matching node_modules or dist path segments.
  */
 const excludePatternsToRegExp = (patterns: string[]): RegExp | null => {
-  const keywords: string[] = [];
-  for (const pattern of patterns) {
-    // Extract the core part between ** wildcards
-    // e.g., '**/node_modules/**' -> 'node_modules'
-    // e.g., '**/dist/**' -> 'dist'
-    // e.g., '**/.{idea,git,cache,output,temp}/**' -> extract each part
-    const match = pattern.match(
-      /\*\*\/\.?\{?([^/*{}]+(?:,[^/*{}]+)*)\}?\/?\*?\*?/,
-    );
-    if (match) {
-      // Handle {a,b,c} patterns
-      const parts = match[1]!.split(',');
-      for (const part of parts) {
-        // Clean up the part (remove leading dots for hidden dirs)
-        const cleaned = part.replace(/^\./, '');
-        if (cleaned && !keywords.includes(cleaned)) {
-          keywords.push(cleaned);
-        }
-      }
+  const sources = patterns.map((pattern) => {
+    const regex = globToRegexp(normalizePathForRegExp(pattern));
+    let source = regex.source;
+    if (source.startsWith('^')) {
+      source = source.substring(1);
     }
-  }
+    if (source.endsWith('$')) {
+      source = source.substring(0, source.length - 1);
+    }
+    return source.replaceAll('\\/', '[\\\\/]');
+  });
 
-  if (keywords.length === 0) {
+  if (sources.length === 0) {
     return null;
   }
 
-  // Create regex that matches paths containing these directory names
-  // Use [\\/] to match both forward and back slashes
-  return new RegExp(`[\\\\/](${keywords.join('|')})[\\\\/]`);
+  return new RegExp(`^(?:${sources.join('|')})$`);
+};
+
+export const createBrowserContextExcludeRegExp = (
+  patterns: string[],
+  projectRoot: string,
+): RegExp | null => {
+  const excludeRegExp = excludePatternsToRegExp(patterns);
+  if (!excludeRegExp) {
+    return null;
+  }
+
+  const projectRootSource = escapeRegExp(normalizePathForRegExp(projectRoot));
+  let source = excludeRegExp.source;
+  if (source.startsWith('^')) {
+    source = source.substring(1);
+  }
+  if (source.endsWith('$')) {
+    source = source.substring(0, source.length - 1);
+  }
+
+  return new RegExp(`^(?:${projectRootSource}[\\\\/])?(?:${source})$`);
 };
 
 type StatsModule = {
@@ -1087,7 +1104,10 @@ const generateManifestModule = ({
       project.normalizedConfig.include,
     );
     const excludePatterns = project.normalizedConfig.exclude.patterns;
-    const excludeRegExp = excludePatternsToRegExp(excludePatterns);
+    const excludeRegExp = createBrowserContextExcludeRegExp(
+      excludePatterns,
+      projectRootPosix,
+    );
 
     lines.push(
       `const ${varName} = import.meta.webpackContext(${JSON.stringify(projectRootPosix)}, {`,

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -692,6 +692,9 @@ const normalizeExcludePatternForRegExp = (value: string): string =>
     ? `./${normalizePathForRegExp(value.substring(2))}`
     : normalizePathForRegExp(value);
 
+const isAbsolutePatternForRegExp = (value: string): boolean =>
+  value.startsWith('/') || /^[A-Za-z]:\//.test(value);
+
 const isEscapedRegExpCharacter = (source: string, index: number): boolean => {
   let backslashCount = 0;
   for (
@@ -735,6 +738,7 @@ const replacePathSeparatorsInRegExpSource = (source: string): string => {
 type BrowserContextExcludeSource = {
   relative: string;
   absolute: string;
+  isAbsolute: boolean;
 };
 
 /**
@@ -765,6 +769,7 @@ const excludePatternsToRegExpSources = (
       absolute: normalizedPattern.startsWith('./')
         ? source.substring(2)
         : source,
+      isAbsolute: isAbsolutePatternForRegExp(normalizedPattern),
     };
   });
 
@@ -792,20 +797,41 @@ export const createBrowserContextExcludeRegExp = (
     .split('/')
     .map(escapeRegExp)
     .join(PATH_SEPARATOR_SOURCE);
-  const relativePatternSource = `(?:${excludeSources
-    .map((source) => source.relative)
-    .join('|')})`;
-  const absolutePatternSource = `(?:${excludeSources
-    .map((source) => source.absolute)
-    .join('|')})`;
-
-  const relativeSource = `(?:(?:${relativePatternSource})|\\.(?:${relativePatternSource}))`;
-  const absoluteSource = normalizedProjectRoot
-    ? `${projectRootSource}(?=${PATH_SEPARATOR_SOURCE})(?:${absolutePatternSource})`
-    : `(?:${absolutePatternSource})`;
-  return new RegExp(
-    `^(?:(?!${WINDOWS_ABSOLUTE_PATH_SOURCE}|${PATH_SEPARATOR_SOURCE})${relativeSource}|${absoluteSource})$`,
+  const relativeExcludeSources = excludeSources.filter(
+    (source) => !source.isAbsolute,
   );
+  const absoluteExcludeSources = excludeSources.filter(
+    (source) => source.isAbsolute,
+  );
+  const sourceBranches: string[] = [];
+
+  if (relativeExcludeSources.length > 0) {
+    const relativePatternSource = `(?:${relativeExcludeSources
+      .map((source) => source.relative)
+      .join('|')})`;
+    const absolutePatternSource = `(?:${relativeExcludeSources
+      .map((source) => source.absolute)
+      .join('|')})`;
+    const relativeSource = `(?:(?:${relativePatternSource})|\\.(?:${relativePatternSource}))`;
+    const absoluteSource = normalizedProjectRoot
+      ? `${projectRootSource}(?=${PATH_SEPARATOR_SOURCE})(?:${absolutePatternSource})`
+      : `(?:${absolutePatternSource})`;
+
+    sourceBranches.push(
+      `(?!${WINDOWS_ABSOLUTE_PATH_SOURCE}|${PATH_SEPARATOR_SOURCE})${relativeSource}`,
+      absoluteSource,
+    );
+  }
+
+  if (absoluteExcludeSources.length > 0) {
+    sourceBranches.push(
+      `(?:${absoluteExcludeSources
+        .map((source) => source.relative)
+        .join('|')})`,
+    );
+  }
+
+  return new RegExp(`^(?:${sourceBranches.join('|')})$`);
 };
 
 type StatsModule = {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -732,8 +732,10 @@ const replacePathSeparatorsInRegExpSource = (source: string): string => {
   return result;
 };
 
-const normalizeRegExpPathSeparators = (regex: RegExp): RegExp =>
-  new RegExp(replacePathSeparatorsInRegExpSource(regex.source));
+type BrowserContextExcludeSource = {
+  relative: string;
+  absolute: string;
+};
 
 /**
  * Convert exclude patterns to a RegExp for import.meta.webpackContext's exclude option
@@ -743,11 +745,12 @@ const normalizeRegExpPathSeparators = (regex: RegExp): RegExp =>
  *   Input: ['**\/node_modules\/**', '**\/dist\/**']
  *   Output: a regexp matching node_modules or dist path segments.
  */
-const excludePatternsToRegExp = (patterns: string[]): RegExp | null => {
+const excludePatternsToRegExpSources = (
+  patterns: string[],
+): BrowserContextExcludeSource[] | null => {
   const sources = patterns.map((pattern) => {
-    const regex = normalizeRegExpPathSeparators(
-      globToRegexp(normalizeExcludePatternForRegExp(pattern)),
-    );
+    const normalizedPattern = normalizeExcludePatternForRegExp(pattern);
+    const regex = globToRegexp(normalizedPattern);
     let source = regex.source;
     if (source.startsWith('^')) {
       source = source.substring(1);
@@ -755,22 +758,29 @@ const excludePatternsToRegExp = (patterns: string[]): RegExp | null => {
     if (source.endsWith('$')) {
       source = source.substring(0, source.length - 1);
     }
-    return replacePathSeparatorsInRegExpSource(source);
+
+    source = replacePathSeparatorsInRegExpSource(source);
+    return {
+      relative: source,
+      absolute: normalizedPattern.startsWith('./')
+        ? source.substring(2)
+        : source,
+    };
   });
 
   if (sources.length === 0) {
     return null;
   }
 
-  return new RegExp(`^(?:${sources.join('|')})$`);
+  return sources;
 };
 
 export const createBrowserContextExcludeRegExp = (
   patterns: string[],
   projectRoot: string,
 ): RegExp | null => {
-  const excludeRegExp = excludePatternsToRegExp(patterns);
-  if (!excludeRegExp) {
+  const excludeSources = excludePatternsToRegExpSources(patterns);
+  if (!excludeSources) {
     return null;
   }
 
@@ -782,18 +792,17 @@ export const createBrowserContextExcludeRegExp = (
     .split('/')
     .map(escapeRegExp)
     .join(PATH_SEPARATOR_SOURCE);
-  let source = excludeRegExp.source;
-  if (source.startsWith('^')) {
-    source = source.substring(1);
-  }
-  if (source.endsWith('$')) {
-    source = source.substring(0, source.length - 1);
-  }
+  const relativePatternSource = `(?:${excludeSources
+    .map((source) => source.relative)
+    .join('|')})`;
+  const absolutePatternSource = `(?:${excludeSources
+    .map((source) => source.absolute)
+    .join('|')})`;
 
-  const relativeSource = `(?:(?:${source})|\\.(?:${source}))`;
+  const relativeSource = `(?:(?:${relativePatternSource})|\\.(?:${relativePatternSource}))`;
   const absoluteSource = normalizedProjectRoot
-    ? `${projectRootSource}(?=${PATH_SEPARATOR_SOURCE})(?:${source})`
-    : `(?:${source})`;
+    ? `${projectRootSource}(?=${PATH_SEPARATOR_SOURCE})(?:${absolutePatternSource})`
+    : `(?:${absolutePatternSource})`;
   return new RegExp(
     `^(?:(?!${WINDOWS_ABSOLUTE_PATH_SOURCE}|${PATH_SEPARATOR_SOURCE})${relativeSource}|${absoluteSource})$`,
   );

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -678,6 +678,8 @@ const globPatternsToRegExp = (patterns: string[]): RegExp => {
 };
 
 const REGEXP_SPECIAL_CHARACTERS = /[|\\{}()[\]^$+*?.]/g;
+const PATH_SEPARATOR_SOURCE = String.raw`[\\/]`;
+const WINDOWS_ABSOLUTE_PATH_SOURCE = String.raw`[A-Za-z]:[\\/]`;
 
 const escapeRegExp = (value: string): string =>
   value.replace(REGEXP_SPECIAL_CHARACTERS, '\\$&');
@@ -703,7 +705,7 @@ const excludePatternsToRegExp = (patterns: string[]): RegExp | null => {
     if (source.endsWith('$')) {
       source = source.substring(0, source.length - 1);
     }
-    return source.replaceAll('\\/', '[\\\\/]');
+    return source.replaceAll('\\/', PATH_SEPARATOR_SOURCE);
   });
 
   if (sources.length === 0) {
@@ -726,7 +728,10 @@ export const createBrowserContextExcludeRegExp = (
     /[\\/]$/,
     '',
   );
-  const projectRootSource = escapeRegExp(normalizedProjectRoot);
+  const projectRootSource = normalizedProjectRoot
+    .split('/')
+    .map(escapeRegExp)
+    .join(PATH_SEPARATOR_SOURCE);
   let source = excludeRegExp.source;
   if (source.startsWith('^')) {
     source = source.substring(1);
@@ -737,10 +742,10 @@ export const createBrowserContextExcludeRegExp = (
 
   const relativeSource = `(?:(?:${source})|\\.(?:${source}))`;
   const absoluteSource = normalizedProjectRoot
-    ? `${projectRootSource}(?=[\\/])(?:${source})`
+    ? `${projectRootSource}(?=${PATH_SEPARATOR_SOURCE})(?:${source})`
     : `(?:${source})`;
   return new RegExp(
-    `^(?:(?![A-Za-z]:[\\/]|[\\/])${relativeSource}|${absoluteSource})$`,
+    `^(?:(?!${WINDOWS_ABSOLUTE_PATH_SOURCE}|${PATH_SEPARATOR_SOURCE})${relativeSource}|${absoluteSource})$`,
   );
 };
 

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -186,8 +186,27 @@ describe('browser config resolution', () => {
 
     expect(exclude?.test('./fixtures/example.test.ts')).toBe(true);
     expect(exclude?.test('.\\fixtures\\example.test.ts')).toBe(true);
+    expect(exclude?.test('/repo/project/fixtures/example.test.ts')).toBe(true);
+    expect(exclude?.test('/repo/project/src/fixtures/example.test.ts')).toBe(
+      false,
+    );
     expect(exclude?.test('fixtures/example.test.ts')).toBe(false);
     expect(exclude?.test('./src/fixtures/example.test.ts')).toBe(false);
+  });
+
+  it('should match dot-prefixed browser context exclude patterns on Windows absolute paths', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['./fixtures/**'],
+      'C:\\repo\\project',
+    );
+
+    expect(exclude?.test('C:\\repo\\project\\fixtures\\example.test.ts')).toBe(
+      true,
+    );
+    expect(
+      exclude?.test('C:\\repo\\project\\src\\fixtures\\example.test.ts'),
+    ).toBe(false);
+    expect(exclude?.test('.\\fixtures\\example.test.ts')).toBe(true);
   });
 
   it('should scope Windows absolute browser context exclude patterns to project root', () => {

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -160,6 +160,8 @@ describe('browser config resolution', () => {
     );
     expect(exclude?.test('tests/example.test.ts')).toBe(false);
     expect(exclude?.test('.git/config')).toBe(true);
+    expect(exclude?.test('./.git/config')).toBe(true);
+    expect(exclude?.test('./node_modules/pkg/index.js')).toBe(true);
   });
 
   it('should apply absolute browser context exclude patterns from project root', () => {
@@ -172,6 +174,7 @@ describe('browser config resolution', () => {
     expect(exclude?.test('/tmp/.cache/app/.cache/output.js')).toBe(true);
     expect(exclude?.test('tests/example.test.ts')).toBe(false);
     expect(exclude?.test('.cache/output.js')).toBe(true);
+    expect(exclude?.test('./.cache/output.js')).toBe(true);
   });
 
   it('should normalize setup file paths before filtering lazy compilation', () => {

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -3,6 +3,7 @@ import type { ProjectContext, Rstest } from '@rstest/core/internal/browser';
 import {
   createBrowserLazyCompilationConfig,
   createBrowserRsbuildDevConfig,
+  createBrowserContextExcludeRegExp,
   resolveListenPort,
 } from '../src/hostController';
 
@@ -136,6 +137,29 @@ describe('browser config resolution', () => {
         nameForCondition: () => '/project/tests/example.test.tsx',
       }),
     ).toBe(true);
+  });
+
+  it('should keep leading dots in browser context exclude patterns', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/.{idea,git,cache,output,temp}/**',
+      ],
+      '/repo/git/project',
+    );
+
+    expect(exclude?.test('/repo/git/project/tests/example.test.ts')).toBe(
+      false,
+    );
+    expect(exclude?.test('/repo/git/project/.git/config')).toBe(true);
+    expect(exclude?.test('/repo/git/project/.cache/output.js')).toBe(true);
+    expect(exclude?.test('/repo/git/project/cache/output.js')).toBe(false);
+    expect(exclude?.test('/repo/git/project/node_modules/pkg/index.js')).toBe(
+      true,
+    );
+    expect(exclude?.test('tests/example.test.ts')).toBe(false);
+    expect(exclude?.test('.git/config')).toBe(true);
   });
 
   it('should normalize setup file paths before filtering lazy compilation', () => {

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -162,6 +162,18 @@ describe('browser config resolution', () => {
     expect(exclude?.test('.git/config')).toBe(true);
   });
 
+  it('should apply absolute browser context exclude patterns from project root', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['**/.{idea,git,cache,output,temp}/**'],
+      '/tmp/.cache/app',
+    );
+
+    expect(exclude?.test('/tmp/.cache/app/tests/example.test.ts')).toBe(false);
+    expect(exclude?.test('/tmp/.cache/app/.cache/output.js')).toBe(true);
+    expect(exclude?.test('tests/example.test.ts')).toBe(false);
+    expect(exclude?.test('.cache/output.js')).toBe(true);
+  });
+
   it('should normalize setup file paths before filtering lazy compilation', () => {
     const lazyCompilation = createBrowserLazyCompilationConfig([
       '/project/tests/rstest.setup.ts',

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -194,6 +194,18 @@ describe('browser config resolution', () => {
     expect(exclude?.test('./src/fixtures/example.test.ts')).toBe(false);
   });
 
+  it('should match non-globstar relative browser context exclude patterns with ./ prefixes', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['dist/**'],
+      '/repo/project',
+    );
+
+    expect(exclude?.test('dist/example.test.ts')).toBe(true);
+    expect(exclude?.test('./dist/example.test.ts')).toBe(true);
+    expect(exclude?.test('/repo/project/dist/example.test.ts')).toBe(true);
+    expect(exclude?.test('/repo/project/src/dist/example.test.ts')).toBe(false);
+  });
+
   it('should match dot-prefixed browser context exclude patterns on Windows absolute paths', () => {
     const exclude = createBrowserContextExcludeRegExp(
       ['./fixtures/**'],

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -209,6 +209,42 @@ describe('browser config resolution', () => {
     expect(exclude?.test('.\\fixtures\\example.test.ts')).toBe(true);
   });
 
+  it('should not prefix POSIX absolute browser context exclude patterns twice', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['/repo/project/fixtures/**'],
+      '/repo/project',
+    );
+
+    expect(exclude?.test('/repo/project/fixtures/example.test.ts')).toBe(true);
+    expect(exclude?.test('/repo/project/src/fixtures/example.test.ts')).toBe(
+      false,
+    );
+    expect(
+      exclude?.test('/repo/project/repo/project/fixtures/example.test.ts'),
+    ).toBe(false);
+    expect(exclude?.test('./fixtures/example.test.ts')).toBe(false);
+  });
+
+  it('should not prefix Windows absolute browser context exclude patterns twice', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['C:\\repo\\project\\fixtures\\**'],
+      'C:\\repo\\project',
+    );
+
+    expect(exclude?.test('C:\\repo\\project\\fixtures\\example.test.ts')).toBe(
+      true,
+    );
+    expect(
+      exclude?.test('C:\\repo\\project\\src\\fixtures\\example.test.ts'),
+    ).toBe(false);
+    expect(
+      exclude?.test(
+        'C:\\repo\\project\\C:\\repo\\project\\fixtures\\example.test.ts',
+      ),
+    ).toBe(false);
+    expect(exclude?.test('.\\fixtures\\example.test.ts')).toBe(false);
+  });
+
   it('should scope Windows absolute browser context exclude patterns to project root', () => {
     const exclude = createBrowserContextExcludeRegExp(
       ['**/dist/**'],

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -178,6 +178,18 @@ describe('browser config resolution', () => {
     expect(exclude?.test('./.cache/output.js')).toBe(true);
   });
 
+  it('should match dot-prefixed browser context exclude patterns', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['./fixtures/**'],
+      '/repo/project',
+    );
+
+    expect(exclude?.test('./fixtures/example.test.ts')).toBe(true);
+    expect(exclude?.test('.\\fixtures\\example.test.ts')).toBe(true);
+    expect(exclude?.test('fixtures/example.test.ts')).toBe(false);
+    expect(exclude?.test('./src/fixtures/example.test.ts')).toBe(false);
+  });
+
   it('should scope Windows absolute browser context exclude patterns to project root', () => {
     const exclude = createBrowserContextExcludeRegExp(
       ['**/dist/**'],

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -178,6 +178,36 @@ describe('browser config resolution', () => {
     expect(exclude?.test('./.cache/output.js')).toBe(true);
   });
 
+  it('should scope Windows absolute browser context exclude patterns to project root', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['**/dist/**'],
+      'C:\\repo\\dist\\project',
+    );
+
+    expect(
+      exclude?.test('C:\\repo\\dist\\project\\tests\\example.test.ts'),
+    ).toBe(false);
+    expect(exclude?.test('C:\\repo\\dist\\project\\dist\\output.js')).toBe(
+      true,
+    );
+    expect(
+      exclude?.test('C:\\repo\\dist\\project-other\\dist\\output.js'),
+    ).toBe(false);
+    expect(exclude?.test('dist\\output.js')).toBe(true);
+  });
+
+  it('should apply hidden-dir browser context exclude patterns on Windows paths', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['**/.{idea,git,cache,output,temp}/**'],
+      'C:\\tmp\\.cache\\app',
+    );
+
+    expect(exclude?.test('C:\\tmp\\.cache\\app\\tests\\example.test.ts')).toBe(
+      false,
+    );
+    expect(exclude?.test('C:\\tmp\\.cache\\app\\.cache\\output.js')).toBe(true);
+  });
+
   it('should match hidden files under browser context exclude patterns', () => {
     const exclude = createBrowserContextExcludeRegExp(
       ['**/dist/**'],

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -152,6 +152,7 @@ describe('browser config resolution', () => {
     expect(exclude?.test('/repo/git/project/tests/example.test.ts')).toBe(
       false,
     );
+    expect(exclude?.test('/repo/git/project-other/.git/config')).toBe(false);
     expect(exclude?.test('/repo/git/project/.git/config')).toBe(true);
     expect(exclude?.test('/repo/git/project/.cache/output.js')).toBe(true);
     expect(exclude?.test('/repo/git/project/cache/output.js')).toBe(false);
@@ -175,6 +176,20 @@ describe('browser config resolution', () => {
     expect(exclude?.test('tests/example.test.ts')).toBe(false);
     expect(exclude?.test('.cache/output.js')).toBe(true);
     expect(exclude?.test('./.cache/output.js')).toBe(true);
+  });
+
+  it('should match hidden files under browser context exclude patterns', () => {
+    const exclude = createBrowserContextExcludeRegExp(
+      ['**/dist/**'],
+      '/repo/project',
+    );
+
+    expect(exclude?.test('./dist/.fixtures/example.test.ts')).toBe(true);
+    expect(exclude?.test('/repo/project/dist/.fixtures/example.test.ts')).toBe(
+      true,
+    );
+    expect(exclude?.test('.dist/.fixtures/example.test.ts')).toBe(false);
+    expect(exclude?.test('./src/.fixtures/example.test.ts')).toBe(false);
   });
 
   it('should normalize setup file paths before filtering lazy compilation', () => {


### PR DESCRIPTION
## Summary

This PR fixes browser mode test context generation so default exclude globs like `**/.{idea,git,cache,output,temp}/**` preserve their leading dot. Previously the browser-side `exclude` regexp reduced hidden-directory globs to bare names such as `git` or `cache`, which could exclude valid tests under source directories or checkout ancestor paths with those names. The fix derives the exclude regexp from picomatch glob conversion and adds unit plus browser e2e regression coverage.

## Related Links

close https://github.com/web-infra-dev/rstest/issues/1425

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).