### PR TITLE
docs: update start guide package and example links

### DIFF
--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -48,6 +48,23 @@ Rstack includes the following tools:
 | [Rstest](https://github.com/web-infra-dev/rstest)     | Testing framework        | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 | [Rslint](https://github.com/web-infra-dev/rslint)     | Linter                   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
+## 📦 Core packages
+
+Rstest's base functionality is provided by [@rstest/core](https://github.com/web-infra-dev/rstest/tree/main/packages/core). Other core packages add support for Browser Mode, coverage collection, and reusing Rstack configurations. You can install them as needed for your project.
+
+Rstest includes the following core packages:
+
+| Name                                                                                                      | Description                | Version                                                                                                                                                                                                |
+| --------------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [@rstest/core](https://github.com/web-infra-dev/rstest/tree/main/packages/core)                           | Core testing framework     | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>                           |
+| [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser)                     | Browser Mode support       | <a href="https://npmjs.com/package/@rstest/browser"><img src="https://img.shields.io/npm/v/@rstest/browser?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>                     |
+| [@rstest/browser-react](https://github.com/web-infra-dev/rstest/tree/main/packages/browser-react)         | React component testing    | <a href="https://npmjs.com/package/@rstest/browser-react"><img src="https://img.shields.io/npm/v/@rstest/browser-react?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>         |
+| [@rstest/coverage-v8](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-v8)             | V8 coverage provider       | <a href="https://npmjs.com/package/@rstest/coverage-v8"><img src="https://img.shields.io/npm/v/@rstest/coverage-v8?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>             |
+| [@rstest/coverage-istanbul](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-istanbul) | Istanbul coverage provider | <a href="https://npmjs.com/package/@rstest/coverage-istanbul"><img src="https://img.shields.io/npm/v/@rstest/coverage-istanbul?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a> |
+| [@rstest/adapter-rsbuild](https://github.com/web-infra-dev/rstest/tree/main/packages/adapter-rsbuild)     | Reuse Rsbuild config       | <a href="https://npmjs.com/package/@rstest/adapter-rsbuild"><img src="https://img.shields.io/npm/v/@rstest/adapter-rsbuild?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
+| [@rstest/adapter-rslib](https://github.com/web-infra-dev/rstest/tree/main/packages/adapter-rslib)         | Reuse Rslib config         | <a href="https://npmjs.com/package/@rstest/adapter-rslib"><img src="https://img.shields.io/npm/v/@rstest/adapter-rslib?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>         |
+| [@rstest/adapter-rspack](https://github.com/web-infra-dev/rstest/tree/main/packages/adapter-rspack)       | Reuse Rspack config        | <a href="https://npmjs.com/package/@rstest/adapter-rspack"><img src="https://img.shields.io/npm/v/@rstest/adapter-rspack?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>       |
+
 ## 🔗 Links
 
 - [awesome-rstack](https://github.com/rstackjs/awesome-rstack): A curated list of awesome things related to Rstack.

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -110,3 +110,14 @@ Next, you can execute the test by using the command configured in [Using Rstest]
       Tests 1 passed
    Duration 140 ms (build 17 ms, tests 123 ms)
 ```
+
+## Next steps
+
+If you want to see complete project structures, refer to these common examples:
+
+- [node](https://github.com/web-infra-dev/rstest/tree/main/examples/node): Node.js testing and coverage collection.
+- [react](https://github.com/web-infra-dev/rstest/tree/main/examples/react): React component, hook, and SSR tests with happy-dom.
+- [vue](https://github.com/web-infra-dev/rstest/tree/main/examples/vue): Vue component and SSR testing.
+- [browser-react](https://github.com/web-infra-dev/rstest/tree/main/examples/browser-react): React component testing in Browser Mode.
+
+For more examples, see [Rstest examples](https://github.com/web-infra-dev/rstest/tree/main/examples).

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -48,6 +48,23 @@ Rstack 包含以下工具：
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 | [Rslint](https://github.com/web-infra-dev/rslint)     | 代码检查工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
+## 📦 核心包
+
+Rstest 的基础能力由 [@rstest/core](https://github.com/web-infra-dev/rstest/tree/main/packages/core) 提供，其他核心包则用于补充 Browser Mode、覆盖率和 Rstack 配置复用等场景。你可以根据项目需要按需安装。
+
+Rstest 包含以下核心包：
+
+| 名称                                                                                                      | 描述                     | 版本                                                                                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [@rstest/core](https://github.com/web-infra-dev/rstest/tree/main/packages/core)                           | 测试框架核心包           | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>                           |
+| [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser)                     | Browser Mode 支持        | <a href="https://npmjs.com/package/@rstest/browser"><img src="https://img.shields.io/npm/v/@rstest/browser?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>                     |
+| [@rstest/browser-react](https://github.com/web-infra-dev/rstest/tree/main/packages/browser-react)         | React 组件测试工具       | <a href="https://npmjs.com/package/@rstest/browser-react"><img src="https://img.shields.io/npm/v/@rstest/browser-react?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>         |
+| [@rstest/coverage-v8](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-v8)             | V8 覆盖率 Provider       | <a href="https://npmjs.com/package/@rstest/coverage-v8"><img src="https://img.shields.io/npm/v/@rstest/coverage-v8?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>             |
+| [@rstest/coverage-istanbul](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-istanbul) | Istanbul 覆盖率 Provider | <a href="https://npmjs.com/package/@rstest/coverage-istanbul"><img src="https://img.shields.io/npm/v/@rstest/coverage-istanbul?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a> |
+| [@rstest/adapter-rsbuild](https://github.com/web-infra-dev/rstest/tree/main/packages/adapter-rsbuild)     | 复用 Rsbuild 配置        | <a href="https://npmjs.com/package/@rstest/adapter-rsbuild"><img src="https://img.shields.io/npm/v/@rstest/adapter-rsbuild?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
+| [@rstest/adapter-rslib](https://github.com/web-infra-dev/rstest/tree/main/packages/adapter-rslib)         | 复用 Rslib 配置          | <a href="https://npmjs.com/package/@rstest/adapter-rslib"><img src="https://img.shields.io/npm/v/@rstest/adapter-rslib?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>         |
+| [@rstest/adapter-rspack](https://github.com/web-infra-dev/rstest/tree/main/packages/adapter-rspack)       | 复用 Rspack 配置         | <a href="https://npmjs.com/package/@rstest/adapter-rspack"><img src="https://img.shields.io/npm/v/@rstest/adapter-rspack?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>       |
+
 ## 🔗 链接
 
 - [awesome-rstack](https://github.com/rstackjs/awesome-rstack)：与 Rstack 相关的精彩内容列表。

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -110,3 +110,14 @@ test('should sayHi correctly', () => {
       Tests 1 passed
    Duration 140 ms (build 17 ms, tests 123 ms)
 ```
+
+## 下一步
+
+如果你想查看完整项目结构，可以参考以下常用示例：
+
+- [node](https://github.com/web-infra-dev/rstest/tree/main/examples/node)：Node.js 测试与覆盖率收集。
+- [react](https://github.com/web-infra-dev/rstest/tree/main/examples/react)：使用 happy-dom 的 React 组件、Hook 和 SSR 测试。
+- [vue](https://github.com/web-infra-dev/rstest/tree/main/examples/vue)：Vue 组件与 SSR 测试。
+- [browser-react](https://github.com/web-infra-dev/rstest/tree/main/examples/browser-react)：Browser Mode 下的 React 组件测试。
+
+更多示例请参考 [Rstest examples](https://github.com/web-infra-dev/rstest/tree/main/examples)。


### PR DESCRIPTION
## Summary

This PR updates the start guide docs to better separate quick-start flow from product/package orientation. The introduction page now includes a 📦 Core packages section after the Rstack overview, while the quick-start page ends with a concise next-steps section linking to common examples.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).