### PR TITLE
ci: skip webkit install for non-browser e2e and relax watch-reporter timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,10 @@ jobs:
         run: pnpm run build
 
       - name: Setup Playwright
-        if: matrix.test_script != 'test:no-isolate'
+        # Only test/test:commonjs run browser-mode e2e (incl. the WebKit
+        # fixture). test:no-isolate and test:threads exclude browser-mode/**,
+        # so they need no Playwright browsers.
+        if: matrix.test_script == 'test' || matrix.test_script == 'test:commonjs'
         uses: ./.github/actions/setup-playwright
         with:
           install-webkit: 'true'

--- a/e2e/browser-mode/watchReporter.test.ts
+++ b/e2e/browser-mode/watchReporter.test.ts
@@ -15,8 +15,9 @@ const getHookCountFromLog = (content: string, hookName: string): number => {
   return content.split('\n').filter((line) => line.trim() === hookName).length;
 };
 
-const WATCH_REPORTER_HOOK_TIMEOUT_MS =
-  process.platform === 'win32' ? 15_000 : 5_000;
+// Real Chrome (channel=chrome) cold-launch on loaded CI runners can push the
+// first run past a tight budget, so keep this generous across platforms.
+const WATCH_REPORTER_HOOK_TIMEOUT_MS = 15_000;
 
 describe('browser mode - watch reporter lifecycle', () => {
   it('should call onTestRunStart and onTestRunEnd on rerun', async () => {

--- a/examples/browser-react/rstest.config.ts
+++ b/examples/browser-react/rstest.config.ts
@@ -2,6 +2,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
+  // Real Chrome (channel=chrome) cold-launch on CI runners (esp. Windows) can
+  // exceed the default 5s test timeout, so relax it under CI.
+  testTimeout: process.env.CI ? 15_000 : 5_000,
   browser: {
     enabled: true,
     provider: 'playwright',

--- a/examples/react-rspack-browser/rstest.config.ts
+++ b/examples/react-rspack-browser/rstest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   extends: withRspackConfig(),
+  // Real Chrome (channel=chrome) cold-launch on CI runners (esp. Windows) can
+  // exceed the default 5s test timeout, so relax it under CI.
+  testTimeout: process.env.CI ? 15_000 : 5_000,
   browser: {
     enabled: true,
     provider: 'playwright',


### PR DESCRIPTION
## Summary

Follow-up to #1474, which switched browser e2e and browser examples to GitHub-hosted Chrome (`channel=chrome`) and made WebKit installs conditional. Cleaning up three leftovers from that switch:

- **Wasted WebKit download on `test:threads`.** Both `test:no-isolate` and `test:threads` exclude `browser-mode/**` in `e2e/rstest.config.mts`, so neither runs any browser test — but the Setup Playwright step only skipped `test:no-isolate`, so `test:threads` still ran `playwright install webkit`. Gate the step to `test`/`test:commonjs` (the only scripts that run browser-mode e2e) via an allowlist, so future non-browser pool variants stay excluded by default.
- **Flaky `watchReporter` timeout.** With real Chrome cold-launch on loaded CI runners, the first watch run can exceed the previous 5s macOS/Linux budget for `onTestRunStart`/`onTestRunEnd`. Unify `WATCH_REPORTER_HOOK_TIMEOUT_MS` to 15s across platforms (matching the prior win32 value).
- **Flaky browser example timeout.** `examples/browser-react` and `examples/react-rspack-browser` `counter.test.tsx` now run real Chrome on CI; cold-launch on Windows runners can exceed the default 5s test timeout. Relax `testTimeout` to 15s under CI.

## Related Links

- #1474

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).