### PR TITLE
release: 0.10.6

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
## What's Changed
### Bug Fixes 🐞
* fix(core): preserve base environment project name by @9aoy in https://github.com/web-infra-dev/rstest/pull/1431
* fix(browser): preserve dot dirs in context exclude globs by @9aoy in https://github.com/web-infra-dev/rstest/pull/1426
### Document 📖
* docs: add runtime troubleshooting guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/1436
* docs: add CI guide by @9aoy in https://github.com/web-infra-dev/rstest/pull/1438
* docs: update start guide package and example links by @9aoy in https://github.com/web-infra-dev/rstest/pull/1429
* docs: add browser viewport config by @9aoy in https://github.com/web-infra-dev/rstest/pull/1428
### Other Changes
* release: 0.10.6 by @9aoy in https://github.com/web-infra-dev/rstest/pull/1440
* chore(deps): update rstackjs/rstack-ecosystem-ci digest to 0ac4127 by @renovate in https://github.com/web-infra-dev/rstest/pull/1437
* chore(deps): update all non-major dependencies by @renovate in https://github.com/web-infra-dev/rstest/pull/1433
* chore(deps): bump rsbuild to 2.0.15 by @9aoy in https://github.com/web-infra-dev/rstest/pull/1435
* chore(deps): update dependency rsbuild-plugin-publint to v1 by @renovate in https://github.com/web-infra-dev/rstest/pull/1434
* chore(e2e): skip browser mode in threads run by @9aoy in https://github.com/web-infra-dev/rstest/pull/1432
* ci: consolidate static checks in lint workflow by @9aoy in https://github.com/web-infra-dev/rstest/pull/1430
* chore(core): add package homepage by @9aoy in https://github.com/web-infra-dev/rstest/pull/1427

**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.10.5...v0.10.6