### PR TITLE
docs: add CI guide

### DIFF
--- a/website/docs/en/guide/advanced/_meta.json
+++ b/website/docs/en/guide/advanced/_meta.json
@@ -1,1 +1,1 @@
-["debugging", "profiling"]
+["debugging", "ci", "profiling"]

--- a/website/docs/en/guide/advanced/ci.mdx
+++ b/website/docs/en/guide/advanced/ci.mdx
@@ -1,0 +1,196 @@
+---
+description: Configure Rstest in CI, including basic workflows, coverage, Browser Mode, sharding, and report artifacts.
+---
+
+# CI
+
+Rstest uses the same CLI in CI as it does locally. The main difference is that CI should run tests in run mode with `rstest`, then upload any reports that other tools need to read.
+
+## Basic workflow
+
+Use `rstest` in CI so the process exits after one test pass. If your project already has a `test` script, keep CI calling that script and make the script run `rstest`.
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "rstest"
+  }
+}
+```
+
+A minimal GitHub Actions workflow installs dependencies, restores the package-manager cache, and runs the test script:
+
+```yaml title=".github/workflows/test.yml"
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+```
+
+When Rstest detects GitHub Actions and no reporter is manually configured, it automatically enables the `github-actions` reporter. Failed assertions are turned into GitHub annotations, and a Markdown summary is appended to the workflow summary. See [reporters](/guide/basic/reporters#github-actions-reporter) for reporter details.
+
+Other CI systems can use the same commands. The important part is to run `pnpm install --frozen-lockfile` before `pnpm rstest` or your package script.
+
+## Add coverage
+
+Coverage collection is opt-in. Install the provider you want to use before enabling `--coverage`:
+
+- [@rstest/coverage-istanbul](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-istanbul): the default Istanbul provider, works in Node mode and Browser Mode.
+- [@rstest/coverage-v8](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-v8): V8-based provider for Node mode only.
+
+```bash
+pnpm add @rstest/coverage-istanbul -D
+pnpm rstest --coverage
+```
+
+Upload the generated `coverage/` directory if your CI needs to keep the HTML report or pass coverage data to another service:
+
+```yaml
+- run: pnpm rstest --coverage
+
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: coverage
+    path: coverage
+```
+
+Use `if: always()` when the report is useful for failed runs too. For available providers, reporters, thresholds, and output paths, see [coverage](/config/test/coverage).
+
+## Browser Mode in CI
+
+Browser Mode runs tests in a real browser, so CI must install both the Rstest browser package and the browser binaries. Install [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser) in the project, then install the Playwright browser used by your config.
+
+```bash
+pnpm add @rstest/browser -D
+pnpm dlx playwright install --with-deps chromium
+```
+
+In CI, `browser.headless` defaults to `true`, so the browser runs without a visible window. A GitHub Actions workflow usually adds the browser installation step before running tests:
+
+```yaml
+jobs:
+  browser-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx playwright install --with-deps chromium
+      - run: pnpm rstest --browser
+```
+
+If you test with `firefox` or `webkit`, install the same browser that `browser.browser` selects. See [Browser Mode getting started](/guide/browser-testing/getting-started) and [browser configuration](/config/test/browser) for full setup options.
+
+## Split tests with shards
+
+Use `--shard <index>/<count>` when the full suite is stable but too slow for one CI machine. Each shard runs a different subset of test files. To combine results and coverage afterward, run every shard with the `blob` reporter, upload the blob files, then merge them in a follow-up job.
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm rstest --shard ${{ matrix.shard }}/3 --reporters=blob --coverage
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: rstest-blob-${{ matrix.shard }}
+          path: .rstest-reports
+
+  merge-reports:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: rstest-blob-*
+          path: .rstest-reports
+          merge-multiple: true
+      - run: pnpm rstest merge-reports --coverage --cleanup
+```
+
+Each shard writes `.rstest-reports/blob-{index}-{count}.json`. The merge job collects those files into one `.rstest-reports/` directory, then `rstest merge-reports` runs the configured reporters on the unified result and merges coverage data. See [shard](/config/test/shard) and [`rstest merge-reports`](/guide/basic/cli#rstest-merge-reports) for details.
+
+## Publish machine-readable reports
+
+CI tools often need structured report files in addition to terminal output. Add reporters when you need XML, JSON, Markdown, or blob output:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: [
+    'default',
+    ['junit', { outputPath: './reports/junit.xml' }],
+    ['json', { outputPath: './reports/rstest.json' }],
+  ],
+});
+```
+
+Then upload the report directory:
+
+```yaml
+- run: pnpm rstest
+
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: rstest-reports
+    path: reports
+```
+
+Use `junit` for CI test-result integrations, `json` for custom tooling, `md` for Markdown summaries, `github-actions` for GitHub annotations, and `blob` for sharded report merging. See [reporters](/guide/basic/reporters) for the complete list and options.
+
+## Cache dependencies
+
+Start with the package-manager cache because it is safe and usually gives the biggest CI improvement. In GitHub Actions, `actions/setup-node` with `cache: pnpm` restores the pnpm store based on the lockfile.
+
+## Recommended checklist
+
+- Use Node.js `^20.19.0` or `>=22.12.0` to match Rstest's supported runtime range.
+- Run `rstest` in CI, either directly or through a package script.
+- Install coverage and browser packages only when the workflow needs those features.
+- Upload coverage, JUnit, JSON, or blob artifacts with `if: always()` if they help debug failures.
+- Add sharding only after the single-machine workflow is stable.
+- Keep Browser Mode browser installation aligned with the browser selected in Rstest config.

--- a/website/docs/en/guide/advanced/ci.mdx
+++ b/website/docs/en/guide/advanced/ci.mdx
@@ -74,7 +74,7 @@ Upload the generated `coverage/` directory if your CI needs to keep the HTML rep
 
 Use `if: always()` when the report is useful for failed runs too. For available providers, reporters, thresholds, and output paths, see [coverage](/config/test/coverage).
 
-## Browser Mode in CI
+## Browser mode in CI
 
 Browser Mode runs tests in a real browser, so CI must install both the Rstest browser package and the browser binaries. Install [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser) in the project, then install the Playwright browser used by your config.
 

--- a/website/docs/en/guide/advanced/ci.mdx
+++ b/website/docs/en/guide/advanced/ci.mdx
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
 
       - uses: actions/setup-node@v4
         with:
@@ -63,7 +65,7 @@ pnpm rstest --coverage
 Upload the generated `coverage/` directory if your CI needs to keep the HTML report or pass coverage data to another service:
 
 ```yaml
