### PR TITLE
docs: fix fake timers API meta version

### DIFF
--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -112,6 +112,7 @@ Documentation is not a follow-up task — it ships with the code. **Do not merge
 
 - All docs exist in **both** `en/` and `zh/` — update both languages.
 - Use Rspress frontmatter conventions (see existing docs for examples).
+- When adding `ApiMeta` markers for a new API or config option, default `addedVersion` to the current package version with its patch segment incremented by 1. For example, if `@rstest/core` is currently `0.10.6`, a newly documented core API should use `<ApiMeta addedVersion="0.10.7" />`.
 - Include code examples that are copy-pasteable.
 
 ## 6. Quick Self-Check Before Committing

--- a/website/docs/en/api/runtime-api/rstest/fake-timers.mdx
+++ b/website/docs/en/api/runtime-api/rstest/fake-timers.mdx
@@ -162,7 +162,7 @@ Advances the timers to the next animation frame.
 
 ## rs.jumpTimersByTime
 
-<ApiMeta addedVersion="0.10.5" />
+<ApiMeta addedVersion="0.10.7" />
 
 - **Alias:** `rstest.jumpTimersByTime`
 - **Type:** `(ms: number | string | Temporal.Duration) => Rstest`
@@ -182,7 +182,7 @@ expect(cb).toHaveBeenCalledTimes(1);
 
 ## rs.setTickMode
 
-<ApiMeta addedVersion="0.10.5" />
+<ApiMeta addedVersion="0.10.7" />
 
 - **Alias:** `rstest.setTickMode`
 - **Type:** `(mode: { mode: 'manual' | 'nextAsync' } | { mode: 'interval'; delta?: number }) => Rstest`

--- a/website/docs/zh/api/runtime-api/rstest/fake-timers.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/fake-timers.mdx
@@ -162,7 +162,7 @@ const realTime = rs.getRealSystemTime();
 
 ## rs.jumpTimersByTime
 
-<ApiMeta addedVersion="0.10.5" />
+<ApiMeta addedVersion="0.10.7" />
 
 - **别名：** `rstest.jumpTimersByTime`
 - **类型：** `(ms: number | string | Temporal.Duration) => Rstest`
@@ -182,7 +182,7 @@ expect(cb).toHaveBeenCalledTimes(1);
 
 ## rs.setTickMode
 
-<ApiMeta addedVersion="0.10.5" />
+<ApiMeta addedVersion="0.10.7" />
 
 - **别名：** `rstest.setTickMode`
 - **类型：** `(mode: { mode: 'manual' | 'nextAsync' } | { mode: 'interval'; delta?: number }) => Rstest`


### PR DESCRIPTION
## Summary

This PR fixes the `ApiMeta` version markers added by #1439 for the new fake timers APIs. Since the current `@rstest/core` version is `0.10.6`, the newly documented `jumpTimersByTime` and `setTickMode` APIs should be marked as added in `0.10.7`. It also updates the development skill so future `ApiMeta` markers default to the current package version with the patch segment incremented by 1.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1439

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
