### PR TITLE
ci: use GitHub Chrome for browser tests

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,37 +1,18 @@
 name: 'Setup Playwright'
-description: 'Resolve the Playwright browser cache path + version, restore the browser cache, and install browsers (chromium + webkit). Run after dependencies are installed.'
+description: 'Install only Playwright browsers that are not provided by GitHub-hosted runners. Run after dependencies are installed.'
+
+inputs:
+  install-webkit:
+    description: 'Install Playwright WebKit.'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
   steps:
-    - name: Set Playwright cache path and version
+    - name: Install Playwright WebKit
+      if: inputs.install-webkit == 'true'
       shell: bash
+      # Only browser-mode e2e includes the explicit WebKit fixture.
       run: |
-        if [ "$RUNNER_OS" = "Windows" ]; then
-          echo "PLAYWRIGHT_BROWSERS_PATH=$USERPROFILE/AppData/Local/ms-playwright" >> "$GITHUB_ENV"
-        else
-          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_ENV"
-        fi
-        # Resolve the installed Playwright version so the browser cache key
-        # invalidates exactly when Playwright (and thus its browser builds)
-        # changes — not on every unrelated lockfile bump.
-        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('playwright/package.json').version)")" >> "$GITHUB_ENV"
-
-    - name: Cache Playwright Browsers
-      continue-on-error: true
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-        key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
-        # Keyed on the Playwright version (set in the step above): unrelated
-        # lockfile bumps no longer cold-miss, and a Playwright version bump
-        # invalidates correctly. restore-keys lets `playwright install` patch
-        # from the previous version's cache instead of a full cold download.
-        restore-keys: |
-          playwright-${{ runner.os }}-
-
-    - name: Install Playwright Browsers
-      shell: bash
-      # chromium + webkit: browser-mode e2e (e.g. browser-mode/webkit.test.ts,
-      # which runs under the default `test` script) needs both.
-      run: npx playwright install chromium webkit
+        npx playwright install webkit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,9 +136,6 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-
       - name: Run Test
         run: pnpm run test
 
@@ -208,7 +205,10 @@ jobs:
         run: pnpm run build
 
       - name: Setup Playwright
+        if: matrix.test_script != 'test:no-isolate'
         uses: ./.github/actions/setup-playwright
+        with:
+          install-webkit: 'true'
 
       - name: E2E Test (${{ matrix.test_script }})
         run: cd e2e && pnpm ${{ matrix.test_script }}

