### PR TITLE
chore(core): add package homepage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "rstack",
     "rspack"
   ],
+  "homepage": "https://rstest.rs",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rstest/issues"
   },
@@ -16,7 +17,6 @@
     "url": "git+https://github.com/web-infra-dev/rstest.git",
     "directory": "packages/core"
   },
-  "homepage": "https://rstest.rs",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "url": "git+https://github.com/web-infra-dev/rstest.git",
     "directory": "packages/core"
   },
+  "homepage": "https://rstest.rs",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

This PR adds the npm package homepage metadata for `@rstest/core`, pointing users from the package registry to the Rstest website.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).