### PR TITLE
chore: add pre-push lint gate via lefthook

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,12 @@ dist
 compiled
 doc_build
 
+# Per-package third-party license bundles are generated and prettier-formatted by
+# each package's own build (`rslib build && prettier ./LICENSE.md --write`), so the
+# lint gate must not re-check them — nor race the build writing them when pre-push
+# runs format-spell and typecheck in parallel.
+LICENSE.md
+
 # Symlinks (prettier does not handle symlinks)
 CLAUDE.md
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,14 +2,37 @@ pre-commit:
   parallel: true
   commands:
     prettier:
-      glob: '**/*.{js,jsx,ts,tsx,mjs,mts,cjs,cts,md,mdx,css,less,scss,json,jsonc,json5}'
-      exclude: 'CLAUDE.md'
+      # No glob: let prettier pick which staged files it can format (via
+      # --ignore-unknown, honoring .prettierignore), so this matches the whole-repo
+      # `prettier --check .` run on pre-push and in CI. An explicit extension list
+      # drifts (it was missing yaml) and **/*.x does not match repo-root files.
       stage_fixed: true
-      run: pnpm prettier --write {staged_files}
+      run: pnpm prettier --write --ignore-unknown {staged_files}
+
+pre-push:
+  parallel: true
+  commands:
+    # Build-free checks — whole-repo prettier + spell/heading-case. Runs on every
+    # push, including docs-only ones. Overlaps the typecheck build, so on a code
+    # push it adds no wall-clock. The build's only prettier-checked output,
+    # packages/*/LICENSE.md, is in .prettierignore so it cannot race this scan.
+    format-spell:
+      run: pnpm prettier --check . && pnpm run check-spell
+    # Type-check needs built package .d.ts, so build first. Runs unless the push
+    # is entirely markdown, so a docs-only push still skips the build while config
+    # inputs (tsconfig.json, rslint.config.mts, ...) keep gating it. An inclusive
+    # extension glob would miss those: lefthook's **/*.x does not match repo-root
+    # files such as rslint.config.mts.
+    typecheck:
+      exclude:
+        - '*.md'
+        - '*.mdx'
+      run: pnpm run build && pnpm run lint:type
+    # Dependency-version check lives here rather than on pre-commit; lefthook skips
+    # it instantly when no pushed file matches its glob, so a code-only push pays
+    # nothing. `pnpm dedupe --check` is intentionally left to CI: it can perturb
+    # pnpm's modules state, and CI keeps it last to stay safe — pre-push runs in
+    # parallel and gives no ordering control to isolate it from the build.
     check-dependency-version:
       glob: '**/package.json'
-      stage_fixed: true
-      run: pnpm run check-dependency-version && pnpm prettier --write {staged_files}
-    pnpm-dedupe:
-      glob: 'pnpm-lock.yaml'
-      run: pnpm dedupe --check --config.minimum-release-age=0
+      run: pnpm run check-dependency-version


### PR DESCRIPTION
## Summary

The CI "Lint" gate (`prettier --check`, cspell, `rslint --type-check`) only runs after push, so lint failures surface in CI instead of locally — especially for commits made in worktrees where the `pre-commit` hook was skipped. This adds a lefthook `pre-push` stage that mirrors those checks before pushing:

- **`format-spell`** — whole-repo `prettier --check` + spell check; runs on every push (build-free).
- **`typecheck`** — `pnpm build && rslint --type-check`. `rslint --type-check` reads built `.d.ts`, so it builds first. Runs unless the push is entirely markdown, so a docs-only push skips the build while config inputs (`tsconfig.json`, `rslint.config.mts`, …) still gate it.
- **`check-dependency-version`** moves off `pre-commit` onto `pre-push`, gated by glob so it runs only when `package.json` changes.

`format-spell` and `typecheck` run in parallel. The build's only prettier-checked output — the generated `packages/*/LICENSE.md` bundles — is added to `.prettierignore` so the whole-repo `prettier --check` cannot race the build writing them.

The pre-commit `pnpm dedupe --check` is dropped rather than moved: it perturbs pnpm's modules state, CI already runs it (ordered last to stay safe), and pre-push's parallel commands give no ordering control to isolate it from the build.

`pre-commit` now runs `prettier --write --ignore-unknown` on staged files (no extension glob), so it formats the same files `prettier --check .` validates — yaml included. Hooks install through the existing `prepare` script (`lefthook install`).

## Checklist

- [x] Tests updated (or not required). — tooling/config change, no code under test.
- [x] Documentation updated (or not required).
