### PR TITLE
chore: move build out of root prepare script

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Build Packages
+        run: pnpm run build
+
       - name: Publish Preview
         id: publish
         # `pnpm exec` (not `pnpx`/`pnpm dlx`) per pkg.pr.new CAUTION:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Build Packages
+        run: pnpm run build
+
       - name: Publish to npm
         run: |
           pnpm --filter './packages/*' -r stage publish --tag ${{ github.event.inputs.npm_tag }} --no-git-checks
@@ -119,6 +122,9 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install
+
+      - name: Build Packages
+        run: pnpm run build
 
       - name: Package VS Code Extension
         run: pnpm --filter ./packages/vscode run package:vsce -o "rstest-${{ matrix.vsce-target }}.vsix"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,9 +130,11 @@ jobs:
       - name: Install Dependencies
         # setup-node's `cache: pnpm` restores the store; `--prefer-offline`
         # reuses it. A standalone `pnpm fetch` only re-warms an already-warm
-        # store (~26s/job of no gain). Install still runs the root `prepare`
-        # lifecycle (`pnpm run build`), so packages are built as before.
+        # store (~26s/job of no gain).
         run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build Packages
+        run: pnpm run build
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
@@ -199,9 +201,11 @@ jobs:
       - name: Install Dependencies
         # setup-node's `cache: pnpm` restores the store; `--prefer-offline`
         # reuses it. A standalone `pnpm fetch` only re-warms an already-warm
-        # store (~26s/job of no gain). Install still runs the root `prepare`
-        # lifecycle (`pnpm run build`), so packages are built as before.
+        # store (~26s/job of no gain).
         run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build Packages
+        run: pnpm run build
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,13 @@ What this will do:
 
 - Install all dependencies.
 - Create symlinks between packages in the monorepo
-- Run the prepare script to build all packages.
+- Run the prepare script to set up Git hooks.
+
+Then build all packages before running tests or e2e, as they consume the built output:
+
+```bash
+pnpm run build
+```
 
 ## Making changes and building
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write . && heading-case --write",
     "lint": "prettier --check . && pnpm run check-spell && pnpm run lint:type",
     "lint:type": "rslint --type-check",
-    "prepare": "lefthook install && pnpm run build",
+    "prepare": "lefthook install",
     "test": "rstest",
     "test:examples": "pnpm --filter \"@examples/*\" test",
     "test:vscode": "pnpm --filter ./packages/vscode test",


### PR DESCRIPTION
## Summary

pnpm 11's `verifyDepsBeforeRun` (default value: `install`) checks `node_modules` against the lockfile before every `pnpm run`/`pnpm exec`, and runs an implicit install when they drift. Because the root `prepare` was `lefthook install && pnpm run build`, that implicit install re-ran a **full `pnpm run build`** — so routine commands like `pnpm run test` could trigger a complete rebuild.

This PR moves `build` out of `prepare`:

- `prepare` is now just `lefthook install`, so install no longer builds packages.
- Adds explicit `Build Packages` steps to the CI jobs that previously relied on the install-time build: `test.yml` (`ut`, `e2e`), `release.yml` (npm publish + VS Code publish), and `preview.yml` (pkg.pr.new).
- The `lint` job already builds explicitly with `--ignore-scripts`, so it is unaffected; `bundle-diff.yml` and `codspeed.yml` already build explicitly, so they simply stop double-building.
- Updates `CONTRIBUTING.md`: install now sets up Git hooks only, and a separate `pnpm run build` is needed before tests/e2e.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).