### PR TITLE
ci: avoid pnpm cache restore in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: pnpm install --ignore-scripts
@@ -124,13 +123,9 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
+          package-manager-cache: false
 
       - name: Install Dependencies
-        # setup-node's `cache: pnpm` restores the store; `--prefer-offline`
-        # reuses it. A standalone `pnpm fetch` only re-warms an already-warm
-        # store (~26s/job of no gain).
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build Packages
@@ -182,23 +177,24 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup pnpm
+      - name: Setup pnpm standalone
+        if: matrix.node_version == '20'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           # pnpm 11 requires Node >=22, but this matrix intentionally tests Node 20 runtime behavior.
           standalone: true
 
+      - name: Setup pnpm
+        if: matrix.node_version != '20'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
       - name: Setup Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node_version }}
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
+          package-manager-cache: false
 
       - name: Install Dependencies
-        # setup-node's `cache: pnpm` restores the store; `--prefer-offline`
-        # reuses it. A standalone `pnpm fetch` only re-warms an already-warm
-        # store (~26s/job of no gain).
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build Packages


### PR DESCRIPTION
## Summary

This PR reduces test workflow setup overhead by disabling pnpm package-manager cache restore/save in `actions/setup-node`, keeping dependency installation explicit in the existing install steps. It also limits standalone pnpm setup to Node 20 e2e jobs, where it is needed because pnpm 11 requires Node >=22 while the matrix still validates Node 20 runtime behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).