### PR TITLE
feat(core)!: move TestOptions to the second argument of test/it

### DIFF
--- a/e2e/test-api/fixtures/testOptionsOnFinishedScope.test.ts
+++ b/e2e/test-api/fixtures/testOptionsOnFinishedScope.test.ts
@@ -8,19 +8,20 @@ let cleanupCalls = 0;
 
 it(
   'onTestFinished does not leak across repeats',
+  { repeats: 2 },
   ({ onTestFinished }) => {
     runs++;
     onTestFinished(() => {
       cleanupCalls++;
     });
   },
-  { repeats: 2 },
 );
 
 let retryAttempts = 0;
 let retryCleanupCalls = 0;
 it(
   'onTestFinished does not leak across retries',
+  { retry: 1 },
   ({ onTestFinished }) => {
     retryAttempts++;
     onTestFinished(() => {
@@ -29,7 +30,6 @@ it(
     // Force a retry by failing the first attempt.
     expect(retryAttempts).toBe(2);
   },
-  { retry: 1 },
 );
 
 it('cleanup count matches the number of attempts', () => {

--- a/e2e/test-api/fixtures/testOptionsRepeatsErrorScope.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsErrorScope.test.ts
@@ -5,6 +5,7 @@ import { expect, it } from '@rstest/core';
 let runs = 0;
 it(
   'each repeat reports only its own retry errors',
+  { retry: 1, repeats: 1 },
   () => {
     runs++;
     // Repeat 0: fail then pass on retry.
@@ -20,7 +21,6 @@ it(
     }
     throw new Error('REPEAT_1_ATTEMPT_B');
   },
-  { retry: 1, repeats: 1 },
 );
 
 // Sanity guard: ensure the test fn ran exactly 4 times. If runner short-circuits

--- a/e2e/test-api/fixtures/testOptionsRepeatsFail.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsFail.test.ts
@@ -2,11 +2,7 @@ import { expect, it } from '@rstest/core';
 
 // repeats short-circuits on first failure. Total executions <= repeats + 1.
 let runs = 0;
-it(
-  'fails on the second repeat',
-  () => {
-    runs++;
-    expect(runs).toBeLessThan(2);
-  },
-  { repeats: 4 },
-);
+it('fails on the second repeat', { repeats: 4 }, () => {
+  runs++;
+  expect(runs).toBeLessThan(2);
+});

--- a/e2e/test-api/fixtures/testOptionsRepeatsInvalid.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsInvalid.test.ts
@@ -3,32 +3,20 @@ import { expect, it } from '@rstest/core';
 // Regression: invalid `repeats` values (negative, NaN, fractional) must not
 // cause the runner to silently skip the test — they should clamp to 0.
 let neg = 0;
-it(
-  'negative repeats clamps to a single run',
-  () => {
-    neg++;
-    expect(neg).toBe(1);
-  },
-  { repeats: -3 },
-);
+it('negative repeats clamps to a single run', { repeats: -3 }, () => {
+  neg++;
+  expect(neg).toBe(1);
+});
 
 let nan = 0;
-it(
-  'NaN repeats clamps to a single run',
-  () => {
-    nan++;
-    expect(nan).toBe(1);
-  },
-  { repeats: Number.NaN },
-);
+it('NaN repeats clamps to a single run', { repeats: Number.NaN }, () => {
+  nan++;
+  expect(nan).toBe(1);
+});
 
 let frac = 0;
-it(
-  'fractional repeats floors',
-  () => {
-    frac++;
-    expect(frac).toBeGreaterThanOrEqual(1);
-    expect(frac).toBeLessThanOrEqual(2);
-  },
-  { repeats: 1.9 },
-);
+it('fractional repeats floors', { repeats: 1.9 }, () => {
+  frac++;
+  expect(frac).toBeGreaterThanOrEqual(1);
+  expect(frac).toBeLessThanOrEqual(2);
+});

--- a/e2e/test-api/fixtures/testOptionsRepeatsPass.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRepeatsPass.test.ts
@@ -16,11 +16,7 @@ afterEach(() => {
   expect(beforeEachCalls).toBe(afterEachCalls);
 });
 
-it(
-  'repeats 3 times when all pass',
-  () => {
-    runs++;
-    expect(beforeEachCalls).toBe(runs);
-  },
-  { repeats: 2 },
-);
+it('repeats 3 times when all pass', { repeats: 2 }, () => {
+  runs++;
+  expect(beforeEachCalls).toBe(runs);
+});

--- a/e2e/test-api/fixtures/testOptionsRetry.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRetry.test.ts
@@ -8,14 +8,10 @@ beforeEach(() => {
   beforeEachCalls++;
 });
 
-it(
-  'per-test retry overrides config retry',
-  () => {
-    attempts++;
-    // Pass on the third attempt (initial + 2 retries).
-    expect(attempts).toBe(3);
-    // beforeEach should have run for every attempt, including the passing one.
-    expect(beforeEachCalls).toBe(attempts);
-  },
-  { retry: 2 },
-);
+it('per-test retry overrides config retry', { retry: 2 }, () => {
+  attempts++;
+  // Pass on the third attempt (initial + 2 retries).
+  expect(attempts).toBe(3);
+  // beforeEach should have run for every attempt, including the passing one.
+  expect(beforeEachCalls).toBe(attempts);
+});

--- a/e2e/test-api/fixtures/testOptionsRetryOverride.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRetryOverride.test.ts
@@ -4,24 +4,16 @@ import { expect, it } from '@rstest/core';
 // directions of override.
 
 let extendingAttempts = 0;
-it(
-  'options.retry can extend config.retry',
-  () => {
-    extendingAttempts++;
-    // Pass on attempt 8, which exceeds config.retry=5 but fits options.retry=9.
-    expect(extendingAttempts).toBe(8);
-  },
-  { retry: 9 },
-);
+it('options.retry can extend config.retry', { retry: 9 }, () => {
+  extendingAttempts++;
+  // Pass on attempt 8, which exceeds config.retry=5 but fits options.retry=9.
+  expect(extendingAttempts).toBe(8);
+});
 
 let disablingAttempts = 0;
-it(
-  'options.retry: 0 disables config.retry',
-  () => {
-    disablingAttempts++;
-    // Force a failure; options.retry=0 should stop retries immediately even
-    // though config.retry=5 is set.
-    throw new Error(`attempt ${disablingAttempts}`);
-  },
-  { retry: 0 },
-);
+it('options.retry: 0 disables config.retry', { retry: 0 }, () => {
+  disablingAttempts++;
+  // Force a failure; options.retry=0 should stop retries immediately even
+  // though config.retry=5 is set.
+  throw new Error(`attempt ${disablingAttempts}`);
+});

--- a/e2e/test-api/fixtures/testOptionsRetryRepeats.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRetryRepeats.test.ts
@@ -5,12 +5,8 @@ import { expect, it } from '@rstest/core';
 // the second repeat passes on attempt 2 (retry used again), the third repeat
 // passes on attempt 2 (retry used a third time). Total executions = 6.
 let runs = 0;
-it(
-  'retry budget is per-repeat',
-  () => {
-    runs++;
-    // Fail on odd attempts (1, 3, 5) and pass on even attempts (2, 4, 6).
-    expect(runs % 2).toBe(0);
-  },
-  { retry: 1, repeats: 2 },
-);
+it('retry budget is per-repeat', { retry: 1, repeats: 2 }, () => {
+  runs++;
+  // Fail on odd attempts (1, 3, 5) and pass on even attempts (2, 4, 6).
+  expect(runs % 2).toBe(0);
+});

--- a/e2e/test-api/fixtures/testOptionsTimeout.test.ts
+++ b/e2e/test-api/fixtures/testOptionsTimeout.test.ts
@@ -9,10 +9,10 @@ describe('timeout shorthand vs options', () => {
 
   it(
     'options.timeout trips on slow body',
+    { timeout: 50 },
     async ({ expect }) => {
       await sleep(100);
       expect(1 + 1).toBe(2);
     },
-    { timeout: 50 },
   );
 });

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -35,8 +35,8 @@ import { fileContext } from '../fileContext';
 import {
   formatName,
   isTemplateStringsArray,
-  normalizeTestOptions,
   parseTemplateTable,
+  resolveTestArgs,
   TestRegisterError,
 } from '../util';
 import { normalizeFixtures } from './fixtures';
@@ -465,11 +465,12 @@ export class RunnerRuntime {
     location?: Location;
   }): (
     name: string,
-    fn?: (...args: any[]) => any,
-    testOptions?: number | TestOptions,
+    arg2?: ((...args: any[]) => any) | TestOptions,
+    arg3?: ((...args: any[]) => any) | number,
   ) => void {
-    return (name, fn, testOptions) => {
-      const { timeout, retry, repeats } = normalizeTestOptions(testOptions);
+    return (name, arg2, arg3) => {
+      const { fn, options: testOptions } = resolveTestArgs(arg2, arg3);
+      const { timeout, retry, repeats } = testOptions;
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
         const params = castArray(param) as any[];
@@ -500,11 +501,12 @@ export class RunnerRuntime {
     location?: Location;
   }): (
     name: string,
-    fn?: (...args: any[]) => any,
-    testOptions?: number | TestOptions,
+    arg2?: ((...args: any[]) => any) | TestOptions,
+    arg3?: ((...args: any[]) => any) | number,
   ) => void {
-    return (name, fn, testOptions) => {
-      const { timeout, retry, repeats } = normalizeTestOptions(testOptions);
+    return (name, arg2, arg3) => {
+      const { fn, options: testOptions } = resolveTestArgs(arg2, arg3);
+      const { timeout, retry, repeats } = testOptions;
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
 
@@ -561,8 +563,9 @@ const buildRuntimeAPI = (): CollectionAPI => {
       location?: Location;
     } = {},
   ): TestAPI => {
-    const testFn = ((name, fn, testOptions) => {
-      const { timeout, retry, repeats } = normalizeTestOptions(testOptions);
+    const testFn = ((name, arg2, arg3) => {
+      const { fn, options: testOptions } = resolveTestArgs(arg2, arg3);
+      const { timeout, retry, repeats } = testOptions;
       const rt = currentRuntime();
       rt.it({
         name,

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -1,16 +1,25 @@
 import type { FormattedError, Test, TestOptions } from '../types';
 
 /**
- * Normalize the third argument of `test` / `it` / `test.each` / `test.for`.
- * Accepts `number` (shorthand for `{ timeout }`) or a full `TestOptions` object.
+ * Resolve the overloaded trailing arguments of `test` / `it` / `test.each` /
+ * `test.for`, which accept two shapes:
+ * - `(name, fn, timeout?)` — `arg2` is the test fn, `arg3` an optional numeric timeout.
+ * - `(name, options, fn?)` — `arg2` is a `TestOptions` object, `arg3` the test fn.
+ *
+ * In the function-first shape `arg3` is only honored as a numeric timeout; an options
+ * object is no longer accepted there (it is a type error and ignored at runtime).
  */
-export const normalizeTestOptions = (
-  input?: number | TestOptions,
-): TestOptions => {
-  if (typeof input === 'number') {
-    return { timeout: input };
+export const resolveTestArgs = <Fn extends (...args: any[]) => any>(
+  arg2?: Fn | TestOptions,
+  arg3?: Fn | number,
+): { fn?: Fn; options: TestOptions } => {
+  if (typeof arg2 === 'function') {
+    return {
+      fn: arg2,
+      options: typeof arg3 === 'number' ? { timeout: arg3 } : {},
+    };
   }
-  return input ?? {};
+  return { fn: arg3 as Fn | undefined, options: arg2 ?? {} };
 };
 
 const loadDiffModules = async () => {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -34,8 +34,9 @@ export type TestCallbackFn<ExtraContext = object> = (
 ) => MaybePromise<void>;
 
 /**
- * Per-test options accepted as the third argument of `test` / `it` / `test.each` /
- * `test.for`. Passing a plain `number` is equivalent to `{ timeout: n }`.
+ * Per-test options accepted as the second argument of `test` / `it` / `test.each` /
+ * `test.for`. Passing a plain `number` as the last argument is equivalent to
+ * `{ timeout: n }`.
  *
  * Declared as an `interface` so consumers can use module augmentation to add
  * fields in the future without breaking source compatibility.
@@ -62,60 +63,50 @@ export interface TestOptions {
   repeats?: number;
 }
 
-type TestFn<ExtraContext = object> = (
-  description: string,
-  fn?: TestCallbackFn<ExtraContext>,
-  options?: number | TestOptions,
-) => void;
+/**
+ * The two accepted call shapes shared by `test` / `it` and the functions returned
+ * by `test.each` / `test.for`:
+ * - `(name, fn, timeout?)` — test function second, with an optional numeric timeout
+ *   last (kept for Jest compatibility; shorthand for `{ timeout: n }`).
+ * - `(name, options, fn?)` — `TestOptions` object as the second argument.
+ *
+ * The function-first overload is listed first so the common `test(name, fn)` case
+ * binds the callback's context types — a function value is otherwise assignable to
+ * the all-optional `TestOptions`, which would swallow contextual typing.
+ */
+type TestCall<Fn> = {
+  (description: string, fn?: Fn, timeout?: number): void;
+  (description: string, options: TestOptions, fn?: Fn): void;
+};
+
+type TestFn<ExtraContext = object> = TestCall<TestCallbackFn<ExtraContext>>;
 
 export interface TestEachFn {
   <T extends Record<string, unknown>>(
     cases: readonly T[],
-  ): (
-    description: string,
-    fn?: (param: T) => MaybePromise<void>,
-    options?: number | TestOptions,
-  ) => void;
+  ): TestCall<(param: T) => MaybePromise<void>>;
   <T extends readonly [unknown, ...unknown[]]>(
     cases: readonly T[],
-  ): (
-    description: string,
-    fn?: (...args: [...T]) => MaybePromise<void>,
-    options?: number | TestOptions,
-  ) => void;
-  <T>(
-    cases: readonly T[],
-  ): (
-    description: string,
-    fn?: (...args: T[]) => MaybePromise<void>,
-    options?: number | TestOptions,
-  ) => void;
+  ): TestCall<(...args: [...T]) => MaybePromise<void>>;
+  <T>(cases: readonly T[]): TestCall<(...args: T[]) => MaybePromise<void>>;
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
     ...expressions: unknown[]
-  ): (
-    description: string,
-    fn?: (param: T) => MaybePromise<void>,
-    options?: number | TestOptions,
-  ) => void;
+  ): TestCall<(param: T) => MaybePromise<void>>;
 }
 
 export interface TestForFn<ExtraContext = object> {
   <T>(
     cases: readonly T[],
-  ): (
-    description: string,
-    fn?: (param: T, context: TestContext & ExtraContext) => MaybePromise<void>,
-    options?: number | TestOptions,
-  ) => void;
+  ): TestCall<
+    (param: T, context: TestContext & ExtraContext) => MaybePromise<void>
+  >;
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
     ...expressions: unknown[]
-  ): (
-    description: string,
-    fn?: (param: T, context: TestContext & ExtraContext) => MaybePromise<void>,
-    options?: number | TestOptions,
-  ) => void;
+  ): TestCall<
+    (param: T, context: TestContext & ExtraContext) => MaybePromise<void>
+  >;
 }
 
 export interface DescribeEachFn {

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -123,7 +123,7 @@ describe('RunnerRuntime', () => {
     ).toEqual(['test - 1 - 1']);
   });
 
-  describe('TestOptions third argument', () => {
+  describe('TestOptions second argument', () => {
     const createApi = (testTimeout = 5000) =>
       createPublishedRuntimeAPI({
         testPath: __filename,
@@ -145,7 +145,7 @@ describe('RunnerRuntime', () => {
 
     it('reads timeout/retry/repeats from a TestOptions object', async () => {
       const instance = createApi();
-      runtimeAPI.it('case', () => {}, { timeout: 250, retry: 2, repeats: 3 });
+      runtimeAPI.it('case', { timeout: 250, retry: 2, repeats: 3 }, () => {});
 
       const testCase = (await instance.getTests())[0] as TestCase;
       expect(testCase.timeout).toBe(250);
@@ -153,9 +153,20 @@ describe('RunnerRuntime', () => {
       expect(testCase.repeats).toBe(3);
     });
 
+    it('ignores an options object passed as the third argument', async () => {
+      const instance = createApi(123);
+      // The legacy third-arg object form is no longer supported: it is a type
+      // error and must not leak retry/repeats onto the case at runtime.
+      runtimeAPI.it('case', () => {}, { timeout: 250, retry: 2 } as any);
+
+      const testCase = (await instance.getTests())[0] as TestCase;
+      expect(testCase.timeout).toBe(123);
+      expect(testCase.retry).toBeUndefined();
+    });
+
     it('falls back to config.testTimeout when timeout omitted', async () => {
       const instance = createApi(123);
-      runtimeAPI.it('case', () => {}, { retry: 1 });
+      runtimeAPI.it('case', { retry: 1 }, () => {});
 
       const testCase = (await instance.getTests())[0] as TestCase;
       expect(testCase.timeout).toBe(123);
@@ -164,10 +175,11 @@ describe('RunnerRuntime', () => {
 
     it('propagates options through test.each', async () => {
       const instance = createApi();
-      runtimeAPI.it.each([1, 2])('case %s', () => {}, {
-        timeout: 50,
-        retry: 1,
-      });
+      runtimeAPI.it.each([1, 2])(
+        'case %s',
+        { timeout: 50, retry: 1 },
+        () => {},
+      );
 
       const cases = (await instance.getTests()) as TestCase[];
       expect(cases).toHaveLength(2);
@@ -179,10 +191,11 @@ describe('RunnerRuntime', () => {
 
     it('propagates options through test.for', async () => {
       const instance = createApi();
-      runtimeAPI.it.for([1, 2])('case %s', () => {}, {
-        timeout: 50,
-        repeats: 2,
-      });
+      runtimeAPI.it.for([1, 2])(
+        'case %s',
+        { timeout: 50, repeats: 2 },
+        () => {},
+      );
 
       const cases = (await instance.getTests()) as TestCase[];
       expect(cases).toHaveLength(2);

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -13,7 +13,7 @@ Alias: `it`.
 
 ## test
 
-- **Type:** `(name: string, fn?: (testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
+- **Type:** `(name: string, options: TestOptions, fn?: (testContext: TestContext) => void | Promise<void>) => void`
 
 Defines a test case.
 
@@ -28,23 +28,22 @@ test('should add two numbers correctly', () => {
 
 ### TestOptions
 
-<ApiMeta addedVersion="0.10.3" />
+<ApiMeta addedVersion="0.11.0" />
 
-The third argument tunes the behavior of a single test. Passing a number is shorthand for `{ timeout: n }` so existing code keeps working:
+Pass a `TestOptions` object as the **second argument** (before the test function) to tune the behavior of a single test:
+
+```ts
+test('flaky network call', { retry: 3 }, async () => {
+  /* ... */
+});
+```
+
+As a shorthand, you can still pass a number as the **last argument** to set only the timeout (equivalent to `{ timeout: n }`):
 
 ```ts
 test('runs within 3s', async () => {
   /* ... */
 }, 3000);
-
-// equivalent to:
-test(
-  'runs within 3s',
-  async () => {
-    /* ... */
-  },
-  { timeout: 3000 },
-);
 ```
 
 `TestOptions` accepts:
@@ -54,24 +53,17 @@ test(
 - `repeats?: number` — re-runs an already-passing test this many extra times; any failure marks the whole case as failed. Each repeat runs the full `beforeEach`/`afterEach` lifecycle and gets an independent `retry` budget.
 
 ```ts
-test(
-  'flaky network call',
-  async () => {
-    /* ... */
-  },
-  { retry: 3 },
-);
+test('flaky network call', { retry: 3 }, async () => {
+  /* ... */
+});
 
-test(
-  'stays green across runs',
-  async () => {
-    /* ... */
-  },
-  { repeats: 9 },
-); // 10 total runs; first failure short-circuits the rest
+// 10 total runs; first failure short-circuits the rest
+test('stays green across runs', { repeats: 9 }, async () => {
+  /* ... */
+});
 ```
 
-`test.each` and `test.for` accept the same third argument and apply it to every generated case.
+`test.each` and `test.for` accept the same options as their second argument and apply it to every generated case.
 
 ## test.only
 
@@ -114,7 +106,7 @@ test.todo('should implement this test');
 
 ## test.each
 
-- **Type:** `test.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, options?: number | TestOptions) => void`
+- **Type:** `test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>) => void`
 
 Runs the same test logic for each item in the provided array.
 
@@ -197,7 +189,7 @@ test.each([
 
 ## test.for
 
-- **Type:** `test.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T, testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
+- **Type:** `test.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T, testContext: TestContext) => void | Promise<void>) => void`
 
 Alternative to `test.each` to provide `TestContext`.
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -13,7 +13,7 @@ import { ApiMeta } from '@components/ApiMeta';
 
 ## test
 
-- **类型：** `(name: string, fn?: (testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
+- **类型：** `(name: string, options: TestOptions, fn?: (testContext: TestContext) => void | Promise<void>) => void`
 
 定义一个测试用例。
 
@@ -28,23 +28,22 @@ test('should add two numbers correctly', () => {
 
 ### TestOptions
 
-<ApiMeta addedVersion="0.10.3" />
+<ApiMeta addedVersion="0.11.0" />
 
-第三个参数用于细化单个测试的运行行为。传入数字等价于 `{ timeout: n }`，原有写法保持兼容：
+将 `TestOptions` 对象作为**第二个参数**（位于测试函数之前）传入，用于细化单个测试的运行行为：
+
+```ts
+test('flaky network call', { retry: 3 }, async () => {
+  /* ... */
+});
+```
+
+作为简写，你仍可以将数字作为**最后一个参数**传入，仅用于设置超时（等价于 `{ timeout: n }`）：
 
 ```ts
 test('runs within 3s', async () => {
   /* ... */
 }, 3000);
-
-// 等价于：
-test(
-  'runs within 3s',
-  async () => {
-    /* ... */
-  },
-  { timeout: 3000 },
-);
 ```
 
 `TestOptions` 支持以下字段：
@@ -54,24 +53,17 @@ test(
 - `repeats?: number` — 在通过的前提下额外重跑指定次数，任一次失败则整体判定为失败。每次重跑会完整执行 `beforeEach` / `afterEach`，并各自享有独立的 `retry` 配额。
 
 ```ts
-test(
-  'flaky network call',
-  async () => {
-    /* ... */
-  },
-  { retry: 3 },
-);
+test('flaky network call', { retry: 3 }, async () => {
+  /* ... */
+});
 
-test(
-  'stays green across runs',
-  async () => {
-    /* ... */
-  },
-  { repeats: 9 },
-); // 共执行 10 次；任一次失败即短路后续重跑
+// 共执行 10 次；任一次失败即短路后续重跑
+test('stays green across runs', { repeats: 9 }, async () => {
+  /* ... */
+});
 ```
 
-`test.each` 与 `test.for` 第三参语义相同，会作用于生成的每个 case。
+`test.each` 与 `test.for` 的第二个参数语义相同，会作用于生成的每个 case。
 
 ## test.only
 
@@ -114,7 +106,7 @@ test.todo('should implement this test');
 
 ## test.each
 
-- **类型：** `test.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, options?: number | TestOptions) => void`
+- **类型：** `test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>) => void`
 
 对提供的数组中的每一项运行相同的测试逻辑。
 
@@ -197,7 +189,7 @@ test.each([
 
 ## test.for
 
-- **类型：** `test.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T, testContext: TestContext) => void | Promise<void>, options?: number | TestOptions) => void`
+- **类型：** `test.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T, testContext: TestContext) => void | Promise<void>) => void`
 
 `test.each` 的替代方案，提供 `TestContext`。
 


### PR DESCRIPTION
## Summary

The `TestOptions` object (`retry` / `repeats` / `timeout`) for `test` / `it` / `test.each` / `test.for` was accepted as the **last** argument, after the test function. With a long test body the options were easy to miss at a glance, and code formatters tend to push the trailing object onto an awkward standalone line. This moves the options object to the **second** argument (before the test fn), aligning the API shape with Vitest and Node.js' native test runner.

- **Breaking:** an options object must now be the second argument — `test('name', { retry: 2 }, fn)`. Passing an options object as the last argument is no longer supported (it is a type error and is ignored at runtime).
- The numeric timeout shorthand is unchanged: `test('name', fn, 1000)` still works as the last argument, so the Jest-style `test(name, fn, timeout)` form is unaffected.
- `test.each` / `test.for` follow the same ordering.

Migration:

```ts
// Before
test('name', () => {}, { retry: 2 });
// After
test('name', { retry: 2 }, () => {});
```

## Related Links

- #1324

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).