### PR TITLE
fix(core): preserve base environment project name

### DIFF
--- a/e2e/watch/index.test.ts
+++ b/e2e/watch/index.test.ts
@@ -60,11 +60,9 @@ describe.skipIf(process.platform === 'win32')('watch', () => {
 
     await cli.waitForStdout('Duration');
     expect(cli.stdout).toMatch('Tests 2 passed');
+    expect(cli.stdout).toMatch('Run all tests in project(rstest).');
     expect(cli.stdout).toMatch(
       'Run all tests in project(rstest-environment-1).',
-    );
-    expect(cli.stdout).toMatch(
-      'Run all tests in project(rstest-environment-2).',
     );
 
     cli.resetStd();

--- a/packages/core/src/core/environmentGroups.ts
+++ b/packages/core/src/core/environmentGroups.ts
@@ -107,10 +107,15 @@ export const groupProjectEntriesByEnvironment = async ({
 
     changed = true;
     let groupIndex = 0;
-    for (const group of groups.values()) {
-      groupIndex += 1;
-      const groupName = formatGroupName(project.name, groupIndex);
-      const environmentName = formatEnvironmentName(groupName);
+    for (const [key, group] of groups) {
+      const isBaseEnvironment = key === baseEnvironmentKey;
+      const groupName = isBaseEnvironment
+        ? project.name
+        : formatGroupName(project.name, (groupIndex += 1));
+      const environmentName = isBaseEnvironment
+        ? project.environmentName
+        : formatEnvironmentName(groupName);
+
       group.config.name = groupName;
 
       groupedProjects.push({

--- a/packages/core/src/utils/environmentComments.ts
+++ b/packages/core/src/utils/environmentComments.ts
@@ -23,6 +23,64 @@ const environmentCommentCache = new Map<string, CachedEnvironmentComment>();
 const isEnvironmentName = (name: string): name is EnvironmentName =>
   SUPPORTED_ENVIRONMENTS.includes(name as EnvironmentName);
 
+const canStartRegexLiteral = (code: string, index: number): boolean => {
+  let cursor = index - 1;
+  while (cursor >= 0 && /\s/.test(code[cursor]!)) {
+    cursor -= 1;
+  }
+
+  if (cursor < 0) {
+    return true;
+  }
+
+  const char = code[cursor]!;
+  if ('([{=,:;!&|?+-*%^~<>'.includes(char)) {
+    return true;
+  }
+
+  return /\b(?:return|throw|case|delete|void|typeof|instanceof|in|yield|await)\s*$/.test(
+    code.slice(0, cursor + 1),
+  );
+};
+
+const skipRegexLiteral = (code: string, index: number): number | null => {
+  let cursor = index + 1;
+  let inCharacterClass = false;
+
+  while (cursor < code.length) {
+    const char = code[cursor]!;
+
+    if (char === '\\') {
+      cursor += 2;
+      continue;
+    }
+
+    if (char === '[') {
+      inCharacterClass = true;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === ']') {
+      inCharacterClass = false;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === '/' && !inCharacterClass) {
+      cursor += 1;
+      while (cursor < code.length && /[a-z]/i.test(code[cursor]!)) {
+        cursor += 1;
+      }
+      return cursor;
+    }
+
+    cursor += 1;
+  }
+
+  return null;
+};
+
 const readCommentText = (code: string): string => {
   const comments: string[] = [];
   let index = 0;
@@ -30,6 +88,49 @@ const readCommentText = (code: string): string => {
   while (index < code.length) {
     const char = code[index];
     const nextChar = code[index + 1];
+
+    if (char === '/' && nextChar === '/') {
+      const start = index + 2;
+      index = start;
+      while (
+        index < code.length &&
+        code[index] !== '\n' &&
+        code[index] !== '\r'
+      ) {
+        index += 1;
+      }
+      comments.push(code.slice(start, index));
+      if (code[index] === '\r' && code[index + 1] === '\n') {
+        index += 2;
+      } else if (code[index] === '\r' || code[index] === '\n') {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === '/' && nextChar === '*') {
+      const start = index + 2;
+      index = start;
+      while (
+        index < code.length &&
+        !(code[index] === '*' && code[index + 1] === '/')
+      ) {
+        index += 1;
+      }
+      comments.push(code.slice(start, index));
+      if (index < code.length) {
+        index += 2;
+      }
+      continue;
+    }
+
+    if (char === '/' && canStartRegexLiteral(code, index)) {
+      const nextIndex = skipRegexLiteral(code, index);
+      if (nextIndex) {
+        index = nextIndex;
+        continue;
+      }
+    }
 
     if (char === '"' || char === "'" || char === '`') {
       const quote = char;
@@ -45,30 +146,6 @@ const readCommentText = (code: string): string => {
           break;
         }
       }
-      continue;
-    }
-
-    if (char === '/' && nextChar === '/') {
-      const start = index + 2;
-      index = start;
-      while (index < code.length && code[index] !== '\n') {
-        index += 1;
-      }
-      comments.push(code.slice(start, index));
-      continue;
-    }
-
-    if (char === '/' && nextChar === '*') {
-      const start = index + 2;
-      index = start;
-      while (
-        index < code.length &&
-        !(code[index] === '*' && code[index + 1] === '/')
-      ) {
-        index += 1;
-      }
-      comments.push(code.slice(start, index));
-      index += 2;
       continue;
     }
 

--- a/packages/core/src/utils/environmentComments.ts
+++ b/packages/core/src/utils/environmentComments.ts
@@ -23,6 +23,61 @@ const environmentCommentCache = new Map<string, CachedEnvironmentComment>();
 const isEnvironmentName = (name: string): name is EnvironmentName =>
   SUPPORTED_ENVIRONMENTS.includes(name as EnvironmentName);
 
+const readCommentText = (code: string): string => {
+  const comments: string[] = [];
+  let index = 0;
+
+  while (index < code.length) {
+    const char = code[index];
+    const nextChar = code[index + 1];
+
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      index += 1;
+      while (index < code.length) {
+        const current = code[index];
+        if (current === '\\') {
+          index += 2;
+          continue;
+        }
+        index += 1;
+        if (current === quote) {
+          break;
+        }
+      }
+      continue;
+    }
+
+    if (char === '/' && nextChar === '/') {
+      const start = index + 2;
+      index = start;
+      while (index < code.length && code[index] !== '\n') {
+        index += 1;
+      }
+      comments.push(code.slice(start, index));
+      continue;
+    }
+
+    if (char === '/' && nextChar === '*') {
+      const start = index + 2;
+      index = start;
+      while (
+        index < code.length &&
+        !(code[index] === '*' && code[index + 1] === '/')
+      ) {
+        index += 1;
+      }
+      comments.push(code.slice(start, index));
+      index += 2;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return comments.join('\n');
+};
+
 const readFileHead = async (file: string): Promise<string> => {
   const handle = await open(file, 'r');
   try {
@@ -48,8 +103,9 @@ export const parseEnvironmentComment = (
     return null;
   }
 
-  const environmentMatch = environmentCommentRE.exec(code);
-  const optionsMatch = environmentOptionsCommentRE.exec(code);
+  const commentText = readCommentText(code);
+  const environmentMatch = environmentCommentRE.exec(commentText);
+  const optionsMatch = environmentOptionsCommentRE.exec(commentText);
 
   if (!environmentMatch && !optionsMatch) {
     return null;

--- a/packages/core/tests/utils/environmentComments.test.ts
+++ b/packages/core/tests/utils/environmentComments.test.ts
@@ -57,6 +57,16 @@ describe('environment comments', () => {
     });
   });
 
+  it('ignores environment markers inside code strings', () => {
+    expect(
+      parseEnvironmentComment(`
+const packageName = '@rstest/core';
+describe('resolveTestEnvironmentFromTarget', () => {});
+const jsdom = '// @rstest-environment jsdom';
+`),
+    ).toBeNull();
+  });
+
   it('merges options when comment keeps the base environment', () => {
     expect(
       applyEnvironmentComment(
@@ -150,6 +160,88 @@ describe('environment comments', () => {
       expect(grouped.changed).toBe(true);
       expect(grouped.projects).toHaveLength(2);
       expect(grouped.projects.every((item) => item._globalSetups)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves the base project name for files without environment comments', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
+    try {
+      const nodeFile = path.join(root, 'node.test.ts');
+      const jsdomFile = path.join(root, 'jsdom.test.ts');
+      writeFileSync(nodeFile, '// node test\n');
+      writeFileSync(jsdomFile, '// @rstest-environment jsdom\n');
+
+      const project = createProject();
+
+      const grouped = await groupProjectEntriesByEnvironment({
+        entriesCache: new Map([
+          [
+            project.environmentName,
+            {
+              entries: {
+                node: nodeFile,
+                jsdom: jsdomFile,
+              },
+            },
+          ],
+        ]),
+        projects: [project],
+      });
+
+      expect(grouped.changed).toBe(true);
+      expect(grouped.projects.map((item) => item.name)).toEqual([
+        'default',
+        'default-environment-1',
+      ]);
+      expect(grouped.projects.map((item) => item.environmentName)).toEqual([
+        'default',
+        'default-environment-1',
+      ]);
+      expect(grouped.entriesCache.get('default')?.entries).toEqual({
+        node: nodeFile,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not split projects when environment markers only appear in code strings', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
+    try {
+      const file = path.join(root, 'code-string.test.ts');
+      writeFileSync(
+        file,
+        `const packageName = '@rstest/core';
+describe('resolveTestEnvironmentFromTarget', () => {});
+const jsdom = '// @rstest-environment jsdom';
+`,
+      );
+
+      const project = createProject();
+
+      const grouped = await groupProjectEntriesByEnvironment({
+        entriesCache: new Map([
+          [
+            project.environmentName,
+            {
+              entries: {
+                file,
+              },
+            },
+          ],
+        ]),
+        projects: [project],
+      });
+
+      expect(grouped.changed).toBe(false);
+      expect(grouped.projects).toEqual([project]);
+      expect(
+        grouped.entriesCache.get(project.environmentName)?.entries,
+      ).toEqual({
+        file,
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/core/tests/utils/environmentComments.test.ts
+++ b/packages/core/tests/utils/environmentComments.test.ts
@@ -67,6 +67,30 @@ const jsdom = '// @rstest-environment jsdom';
     ).toBeNull();
   });
 
+  it('keeps reading comments after regex literals with quotes', () => {
+    expect(
+      parseEnvironmentComment(`
+const regexp = /"/;
+// @rstest-environment jsdom
+`),
+    ).toEqual({
+      name: 'jsdom',
+    });
+  });
+
+  it('parses CRLF line comments without a final newline', () => {
+    expect(
+      parseEnvironmentComment(
+        '// @rstest-environment jsdom\r\n// @rstest-environment-options { "url": "https://example.test/" }\r',
+      ),
+    ).toEqual({
+      name: 'jsdom',
+      options: {
+        url: 'https://example.test/',
+      },
+    });
+  });
+
   it('merges options when comment keeps the base environment', () => {
     expect(
       applyEnvironmentComment(


### PR DESCRIPTION
## Summary

This PR fixes a regression from environment comment grouping where files without environment comments could be reported under synthetic project names such as `core-environment-1`. The base environment group now keeps the original project name, while only comment-created environment groups receive synthetic names. It also restricts environment marker parsing to actual comments so marker-like strings in test code do not accidentally split projects.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1404

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
