### PR TITLE
feat(core): add teamcity reporter

### DIFF
--- a/e2e/reporter/fixtures/teamcity.test.ts
+++ b/e2e/reporter/fixtures/teamcity.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('Teamcity test', () => {
+  it('should pass', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  it('should fail', () => {
+    expect('hi').toBe('hii');
+  });
+
+  it.skip('should skip', () => {
+    expect(1 + 1).toBe(3);
+  });
+});

--- a/e2e/reporter/teamcity.test.ts
+++ b/e2e/reporter/teamcity.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+it('teamcity', async () => {
+  const { cli, expectLog } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'teamcity', '--reporter', 'teamcity'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await cli.exec;
+  expect(cli.exec.process?.exitCode).toBe(1);
+
+  const logs = cli.stdout.split('\n').filter(Boolean);
+
+  expectLog(
+    "##teamcity[testSuiteStarted flowId='fixtures/teamcity.test.ts' name='fixtures/teamcity.test.ts']",
+    logs,
+  );
+  expectLog(
+    "##teamcity[testStarted flowId='fixtures/teamcity.test.ts' name='Teamcity test > should pass']",
+    logs,
+  );
+  expectLog(
+    /##teamcity\[testFailed .*name='Teamcity test > should fail'.*type='comparisonFailure'/,
+    logs,
+  );
+  expectLog(
+    "##teamcity[testIgnored flowId='fixtures/teamcity.test.ts' name='Teamcity test > should skip']",
+    logs,
+  );
+  expectLog(
+    "##teamcity[testSuiteFinished flowId='fixtures/teamcity.test.ts' name='fixtures/teamcity.test.ts']",
+    logs,
+  );
+});

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -10,6 +10,7 @@ import { GithubActionsReporter } from '../reporter/githubActions';
 import { JsonReporter } from '../reporter/json';
 import { JUnitReporter } from '../reporter/junit';
 import { MdReporter } from '../reporter/md';
+import { TeamcityReporter } from '../reporter/teamcity';
 import { VerboseReporter } from '../reporter/verbose';
 import type {
   BuiltInReporterNames,
@@ -313,6 +314,7 @@ const reportersMap = {
   'github-actions': GithubActionsReporter,
   junit: JUnitReporter,
   json: JsonReporter,
+  teamcity: TeamcityReporter,
   md: MdReporter,
   blob: BlobReporter,
 } satisfies Record<BuiltInReporterNames, new (...args: any[]) => unknown>;

--- a/packages/core/src/reporter/teamcity.ts
+++ b/packages/core/src/reporter/teamcity.ts
@@ -1,0 +1,205 @@
+import { relative } from 'pathe';
+import stripAnsi from 'strip-ansi';
+import type {
+  Duration,
+  FormattedError,
+  GetSourcemap,
+  Reporter,
+  TestFileResult,
+  TestResult,
+} from '../types';
+import { getTaskNameWithPrefix, logger } from '../utils';
+import { formatStack, parseErrorStacktrace } from '../utils/error';
+
+const SETUP_TEST_NAME = 'file setup';
+const UNKNOWN_FAILURE_MESSAGE = 'Test failed without error details';
+
+type ServiceMessageAttributes = Record<string, string | number | undefined>;
+
+// https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values
+function escapeValue(value: string | number | undefined): string {
+  return stripAnsi(String(value ?? ''))
+    .replace(/\|/g, '||')
+    .replace(/\n/g, '|n')
+    .replace(/\r/g, '|r')
+    .replace(/\[/g, '|[')
+    .replace(/\]/g, '|]')
+    .replace(/\u0085/g, '|x')
+    .replace(/\u2028/g, '|l')
+    .replace(/\u2029/g, '|p')
+    .replace(/'/g, "|'");
+}
+
+function formatServiceMessage(
+  type: string,
+  attributes: ServiceMessageAttributes,
+): string {
+  const formatted = Object.entries(attributes)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}='${escapeValue(value)}'`)
+    .join(' ');
+
+  return `##teamcity[${type} ${formatted}]`;
+}
+
+/**
+ * Reports test results as TeamCity service messages on stdout, which TeamCity
+ * (and compatible CIs) parse from the build log to populate the Tests tab.
+ *
+ * Like the `junit` and `github-actions` reporters, all messages are emitted in
+ * a single `onTestRunEnd` pass over the result tree, so started/finished
+ * messages are always balanced without tracking state.
+ */
+export class TeamcityReporter implements Reporter {
+  private readonly rootPath: string;
+
+  constructor({
+    rootPath,
+  }: {
+    rootPath: string;
+    options?: Record<string, unknown>;
+  }) {
+    this.rootPath = rootPath;
+  }
+
+  async onTestRunEnd({
+    results,
+    getSourcemap,
+  }: {
+    results: TestFileResult[];
+    testResults: TestResult[];
+    duration: Duration;
+    getSourcemap: GetSourcemap;
+  }): Promise<void> {
+    for (const file of results) {
+      await this.reportFile(file, getSourcemap);
+    }
+  }
+
+  private emit(type: string, attributes: ServiceMessageAttributes): void {
+    logger.log(formatServiceMessage(type, attributes));
+  }
+
+  private async errorDetails(
+    error: FormattedError,
+    getSourcemap: GetSourcemap,
+  ): Promise<string | undefined> {
+    const parts: string[] = [];
+
+    if (error.diff) {
+      parts.push(error.diff);
+    }
+
+    if (error.stack) {
+      const stackFrames = await parseErrorStacktrace({
+        stack: error.stack,
+        fullStack: error.fullStack,
+        getSourcemap,
+      });
+      const formattedStack = stackFrames
+        .map((frame) => formatStack(frame, this.rootPath))
+        .join('\n');
+
+      if (formattedStack) {
+        parts.push(formattedStack);
+      }
+    }
+
+    return parts.length > 0 ? parts.join('\n') : undefined;
+  }
+
+  // TeamCity keeps only one testFailed per test, so aggregate all errors
+  // (e.g. expect.soft) into a single message. A comparison diff can only carry
+  // one expected/actual pair, so it is reported only for a lone comparison error.
+  private async reportFailure(
+    test: TestResult,
+    flowId: string,
+    name: string,
+    getSourcemap: GetSourcemap,
+  ): Promise<void> {
+    const errors = test.errors ?? [];
+
+    if (errors.length === 0) {
+      this.emit('testFailed', {
+        flowId,
+        message: UNKNOWN_FAILURE_MESSAGE,
+        name,
+      });
+      return;
+    }
+
+    const [firstError] = errors;
+    const comparison =
+      errors.length === 1 &&
+      firstError &&
+      (firstError.expected !== undefined || firstError.actual !== undefined)
+        ? firstError
+        : undefined;
+    const details =
+      (
+        await Promise.all(
+          errors.map((error) => this.errorDetails(error, getSourcemap)),
+        )
+      )
+        .filter(Boolean)
+        .join('\n\n') || undefined;
+
+    this.emit('testFailed', {
+      actual: comparison?.actual,
+      details,
+      expected: comparison?.expected,
+      flowId,
+      message: errors.map((error) => error.message).join('\n'),
+      name,
+      type: comparison ? 'comparisonFailure' : undefined,
+    });
+  }
+
+  private async reportCase(
+    test: TestResult,
+    flowId: string,
+    getSourcemap: GetSourcemap,
+  ): Promise<void> {
+    const name = getTaskNameWithPrefix(test);
+
+    this.emit('testStarted', { flowId, name });
+
+    if (test.status === 'skip' || test.status === 'todo') {
+      this.emit('testIgnored', { flowId, name });
+    } else if (test.status === 'fail') {
+      await this.reportFailure(test, flowId, name, getSourcemap);
+    }
+
+    this.emit('testFinished', {
+      duration:
+        typeof test.duration === 'number'
+          ? Math.round(test.duration)
+          : undefined,
+      flowId,
+      name,
+    });
+  }
+
+  private async reportFile(
+    file: TestFileResult,
+    getSourcemap: GetSourcemap,
+  ): Promise<void> {
+    const name = relative(this.rootPath, file.testPath);
+
+    this.emit('testSuiteStarted', { flowId: name, name });
+
+    if (file.results.length > 0) {
+      for (const test of file.results) {
+        await this.reportCase(test, name, getSourcemap);
+      }
+    } else if (file.status === 'fail' && file.errors?.length) {
+      await this.reportCase(
+        { ...file, name: SETUP_TEST_NAME, parentNames: [] },
+        name,
+        getSourcemap,
+      );
+    }
+
+    this.emit('testSuiteFinished', { flowId: name, name });
+  }
+}

--- a/packages/core/src/types/reporter.ts
+++ b/packages/core/src/types/reporter.ts
@@ -32,6 +32,7 @@ export type BuiltInReporterNames =
   | 'github-actions'
   | 'junit'
   | 'json'
+  | 'teamcity'
   | 'blob';
 
 export type DefaultReporterOptions = {
@@ -180,6 +181,7 @@ type BuiltinReporterOptions = {
   'github-actions': GithubActionsReporterOptions;
   junit: Record<string, unknown>;
   json: JsonReporterOptions;
+  teamcity: Record<string, unknown>;
   blob: BlobReporterOptions;
 };
 

--- a/packages/core/tests/reporter/teamcity.test.ts
+++ b/packages/core/tests/reporter/teamcity.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, onTestFinished, rs } from '@rstest/core';
+import { TeamcityReporter } from '../../src/reporter/teamcity';
+import type { Duration, TestFileResult, TestResult } from '../../src/types';
+
+const ROOT_PATH = '/test/root';
+const TEST_PATH = '/test/root/example.test.ts';
+const NO_DURATION: Duration = { totalTime: 0, buildTime: 0, testTime: 0 };
+
+function testResult(overrides: Partial<TestResult> = {}): TestResult {
+  return {
+    testId: 'test-id',
+    status: 'pass',
+    name: 'reports a case',
+    parentNames: ['suite'],
+    testPath: TEST_PATH,
+    duration: 12,
+    project: 'default',
+    ...overrides,
+  };
+}
+
+function fileResult(overrides: Partial<TestFileResult> = {}): TestFileResult {
+  return {
+    testId: TEST_PATH,
+    status: 'pass',
+    name: 'example.test.ts',
+    testPath: TEST_PATH,
+    duration: 12,
+    project: 'default',
+    results: [],
+    ...overrides,
+  };
+}
+
+async function run(...results: TestFileResult[]): Promise<string[]> {
+  const logs: string[] = [];
+  rs.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  onTestFinished(() => {
+    rs.resetAllMocks();
+  });
+
+  const reporter = new TeamcityReporter({ rootPath: ROOT_PATH, options: {} });
+  await reporter.onTestRunEnd({
+    results,
+    testResults: results.flatMap((file) => file.results),
+    duration: NO_DURATION,
+    getSourcemap: () => Promise.resolve(null),
+  });
+
+  return logs.filter((log) => log.includes('##teamcity['));
+}
+
+const messageType = (log: string): string =>
+  log.match(/##teamcity\[(\w+)/)?.[1] ?? '';
+
+describe('TeamcityReporter', () => {
+  it('wraps each file in a balanced suite and scopes test names to the suite', async () => {
+    const logs = await run(
+      fileResult({
+        status: 'fail',
+        results: [
+          testResult({ name: 'passes' }),
+          testResult({
+            name: 'fails',
+            status: 'fail',
+            errors: [
+              {
+                message: 'expected 1 to be 2',
+                expected: '2',
+                actual: '1',
+                stack:
+                  'AssertionError: expected 1 to be 2\n    at test (/test/root/example.test.ts:4:17)',
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    expect(logs.map(messageType)).toEqual([
+      'testSuiteStarted',
+      'testStarted',
+      'testFinished',
+      'testStarted',
+      'testFailed',
+      'testFinished',
+      'testSuiteFinished',
+    ]);
+    // suite carries the file path; test names do not repeat it
+    expect(logs[0]).toContain("name='example.test.ts'");
+    expect(logs[1]).toContain("name='suite > passes'");
+    expect(logs[4]).toContain("type='comparisonFailure'");
+    expect(logs[4]).toContain("expected='2'");
+    expect(logs[4]).toContain("actual='1'");
+    expect(logs[4]).toContain("name='suite > fails'");
+  });
+
+  it('emits testIgnored for skipped and todo tests', async () => {
+    const logs = await run(
+      fileResult({
+        results: [
+          testResult({ status: 'skip' }),
+          testResult({ status: 'todo' }),
+        ],
+      }),
+    );
+
+    expect(
+      logs.filter((log) => messageType(log) === 'testIgnored'),
+    ).toHaveLength(2);
+  });
+
+  it('aggregates multiple errors into a single testFailed without a comparison type', async () => {
+    const logs = await run(
+      fileResult({
+        status: 'fail',
+        results: [
+          testResult({
+            status: 'fail',
+            errors: [
+              {
+                message: 'first soft failure',
+                stack: 'Error: first soft failure',
+              },
+              {
+                message: 'second soft failure',
+                stack: 'Error: second soft failure',
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const failures = logs.filter((log) => messageType(log) === 'testFailed');
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain(
+      "message='first soft failure|nsecond soft failure'",
+    );
+    expect(failures[0]).not.toContain('comparisonFailure');
+  });
+
+  it('reports a file-load failure as a synthetic "file setup" test', async () => {
+    const logs = await run(
+      fileResult({
+        status: 'fail',
+        errors: [
+          {
+            message: "Cannot find module './missing'",
+            stack: "Error: Cannot find module './missing'",
+          },
+        ],
+      }),
+    );
+
+    expect(logs.map(messageType)).toEqual([
+      'testSuiteStarted',
+      'testStarted',
+      'testFailed',
+      'testFinished',
+      'testSuiteFinished',
+    ]);
+    expect(logs[1]).toContain("name='file setup'");
+    expect(logs[2]).toContain("message='Cannot find module |'./missing|''");
+  });
+
+  it('escapes service-message values', async () => {
+    const logs = await run(
+      fileResult({
+        status: 'fail',
+        results: [
+          testResult({
+            name: "it's [special]",
+            parentNames: [],
+            status: 'fail',
+            errors: [{ message: 'line one\nline two' }],
+          }),
+        ],
+      }),
+    );
+
+    const started = logs.find((log) => messageType(log) === 'testStarted')!;
+    const failed = logs.find((log) => messageType(log) === 'testFailed')!;
+    expect(started).toContain("name='it|'s |[special|]'");
+    expect(failed).toContain("message='line one|nline two'");
+  });
+});

--- a/website/docs/en/guide/basic/reporters.mdx
+++ b/website/docs/en/guide/basic/reporters.mdx
@@ -49,6 +49,7 @@ Rstest provides several built-in reporters:
 | `github-actions` | CI error annotations       | GitHub Actions workflows |
 | `junit`          | JUnit XML format           | CI/CD integration        |
 | `json`           | Structured JSON report     | CI tooling and scripting |
+| `teamcity`       | TeamCity service messages  | TeamCity CI servers      |
 | `md`             | Markdown agent report      | Agent / LLM integrations |
 | `blob`           | Serialized JSON output     | Merging sharded reports  |
 
@@ -336,6 +337,47 @@ export default defineConfig({
 - `unhandledErrors`: Top-level unhandled errors when present
 
 The JSON reporter writes relative `testPath` values so the output remains stable across different machines and CI workspaces.
+
+### TeamCity reporter
+
+Emits [TeamCity service messages](https://www.jetbrains.com/help/teamcity/service-messages.html) to stdout, which TeamCity (and compatible CI servers) parse from the build log to populate the Tests tab. Unlike `junit`, no output file is written, so it is usually paired with `default`.
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+```bash
+npx rstest --reporters=teamcity
+```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: ['default', 'teamcity'],
+});
+```
+  </Tab>
+</Tabs>
+
+Each test file is reported as a `testSuite` (the file path is its name), and each case maps to TeamCity test messages:
+
+- `pass`: `testStarted` / `testFinished`
+- `fail`: `testStarted` / `testFailed` / `testFinished`; comparison failures add `expected`/`actual` via `type='comparisonFailure'`
+- `skip` / `todo`: `testIgnored`
+- a file that fails to load with no cases is reported as a synthetic `file setup` failed test
+
+The TeamCity reporter generates service messages as follows:
+
+```text
+##teamcity[testSuiteStarted flowId='test1.test.ts' name='test1.test.ts']
+##teamcity[testStarted flowId='test1.test.ts' name='should pass']
+##teamcity[testFinished duration='1' flowId='test1.test.ts' name='should pass']
+##teamcity[testStarted flowId='test1.test.ts' name='should fail']
+##teamcity[testFailed actual='hi' details='...' expected='hii' flowId='test1.test.ts' message='expected |'hi|' to be |'hii|'' name='should fail' type='comparisonFailure']
+##teamcity[testFinished duration='2' flowId='test1.test.ts' name='should fail']
+##teamcity[testIgnored flowId='test1.test.ts' name='should skip']
+##teamcity[testSuiteFinished flowId='test1.test.ts' name='test1.test.ts']
+```
 
 ### Markdown reporter
 

--- a/website/docs/zh/guide/basic/reporters.mdx
+++ b/website/docs/zh/guide/basic/reporters.mdx
@@ -49,6 +49,7 @@ Rstest 提供了多种内置报告器：
 | `github-actions` | CI 错误注释         | GitHub Actions 工作流 |
 | `junit`          | JUnit XML 格式      | CI/CD 集成            |
 | `json`           | 结构化 JSON 报告    | CI 工具和脚本处理     |
+| `teamcity`       | TeamCity 服务消息   | TeamCity CI 服务器    |
 | `md`             | Markdown agent 报告 | Agent / LLM 集成      |
 | `blob`           | 序列化 JSON 输出    | 合并分片报告          |
 
@@ -334,6 +335,47 @@ export default defineConfig({
 - `unhandledErrors`：顶层 unhandled errors（如果有）
 
 JSON 报告器会将 `testPath` 写成相对路径，这样在不同机器和 CI workspace 中输出更稳定。
+
+### TeamCity 报告器
+
+向 stdout 输出 [TeamCity 服务消息](https://www.jetbrains.com/help/teamcity/service-messages.html)，TeamCity（及兼容的 CI 服务器）会从构建日志中解析这些消息以填充 Tests 标签页。与 `junit` 不同，它不写入文件，因此通常与 `default` 搭配使用。
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+```bash
+npx rstest --reporters=teamcity
+```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  reporters: ['default', 'teamcity'],
+});
+```
+  </Tab>
+</Tabs>
+
+每个测试文件被报告为一个 `testSuite`（以文件路径作为名称），每个用例映射为对应的 TeamCity 测试消息：
+
+- `pass`: `testStarted` / `testFinished`
+- `fail`: `testStarted` / `testFailed` / `testFinished`；比较类失败会通过 `type='comparisonFailure'` 附带 `expected`/`actual`
+- `skip` / `todo`: `testIgnored`
+- 加载失败且没有任何用例的文件会被报告为一个合成的 `file setup` 失败测试
+
+TeamCity 报告器生成如下服务消息：
+
+```text
+##teamcity[testSuiteStarted flowId='test1.test.ts' name='test1.test.ts']
+##teamcity[testStarted flowId='test1.test.ts' name='should pass']
+##teamcity[testFinished duration='1' flowId='test1.test.ts' name='should pass']
+##teamcity[testStarted flowId='test1.test.ts' name='should fail']
+##teamcity[testFailed actual='hi' details='...' expected='hii' flowId='test1.test.ts' message='expected |'hi|' to be |'hii|'' name='should fail' type='comparisonFailure']
+##teamcity[testFinished duration='2' flowId='test1.test.ts' name='should fail']
+##teamcity[testIgnored flowId='test1.test.ts' name='should skip']
+##teamcity[testSuiteFinished flowId='test1.test.ts' name='test1.test.ts']
+```
 
 ### Markdown 报告器
 


### PR DESCRIPTION
## Summary

Adds a built-in `teamcity` reporter that emits [TeamCity service messages](https://www.jetbrains.com/help/teamcity/service-messages.html) to stdout, so TeamCity (and compatible CI servers) populate the **Tests** tab directly from the build log — the service-message counterpart to the existing `junit` (XML file) and `github-actions` (annotations) reporters.

Opt-in via config:

```ts
export default defineConfig({
  reporters: ['default', 'teamcity'],
});
```

## Behavior

- Emits in a single `onTestRunEnd` pass over the result tree (same shape as `junit`/`github-actions`), so `started`/`finished` messages are always balanced without tracking state.
- Each test file → a `testSuite` (relative path as `name`/`flowId`); cases → `testStarted`/`testFinished`, `testIgnored` (skip/todo), or a single `testFailed`.
- Comparison failures carry `expected`/`actual` via `type='comparisonFailure'`.
- Multiple errors per test are aggregated into one `testFailed` (TeamCity records only the first `testFailed` per test).
- A file that fails to load with no cases is reported as a synthetic `file setup` failed test.
- Values escaped per the TeamCity spec; ANSI stripped; stacks sourcemapped via the shared `parseErrorStacktrace`/`formatStack` helpers.

Example output:

```text
##teamcity[testSuiteStarted flowId='test1.test.ts' name='test1.test.ts']
##teamcity[testStarted flowId='test1.test.ts' name='should pass']
##teamcity[testFinished duration='1' flowId='test1.test.ts' name='should pass']
##teamcity[testStarted flowId='test1.test.ts' name='should fail']
##teamcity[testFailed actual='hi' details='...' expected='hii' flowId='test1.test.ts' message='...' name='should fail' type='comparisonFailure']
##teamcity[testFinished duration='2' flowId='test1.test.ts' name='should fail']
##teamcity[testIgnored flowId='test1.test.ts' name='should skip']
##teamcity[testSuiteFinished flowId='test1.test.ts' name='test1.test.ts']
```

## Tests & docs

- Unit: `packages/core/tests/reporter/teamcity.test.ts`
- E2E: `e2e/reporter/teamcity.test.ts` (+ fixture), running the real CLI with `--reporter teamcity`
- Docs: `website/docs/{en,zh}/guide/basic/reporters.mdx`

## Open questions for reviewers

- **`details` content:** this reporter formats the full sourcemapped stack into `details` (TeamCity's details pane is built for full traces). `junit`/`github-actions` use only the top frame — happy to switch to top-frame for parity if preferred.
