### PR TITLE
feat(core): support TestOptions as the second argument of describe

### DIFF
--- a/e2e/test-api/fixtures/describeOptionsRetry.test.ts
+++ b/e2e/test-api/fixtures/describeOptionsRetry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@rstest/core';
+
+// A `retry` set on `describe` propagates to inner tests as a default; a
+// per-test `retry` still overrides it.
+describe('suite retry propagates', { retry: 2 }, () => {
+  let inherited = 0;
+  it('inner test inherits the suite retry budget', () => {
+    inherited++;
+    // Pass on the third attempt (initial + 2 inherited retries).
+    expect(inherited).toBe(3);
+  });
+
+  let overridden = 0;
+  it('per-test retry overrides the suite retry', { retry: 0 }, () => {
+    overridden++;
+    // retry: 0 disables retries even though the suite set retry: 2.
+    expect(overridden).toBe(1);
+  });
+});

--- a/e2e/test-api/fixtures/describeOptionsTimeout.test.ts
+++ b/e2e/test-api/fixtures/describeOptionsTimeout.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from '@rstest/core';
+import { sleep } from '../../scripts';
+
+// A `timeout` set on `describe` propagates to inner tests as a default; a
+// per-test `timeout` still overrides it.
+describe('suite timeout propagates', { timeout: 50 }, () => {
+  it('inner test inherits the suite timeout', async ({ expect }) => {
+    await sleep(100);
+    expect(1 + 1).toBe(2);
+  });
+
+  it(
+    'per-test timeout overrides the suite timeout',
+    { timeout: 200 },
+    async ({ expect }) => {
+      await sleep(100);
+      expect(1 + 1).toBe(2);
+    },
+  );
+});

--- a/e2e/test-api/testOptions.test.ts
+++ b/e2e/test-api/testOptions.test.ts
@@ -149,4 +149,37 @@ describe('TestOptions', () => {
     // Both tests (shorthand + options) should report the same 50ms timeout.
     expectStderrLog(/test timed out in 50ms/);
   }, 10000);
+
+  it('describe options propagate retry to inner tests, per-test wins', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/describeOptionsRetry.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await expectExecSuccess();
+  });
+
+  it('describe options propagate timeout to inner tests, per-test wins', async () => {
+    const { cli, expectLog, expectStderrLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/describeOptionsTimeout.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+    await cli.exec;
+    expect(cli.exec.process?.exitCode).toBe(1);
+    const logs = cli.stdout.split('\n').filter(Boolean);
+    // Inherited 50ms timeout trips; the per-test 200ms override passes.
+    expectLog(/Tests 1 failed/, logs);
+    expectLog(/1 passed/, logs);
+    expectStderrLog(/test timed out in 50ms/);
+    expect(cli.stderr).not.toContain('test timed out in 200ms');
+  }, 10000);
 });

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -200,6 +200,9 @@ export class RunnerRuntime {
     each = false,
     concurrent,
     sequential,
+    timeout,
+    retry,
+    repeats,
     location,
   }: {
     name: string;
@@ -208,6 +211,9 @@ export class RunnerRuntime {
     each?: boolean;
     concurrent?: boolean;
     sequential?: boolean;
+    timeout?: number;
+    retry?: number;
+    repeats?: number;
     location?: Location;
   }): void {
     this.checkStatus(name, 'suite');
@@ -221,6 +227,9 @@ export class RunnerRuntime {
       testPath: this.testPath,
       concurrent,
       sequential,
+      timeout,
+      retry,
+      repeats,
       location,
     };
 
@@ -298,7 +307,21 @@ export class RunnerRuntime {
           'Calling the test function inside another test function is not allowed. Please put it inside "describe" so it can be properly collected.',
         );
       }
