### PR TITLE
chore(e2e): skip browser mode in threads run

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,7 @@
     "test": "rstest run",
     "test:commonjs": "cross-env RSTEST_OUTPUT_MODULE=false rstest run",
     "test:no-isolate": "cross-env ISOLATE=false rstest --isolate false",
-    "test:threads": "rstest run --pool.type threads"
+    "test:threads": "cross-env RSTEST_POOL_TYPE=threads rstest run --pool.type threads"
   },
   "devDependencies": {
     "@rsbuild/core": "~2.0.12",

--- a/e2e/rstest.config.mts
+++ b/e2e/rstest.config.mts
@@ -9,6 +9,15 @@ import { defineConfig } from '@rstest/core';
  */
 const NO_ISOLATE_EXCLUDES = ['watch/**', 'mock/**', 'browser-mode/**'];
 
+/**
+ * Test directories to skip in threads mode.
+ *
+ * - browser-mode: browser tests run in Playwright-managed browser contexts/pages,
+ *   not in the Node.js worker pool, so they do not add coverage for the threads
+ *   transport while increasing CI runtime and flake surface.
+ */
+const THREADS_EXCLUDES = ['browser-mode/**'];
+
 export default defineConfig({
   name: 'rstest:e2e',
   setupFiles: ['../scripts/rstest.setup.ts'],
@@ -51,5 +60,8 @@ export default defineConfig({
     '**/fixtures/**',
     '**/fixtures-*/**',
     '**/flaky-fixtures/**',
-  ].concat(process.env.ISOLATE === 'false' ? NO_ISOLATE_EXCLUDES : []),
+  ].concat(
+    process.env.ISOLATE === 'false' ? NO_ISOLATE_EXCLUDES : [],
+    process.env.RSTEST_POOL_TYPE === 'threads' ? THREADS_EXCLUDES : [],
+  ),
 });


### PR DESCRIPTION
## Summary

This PR excludes `browser-mode/**` from the CI threads e2e run. Browser mode tests execute in Playwright-managed browser contexts/pages rather than in the Node.js worker pool, so they do not add coverage for the `worker_threads` transport while increasing CI runtime and flake surface. The threads script now sets an explicit `RSTEST_POOL_TYPE=threads` marker that the e2e config uses to apply this targeted exclusion.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).