### PR TITLE
fix(core): surface testPath with OS-native separators

### DIFF
--- a/e2e/expect/test/index.test.ts
+++ b/e2e/expect/test/index.test.ts
@@ -107,4 +107,19 @@ describe('Expect API', () => {
     expect(1 + 2).toBe(3);
     expect(1 + 3).toBe(4);
   });
+
+  // testPath must be the OS-native absolute path so it equals
+  // `import.meta.filename`/`__filename` on every platform (incl. Windows).
+  // https://github.com/web-infra-dev/rstest/issues/1465
+  it('expect.getState().testPath should be the native file path', () => {
+    expect(expect.getState().testPath).toBe(import.meta.filename);
+  });
+
+  // The public per-test `context.expect` reads testPath through a separate
+  // state getter, so it must agree with the global `expect` (#1465).
+  it('context.expect.getState().testPath should also be native', ({
+    expect,
+  }) => {
+    expect(expect.getState().testPath).toBe(import.meta.filename);
+  });
 });

--- a/e2e/lifecycle/fixtures/beforeAll.test.ts
+++ b/e2e/lifecycle/fixtures/beforeAll.test.ts
@@ -1,10 +1,10 @@
 import { beforeAll, describe, expect, it } from '@rstest/core';
-import pathe from 'pathe';
 import { sleep } from '../../scripts';
 
 beforeAll((ctx) => {
   console.log('[beforeAll] root');
-  expect(ctx.filepath).toBe(pathe.normalize(__filename));
+  // `ctx.filepath` is the OS-native test path, equal to `__filename` (#1465).
+  expect(ctx.filepath).toBe(__filename);
 });
 
 beforeAll(async () => {

--- a/e2e/setup/index.test.ts
+++ b/e2e/setup/index.test.ts
@@ -98,11 +98,13 @@ describe('test setup file', async () => {
     const logs = cli.stdout.split('\n');
     await expectExecSuccess();
 
+    // `ctx.filepath` is OS-native (#1465), so build the expected suffix with
+    // `join` to match backslashes on Windows and forward slashes on POSIX.
     expect(
-      logs.filter((log) => log.endsWith('no-isolate/foo.test.ts')),
+      logs.filter((log) => log.endsWith(join('no-isolate', 'foo.test.ts'))),
     ).toHaveLength(1);
     expect(
-      logs.filter((log) => log.endsWith('no-isolate/bar.test.ts')),
+      logs.filter((log) => log.endsWith(join('no-isolate', 'bar.test.ts'))),
     ).toHaveLength(1);
     expect(logs.filter((log) => log.endsWith('[beforeAll] root'))).toHaveLength(
       2,

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -44,6 +44,7 @@ import type {
   TestCase,
   WorkerState,
 } from '../../types';
+import { toNativePath } from '../../utils/helper';
 import { fileContext } from '../fileContext';
 import { createExpectPoll } from './poll';
 
@@ -66,8 +67,11 @@ const freshExpectState = (
   isExpectingAssertionsError: null,
   expectedAssertionsNumber: null,
   expectedAssertionsNumberErrorGen: null,
+  // `testPath` is user-facing; expose the OS-native path (equal to
+  // `import.meta.filename`) for every expect instance — global and the
+  // public per-test `context.expect` alike. Internally it stays POSIX (#1465).
   get testPath() {
-    return getWorkerState().testPath;
+    return toNativePath(getWorkerState().testPath);
   },
 });
 

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -21,7 +21,11 @@ import type {
   WorkerState,
 } from '../../types';
 import { SYNTHETIC_STACK_ERROR_MESSAGE } from '../../utils/constants';
-import { getFileTaskId, getTaskNameWithPrefix } from '../../utils/helper';
+import {
+  getFileTaskId,
+  getTaskNameWithPrefix,
+  toNativePath,
+} from '../../utils/helper';
 import { createExpect } from '../api/expect';
 import { formatTestError, TestSkipError } from '../util';
 import type { TaskContext } from '../worker/taskContext';
@@ -409,7 +413,9 @@ export class TestRunner {
               try {
                 for (const fn of test.beforeAllListeners) {
                   const cleanupFn = await fn({
-                    filepath: testPath,
+                    // `ctx.filepath` is user-facing; expose the OS-native path
+                    // so it matches `__filename`/`import.meta.filename` (#1465).
+                    filepath: toNativePath(testPath),
                   });
                   if (cleanupFn) cleanups.push(cleanupFn);
                 }
@@ -440,7 +446,9 @@ export class TestRunner {
               try {
                 for (const fn of afterAllFns) {
                   await fn({
-                    filepath: testPath,
+                    // `ctx.filepath` is user-facing; expose the OS-native path
+                    // so it matches `__filename`/`import.meta.filename` (#1465).
+                    filepath: toNativePath(testPath),
                   });
                 }
               } catch (error) {
@@ -763,7 +771,10 @@ export class TestRunner {
         isExpectingAssertionsError: null,
         expectedAssertionsNumber: null,
         expectedAssertionsNumberErrorGen: null,
-        testPath: test.testPath,
+        // `expect.getState().testPath` is user-facing; expose the OS-native
+        // path (equal to `import.meta.filename`). Internal consumers
+        // (snapshot, reporter, related) keep the POSIX `test.testPath` (#1465).
+        testPath: toNativePath(test.testPath),
         snapshotState,
         currentTestName: getTaskNameWithPrefix(test),
       },

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -1,3 +1,4 @@
+import { normalize as nativeNormalize } from 'node:path';
 import {
   isAbsolute,
   join,
@@ -60,6 +61,18 @@ export const displayPath = (filePath: string, rootPath: string): string => {
   const rel = relative(rootPath, resolve(rootPath, filePath));
   return rel && !rel.startsWith('..') ? rel : filePath;
 };
+
+/**
+ * Convert a path to the OS-native separator form (`\` on Windows, no-op on
+ * POSIX). Internally `testPath` stays POSIX so the pathe-based consumers
+ * (snapshot, reporter relative paths, related-graph lookup) keep working, but
+ * the user-facing surfaces (`expect.getState().testPath`, hook `ctx.filepath`)
+ * must match `import.meta.filename`/`__filename`, which the rspack plugin
+ * injects in native form. Apply this only at those user-facing boundaries.
+ * See https://github.com/web-infra-dev/rstest/issues/1465.
+ */
+export const toNativePath = (filePath: string): string =>
+  nativeNormalize(filePath);
 
 export const parsePosix = (filePath: string): { dir: string; base: string } => {
   const { dir, base } = parse(filePath);

--- a/packages/core/tests/runtime/api/expect.test.ts
+++ b/packages/core/tests/runtime/api/expect.test.ts
@@ -9,6 +9,7 @@ import {
   setFileContext,
 } from '../../../src/runtime/fileContext';
 import type { TestCase, WorkerState } from '../../../src/types';
+import { toNativePath } from '../../../src/utils/helper';
 
 const fakeTest = (name: string) => ({ name }) as unknown as TestCase;
 
@@ -62,7 +63,8 @@ describe('file-level expect singleton (isolate: false)', () => {
       'vitest-test',
     ) as TestCase;
     expect(attributed.name).toBe('t2');
-    expect(captured.getState().testPath).toBe('/f2');
+    // `getState().testPath` is normalized to OS-native separators (#1465).
+    expect(captured.getState().testPath).toBe(toNativePath('/f2'));
   });
 
   it('resets per-file bookkeeping between files', () => {
@@ -86,7 +88,7 @@ describe('file-level expect singleton (isolate: false)', () => {
     publishFile('/f2', 't2');
     createFileExpect(() => {});
 
-    expect(fileExpect.getState().testPath).toBe('/f2');
+    expect(fileExpect.getState().testPath).toBe(toNativePath('/f2'));
   });
 
   it('keeps the per-test local expect pinned (concurrent isolation)', () => {

--- a/packages/core/tests/utils/helper.test.ts
+++ b/packages/core/tests/utils/helper.test.ts
@@ -5,12 +5,29 @@ import {
   needFlagExperimentalDetectModule,
   parsePosix,
   prettyTime,
+  toNativePath,
 } from '../../src/utils/helper';
 
 it('getFileTaskId builds the file: task-id grammar', () => {
   // Locks the single source of truth so the worker/pool/runner consumers and
   // the tests/pool/fixtures/testWorker.mjs literal copy cannot drift.
   expect(getFileTaskId('/abs/foo.test.ts')).toBe('file:/abs/foo.test.ts');
+});
+
+it('toNativePath converts forward-slash paths to OS-native separators', () => {
+  // The runtime `testPath` must use OS-native separators so it matches
+  // `import.meta.filename` on Windows (#1465). `join(sep)` keeps this
+  // assertion meaningful on both platforms: on Windows the result must use
+  // backslashes, on POSIX it stays `/` (native == POSIX there).
+  expect(toNativePath('packages/core/a.test.ts')).toBe(
+    'packages/core/a.test.ts'.replaceAll('/', sep),
+  );
+  // Absolute paths are converted too.
+  expect(toNativePath('/abs/foo.test.ts')).toBe(
+    '/abs/foo.test.ts'.replaceAll('/', sep),
+  );
+  // The output must never keep `/` unless `/` is the native separator.
+  expect(toNativePath('a/b/c').includes('/')).toBe(sep === '/');
 });
 
 it('parsePosix correctly', () => {


### PR DESCRIPTION
## Summary

`expect.getState().testPath` and the lifecycle hook `ctx.filepath` are real on-disk paths surfaced to users. They were emitted in POSIX form (forward slashes), so on Windows they diverged from `import.meta.filename` / `__filename` (which the rspack plugin injects in OS-native form) and from any path a user builds with `node:path`. A user-side comparison like `expect.getState().testPath === import.meta.filename` therefore failed on Windows. A `testPath` is a real filesystem path, so blanket-forcing POSIX onto it is semantically wrong — these user-facing surfaces should carry OS-native separators.

Internally `testPath` must stay POSIX: the snapshot client, the reporter relative paths, and the related-graph lookup all run it through `pathe`, which only understands `/`. So the conversion happens only at the two user-facing boundaries — the `setState` `testPath` and the hook context `filepath` — via a small `toNativePath` helper, leaving every internal consumer untouched. The change is a no-op on POSIX platforms (native separator is already `/`).

## Related Links

- Closes #1465

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