+
+      // Inherit suite-level `TestOptions` as defaults. An explicit value on the
+      // child (case or nested suite) always wins; a nested describe carries the
+      // inherited value onto its own descendants. Mirrors concurrent/sequential.
+      test.timeout ??= current.timeout;
+      test.retry ??= current.retry;
+      test.repeats ??= current.repeats;
+
       current.tests.push(test);
+    }
+
+    // Cases must carry a concrete timeout for the runner; fall back to the
+    // configured default once suite inheritance (above) has been resolved.
+    if (test.type === 'case' && test.timeout === undefined) {
+      test.timeout = this.runtimeConfig.testTimeout;
     }
 
     this._currentTest.push(test);
@@ -357,7 +380,9 @@ export class RunnerRuntime {
     fn,
     originalFn = fn,
     fixtures,
-    timeout = this.runtimeConfig.testTimeout,
+    // Left undefined when the caller omits it; `addTest` resolves the effective
+    // timeout (explicit > enclosing suite > config.testTimeout).
+    timeout,
     retry,
     repeats,
     runMode = 'run',
@@ -413,15 +438,24 @@ export class RunnerRuntime {
     concurrent?: boolean;
     sequential?: boolean;
     location?: Location;
-  }): (name: string, fn: (...args: any[]) => any) => void {
-    return (name: string, fn) => {
+  }): (
+    name: string,
+    arg2?: ((...args: any[]) => any) | TestOptions,
+    arg3?: ((...args: any[]) => any) | number,
+  ) => void {
+    return (name, arg2, arg3) => {
+      const { fn, options: suiteOptions } = resolveTestArgs(arg2, arg3);
+      const { timeout, retry, repeats } = suiteOptions;
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
-        const params = castArray(param) as Parameters<typeof fn>;
+        const params = castArray(param) as any[];
 
         this.describe({
           name: formatName(name, param, i),
           fn: () => fn?.(...params),
+          timeout,
+          retry,
+          repeats,
           ...options,
           each: true,
         });
@@ -438,14 +472,23 @@ export class RunnerRuntime {
     concurrent?: boolean;
     sequential?: boolean;
     location?: Location;
-  }): (name: string, fn: (...args: any[]) => any) => void {
-    return (name: string, fn) => {
+  }): (
+    name: string,
+    arg2?: ((...args: any[]) => any) | TestOptions,
+    arg3?: ((...args: any[]) => any) | number,
+  ) => void {
+    return (name, arg2, arg3) => {
+      const { fn, options: suiteOptions } = resolveTestArgs(arg2, arg3);
+      const { timeout, retry, repeats } = suiteOptions;
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
 
         this.describe({
           name: formatName(name, param, i),
           fn: () => fn?.(param),
+          timeout,
+          retry,
+          repeats,
           ...options,
           each: true,
         });
@@ -479,7 +522,7 @@ export class RunnerRuntime {
           name: formatName(name, param, i),
           originalFn: fn,
           fn: () => fn?.(...params),
-          timeout: timeout ?? this.runtimeConfig.testTimeout,
+          timeout,
           retry,
           repeats,
           ...options,
@@ -514,7 +557,7 @@ export class RunnerRuntime {
           name: formatName(name, param, i),
           originalFn: fn,
           fn: (context) => fn?.(param, context),
-          timeout: timeout ?? this.runtimeConfig.testTimeout,
+          timeout,
           retry,
           repeats,
           ...options,
@@ -651,11 +694,16 @@ const buildRuntimeAPI = (): CollectionAPI => {
       location?: Location;
     } = {},
   ): DescribeAPI => {
-    const describeFn = ((name, fn) => {
+    const describeFn = ((name, arg2, arg3) => {
+      const { fn, options: suiteOptions } = resolveTestArgs(arg2, arg3);
+      const { timeout, retry, repeats } = suiteOptions;
       const rt = currentRuntime();
       rt.describe({
         name,
         fn,
+        timeout,
+        retry,
+        repeats,
         ...options,
         location: options.location ?? rt.getLocation(),
       });

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -109,33 +109,39 @@ export interface TestForFn<ExtraContext = object> {
   >;
 }
 
+/**
+ * The two accepted call shapes for `describe` and the functions returned by
+ * `describe.each` / `describe.for`, mirroring `TestCall`:
+ * - `(name, fn, timeout?)` — suite function second, optional numeric timeout last.
+ * - `(name, options, fn?)` — `TestOptions` object as the second argument.
+ *
+ * Suite-level options propagate to descendant cases as inheritable defaults.
+ */
+type DescribeCall<Fn> = {
+  (description: string, fn?: Fn, timeout?: number): void;
+  (description: string, options: TestOptions, fn?: Fn): void;
+};
+
 export interface DescribeEachFn {
   <T extends Record<string, unknown>>(
     cases: readonly T[],
-  ): (description: string, fn?: (param: T) => MaybePromise<void>) => void;
+  ): DescribeCall<(param: T) => MaybePromise<void>>;
   <T extends readonly [unknown, ...unknown[]]>(
     cases: readonly T[],
-  ): (
-    description: string,
-    fn?: (...args: [...T]) => MaybePromise<void>,
-  ) => void;
-  <T>(
-    cases: readonly T[],
-  ): (description: string, fn?: (param: T) => MaybePromise<void>) => void;
+  ): DescribeCall<(...args: [...T]) => MaybePromise<void>>;
+  <T>(cases: readonly T[]): DescribeCall<(param: T) => MaybePromise<void>>;
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
     ...expressions: unknown[]
-  ): (description: string, fn?: (param: T) => MaybePromise<void>) => void;
+  ): DescribeCall<(param: T) => MaybePromise<void>>;
 }
 
 export interface DescribeForFn {
-  <T>(
-    cases: readonly T[],
-  ): (description: string, fn?: (param: T) => MaybePromise<void>) => void;
+  <T>(cases: readonly T[]): DescribeCall<(param: T) => MaybePromise<void>>;
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
     ...expressions: unknown[]
-  ): (description: string, fn?: (param: T) => MaybePromise<void>) => void;
+  ): DescribeCall<(param: T) => MaybePromise<void>>;
 }
 
 export type TestAPI<ExtraContext = object> = TestFn<ExtraContext> & {
@@ -151,7 +157,7 @@ export type TestAPI<ExtraContext = object> = TestFn<ExtraContext> & {
   skipIf: (condition: boolean) => TestAPI<ExtraContext>;
 };
 
-type DescribeFn = (description: string, fn?: () => MaybePromise<void>) => void;
+type DescribeFn = DescribeCall<() => MaybePromise<void>>;
 
 export type DescribeAPI = DescribeFn & {
   each: DescribeEachFn;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -116,6 +116,15 @@ export type TestSuite = TestSuiteInfo & {
   inTestEach?: boolean;
   concurrent?: boolean;
   sequential?: boolean;
+  /**
+   * Suite-level `TestOptions` passed to `describe(name, options, fn)`. Applied
+   * as inheritable defaults to descendant cases: an explicit case-level value
+   * wins, and a nested `describe` inherits its parent's value. Stored on the
+   * suite only to propagate down — suites are not executed themselves.
+   */
+  timeout?: number;
+  retry?: number;
+  repeats?: number;
   /** nested cases and suite could in a suite */
   tests: Test[];
   afterAllListeners?: AfterAllListener[];

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -18,6 +18,13 @@ const createPublishedRuntimeAPI = (
 };
 
 describe('RunnerRuntime', () => {
+  const createApi = (testTimeout = 5000) =>
+    createPublishedRuntimeAPI({
+      testPath: __filename,
+      runtimeConfig: { testTimeout } as RuntimeConfig,
+      project: 'rstest',
+    });
+
   it('should add test correctly', async () => {
     const instance = createPublishedRuntimeAPI({
       testPath: __filename,
@@ -124,13 +131,6 @@ describe('RunnerRuntime', () => {
   });
 
   describe('TestOptions second argument', () => {
-    const createApi = (testTimeout = 5000) =>
-      createPublishedRuntimeAPI({
-        testPath: __filename,
-        runtimeConfig: { testTimeout } as RuntimeConfig,
-        project: 'rstest',
-      });
-
     it('treats a numeric third arg as timeout shorthand', async () => {
       const instance = createApi();
       runtimeAPI.it('case', () => {}, 250);
@@ -213,6 +213,94 @@ describe('RunnerRuntime', () => {
       const [a, b] = (await instance.getTests()) as TestCase[];
       expect(a!.timeout).toBe(99);
       expect(b!.timeout).toBe(88);
+    });
+  });
+
+  describe('describe TestOptions second argument', () => {
+    const firstCase = async (instance: RunnerRuntime): Promise<TestCase> => {
+      const suite = (await instance.getTests())[0] as TestSuite;
+      return suite.tests[0] as TestCase;
+    };
+
+    it('propagates suite-level options to inner tests', async () => {
+      const instance = createApi(123);
+      runtimeAPI.describe(
+        'suite',
+        { timeout: 250, retry: 2, repeats: 3 },
+        () => {
+          runtimeAPI.it('case', () => {});
+        },
+      );
+
+      const testCase = await firstCase(instance);
+      expect(testCase.timeout).toBe(250);
+      expect(testCase.retry).toBe(2);
+      expect(testCase.repeats).toBe(3);
+    });
+
+    it('lets an inner test override the suite-level options', async () => {
+      const instance = createApi(123);
+      runtimeAPI.describe('suite', { timeout: 250, retry: 2 }, () => {
+        runtimeAPI.it('case', { timeout: 999, retry: 5 }, () => {});
+      });
+
+      const testCase = await firstCase(instance);
+      expect(testCase.timeout).toBe(999);
+      expect(testCase.retry).toBe(5);
+    });
+
+    it('falls back to config.testTimeout when neither suite nor test set timeout', async () => {
+      const instance = createApi(123);
+      runtimeAPI.describe('suite', { retry: 1 }, () => {
+        runtimeAPI.it('case', () => {});
+      });
+
+      const testCase = await firstCase(instance);
+      expect(testCase.timeout).toBe(123);
+      expect(testCase.retry).toBe(1);
+    });
+
+    it('inherits options through nested describe, nearest wins', async () => {
+      const instance = createApi();
+      runtimeAPI.describe('outer', { timeout: 100, retry: 1 }, () => {
+        runtimeAPI.describe('inner', { timeout: 200 }, () => {
+          runtimeAPI.it('case', () => {});
+        });
+      });
+
+      const outer = (await instance.getTests())[0] as TestSuite;
+      const inner = outer.tests[0] as TestSuite;
+      const testCase = inner.tests[0] as TestCase;
+      // nearest suite wins for timeout, retry inherited from the outer suite
+      expect(testCase.timeout).toBe(200);
+      expect(testCase.retry).toBe(1);
+    });
+
+    it('accepts the numeric timeout shorthand as the third argument', async () => {
+      const instance = createApi();
+      runtimeAPI.describe(
+        'suite',
+        () => {
+          runtimeAPI.it('case', () => {});
+        },
+        321,
+      );
+
+      const testCase = await firstCase(instance);
+      expect(testCase.timeout).toBe(321);
+    });
+
+    it('propagates options through describe.each', async () => {
+      const instance = createApi();
+      runtimeAPI.describe.each([1, 2])('suite %s', { timeout: 50 }, () => {
+        runtimeAPI.it('case', () => {});
+      });
+
+      const suites = (await instance.getTests()) as TestSuite[];
+      expect(suites).toHaveLength(2);
+      for (const suite of suites) {
+        expect((suite.tests[0] as TestCase).timeout).toBe(50);
+      }
     });
   });
 });

--- a/website/docs/en/api/runtime-api/test-api/describe.mdx
+++ b/website/docs/en/api/runtime-api/test-api/describe.mdx
@@ -3,13 +3,20 @@ title: Describe
 description: describe defines a test suite. It supports chainable modifiers and parameterized methods for flexible and organized test grouping.
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Describe
 
 `describe` defines a test suite. It supports chainable modifiers and parameterized methods for flexible and organized test grouping.
 
 ## describe
 
-- **Type:** `(name: string, fn?: () => void | Promise<void>) => void`
+- **Type:**
+
+```ts
+(name: string, fn?: () => void | Promise<void>, timeout?: number): void;
+(name: string, options: TestOptions, fn?: () => void | Promise<void>): void;
+```
 
 Defines a test suite that can contain multiple test cases or nested describe blocks.
 The callback can be asynchronous; Rstest waits for it during collection before running the tests declared inside it.
@@ -33,6 +40,54 @@ describe('async setup', async () => {
 
   test('uses collected data', () => {
     expect(data).toBeDefined();
+  });
+});
+```
+
+### TestOptions
+
+<ApiMeta addedVersion="0.11.0" />
+
+Pass a `TestOptions` object as the **second argument** (before the suite function) to set defaults for every test inside the suite:
+
+```ts
+describe('flaky integration', { retry: 3, timeout: 10000 }, () => {
+  test('reaches the server', async () => {
+    /* inherits retry: 3 and timeout: 10000 */
+  });
+});
+```
+
+As a shorthand, you can still pass a number as the **last argument** to set only the timeout (equivalent to `{ timeout: n }`):
+
+```ts
+describe('slow suite', () => {
+  test('within budget', async () => {
+    /* ... */
+  });
+}, 10000);
+```
+
+`TestOptions` accepts the same fields as on [`test`](/api/runtime-api/test-api/test#testoptions): `timeout`, `retry`, and `repeats`. These propagate to the tests in the suite as **inheritable defaults**:
+
+- A test-level option always wins over the suite-level value.
+- A nested `describe` inherits its parent's options, and the nearest enclosing value applies.
+- A test without its own `timeout` falls back to the nearest suite's `timeout`, then to [`test.testTimeout`](/config/test/test-timeout).
+
+```ts
+describe('parent', { retry: 2, timeout: 100 }, () => {
+  test('a', () => {
+    /* retry: 2, timeout: 100 */
+  });
+
+  describe('child', { timeout: 200 }, () => {
+    test('b', () => {
+      /* retry: 2 (inherited), timeout: 200 (nearest wins) */
+    });
+
+    test('c', { retry: 0 }, () => {
+      /* retry: 0 (own value wins), timeout: 200 */
+    });
   });
 });
 ```
@@ -79,9 +134,14 @@ describe.todo('should implement this suite');
 
 ## describe.each
 
-- **Type:** `describe.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>) => void`
+- **Type:**
 
-Creates a describe block for each item in the provided array.
+```ts
+describe.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+describe.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+```
+
+Creates a describe block for each item in the provided array. Like `describe`, it accepts an optional [`TestOptions`](#testoptions) object as its second argument and applies it to every generated suite.
 
 ```ts
 describe.each([
@@ -124,9 +184,14 @@ describe.each<{ a: number; b: number; expected: number }>`
 
 ## describe.for
 
-- **Type:** `describe.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>) => void`
+- **Type:**
 
-Alternative to `describe.each` for more flexible parameter types.
+```ts
+describe.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+describe.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+```
+
+Alternative to `describe.each` for more flexible parameter types. It accepts the same optional [`TestOptions`](#testoptions) second argument.
 
 ```ts
 describe.for([

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -13,7 +13,12 @@ Alias: `it`.
 
 ## test
 
-- **Type:** `(name: string, options: TestOptions, fn?: (testContext: TestContext) => void | Promise<void>) => void`
+- **Type:**
+
+```ts
+(name: string, fn?: (testContext: TestContext) => void | Promise<void>, timeout?: number): void;
+(name: string, options: TestOptions, fn?: (testContext: TestContext) => void | Promise<void>): void;
+```
 
 Defines a test case.
 
@@ -106,7 +111,12 @@ test.todo('should implement this test');
 
 ## test.each
 
-- **Type:** `test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>) => void`
+- **Type:**
+
+```ts
+test.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+```
 
 Runs the same test logic for each item in the provided array.
 
@@ -189,7 +199,12 @@ test.each([
 
 ## test.for
 
-- **Type:** `test.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T, testContext: TestContext) => void | Promise<void>) => void`
+- **Type:**
+
+```ts
+test.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T, testContext: TestContext) => void | Promise<void>, timeout?: number): void;
+test.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T, testContext: TestContext) => void | Promise<void>): void;
+```
 
 Alternative to `test.each` to provide `TestContext`.
 

--- a/website/docs/zh/api/runtime-api/test-api/describe.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/describe.mdx
@@ -3,13 +3,20 @@ title: Describe
 description: describe 用于定义测试套件（test suite），支持链式修饰符和参数化方法，便于灵活有序地组织测试。
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Describe
 
 `describe` 用于定义测试套件（test suite），支持链式修饰符和参数化方法，便于灵活有序地组织测试。
 
 ## describe
 
-- **类型：** `(name: string, fn?: () => void | Promise<void>) => void`
+- **类型：**
+
+```ts
+(name: string, fn?: () => void | Promise<void>, timeout?: number): void;
+(name: string, options: TestOptions, fn?: () => void | Promise<void>): void;
+```
 
 定义一个测试套件，可以包含多个测试用例或嵌套的 describe。
 回调可以是异步函数；Rstest 会在收集阶段等待它完成，然后再运行其中声明的测试。
@@ -33,6 +40,54 @@ describe('async setup', async () => {
 
   test('uses collected data', () => {
     expect(data).toBeDefined();
+  });
+});
+```
+
+### TestOptions
+
+<ApiMeta addedVersion="0.11.0" />
+
+将 `TestOptions` 对象作为**第二个参数**（位于套件函数之前）传入，用于为套件内的所有测试设置默认值：
+
+```ts
+describe('flaky integration', { retry: 3, timeout: 10000 }, () => {
+  test('reaches the server', async () => {
+    /* 继承 retry: 3 与 timeout: 10000 */
+  });
+});
+```
+
+作为简写，你仍可以将数字作为**最后一个参数**传入，仅用于设置超时（等价于 `{ timeout: n }`）：
+
+```ts
+describe('slow suite', () => {
+  test('within budget', async () => {
+    /* ... */
+  });
+}, 10000);
+```
+
+`TestOptions` 支持的字段与 [`test`](/api/runtime-api/test-api/test#testoptions) 上一致：`timeout`、`retry`、`repeats`。这些选项会作为**可继承的默认值**向套件内的测试传播：
+
+- 测试级别的选项始终优先于套件级别的值。
+- 嵌套的 `describe` 会继承父级选项，最终以最近一层的值为准。
+- 未单独设置 `timeout` 的测试，回退到最近一层套件的 `timeout`，再回退到 [`test.testTimeout`](/config/test/test-timeout)。
+
+```ts
+describe('parent', { retry: 2, timeout: 100 }, () => {
+  test('a', () => {
+    /* retry: 2, timeout: 100 */
+  });
+
+  describe('child', { timeout: 200 }, () => {
+    test('b', () => {
+      /* retry: 2（继承），timeout: 200（最近一层优先） */
+    });
+
+    test('c', { retry: 0 }, () => {
+      /* retry: 0（自身值优先），timeout: 200 */
+    });
   });
 });
 ```
@@ -79,9 +134,14 @@ describe.todo('should implement this suite');
 
 ## describe.each
 
-- **类型：** `describe.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>) => void`
+- **类型：**
 
-为数组中的每一项生成一个 describe 块。
+```ts
+describe.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+describe.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+```
+
+为数组中的每一项生成一个 describe 块。与 `describe` 一样，它的第二个参数可选地接受一个 [`TestOptions`](#testoptions) 对象，并作用于生成的每个套件。
 
 ```ts
 describe.each([
@@ -124,9 +184,14 @@ describe.each<{ a: number; b: number; expected: number }>`
 
 ## describe.for
 
-- **类型：** `describe.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>) => void`
+- **类型：**
 
-类似 each，但参数类型更灵活。
+```ts
+describe.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+describe.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+```
+
+类似 each，但参数类型更灵活。它同样接受可选的 [`TestOptions`](#testoptions) 第二个参数。
 
 ```ts
 describe.for([

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -13,7 +13,12 @@ import { ApiMeta } from '@components/ApiMeta';
 
 ## test
 
-- **类型：** `(name: string, options: TestOptions, fn?: (testContext: TestContext) => void | Promise<void>) => void`
+- **类型：**
+
+```ts
+(name: string, fn?: (testContext: TestContext) => void | Promise<void>, timeout?: number): void;
+(name: string, options: TestOptions, fn?: (testContext: TestContext) => void | Promise<void>): void;
+```
 
 定义一个测试用例。
 
@@ -106,7 +111,12 @@ test.todo('should implement this test');
 
 ## test.each
 
-- **类型：** `test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>) => void`
+- **类型：**
+
+```ts
+test.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+```
 
 对提供的数组中的每一项运行相同的测试逻辑。
 
@@ -189,7 +199,12 @@ test.each([
 
 ## test.for
 
-- **类型：** `test.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T, testContext: TestContext) => void | Promise<void>) => void`
+- **类型：**
+
+```ts
+test.for(cases: ReadonlyArray<T>)(name: string, fn?: (param: T, testContext: TestContext) => void | Promise<void>, timeout?: number): void;
+test.for(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T, testContext: TestContext) => void | Promise<void>): void;
+```
 
 `test.each` 的替代方案，提供 `TestContext`。
 


### PR DESCRIPTION
## Summary

Follow-up to #1453, which moved `TestOptions` to the second argument of `test`/`it`. This extends the same shape to `describe`, aligning Rstest with Vitest and the Node.js test runner — both of which accept a suite options object.

`describe` (and `describe.each` / `describe.for`) now accept a `TestOptions` object as the second argument, plus the numeric-timeout shorthand as the last argument:

```ts
describe('flaky integration', { retry: 3, timeout: 10000 }, () => {
  test('reaches the server', async () => {
    /* inherits retry: 3 and timeout: 10000 */
  });
});

describe('slow suite', () => {
  test('within budget', () => {});
}, 10000); // shorthand: { timeout: 10000 }
```

Scope is intentionally limited to the existing core `TestOptions` fields — `timeout`, `retry`, `repeats` — the same set `test`/`it` already support. `concurrent` / `sequential` stay modifier-only (`describe.concurrent`), unchanged.

### Propagation semantics

Suite options are applied to descendant tests as **inheritable defaults** (matching Vitest):

- A test-level option always wins over the suite-level value.
- A nested `describe` inherits its parent's options; the nearest enclosing value applies.
- A test without its own `timeout` falls back to the nearest suite's `timeout`, then to `test.testTimeout`.

Implementation centralizes timeout resolution in `addTest` (explicit > nearest suite > `config.testTimeout`), mirroring how `concurrent`/`sequential` already propagate from parent suites.

### Browser mode

Not affected — `describe` collection runs through the same runtime layer for both Node and browser modes, and this change only touches collection-time option resolution, not execution or transport.

## Related Links

- Builds on #1453

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