-- run: pnpm rstest --coverage
+- run: pnpm rstest --coverage --coverage.reportOnFailure
 
 - uses: actions/upload-artifact@v4
   if: always()
@@ -79,8 +81,8 @@ Use `if: always()` when the report is useful for failed runs too. For available 
 Browser Mode runs tests in a real browser, so CI must install both the Rstest browser package and the browser binaries. Install [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser) in the project, then install the Playwright browser used by your config.
 
 ```bash
-pnpm add @rstest/browser -D
-pnpm dlx playwright install --with-deps chromium
+pnpm add @rstest/browser playwright -D
+pnpm exec playwright install --with-deps chromium
 ```
 
 In CI, `browser.headless` defaults to `true`, so the browser runs without a visible window. A GitHub Actions workflow usually adds the browser installation step before running tests:
@@ -92,12 +94,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm dlx playwright install --with-deps chromium
+      - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm rstest --browser
 ```
 
@@ -118,6 +122,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
@@ -129,6 +135,7 @@ jobs:
         with:
           name: rstest-blob-${{ matrix.shard }}
           path: .rstest-reports
+          include-hidden-files: true
 
   merge-reports:
     runs-on: ubuntu-latest
@@ -137,6 +144,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22.12.0

--- a/website/docs/zh/guide/advanced/_meta.json
+++ b/website/docs/zh/guide/advanced/_meta.json
@@ -1,1 +1,1 @@
-["debugging", "profiling"]
+["debugging", "ci", "profiling"]

--- a/website/docs/zh/guide/advanced/ci.mdx
+++ b/website/docs/zh/guide/advanced/ci.mdx
@@ -1,0 +1,196 @@
+---
+description: 在 CI 中配置 Rstest，包括基础工作流、覆盖率、Browser Mode、分片和报告产物。
+---
+
+# CI
+
+Rstest 在 CI 中使用的 CLI 与本地相同。主要区别是，CI 应该通过 `rstest` 以 run mode 执行测试，然后上传其他工具需要读取的报告。
+
+## 基础工作流
+
+在 CI 中使用 `rstest`，这样进程会在一次测试完成后退出。如果项目已经有 `test` 脚本，可以让 CI 继续调用该脚本，并让脚本执行 `rstest`。
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "rstest"
+  }
+}
+```
+
+一个最小的 GitHub Actions 工作流会安装依赖、恢复包管理器缓存，并运行测试脚本：
+
+```yaml title=".github/workflows/test.yml"
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+```
+
+当 Rstest 检测到 GitHub Actions 且没有手动配置 reporter 时，会自动启用 `github-actions` reporter。失败断言会转换成 GitHub 注释，并在 workflow summary 中追加 Markdown 摘要。更多 reporter 细节请查看 [reporters](/guide/basic/reporters#github-actions-reporter)。
+
+其他 CI 系统也可以使用相同命令。关键是先运行 `pnpm install --frozen-lockfile`，再运行 `pnpm rstest` 或你的 package script。
+
+## 添加覆盖率
+
+覆盖率收集默认关闭。启用 `--coverage` 前，需要先安装你想使用的 provider：
+
+- [@rstest/coverage-istanbul](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-istanbul)：默认的 Istanbul provider，适用于 Node mode 和 Browser Mode。
+- [@rstest/coverage-v8](https://github.com/web-infra-dev/rstest/tree/main/packages/coverage-v8)：基于 V8 的 provider，仅适用于 Node mode。
+
+```bash
+pnpm add @rstest/coverage-istanbul -D
+pnpm rstest --coverage
+```
+
+如果 CI 需要保留 HTML 报告，或把覆盖率数据传给其他服务，可以上传生成的 `coverage/` 目录：
+
+```yaml
+- run: pnpm rstest --coverage
+
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: coverage
+    path: coverage
+```
+
+当失败运行中的报告也有调试价值时，可以使用 `if: always()`。可用的 provider、reporter、阈值和输出路径请查看 [coverage](/config/test/coverage)。
+
+## CI 中的 Browser Mode
+
+Browser Mode 会在真实浏览器中运行测试，因此 CI 需要同时安装 Rstest 浏览器包和浏览器二进制文件。在项目中安装 [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser)，然后安装配置中使用的 Playwright 浏览器。
+
+```bash
+pnpm add @rstest/browser -D
+pnpm dlx playwright install --with-deps chromium
+```
+
+在 CI 中，`browser.headless` 默认值为 `true`，所以浏览器会以无界面模式运行。GitHub Actions 工作流通常会在运行测试前添加浏览器安装步骤：
+
+```yaml
+jobs:
+  browser-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx playwright install --with-deps chromium
+      - run: pnpm rstest --browser
+```
+
+如果使用 `firefox` 或 `webkit` 测试，需要安装与 `browser.browser` 选择一致的浏览器。完整配置方式请查看 [Browser Mode 快速开始](/guide/browser-testing/getting-started) 和 [browser 配置](/config/test/browser)。
+
+## 使用分片拆分测试
+
+当完整测试套件已经稳定，但单台 CI 机器运行太慢时，可以使用 `--shard <index>/<count>`。每个分片会运行不同的测试文件子集。要在后续合并结果和覆盖率，需要让每个分片都使用 `blob` reporter，上传 blob 文件，然后在后续 job 中合并。
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm rstest --shard ${{ matrix.shard }}/3 --reporters=blob --coverage
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: rstest-blob-${{ matrix.shard }}
+          path: .rstest-reports
+
+  merge-reports:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: rstest-blob-*
+          path: .rstest-reports
+          merge-multiple: true
+      - run: pnpm rstest merge-reports --coverage --cleanup
+```
+
+每个分片会写入 `.rstest-reports/blob-{index}-{count}.json`。合并 job 会把这些文件收集到同一个 `.rstest-reports/` 目录，然后 `rstest merge-reports` 会基于统一结果运行已配置的 reporter，并合并覆盖率数据。更多细节请查看 [shard](/config/test/shard) 和 [`rstest merge-reports`](/guide/basic/cli#rstest-merge-reports)。
+
+## 发布机器可读报告
+
+除了终端输出，CI 工具通常还需要结构化报告文件。当你需要 XML、JSON、Markdown 或 blob 输出时，可以添加 reporter：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: [
+    'default',
+    ['junit', { outputPath: './reports/junit.xml' }],
+    ['json', { outputPath: './reports/rstest.json' }],
+  ],
+});
+```
+
+然后上传报告目录：
+
+```yaml
+- run: pnpm rstest
+
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: rstest-reports
+    path: reports
+```
+
+`junit` 适合 CI 测试结果集成，`json` 适合自定义工具，`md` 适合 Markdown 摘要，`github-actions` 适合 GitHub 注释，`blob` 适合分片报告合并。完整列表和选项请查看 [reporters](/guide/basic/reporters)。
+
+## 缓存依赖
+
+建议先从包管理器缓存开始，因为它安全，通常也能带来最明显的 CI 优化。在 GitHub Actions 中，`actions/setup-node` 配合 `cache: pnpm` 会基于 lockfile 恢复 pnpm store。
+
+## 推荐检查清单
+
+- 使用 Node.js `^20.19.0` 或 `>=22.12.0`，以匹配 Rstest 支持的运行时范围。
+- 在 CI 中运行 `rstest`，可以直接运行，也可以通过 package script 运行。
+- 仅在 workflow 需要对应功能时安装 coverage 和 browser 包。
+- 如果 coverage、JUnit、JSON 或 blob artifact 有助于排查失败，使用 `if: always()` 上传。
+- 在单机 workflow 稳定后，再添加 sharding。
+- 保持 Browser Mode 的浏览器安装与 Rstest 配置中选择的浏览器一致。

--- a/website/docs/zh/guide/advanced/ci.mdx
+++ b/website/docs/zh/guide/advanced/ci.mdx
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
 
       - uses: actions/setup-node@v4
         with:
@@ -44,7 +46,7 @@ jobs:
       - run: pnpm test
 ```
 
-当 Rstest 检测到 GitHub Actions 且没有手动配置 reporter 时，会自动启用 `github-actions` reporter。失败断言会转换成 GitHub 注释，并在 workflow summary 中追加 Markdown 摘要。更多 reporter 细节请查看 [reporters](/guide/basic/reporters#github-actions-reporter)。
+当 Rstest 检测到 GitHub Actions 且没有手动配置 reporter 时，会自动启用 `github-actions` reporter。失败断言会转换成 GitHub 注释，并在 workflow summary 中追加 Markdown 摘要。更多 reporter 细节请查看 [reporters](/guide/basic/reporters#github-actions-报告器)。
 
 其他 CI 系统也可以使用相同命令。关键是先运行 `pnpm install --frozen-lockfile`，再运行 `pnpm rstest` 或你的 package script。
 
@@ -63,7 +65,7 @@ pnpm rstest --coverage
 如果 CI 需要保留 HTML 报告，或把覆盖率数据传给其他服务，可以上传生成的 `coverage/` 目录：
 
 ```yaml
-- run: pnpm rstest --coverage
+- run: pnpm rstest --coverage --coverage.reportOnFailure
 
 - uses: actions/upload-artifact@v4
   if: always()
@@ -79,8 +81,8 @@ pnpm rstest --coverage
 Browser Mode 会在真实浏览器中运行测试，因此 CI 需要同时安装 Rstest 浏览器包和浏览器二进制文件。在项目中安装 [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser)，然后安装配置中使用的 Playwright 浏览器。
 
 ```bash
-pnpm add @rstest/browser -D
-pnpm dlx playwright install --with-deps chromium
+pnpm add @rstest/browser playwright -D
+pnpm exec playwright install --with-deps chromium
 ```
 
 在 CI 中，`browser.headless` 默认值为 `true`，所以浏览器会以无界面模式运行。GitHub Actions 工作流通常会在运行测试前添加浏览器安装步骤：
@@ -92,12 +94,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm dlx playwright install --with-deps chromium
+      - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm rstest --browser
 ```
 
@@ -118,6 +122,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
@@ -129,6 +135,7 @@ jobs:
         with:
           name: rstest-blob-${{ matrix.shard }}
           path: .rstest-reports
+          include-hidden-files: true
 
   merge-reports:
     runs-on: ubuntu-latest
@@ -137,6 +144,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: 22.12.0

--- a/website/docs/zh/guide/advanced/ci.mdx
+++ b/website/docs/zh/guide/advanced/ci.mdx
@@ -74,7 +74,7 @@ pnpm rstest --coverage
 
 当失败运行中的报告也有调试价值时，可以使用 `if: always()`。可用的 provider、reporter、阈值和输出路径请查看 [coverage](/config/test/coverage)。
 
-## CI 中的 Browser Mode
+## CI 中的 browser mode
 
 Browser Mode 会在真实浏览器中运行测试，因此 CI 需要同时安装 Rstest 浏览器包和浏览器二进制文件。在项目中安装 [@rstest/browser](https://github.com/web-infra-dev/rstest/tree/main/packages/browser)，然后安装配置中使用的 Playwright 浏览器。
 


### PR DESCRIPTION
## Summary

This PR adds a CI guide for Rstest so users can set up test workflows with coverage, Browser Mode, sharding, report artifacts, and dependency caching. The English and Chinese docs are kept in sync, and the advanced guide navigation now links to the new page.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).