### PR TITLE
ci: consolidate static checks in lint workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,10 @@ jobs:
 
       - name: Build Packages
         run: pnpm run build
+        env:
+          # Publish checks are comparatively expensive and only need to run once
+          # as part of the lint/static-check gate.
+          RSTEST_PUBLISH_CHECK: true
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,11 +76,15 @@ jobs:
       - name: Check Dependency Version
         run: pnpm run check-dependency-version
 
-      - name: Check pnpm Dedupe
-        run: pnpm dedupe --check --config.minimum-release-age=0
-
       - name: Check Unused Code
         run: pnpm run check-unused
+
+      - name: Check pnpm Dedupe
+        # Keep dedupe last: `pnpm dedupe --check` may leave pnpm's modules
+        # state needing a reconcile. If another `pnpm run ...` follows it,
+        # pnpm can enter its implicit install path and rerun lifecycle scripts
+        # such as the root `prepare`.
+        run: pnpm dedupe --check --config.minimum-release-age=0
 
   # ======== ut ========
   ut:
@@ -122,13 +126,6 @@ jobs:
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
-
-      - name: Run Type Check
-        # tsc is OS-independent, so PR runs it on macOS only; the post-merge
-        # FULL run still typechecks both OSes so push-to-main stays a literal
-        # superset of PR coverage.
-        if: needs.prepare.outputs.is_full_run == 'true' || matrix.os == 'macos-latest'
-        run: pnpm run typecheck
 
       - name: Run Test
         run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "check-unused": "knip",
     "e2e": "cd e2e && pnpm test && pnpm test:commonjs && pnpm test:no-isolate",
     "format": "prettier --write . && heading-case --write",
-    "lint": "prettier --check . && pnpm run check-spell && pnpm lint:type",
-    "lint:type": "rslint",
+    "lint": "prettier --check . && pnpm run check-spell && pnpm run lint:type",
+    "lint:type": "rslint --type-check",
     "prepare": "lefthook install && pnpm run build",
     "test": "rstest",
     "test:examples": "pnpm --filter \"@examples/*\" test",
     "test:vscode": "pnpm --filter ./packages/vscode test",
-    "typecheck": "rslint --type-check-only"
+    "typecheck": "pnpm run lint:type"
   },
   "devDependencies": {
     "@rsdoctor/rspack-plugin": "^1.5.12",

--- a/scripts/publishCheckPlugins.ts
+++ b/scripts/publishCheckPlugins.ts
@@ -12,6 +12,10 @@ import { pluginPublint } from 'rsbuild-plugin-publint';
  * needing dynamic import are intentional, not bugs.
  */
 export function publishCheckPlugins() {
+  if (process.env.RSTEST_PUBLISH_CHECK !== 'true') {
+    return [];
+  }
+
   return [
     pluginPublint(),
     pluginAreTheTypesWrong({


### PR DESCRIPTION
## Summary

This PR makes the lint workflow the single CI gate for static checks: `lint:type` now runs `rslint --type-check`, `typecheck` reuses it, and the UT workflow no longer runs a separate type-check step. It also prevents the lint-only publish package checks from running in every local/package build by gating `publishCheckPlugins` behind `RSTEST_PUBLISH_CHECK`, which is enabled only for the lint CI build step.

To avoid `Check Unused Code` re-triggering root lifecycle scripts, `pnpm dedupe --check` now runs as the final lint job step. Keeping it last avoids a later `pnpm run ...` entering pnpm's implicit install/reconcile path and rerunning `prepare`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
