### PR TITLE
fix(core): show full stack when filtered stack is empty

### DIFF
--- a/e2e/test-api/edgeCase.test.ts
+++ b/e2e/test-api/edgeCase.test.ts
@@ -40,6 +40,25 @@ describe('Test Edge Cases', () => {
     expectStderrLog('Unknown Error: aaaa');
   });
 
+  it('should show fullStack when filtered stack is empty', async () => {
+    const { expectExecFailed, expectStderrLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/fullStackFallback.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecFailed();
+
+    expectStderrLog(
+      "No user error stack found, showing fullStack. Set 'DEBUG=rstest' to always show fullStack.",
+    );
+    expectStderrLog('at fallbackFrame (node:internal/rstest_fallback:10:5)');
+    expectStderrLog('at hiddenFrame (node:internal/rstest_hidden:20:6)');
+  });
+
   it('test module not found', async () => {
     // Module not found errors should be silent at build time, and throw errors at runtime
     const { cli, expectExecSuccess } = await runRstestCli({

--- a/e2e/test-api/edgeCase.test.ts
+++ b/e2e/test-api/edgeCase.test.ts
@@ -41,7 +41,7 @@ describe('Test Edge Cases', () => {
   });
 
   it('should show fullStack when filtered stack is empty', async () => {
-    const { expectExecFailed, expectStderrLog } = await runRstestCli({
+    const { cli, expectExecFailed, expectStderrLog } = await runRstestCli({
       command: 'rstest',
       args: ['run', 'fixtures/fullStackFallback.test.ts'],
       options: {
@@ -55,6 +55,7 @@ describe('Test Edge Cases', () => {
     expectStderrLog(
       "No user error stack found, showing fullStack. Set 'DEBUG=rstest' to always show fullStack.",
     );
+    expect(cli.stderr).not.toContain('nativeFrame');
     expectStderrLog('at fallbackFrame (node:internal/rstest_fallback:10:5)');
     expectStderrLog('at hiddenFrame (node:internal/rstest_hidden:20:6)');
   });

--- a/e2e/test-api/fixtures/fullStackFallback.test.ts
+++ b/e2e/test-api/fixtures/fullStackFallback.test.ts
@@ -1,0 +1,11 @@
+import { it } from '@rstest/core';
+
+it('shows first fullStack frame when user stack is empty', () => {
+  const error = new Error('fallback stack marker');
+  error.stack = [
+    'Error: fallback stack marker',
+    '    at fallbackFrame (node:internal/rstest_fallback:10:5)',
+    '    at hiddenFrame (node:internal/rstest_hidden:20:6)',
+  ].join('\n');
+  throw error;
+});

--- a/e2e/test-api/fixtures/fullStackFallback.test.ts
+++ b/e2e/test-api/fixtures/fullStackFallback.test.ts
@@ -4,6 +4,7 @@ it('shows first fullStack frame when user stack is empty', () => {
   const error = new Error('fallback stack marker');
   error.stack = [
     'Error: fallback stack marker',
+    '    at nativeFrame (native)',
     '    at fallbackFrame (node:internal/rstest_fallback:10:5)',
     '    at hiddenFrame (node:internal/rstest_hidden:20:6)',
   ].join('\n');

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -85,13 +85,17 @@ export async function printError(
         getSourcemap,
       });
 
-      if (fullStackFrames[0]) {
+      const printableFullStackFrames = fullStackFrames.filter(
+        (frame) => frame.file,
+      );
+
+      if (printableFullStackFrames[0]) {
         logger.stderr(
           color.gray(
             "No user error stack found, showing fullStack. Set 'DEBUG=rstest' to always show fullStack.",
           ),
         );
-        stackFrames = fullStackFrames;
+        stackFrames = printableFullStackFrames;
       } else {
         logger.stderr(
           color.gray(

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -69,7 +69,7 @@ export async function printError(
   }
 
   if (error.stack) {
-    const stackFrames = await parseErrorStacktrace({
+    let stackFrames = await parseErrorStacktrace({
       stack: error.stack,
       fullStack: error.fullStack,
       getSourcemap,
@@ -79,11 +79,26 @@ export async function printError(
       !(error.fullStack || isDebug()) &&
       !error.stack.endsWith(error.message)
     ) {
-      logger.stderr(
-        color.gray(
-          "No error stack found, set 'DEBUG=rstest' to show fullStack.",
-        ),
-      );
+      const fullStackFrames = await parseErrorStacktrace({
+        stack: error.stack,
+        fullStack: true,
+        getSourcemap,
+      });
+
+      if (fullStackFrames[0]) {
+        logger.stderr(
+          color.gray(
+            "No user error stack found, showing fullStack. Set 'DEBUG=rstest' to always show fullStack.",
+          ),
+        );
+        stackFrames = fullStackFrames;
+      } else {
+        logger.stderr(
+          color.gray(
+            "No error stack found, set 'DEBUG=rstest' to show fullStack.",
+          ),
+        );
+      }
     }
 
     if (stackFrames[0]) {


### PR DESCRIPTION
## Summary

When the default stack filtering removes every frame from a test error, Rstest now falls back to printing the full stack immediately instead of only telling users to rerun with `DEBUG=rstest`. This keeps the normal filtered output for ordinary failures while still providing actionable stack details for errors whose frames are all filtered as internal/runtime frames.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).