### PR TITLE
fix(core): clarify untransformed mock API error

### DIFF
--- a/e2e/mock/tests/aliasRuntimeError.test.ts
+++ b/e2e/mock/tests/aliasRuntimeError.test.ts
@@ -20,9 +20,11 @@ describe('mock API aliases', () => {
 
     await expectExecFailed();
 
+    expectStderrLog('mock() was not transformed by Rstest');
     expectStderrLog(
-      'rs.mock() must be called as rstest.mock() or rs.mock() so Rstest can transform it',
+      'Module mock APIs must be called directly as rstest.mock() or rs.mock() in files processed by Rstest',
     );
-    expectStderrLog('Import aliases are not supported for module mock APIs');
+    expectStderrLog('calling file is not bundled by Rstest');
+    expectStderrLog('called through an import alias');
   });
 });

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -49,7 +49,7 @@ const normalizeWaitOptions = (
 
 const createUntransformedRuntimeApiError = (apiName: string) =>
   new Error(
-    `[Rstest] rs.${apiName}() must be called as rstest.${apiName}() or rs.${apiName}() so Rstest can transform it. Import aliases are not supported for module mock APIs.`,
+    `[Rstest] ${apiName}() was not transformed by Rstest. Module mock APIs must be called directly as rstest.${apiName}() or rs.${apiName}() in files processed by Rstest. This can happen when the calling file is not bundled by Rstest, or when the API is called through an import alias.`,
   );
 
 const createPluginManagedApi = (apiName: string) => () => {

--- a/packages/core/tests/runtime/api/utilities.test.ts
+++ b/packages/core/tests/runtime/api/utilities.test.ts
@@ -141,13 +141,13 @@ describe('rstest utilities plugin-managed APIs', () => {
     const rs = await createRstestUtilities(createWorkerState());
 
     expect(() => rs.mock('./module')).toThrow(
-      'rs.mock() must be called as rstest.mock() or rs.mock() so Rstest can transform it',
+      'mock() was not transformed by Rstest',
     );
     expect(() => rs.doMock('./module')).toThrow(
-      'Import aliases are not supported for module mock APIs',
+      'Module mock APIs must be called directly as rstest.doMock() or rs.doMock() in files processed by Rstest',
     );
     expect(() => rs.unmock('./module')).toThrow(
-      'Import aliases are not supported for module mock APIs',
+      'This can happen when the calling file is not bundled by Rstest',
     );
   });
 
@@ -155,13 +155,13 @@ describe('rstest utilities plugin-managed APIs', () => {
     const rs = await createRstestUtilities(createWorkerState());
 
     expect(() => rs.importActual('./module')).toThrow(
-      'rs.importActual() must be called as rstest.importActual() or rs.importActual() so Rstest can transform it',
+      'importActual() was not transformed by Rstest',
     );
     expect(() => rs.requireActual('./module')).toThrow(
-      'Import aliases are not supported for module mock APIs',
+      'called directly as rstest.requireActual() or rs.requireActual() in files processed by Rstest',
     );
     expect(() => rs.hoisted(() => ({}))).toThrow(
-      'Import aliases are not supported for module mock APIs',
+      'called directly as rstest.hoisted() or rs.hoisted() in files processed by Rstest',
     );
   });
 });


### PR DESCRIPTION
## Summary

This PR clarifies the runtime error shown when module mock APIs are not transformed by Rstest. The message now explains that these APIs must be called directly from files processed by Rstest, and points to both likely causes: the calling file is not bundled by Rstest, or the API was called through an import alias.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1414
https://github.com/web-infra-dev/rspack/pull/14510

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).