--- a/e2e/browser-mode/entryOverride.test.ts
+++ b/e2e/browser-mode/entryOverride.test.ts
@@ -1,22 +1,16 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
-import { runRstestCli } from '../scripts';
+import { runBrowserCliWithCwd } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('browser mode - entry override', () => {
   it('should not execute user rsbuild entry (rstest controls entry)', async () => {
-    const { cli, expectExecSuccess } = await runRstestCli({
-      command: 'rstest',
-      args: ['run'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures', 'entry-override'),
-        },
-      },
-    });
+    const { cli, expectExecSuccess } = await runBrowserCliWithCwd(
+      join(__dirname, 'fixtures', 'entry-override'),
+    );
 
     await expectExecSuccess();
     expect(cli.stdout).not.toContain('USER_ENTRY_SHOULD_NOT_RUN');

--- a/e2e/browser-mode/env.test.ts
+++ b/e2e/browser-mode/env.test.ts
@@ -1,22 +1,16 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from '@rstest/core';
-import { runRstestCli } from '../scripts';
+import { runBrowserCliWithCwd } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('browser mode - env', () => {
   it('should inject env into browser runtime without process shim', async () => {
-    const { expectExecSuccess } = await runRstestCli({
-      command: 'rstest',
-      args: ['run'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures', 'env'),
-        },
-      },
-    });
+    const { expectExecSuccess } = await runBrowserCliWithCwd(
+      join(__dirname, 'fixtures', 'env'),
+    );
 
     await expectExecSuccess();
   });

--- a/e2e/browser-mode/list.test.ts
+++ b/e2e/browser-mode/list.test.ts
@@ -2,22 +2,17 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
 import pathe from 'pathe';
-import { runRstestCli } from '../scripts';
+import { runBrowserCliWithCwd } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('browser mode - list (collect mode)', () => {
   it('should list browser tests without executing them', async () => {
-    const { cli, expectExecSuccess } = await runRstestCli({
-      command: 'rstest',
-      args: ['list'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures', 'list'),
-        },
-      },
-    });
+    const { cli, expectExecSuccess } = await runBrowserCliWithCwd(
+      join(__dirname, 'fixtures', 'list'),
+      { command: 'list' },
+    );
 
     await expectExecSuccess();
 

--- a/e2e/browser-mode/noTests.test.ts
+++ b/e2e/browser-mode/noTests.test.ts
@@ -1,37 +1,26 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
-import { runRstestCli } from '../scripts';
+import { runBrowserCliWithCwd } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('browser mode - no tests', () => {
   it('should exit with code 1 by default when no tests found', async () => {
-    const { cli, expectExecFailed } = await runRstestCli({
-      command: 'rstest',
-      args: ['run'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures', 'no-tests'),
-        },
-      },
-    });
+    const { cli, expectExecFailed } = await runBrowserCliWithCwd(
+      join(__dirname, 'fixtures', 'no-tests'),
+    );
 
     await expectExecFailed();
     expect(cli.stderr).toContain('No test files found, exiting with code 1.');
   });
 
   it('should exit with code 0 when passWithNoTests flag is enabled', async () => {
-    const { cli, expectExecSuccess } = await runRstestCli({
-      command: 'rstest',
-      args: ['run', '--passWithNoTests'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures', 'no-tests'),
-        },
-      },
-    });
+    const { cli, expectExecSuccess } = await runBrowserCliWithCwd(
+      join(__dirname, 'fixtures', 'no-tests'),
+      { args: ['--passWithNoTests'] },
+    );
 
     await expectExecSuccess();
     expect(cli.stdout).toContain('No test files found, exiting with code 0.');

--- a/e2e/browser-mode/related.test.ts
+++ b/e2e/browser-mode/related.test.ts
@@ -1,26 +1,20 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
-import { runRstestCli } from '../scripts';
+import { runBrowserCliWithCwd } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('browser mode - related', () => {
   it('should filter browser tests by related source files', async () => {
-    const { cli, expectExecSuccess } = await runRstestCli({
-      command: 'rstest',
-      args: ['list', '--related', 'tests/src/index.ts', '--filesOnly'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures', 'related'),
-          env: {
-            CI: '',
-            GITHUB_ACTIONS: '',
-          },
-        },
+    const { cli, expectExecSuccess } = await runBrowserCliWithCwd(
+      join(__dirname, 'fixtures', 'related'),
+      {
+        command: 'list',
+        args: ['--related', 'tests/src/index.ts', '--filesOnly'],
       },
-    });
+    );
 
     await expectExecSuccess();
 
@@ -30,19 +24,10 @@ describe('browser mode - related', () => {
   });
 
   it('should not run the full browser suite when related finds no tests', async () => {
-    const { cli, expectExecFailed } = await runRstestCli({
-      command: 'rstest',
-      args: ['run', '--related', 'tests/src/missing.ts'],
-      options: {
-        nodeOptions: {
-          cwd: join(__dirname, 'fixtures', 'related'),
-          env: {
-            CI: '',
-            GITHUB_ACTIONS: '',
-          },
-        },
-      },
-    });
+    const { cli, expectExecFailed } = await runBrowserCliWithCwd(
+      join(__dirname, 'fixtures', 'related'),
+      { args: ['--related', 'tests/src/missing.ts'] },
+    );
 
     await expectExecFailed();
 

--- a/e2e/browser-mode/utils.ts
+++ b/e2e/browser-mode/utils.ts
@@ -18,6 +18,20 @@ const defaultEnvOverrides: Record<string, string> = {
   GITHUB_ACTIONS: '',
 };
 
+const useGithubActionsChrome = (fixtureName?: string): boolean =>
+  Boolean(process.env.CI) && fixtureName !== 'webkit';
+
+const applyGithubActionsChrome = (args: string[], fixtureName?: string) => {
+  if (
+    !useGithubActionsChrome(fixtureName) ||
+    args.some((arg) => arg.startsWith('--browser.providerOptions.launch.'))
+  ) {
+    return;
+  }
+
+  args.push('--browser.providerOptions.launch.channel=chrome');
+};
+
 const canRunHeadedBrowser =
   process.platform === 'darwin' ||
   process.platform === 'win32' ||
@@ -133,6 +147,8 @@ export const runBrowserCli = async (
 ) => {
   const args = extra?.args || [];
 
+  applyGithubActionsChrome(args, fixtureName);
+
   const result = await runRstestCli({
     command: 'rstest',
     args: ['run', ...args],
@@ -162,12 +178,46 @@ export const runBrowserWatchCli = async (
     env?: Record<string, string>;
   },
 ) => {
+  const args = extra?.args || [];
+
+  applyGithubActionsChrome(args, fixtureName);
+
   const result = await runRstestCli({
     command: 'rstest',
-    args: ['watch', '--disableConsoleIntercept', ...(extra?.args || [])],
+    args: ['watch', '--disableConsoleIntercept', ...args],
     options: {
       nodeOptions: {
         cwd: join(__dirname, 'fixtures', fixtureName),
+        env: { ...defaultEnvOverrides, DEBUG: 'rstest', ...extra?.env },
+      },
+    },
+  });
+  return {
+    ...result,
+    expectExecSuccess: async () => {
+      await result.expectExecSuccess();
+      expectNoFrameworkWarnings(result.cli);
+    },
+  };
+};
+
+export const runBrowserWatchCliWithCwd = async (
+  cwd: string,
+  extra?: {
+    args?: string[];
+    env?: Record<string, string>;
+  },
+) => {
+  const args = extra?.args || [];
+
+  applyGithubActionsChrome(args);
+
+  const result = await runRstestCli({
+    command: 'rstest',
+    args: ['watch', '--disableConsoleIntercept', ...args],
+    options: {
+      nodeOptions: {
+        cwd,
         env: { ...defaultEnvOverrides, DEBUG: 'rstest', ...extra?.env },
       },
     },
@@ -187,13 +237,18 @@ export const runBrowserWatchCli = async (
 export const runBrowserCliWithCwd = async (
   cwd: string,
   extra?: {
+    command?: 'run' | 'list';
     args?: string[];
     env?: Record<string, string>;
   },
 ) => {
+  const args = extra?.args || [];
+
+  applyGithubActionsChrome(args);
+
   const result = await runRstestCli({
     command: 'rstest',
-    args: ['run', ...(extra?.args || [])],
+    args: [extra?.command ?? 'run', ...args],
     options: {
       nodeOptions: {
         cwd,

--- a/e2e/browser-mode/watch.test.ts
+++ b/e2e/browser-mode/watch.test.ts
@@ -1,11 +1,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
-import { prepareFixtures, runRstestCli } from '../scripts';
+import { prepareFixtures } from '../scripts';
 import {
   deleteFixtureTarget,
   killCliProcessTree,
   runBrowserWatchCli,
+  runBrowserWatchCliWithCwd,
 } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -20,16 +21,7 @@ describe('browser mode - watch', () => {
       fixturesTargetPath,
     });
 
-    const { cli } = await runRstestCli({
-      command: 'rstest',
-      args: ['watch', '--disableConsoleIntercept'],
-      options: {
-        nodeOptions: {
-          env: { DEBUG: 'rstest' },
-          cwd: fixturesTargetPath,
-        },
-      },
-    });
+    const { cli } = await runBrowserWatchCliWithCwd(fixturesTargetPath);
 
     // ========== Initial Run ==========
     // Fixture has 2 test files: index.test.ts and another.test.ts
@@ -93,16 +85,7 @@ describe('browser mode - watch', () => {
       fixturesTargetPath,
     });
 
-    const { cli } = await runRstestCli({
-      command: 'rstest',
-      args: ['watch', '--disableConsoleIntercept'],
-      options: {
-        nodeOptions: {
-          env: { DEBUG: 'rstest' },
-          cwd: fixturesTargetPath,
-        },
-      },
-    });
+    const { cli } = await runBrowserWatchCliWithCwd(fixturesTargetPath);
 
     // ========== Initial Run ==========
     // Initial run outputs full summary with Duration

--- a/e2e/browser-mode/watchReporter.test.ts
+++ b/e2e/browser-mode/watchReporter.test.ts
@@ -1,8 +1,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from '@rstest/core';
-import { prepareFixtures, runRstestCli } from '../scripts';
-import { deleteFixtureTarget, killCliProcessTree } from './utils';
+import { prepareFixtures } from '../scripts';
+import {
+  deleteFixtureTarget,
+  killCliProcessTree,
+  runBrowserWatchCliWithCwd,
+} from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,16 +28,7 @@ describe('browser mode - watch reporter lifecycle', () => {
     });
     const reportLogPath = path.join(fixturesTargetPath, 'watch-reporter.log');
 
-    const { cli } = await runRstestCli({
-      command: 'rstest',
-      args: ['watch', '--disableConsoleIntercept'],
-      options: {
-        nodeOptions: {
-          env: { DEBUG: 'rstest' },
-          cwd: fixturesTargetPath,
-        },
-      },
-    });
+    const { cli } = await runBrowserWatchCliWithCwd(fixturesTargetPath);
 
     try {
       const waitForHookCounts = async (

--- a/examples/browser-react/rstest.config.ts
+++ b/examples/browser-react/rstest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
   browser: {
     enabled: true,
     provider: 'playwright',
+    providerOptions: process.env.CI
+      ? {
+          launch: {
+            channel: 'chrome',
+          },
+        }
+      : undefined,
   },
   include: ['tests/**/*.test.tsx'],
   plugins: [pluginReact()],

--- a/examples/react-rspack-browser/rstest.config.ts
+++ b/examples/react-rspack-browser/rstest.config.ts
@@ -6,6 +6,13 @@ export default defineConfig({
   browser: {
     enabled: true,
     provider: 'playwright',
+    providerOptions: process.env.CI
+      ? {
+          launch: {
+            channel: 'chrome',
+          },
+        }
+      : undefined,
   },
   include: ['tests/**/*.test.tsx'],
 });

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -144,6 +144,7 @@ const runtimeOptionDefinitions: OptionDefinition[] = [
   ['--browser.headless', 'Run browser in headless mode (default: true in CI)'],
   ['--browser.port <port>', 'Port for the browser mode dev server'],
   ['--browser.strictPort', 'Exit if the specified port is already in use'],
+  ['--browser.providerOptions.*', 'Provider-specific browser options'],
   [
     '--unstubGlobals',
     'Restores all global variables that were changed with `rstest.stubGlobal` before every test',
@@ -440,9 +441,21 @@ const normalizeCliArgs = (argv: string[]): string[] =>
   normalizePoolCliArgs(normalizeBrowserCliArgs(normalizeCoverageCliArgs(argv)));
 
 const allowedWildcardOptions = {
+  browser: new Set([
+    'enabled',
+    'name',
+    'headless',
+    'port',
+    'strictPort',
+    'providerOptions',
+  ]),
   source: new Set(['tsconfigPath']),
   dev: new Set(['writeToDisk']),
   output: new Set(['emitAssets', 'cleanDistPath', 'module']),
+};
+
+const allowedNestedWildcardOptions = {
+  browser: new Set(['providerOptions']),
 };
 
 const validateWildcardOptions = (options: Record<string, unknown>): void => {
@@ -465,7 +478,10 @@ const validateWildcardOptions = (options: Record<string, unknown>): void => {
       if (
         typeof optionValue === 'object' &&
         optionValue !== null &&
-        !Array.isArray(optionValue)
+        !Array.isArray(optionValue) &&
+        !allowedNestedWildcardOptions[
+          name as keyof typeof allowedNestedWildcardOptions
+        ]?.has(key)
       ) {
         const nestedKey = Object.keys(optionValue)[0];
         throw new Error(

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -53,6 +53,7 @@ export type CommonOptions = {
         headless?: boolean;
         port?: number;
         strictPort?: boolean;
+        providerOptions?: Record<string, unknown>;
       };
   isolate?: boolean;
   include?: string[];
@@ -349,6 +350,9 @@ export function mergeWithCLIOptions(
       }
       if (options.browser.strictPort !== undefined) {
         config.browser.strictPort = options.browser.strictPort;
+      }
+      if (options.browser.providerOptions !== undefined) {
+        config.browser.providerOptions = options.browser.providerOptions;
       }
     }
   }

--- a/packages/core/tests/cli/commands.test.ts
+++ b/packages/core/tests/cli/commands.test.ts
@@ -79,6 +79,7 @@ describe('valueTakingOptions (derived from option definitions)', () => {
     expect(valueTakingOptions.has('--globals')).toBe(false);
     expect(valueTakingOptions.has('--isolate')).toBe(false);
     expect(valueTakingOptions.has('--coverage')).toBe(false);
+    expect(valueTakingOptions.has('--browser.providerOptions.*')).toBe(false);
     expect(valueTakingOptions.has('--output.emitAssets')).toBe(false);
     expect(valueTakingOptions.has('--output.cssModules')).toBe(false);
   });
@@ -107,6 +108,7 @@ describe('requiredDotOptions (derived from option definitions)', () => {
     expect(requiredDotOptions.has('--coverage.changed')).toBe(false);
     expect(requiredDotOptions.has('--coverage.enabled')).toBe(false);
     expect(requiredDotOptions.has('--browser.enabled')).toBe(false);
+    expect(requiredDotOptions.has('--browser.providerOptions.*')).toBe(false);
     expect(requiredDotOptions.has('--output.emitAssets')).toBe(false);
   });
 });
@@ -360,6 +362,26 @@ describe('CLI help output', () => {
     expect(parsed.options.browser).toEqual({
       enabled: false,
       name: 'chromium',
+    });
+  });
+
+  it('allows provider-specific browser options', () => {
+    const parsed = createCli().parse(
+      [
+        'node',
+        'rstest',
+        'run',
+        '--browser.providerOptions.launch.channel=chrome',
+      ],
+      { run: false },
+    );
+
+    expect(parsed.options.browser).toEqual({
+      providerOptions: {
+        launch: {
+          channel: 'chrome',
+        },
+      },
     });
   });
 

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -565,6 +565,45 @@ describe('resolveProjects', () => {
         port: 6000, // overridden by CLI
       });
     });
+
+    it('should override browser provider options with CLI options', async () => {
+      const config: RstestConfig = {
+        projects: [
+          {
+            name: 'test-project',
+            browser: {
+              enabled: true,
+              provider: 'playwright',
+              providerOptions: {
+                launch: {
+                  channel: 'chromium',
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const projects = await resolveProjects({
+        config,
+        root: rootPath,
+        options: {
+          browser: {
+            providerOptions: {
+              launch: {
+                channel: 'chrome',
+              },
+            },
+          },
+        },
+      });
+
+      expect(projects[0]!.config.browser.providerOptions).toEqual({
+        launch: {
+          channel: 'chrome',
+        },
+      });
+    });
   });
 
   describe('coverage CLI options', () => {

--- a/website/docs/en/config/test/browser.mdx
+++ b/website/docs/en/config/test/browser.mdx
@@ -337,6 +337,7 @@ export default defineConfig({
 
 - **Type:** `Record<string, unknown>`
 - **Default:** `{}`
+- **CLI:** `--browser.providerOptions.*`
 
 Provider-specific options passed through to the selected browser provider. Rstest does not validate or interpret the contents of this object — it is forwarded as-is to the provider at both browser launch and context creation time.
 
@@ -356,6 +357,12 @@ export default defineConfig({
     },
   },
 });
+```
+
+You can also pass nested provider options from the CLI:
+
+```bash
+npx rstest --browser.providerOptions.launch.channel=chrome
 ```
 
 ## Current limitation: browser launch options must match in one run

--- a/website/docs/zh/config/test/browser.mdx
+++ b/website/docs/zh/config/test/browser.mdx
@@ -337,6 +337,7 @@ export default defineConfig({
 
 - **类型：** `Record<string, unknown>`
 - **默认值：** `{}`
+- **CLI：** `--browser.providerOptions.*`
 
 传递给选定 browser provider 的特定选项。Rstest 不会验证或解析该对象的内容——它会在浏览器启动和 context 创建时原样转发给 provider。
 
@@ -356,6 +357,12 @@ export default defineConfig({
     },
   },
 });
+```
+
+也可以通过 CLI 传入嵌套的 provider 选项：
+
+```bash
+npx rstest --browser.providerOptions.launch.channel=chrome
 ```
 
 ## 当前限制：同一次 run 的 browser 启动配置必须一致


### PR DESCRIPTION
## Summary

This PR reduces CI setup work for browser tests by using the Chrome already available on GitHub-hosted runners instead of installing Playwright Chromium. Browser e2e helpers and browser examples inject `browser.providerOptions.launch.channel = 'chrome'` when `process.env.CI` is set, while the WebKit fixture still installs WebKit explicitly. It also exposes `--browser.providerOptions.*` so tests can pass provider-specific launch options through CLI without changing Playwright provider/runtime code.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).