### PR TITLE
fix(core): support setSystemTime without a prior useFakeTimers

### DIFF
--- a/e2e/asyncLeaks/fixtures/dateOnlyReset/a.test.ts
+++ b/e2e/asyncLeaks/fixtures/dateOnlyReset/a.test.ts
@@ -1,0 +1,9 @@
+import { expect, rstest, test } from '@rstest/core';
+
+// Pin a Date-only mock and intentionally do NOT call useRealTimers(). Under
+// --detectAsyncLeaks + isolate:false the worker cleanup must undo it so the
+// next file (b.test) does not inherit the mocked Date.
+test('a: pins a date-only system time and leaves it active', () => {
+  rstest.setSystemTime(new Date('2000-01-01T00:00:00.000Z'));
+  expect(new Date().getUTCFullYear()).toBe(2000);
+});

--- a/e2e/asyncLeaks/fixtures/dateOnlyReset/b.test.ts
+++ b/e2e/asyncLeaks/fixtures/dateOnlyReset/b.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@rstest/core';
+
+test('b: sees the real Date, not the pin leaked from a.test', () => {
+  // Would be 2000 if a.test's date-only pin leaked into this reused worker.
+  expect(new Date().getUTCFullYear()).toBeGreaterThan(2000);
+});

--- a/e2e/asyncLeaks/fixtures/dateOnlyReset/rstest.config.ts
+++ b/e2e/asyncLeaks/fixtures/dateOnlyReset/rstest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  isolate: false,
+  // One reused worker so a.test pins the clock and b.test runs after it in the
+  // same realm, making the cross-file Date leak observable.
+  pool: { maxWorkers: 1 },
+});

--- a/e2e/asyncLeaks/index.test.ts
+++ b/e2e/asyncLeaks/index.test.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
 import { runRstestCli } from '../scripts';
@@ -71,6 +71,27 @@ describe('detect async leaks', () => {
       options: {
         nodeOptions: {
           cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
+  it('restores a date-only setSystemTime pin so it does not leak across files', async ({
+    onTestFinished,
+  }) => {
+    // a.test pins a Date-only mock without useRealTimers(); under isolate:false
+    // the cleanup must restore the real Date before b.test runs in the same
+    // reused worker. Regression test for the leak-cleanup predicate that
+    // previously only fired for full fake timers.
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '--detectAsyncLeaks'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures', 'dateOnlyReset'),
         },
       },
     });

--- a/e2e/fakeTimers/index.test.ts
+++ b/e2e/fakeTimers/index.test.ts
@@ -133,3 +133,30 @@ describe('fake timers', () => {
       .toBe(3);
   });
 });
+
+describe('setSystemTime without a prior useFakeTimers', () => {
+  const pinned = new Date('2025-01-01T00:00:00.000Z');
+
+  afterEach(() => {
+    rstest.useRealTimers();
+  });
+
+  it('pins the clock on its own', () => {
+    rstest.setSystemTime(pinned);
+
+    expect(new Date().toISOString()).toBe('2025-01-01T00:00:00.000Z');
+    expect(Date.now()).toBe(pinned.getTime());
+  });
+
+  it('upgrades to fake timers while keeping the pinned time', () => {
+    rstest.setSystemTime(pinned);
+    rstest.useFakeTimers();
+
+    expect(Date.now()).toBe(pinned.getTime());
+
+    const cb = rstest.fn();
+    setTimeout(cb, 1000);
+    rstest.advanceTimersByTime(1000);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/runtime/api/fakeTimers.ts
+++ b/packages/core/src/runtime/api/fakeTimers.ts
@@ -11,6 +11,7 @@ import type {
   Clock as InstalledClock,
   Timer as FakeTimerRecord,
 } from '@sinonjs/fake-timers';
+import { mockDate, RealDate, resetDate } from './mockDate';
 
 export type { FakeTimerInstallOpts };
 
@@ -18,7 +19,6 @@ type FakeTimerTickTime = Parameters<InstalledClock['tick']>[0];
 type FakeTimerSystemTime = Parameters<InstalledClock['setSystemTime']>[0];
 type FakeTimerTickMode = Parameters<InstalledClock['setTickMode']>[0];
 
-const RealDate = Date;
 type FakeMethod = NonNullable<FakeTimerInstallOpts['toFake']>[number];
 
 export type FakeTimersSnapshot = {
@@ -33,6 +33,11 @@ const cloneFakeTimerRecord = (record: FakeTimerRecord): FakeTimerRecord => ({
   args: record.args ? [...record.args] : undefined,
 });
 
+// Detect `Date` structurally rather than with `instanceof`, so a `Date` from
+// another realm (iframe / vm context) or created via a mocked global is matched.
+const isDate = (value: unknown): value is Date =>
+  Object.prototype.toString.call(value) === '[object Date]';
+
 const loadFakeTimersModule = () => {
   // TODO: Switch back to createRequire(import.meta.url) once Rspack supports
   // preserving that pattern without breaking bundling/runtime resolution.
@@ -46,7 +51,14 @@ const loadFakeTimersModule = () => {
 export class FakeTimers {
   private _clock!: InstalledClock;
   private readonly _config: FakeTimerInstallOpts;
+  // | _fakingTime | _fakingDate |
+  // +-------------+-------------+
+  // | false       | falsy       | initial
+  // | false       | truthy      | setSystemTime called first (mock only Date without fake timers)
+  // | true        | falsy       | useFakeTimers called first
+  // | true        | truthy      | unreachable
   private _fakingTime: boolean;
+  private _fakingDate: Date | null;
   private readonly _fakeTimers: FakeTimerWithContext;
 
   constructor({
@@ -58,6 +70,7 @@ export class FakeTimers {
   }) {
     this._config = config;
     this._fakingTime = false;
+    this._fakingDate = null;
     this._fakeTimers = loadFakeTimersModule().withGlobal(global);
   }
 
@@ -159,7 +172,16 @@ export class FakeTimers {
     }
   }
 
+  private _resetFakingDate(): void {
+    if (this._fakingDate) {
+      resetDate();
+      this._fakingDate = null;
+    }
+  }
+
   useRealTimers(): void {
+    this._resetFakingDate();
+
     if (this._fakingTime) {
       this._clock.uninstall();
       this._fakingTime = false;
@@ -170,6 +192,11 @@ export class FakeTimers {
     toNotFake = [],
     ...restFakeTimersConfig
   }: FakeTimerInstallOpts = {}): void {
+    // Carry over the time pinned by a prior Date-only setSystemTime() so that
+    // promoting to full fake timers keeps the same "now".
+    const fakeDate = this._fakingDate ?? Date.now();
+    this._resetFakingDate();
+
     if (this._fakingTime) {
       this._clock.uninstall();
     }
@@ -191,7 +218,7 @@ export class FakeTimers {
     this._clock = this._fakeTimers.install({
       loopLimit: 10_000,
       shouldClearNativeTimers: true,
-      now: Date.now(),
+      now: fakeDate,
       toFake: [...toFake],
       ignoreMissingTimers: true,
       ...restFakeTimersConfig,
@@ -211,9 +238,35 @@ export class FakeTimers {
   }
 
   setSystemTime(now?: FakeTimerSystemTime): void {
-    if (this._checkFakeTimers()) {
+    if (this._fakingTime) {
+      // `@sinonjs/fake-timers` accepts `number | Date | { epochMilliseconds }`
+      // directly, so forward it untouched.
       this._clock.setSystemTime(now);
+      return;
     }
+    // Mock only the global `Date` without installing full fake timers, so
+    // setSystemTime() works on its own (matching Vitest). Assign `_fakingDate`
+    // only after `mockDate` validates the input, so an invalid value throws
+    // without corrupting a previously pinned date.
+    const date = this._toFakeDate(now);
+    mockDate(date);
+    this._fakingDate = date;
+  }
+
+  private _toFakeDate(now?: FakeTimerSystemTime): Date {
+    if (now === undefined) {
+      return new Date(this.getRealSystemTime());
+    }
+    if (typeof now === 'number') {
+      return new Date(now);
+    }
+    // Clone the Date so a later mutation of the caller's object can't leak into
+    // the pin (which a promotion or scoped restore would otherwise pick up).
+    if (isDate(now)) {
+      return new RealDate(now.valueOf());
+    }
+    // Temporal-like value, e.g. `{ epochMilliseconds }`.
+    return new Date(now.epochMilliseconds);
   }
 
   snapshot(): FakeTimersSnapshot | undefined {
@@ -261,6 +314,15 @@ export class FakeTimers {
 
   getRealSystemTime(): number {
     return RealDate.now();
+  }
+
+  /**
+   * The time pinned by a Date-only `setSystemTime()` (i.e. without full fake
+   * timers), or `null`. Used to restore that pin after a scoped
+   * `useFakeTimers()` disposes.
+   */
+  getMockedSystemTime(): Date | null {
+    return this._fakingDate;
   }
 
   now(): number {

--- a/packages/core/src/runtime/api/mockDate.ts
+++ b/packages/core/src/runtime/api/mockDate.ts
@@ -1,0 +1,129 @@
+/**
+ * Ported from https://github.com/boblauer/MockDate/blob/master/src/mockdate.ts
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Bob Lauer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+
+export const RealDate: DateConstructor = Date;
+
+let now: number | null = null;
+
+class MockDate extends RealDate {
+  constructor();
+  constructor(value: number | string | Date);
+  constructor(
+    year: number,
+    month: number,
+    date?: number,
+    hours?: number,
+    minutes?: number,
+    seconds?: number,
+    ms?: number,
+  );
+  constructor(
+    ...args:
+      | []
+      | [value: number | string | Date]
+      | [
+          year: number,
+          month: number,
+          date?: number,
+          hours?: number,
+          minutes?: number,
+          seconds?: number,
+          ms?: number,
+        ]
+  ) {
+    super();
+
+    let date: Date;
+    if (args.length === 0) {
+      date = now !== null ? new RealDate(now) : new RealDate();
+    } else if (args.length === 1) {
+      date = new RealDate(args[0]);
+    } else {
+      // Forward the arguments verbatim so native coercion is preserved — e.g.
+      // an explicit `undefined`/`NaN` field yields `Invalid Date`, while an
+      // omitted field still defaults the same way the native `Date` does.
+      date = new RealDate(...args);
+    }
+
+    // Re-point the freshly built RealDate at the actual construction target's
+    // prototype (`new.target`), not a hard-coded `MockDate.prototype`. For
+    // `new Date()` that is `MockDate`; for `class X extends Date` it is `X`, so
+    // `instanceof X` and the subclass's own members are preserved like native.
+    Object.setPrototypeOf(date, new.target.prototype);
+
+    // The constructor of a subclass implicitly returns `this`, but here we
+    // return that freshly built RealDate so the mocked "now" is honored for the
+    // zero-argument case.
+    // eslint-disable-next-line no-constructor-return
+    return date;
+  }
+}
+
+// Make `instanceof Date` recognize every real Date, including ones built before
+// the global was swapped (cached/imported values). Without this only
+// MockDate-constructed dates pass, so user validation of a pre-existing Date
+// would wrongly reject it under the date-only clock.
+//
+// NOTE: this hook is a DELIBERATE divergence from Vitest's port, which has no
+// `Symbol.hasInstance` at all. The `this !== MockDate` guard below exists solely
+// to contain that divergence (subclasses must not inherit the broadened check),
+// so do not "simplify" it away — dropping it reintroduces the subclass leak
+// where `new Date() instanceof (class X extends Date {})` wrongly returns true.
+Object.defineProperty(MockDate, Symbol.hasInstance, {
+  value(this: unknown, instance: unknown): boolean {
+    // This static hook is inherited by `class X extends Date` subclasses, so
+    // only broaden `instanceof` for `Date`/`MockDate` itself. Subclasses fall
+    // back to the native algorithm, otherwise every real Date would wrongly
+    // satisfy `x instanceof X`.
+    if (this !== MockDate) {
+      return Function.prototype[Symbol.hasInstance].call(this, instance);
+    }
+    return instance instanceof RealDate;
+  },
+});
+
+MockDate.UTC = RealDate.UTC;
+
+MockDate.now = function now() {
+  return new MockDate().valueOf();
+};
+
+MockDate.parse = function parse(dateString: string) {
+  return RealDate.parse(dateString);
+};
+
+MockDate.toString = function toString() {
+  return RealDate.toString();
+};
+
+export function mockDate(date: string | number | Date): void {
+  const dateObj = new RealDate(date.valueOf());
+  if (Number.isNaN(dateObj.getTime())) {
+    throw new TypeError(`mockdate: The time set is an invalid date: ${date}`);
+  }
+
+  // MockDate intentionally omits `Date`'s callable-without-new string overload.
+  // @ts-expect-error overriding the global Date constructor
+  globalThis.Date = MockDate;
+
+  now = dateObj.valueOf();
+}
+
+export function resetDate(): void {
+  globalThis.Date = RealDate;
+}

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -149,6 +149,9 @@ const buildRstestUtilities = async (): Promise<{
     config: FakeTimerInstallOpts | undefined;
     snapshot: FakeTimersSnapshot | undefined;
     wasFakeTimers: boolean;
+    // The Date-only pin (from a prior `setSystemTime()` without fake timers)
+    // active when this scope was entered, so it can be restored on dispose.
+    fakingDate: Date | null;
   };
 
   const originalEnvValues = new Map<string, EnvStackEntry[]>();
@@ -268,6 +271,7 @@ const buildRstestUtilities = async (): Promise<{
         laterEntry.config = entry.config;
         laterEntry.snapshot = entry.snapshot;
         laterEntry.wasFakeTimers = entry.wasFakeTimers;
+        laterEntry.fakingDate = entry.fakingDate;
       },
       onTail: () => {
         if (entry.wasFakeTimers) {
@@ -278,6 +282,10 @@ const buildRstestUtilities = async (): Promise<{
           currentFakeTimersConfig = entry.config;
         } else {
           timers().useRealTimers();
+          // Re-establish a Date-only pin that was active before this scope.
+          if (entry.fakingDate) {
+            timers().setSystemTime(entry.fakingDate);
+          }
           currentFakeTimersConfig = undefined;
         }
       },
@@ -457,6 +465,7 @@ const buildRstestUtilities = async (): Promise<{
         config: currentFakeTimersConfig,
         snapshot: wasFakeTimers ? timerApi.snapshot() : undefined,
         wasFakeTimers,
+        fakingDate: timerApi.getMockedSystemTime(),
       };
       timerStack.push(entry);
       timerApi.useFakeTimers(opts);

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -657,9 +657,11 @@ export const runInPool = async (
     );
 
     if (asyncLeakDetector) {
-      if (api.rstest.isFakeTimers()) {
-        api.rstest.useRealTimers();
-      }
+      // Undo any time mocking before collecting leaks and before a reused worker
+      // runs the next file. This must cover BOTH full fake timers and a
+      // date-only `setSystemTime()` pin (which leaves `isFakeTimers()` false);
+      // `useRealTimers()` is an idempotent no-op when nothing is mocked.
+      api.rstest.useRealTimers();
       const asyncLeakErrors = await asyncLeakDetector.collectErrors();
       if (asyncLeakErrors.length > 0) {
         results.status = 'fail';

--- a/packages/core/tests/runtime/api/fakeTimers.test.ts
+++ b/packages/core/tests/runtime/api/fakeTimers.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'node:vm';
 import { setRealTimers } from '../../../src/runtime/util';
 import { createUtilities } from './helpers';
 
@@ -61,6 +62,163 @@ describe('fake timers API', () => {
     expect(Date.now()).toBe(1234);
 
     rs.useRealTimers();
+  });
+
+  describe('setSystemTime without a prior useFakeTimers', () => {
+    const pinned = new Date('2025-01-01T00:00:00.000Z');
+    let rs: Awaited<ReturnType<typeof createUtilities>>;
+
+    beforeEach(async () => {
+      rs = await createUtilities();
+    });
+
+    afterEach(() => {
+      rs.useRealTimers();
+    });
+
+    it('pins the clock to the given date', () => {
+      rs.setSystemTime(pinned);
+
+      expect(new Date().toISOString()).toBe('2025-01-01T00:00:00.000Z');
+      expect(Date.now()).toBe(pinned.getTime());
+    });
+
+    it('leaves the timer APIs unmocked', async () => {
+      rs.setSystemTime(0);
+
+      let fired = false;
+      setTimeout(() => {
+        fired = true;
+      }, 5);
+
+      // Only `Date` is faked, so there is no fake clock to advance...
+      expect(rs.isFakeTimers()).toBe(false);
+      expect(() => rs.advanceTimersByTime(10)).toThrow(/not mocked/);
+
+      // ...and the real timer still fires on its own.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(fired).toBe(true);
+    });
+
+    it('still honors explicit Date arguments', () => {
+      rs.setSystemTime(pinned);
+
+      expect(new Date(2030, 5, 15).getFullYear()).toBe(2030);
+      expect(new Date(Date.UTC(2030, 5, 15)).toISOString()).toBe(
+        '2030-06-15T00:00:00.000Z',
+      );
+      // An omitted field defaults like native `Date`...
+      expect(Number.isNaN(new Date(2030, 5).getTime())).toBe(false);
+      // ...but an explicit `undefined`/`NaN` field yields `Invalid Date`.
+      expect(Number.isNaN(new Date(2030, 5, undefined).getTime())).toBe(true);
+      expect(Number.isNaN(new Date(2030, 5, 15, Number.NaN).getTime())).toBe(
+        true,
+      );
+    });
+
+    it('accepts a Date created in another realm', () => {
+      // A Date from a different realm is not `instanceof` this realm's `Date`.
+      const crossRealmDate: Date = runInNewContext(
+        'new Date("2030-06-15T00:00:00.000Z")',
+      );
+      expect(crossRealmDate instanceof Date).toBe(false);
+
+      expect(() => rs.setSystemTime(crossRealmDate)).not.toThrow();
+      expect(new Date().toISOString()).toBe('2030-06-15T00:00:00.000Z');
+    });
+
+    it('preserves prototypes for Date subclasses defined under the mock', () => {
+      rs.setSystemTime(pinned);
+
+      class MyDate extends Date {
+        greet(): string {
+          return 'hi';
+        }
+      }
+      const instance = new MyDate();
+
+      expect(instance).toBeInstanceOf(MyDate);
+      expect(instance.greet()).toBe('hi');
+      // A subclass with no args still reflects the pinned time.
+      expect(instance.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+      // A plain Date must NOT satisfy the subclass check (the broadened
+      // `instanceof` hook applies to `Date` itself, not inherited subclasses).
+      expect(new Date() instanceof MyDate).toBe(false);
+    });
+
+    it('keeps the previous pin when a later setSystemTime is invalid', () => {
+      rs.setSystemTime(pinned);
+
+      expect(() => rs.setSystemTime(Number.NaN)).toThrow();
+
+      // The failed call must not corrupt the previously pinned date.
+      expect(new Date().toISOString()).toBe('2025-01-01T00:00:00.000Z');
+      rs.useFakeTimers();
+      expect(new Date().toISOString()).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('restores the real clock on useRealTimers', () => {
+      rs.setSystemTime(pinned);
+      rs.useRealTimers();
+
+      expect(new Date().getFullYear()).toBeGreaterThan(2025);
+    });
+
+    it('upgrades to fake timers while keeping the pinned time', () => {
+      rs.setSystemTime(pinned);
+      rs.useFakeTimers();
+
+      expect(rs.isFakeTimers()).toBe(true);
+      expect(Date.now()).toBe(pinned.getTime());
+
+      const cb = rs.fn();
+      setTimeout(cb, 1000);
+      rs.advanceTimersByTime(1000);
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps instanceof Date working for dates created before the mock', () => {
+      // A Date cached before the pin is a `RealDate`, not a `MockDate`, yet user
+      // code validating it with `instanceof Date` must still accept it.
+      const cached = new Date('2020-01-01T00:00:00.000Z');
+      rs.setSystemTime(pinned);
+
+      expect(cached instanceof Date).toBe(true);
+      // A date created under the mock is still a Date too.
+      expect(new Date() instanceof Date).toBe(true);
+    });
+
+    it('re-pins from a Date created before the mock was installed', () => {
+      // `stored` predates the mock, so once the global `Date` is `MockDate` it
+      // is no longer `instanceof globalThis.Date`.
+      const stored = new Date('2030-06-15T00:00:00.000Z');
+      rs.setSystemTime(pinned);
+
+      expect(() => rs.setSystemTime(stored)).not.toThrow();
+      expect(new Date().toISOString()).toBe('2030-06-15T00:00:00.000Z');
+    });
+
+    it('snapshots the pin so later mutation of the input does not leak', () => {
+      const input = new Date('2025-01-01T00:00:00.000Z');
+      rs.setSystemTime(input);
+      input.setUTCFullYear(2099);
+
+      // Promotion to full fake timers must keep the value set at call time.
+      rs.useFakeTimers();
+      expect(new Date().getUTCFullYear()).toBe(2025);
+    });
+
+    it('restores the Date-only pin after a scoped useFakeTimers disposes', () => {
+      rs.setSystemTime(pinned);
+
+      const scoped = rs.useFakeTimers();
+      expect(rs.isFakeTimers()).toBe(true);
+      scoped[Symbol.dispose]?.();
+
+      // Back to the Date-only pin, not the real clock.
+      expect(rs.isFakeTimers()).toBe(false);
+      expect(Date.now()).toBe(pinned.getTime());
+    });
   });
 
   it('jumpTimersByTime fires recurring timers at most once', async () => {

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -76,6 +76,7 @@ jsdom
 jsesc
 jsxs
 koppers
+Lauer
 lightningcss
 liyincode
 llms

--- a/website/docs/en/api/runtime-api/rstest/fake-timers.mdx
+++ b/website/docs/en/api/runtime-api/rstest/fake-timers.mdx
@@ -70,11 +70,16 @@ if (rs.isFakeTimers()) {
 
 Sets the current system time used by fake timers. Useful for testing code that depends on the current date or time.
 
+If fake timers are enabled, this simulates the user changing the system clock (affecting date-related APIs like `Date` and `performance.now`) without firing any timers. If fake timers are not enabled, this only mocks `Date.*` calls, so you can pin the clock without calling [`rs.useFakeTimers`](#rsusefaketimers) first.
+
 The `now` value can also be a Temporal-like object such as `Temporal.Instant` or `Temporal.ZonedDateTime`.
 
 ```ts
-rs.useFakeTimers();
 rs.setSystemTime(new Date('2020-01-01T00:00:00Z'));
+
+expect(new Date().toISOString()).toBe('2020-01-01T00:00:00.000Z');
+
+rs.useRealTimers();
 ```
 
 ## rs.getRealSystemTime

--- a/website/docs/zh/api/runtime-api/rstest/fake-timers.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/fake-timers.mdx
@@ -70,11 +70,16 @@ if (rs.isFakeTimers()) {
 
 设置 fake timers 使用的当前系统时间。适用于需要测试依赖当前日期或时间的代码。
 
+启用 fake timers 时，该方法会模拟用户修改系统时钟（影响 `Date`、`performance.now` 等与日期相关的 API），但不会触发任何 timer。若未启用 fake timers，则仅 mock `Date.*` 调用，因此无需先调用 [`rs.useFakeTimers`](#rsusefaketimers) 即可固定时钟。
+
 `now` 也可以是类似 Temporal 的对象，例如 `Temporal.Instant` 或 `Temporal.ZonedDateTime`。
 
 ```ts
-rs.useFakeTimers();
 rs.setSystemTime(new Date('2020-01-01T00:00:00Z'));
+
+expect(new Date().toISOString()).toBe('2020-01-01T00:00:00.000Z');
+
+rs.useRealTimers();
 ```
 
 ## rs.getRealSystemTime


### PR DESCRIPTION
## Summary

`rs.setSystemTime(date)` threw `Timers are not mocked. Try calling "rstest.useFakeTimers()" first.` unless `rs.useFakeTimers()` had been called first. This made it impossible to pin only the system clock — a common need when testing date-dependent code — without also taking over the timer APIs. The behavior also diverged from Vitest, where the same test passes.

This PR lets `setSystemTime` work on its own: when fake timers are not active, it now mocks only the global `Date` (leaving `setTimeout`/`setInterval`/etc. real). A later `useFakeTimers()` upgrades to full fake timers while keeping the pinned time. Calling `setSystemTime` after `useFakeTimers()` is unchanged. Docs (EN/ZH) and unit + e2e coverage are updated.

## Related Links

- Closes #1462