### PR TITLE
fix(browser): isolate each project in its own rsbuild instance (#1473)

### DIFF
--- a/e2e/browser-mode/fixtures/multi-project-config/env.d.ts
+++ b/e2e/browser-mode/fixtures/multi-project-config/env.d.ts
@@ -1,0 +1,6 @@
+// `@only-b` is provided at build time via project-b's `resolve.alias`. Declare
+// it for the type-checker, which uses e2e/tsconfig.json (not the per-fixture
+// tsconfig `paths`).
+declare module '@only-b' {
+  export const onlyB: string;
+}

--- a/e2e/browser-mode/fixtures/multi-project-config/project-b/only-b.ts
+++ b/e2e/browser-mode/fixtures/multi-project-config/project-b/only-b.ts
@@ -1,0 +1,1 @@
+export const onlyB = 'b-value';

--- a/e2e/browser-mode/fixtures/multi-project-config/project-b/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/multi-project-config/project-b/rstest.config.mts
@@ -1,9 +1,20 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@rstest/core';
 import { BROWSER_PORTS } from '../../ports';
 
 export default defineConfig({
   name: 'project-b',
   include: ['tests/**/*.test.ts'],
+  // Divergent per-project resolve config that only project-b's tests use. If
+  // project-b's files were compiled inside project-a's environment (the old
+  // shared manifest), `@only-b` would be unresolved -> "Module not found". This
+  // is the deterministic trigger for
+  // https://github.com/web-infra-dev/rstest/issues/1473.
+  resolve: {
+    alias: {
+      '@only-b': fileURLToPath(new URL('./only-b.ts', import.meta.url)),
+    },
+  },
   browser: {
     enabled: true,
     provider: 'playwright',

--- a/e2e/browser-mode/fixtures/multi-project-config/project-b/tests/smoke.test.ts
+++ b/e2e/browser-mode/fixtures/multi-project-config/project-b/tests/smoke.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@rstest/core';
+// Resolves only via project-b's `resolve.alias`. Fails to compile if project-b's
+// files are built with another project's resolve config (issue #1473).
+import { onlyB } from '@only-b';
 
 test('smoke', () => {
   expect(1 + 1).toBe(2);
+  expect(onlyB).toBe('b-value');
 });

--- a/e2e/browser-mode/multiProjectConfig.test.ts
+++ b/e2e/browser-mode/multiProjectConfig.test.ts
@@ -5,10 +5,10 @@ import { runBrowserCli } from './utils';
  * Regression test: in multi-project browser mode, each project must compile with
  * its own config instead of inheriting config from the first browser project.
  *
- * This file also covers https://github.com/web-infra-dev/rstest/issues/1363.
+ * This file also covers https://github.com/web-infra-dev/rstest/issues/1363 and
+ * https://github.com/web-infra-dev/rstest/issues/1473.
  * Keep these multi-project cases in one file so the browser-mode suite does not
- * start two independent `multi-project-config` fixtures at once; all projects in
- * that fixture intentionally share one browser server port.
+ * start the `multi-project-config` fixture from several test files at once.
  */
 describe.sequential('browser mode - multi project config isolation', () => {
   it('should apply each browser project config independently', async () => {
@@ -33,5 +33,23 @@ describe.sequential('browser mode - multi project config isolation', () => {
     await expectExecSuccess();
     expect(cli.stdout).toContain('smoke.test.ts');
     expect(cli.stdout).toMatch(/Tests.*passed/);
+  });
+
+  // https://github.com/web-infra-dev/rstest/issues/1473
+  // Run BOTH browser projects together (no file filter). project-a needs its
+  // own `pluginReact` and project-b needs its own `resolve.alias` (`@only-b`).
+  // With the old shared rsbuild instance, each project's files were compiled in
+  // the other project's environment, so `@only-b` failed to resolve -> "Module
+  // not found" -> the whole run hung. Each project now owns an isolated rsbuild
+  // instance, so both compile with their own config.
+  it('runs all browser projects together with divergent per-project config', async () => {
+    const { expectExecSuccess, cli } = await runBrowserCli(
+      'multi-project-config',
+    );
+
+    await expectExecSuccess();
+    expect(cli.stdout).toContain('jsxRuntime.test.tsx');
+    expect(cli.stdout).toContain('smoke.test.ts');
+    expect(cli.stdout).toMatch(/Tests.*2 passed/);
   });
 });

--- a/packages/browser-ui/src/core/runtime.ts
+++ b/packages/browser-ui/src/core/runtime.ts
@@ -12,6 +12,25 @@ export const createWebSocketUrl = (wsPort: number): string => {
   return `${protocol}//${window.location.hostname}:${wsPort}`;
 };
 
+/**
+ * Resolve the runner origin for a test file's project. Each browser project
+ * runs on its own dev server, so the container must load that file's iframe
+ * from the project's own origin. Falls back to the container-level `runnerUrl`
+ * (and ultimately the container origin) when no per-project URL is known.
+ */
+export const resolveRunnerBase = (
+  options: {
+    projectRunnerUrls?: Record<string, string>;
+    runnerUrl?: string;
+  },
+  projectName: string | undefined,
+): string | undefined => {
+  if (projectName && options.projectRunnerUrls?.[projectName]) {
+    return options.projectRunnerUrls[projectName];
+  }
+  return options.runnerUrl;
+};
+
 export const createRunnerUrl = (
   testFile: string,
   runnerBase?: string,

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -27,7 +27,11 @@ import {
 } from './core/caseMap';
 import { projectKey as toProjectKey, suiteKey } from './core/treeNodeKey';
 import { forwardDispatchRpcRequest, readDispatchMessage } from './core/channel';
-import { createRunId, createRunnerUrl } from './core/runtime';
+import {
+  createRunId,
+  createRunnerUrl,
+  resolveRunnerBase,
+} from './core/runtime';
 import { useRpc } from './hooks/useRpc';
 import type {
   BrowserClientFileResult,
@@ -242,9 +246,10 @@ const BrowserRunner: React.FC<{
         }
         return { ...prev, [testFile]: updatedCases };
       });
+      const projectName = iframe.getAttribute('data-test-project') ?? undefined;
       const newSrc = createRunnerUrl(
         testFile,
-        options.runnerUrl,
+        resolveRunnerBase(options, projectName),
         testNamePattern,
         false,
         nextRunId,
@@ -256,7 +261,7 @@ const BrowserRunner: React.FC<{
         runId: nextRunId,
       };
     },
-    [options.runnerUrl],
+    [options.runnerUrl, options.projectRunnerUrls],
   );
 
   const { rpc, loading, connected } = useRpc(
@@ -866,7 +871,10 @@ const BrowserRunner: React.FC<{
                             runId
                               ? createRunnerUrl(
                                   fileInfo.testPath,
-                                  options.runnerUrl,
+                                  resolveRunnerBase(
+                                    options,
+                                    fileInfo.projectName,
+                                  ),
                                   undefined,
                                   false,
                                   runId,

--- a/packages/browser-ui/src/main.tsx
+++ b/packages/browser-ui/src/main.tsx
@@ -866,6 +866,7 @@ const BrowserRunner: React.FC<{
                       >
                         <iframe
                           data-test-file={fileInfo.testPath}
+                          data-test-project={fileInfo.projectName}
                           title={`Test runner for ${getDisplayName(fileInfo.testPath)}`}
                           src={
                             runId

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -129,10 +129,6 @@ const serializeForInlineScript = (value: unknown): string => {
 // Type Definitions
 // ============================================================================
 
-type VirtualModulesPluginInstance = InstanceType<
-  (typeof rspack.experiments)['VirtualModulesPlugin']
->;
-
 type BrowserProjectEntries = {
   project: ProjectContext;
   setupFiles: string[];
@@ -406,16 +402,30 @@ class ContainerRpcManager {
 // Browser Runtime - Core runtime state
 // ============================================================================
 
-type BrowserRuntime = {
+// One isolated rsbuild instance + dev server per browser project. Physical
+// isolation (separate compiler, dev server, port, virtual manifest, runner)
+// prevents one project's build/resolve config from leaking into another's
+// compilation and avoids shared-dev-server races (chunk filenames,
+// lazyCompilation backend) between projects.
+type BrowserProjectServer = {
+  projectName: string;
+  environmentName: string;
   rsbuildInstance: RsbuildInstance;
   devServer: RsbuildDevServer;
+  port: number;
+  manifestPath: string;
+};
+
+type BrowserRuntime = {
+  // Per-project servers, keyed by project name.
+  projectServers: Map<string, BrowserProjectServer>;
+  // The server that hosts the container UI HTML (headed mode). The WebSocket
+  // server below is shared and reachable from any origin.
+  containerServer: BrowserProjectServer;
   browser: BrowserProviderBrowser;
   browserLaunchOptions: BrowserLaunchOptions;
-  port: number;
   wsPort: number;
-  manifestPath: string;
   tempDir: string;
-  manifestPlugin: VirtualModulesPluginInstance;
   containerPage?: BrowserProviderPage;
   containerContext?: BrowserProviderContext;
   setContainerOptions: (options: BrowserHostConfig) => void;
@@ -1046,17 +1056,18 @@ const ensureConsistentBrowserLaunchOptions = (
 
   for (const project of projects.slice(1)) {
     const options = getBrowserLaunchOptions(project);
+    // Each browser project now runs on its own rsbuild dev server, so ports may
+    // differ per project. Only the shared single Playwright browser forces
+    // provider/browser/headless/providerOptions to match across projects.
     if (
       options.provider !== firstOptions.provider ||
       options.browser !== firstOptions.browser ||
       options.headless !== firstOptions.headless ||
-      options.port !== firstOptions.port ||
-      options.strictPort !== firstOptions.strictPort ||
       !isDeepStrictEqual(options.providerOptions, firstOptions.providerOptions)
     ) {
       throw new Error(
         `Browser launch config mismatch between projects "${firstProject.name}" and "${project.name}". ` +
-          'All browser-enabled projects in one run must share provider/browser/headless/port/strictPort/providerOptions.',
+          'All browser-enabled projects in one run must share provider/browser/headless/providerOptions.',
       );
     }
   }
@@ -1295,6 +1306,27 @@ const VIRTUAL_MANIFEST_FILENAME = 'virtual-manifest.ts';
 // Browser Runtime Lifecycle
 // ============================================================================
 
+const closeAllProjectServers = (
+  servers: Iterable<BrowserProjectServer>,
+): Promise<unknown> =>
+  Promise.allSettled([...servers].map((server) => server.devServer.close()));
+
+// Copy a proxied fetch Response's status + headers onto the Node response,
+// dropping content-length (the body is re-sent, so the original length may not
+// match).
+const copyProxyResponseHeaders = (
+  response: Response,
+  res: ServerResponse,
+): void => {
+  res.statusCode = response.status;
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'content-length') {
+      return;
+    }
+    res.setHeader(key, value);
+  });
+};
+
 const destroyBrowserRuntime = async (
   runtime: BrowserRuntime,
 ): Promise<void> => {
@@ -1303,11 +1335,7 @@ const destroyBrowserRuntime = async (
   } catch {
     // ignore
   }
-  try {
-    await runtime.devServer?.close?.();
-  } catch {
-    // ignore
-  }
+  await closeAllProjectServers(runtime.projectServers.values());
   try {
     runtime.wss?.close();
   } catch {
@@ -1358,8 +1386,7 @@ const registerWatchCleanup = (): void => {
 
 const createBrowserRuntime = async ({
   context,
-  manifestPath,
-  manifestSource,
+  projectEntries,
   tempDir,
   isWatchMode,
   onTriggerRerun,
@@ -1368,8 +1395,7 @@ const createBrowserRuntime = async ({
   forceHeadless,
 }: {
   context: RstestContext;
-  manifestPath: string;
-  manifestSource: string;
+  projectEntries: BrowserProjectEntries[];
   tempDir: string;
   isWatchMode: boolean;
   onTriggerRerun?: () => Promise<void>;
@@ -1378,10 +1404,7 @@ const createBrowserRuntime = async ({
   /** Force headless mode regardless of user config (used for list command) */
   forceHeadless?: boolean;
 }): Promise<BrowserRuntime> => {
-  const virtualManifestPlugin = new rspack.experiments.VirtualModulesPlugin({
-    [manifestPath]: manifestSource,
-  });
-
+  // ---- Shared singletons (created once, wired into every project server) ----
   const containerHtmlTemplate = containerDistPath
     ? await fs.readFile(join(containerDistPath, 'index.html'), 'utf-8')
     : null;
@@ -1402,12 +1425,6 @@ const createBrowserRuntime = async ({
   };
 
   const browserProjects = getBrowserProjects(context);
-  const projectByEnvironmentName = new Map(
-    browserProjects.map((project) => [project.environmentName, project]),
-  );
-  const userPlugins = browserProjects.flatMap(
-    (project) => project.normalizedConfig.plugins || [],
-  );
   const browserLaunchOptions =
     ensureConsistentBrowserLaunchOptions(browserProjects);
 
@@ -1416,8 +1433,9 @@ const createBrowserRuntime = async ({
     import.meta.resolve('@rstest/core/internal/browser-runtime'),
   );
 
-  const rstestInternalAliases = {
-    '@rstest/browser-manifest': manifestPath,
+  // Shared by every project — only the per-project `@rstest/browser-manifest`
+  // alias varies (one virtual manifest per server).
+  const staticRstestAliases = {
     // User test code: import { describe, it } from '@rstest/core'
     '@rstest/core': resolveBrowserFile('client/public.ts'),
     // User test code: import { page } from '@rstest/browser'
@@ -1427,225 +1445,15 @@ const createBrowserRuntime = async ({
     '@rstest/core/internal/browser-runtime': browserRuntimePath,
   };
 
-  const rsbuildInstance = await createRsbuild({
-    callerName: 'rstest-browser',
-    rsbuildConfig: {
-      root: context.rootPath,
-      mode: 'development',
-      plugins: userPlugins,
-      server: {
-        printUrls: false,
-        port: browserLaunchOptions.port ?? 4000,
-        strictPort: browserLaunchOptions.strictPort,
-      },
-      dev: createBrowserRsbuildDevConfig(isWatchMode),
-      environments: {
-        ...Object.fromEntries(
-          browserProjects.map((project) => [project.environmentName, {}]),
-        ),
-      },
-    },
-  });
+  // rspack `define` replaces `process.env` / `import.meta.env` with this literal
+  // expression. JSON.stringify reproduces the exact double-quoted `"rstest.env"`
+  // text, so the owned key can never drift from the runtime
+  // `Symbol.for(RSTEST_ENV_SYMBOL_KEY)` sites.
+  const rstestEnvDefine = `globalThis[Symbol.for(${JSON.stringify(
+    RSTEST_ENV_SYMBOL_KEY,
+  )})]`;
 
-  // Add plugin to merge user Rsbuild config with rstest required config
-  rsbuildInstance.addPlugins([
-    {
-      name: 'rstest:browser-user-config',
-      setup(api) {
-        // Internal extension entry: register host dispatch handlers without
-        // coupling scheduling to individual capability implementations.
-        (api as { expose?: (name: string, value: unknown) => void }).expose?.(
-          'rstest:browser',
-          {
-            registerDispatchHandler: (
-              namespace: string,
-              handler: BrowserDispatchHandler,
-            ) => {
-              dispatchHandlers.set(namespace, handler);
-            },
-          },
-        );
-
-        api.modifyEnvironmentConfig({
-          handler: (config, { mergeEnvironmentConfig, name }) => {
-            const project = projectByEnvironmentName.get(name);
-            if (!project) {
-              return config;
-            }
-
-            const userRsbuildConfig = project.normalizedConfig;
-            const buildCache = resolveProjectBuildCache({
-              context,
-              project,
-            });
-            const setupFiles = Object.values(
-              getSetupFiles(
-                project.normalizedConfig.setupFiles,
-                project.rootPath,
-              ),
-            );
-            // rspack `define` replaces `process.env` / `import.meta.env` with
-            // this literal expression. JSON.stringify reproduces the exact
-            // double-quoted `"rstest.env"` text, so the owned key can never
-            // drift from the runtime `Symbol.for(RSTEST_ENV_SYMBOL_KEY)` sites.
-            const rstestEnvDefine = `globalThis[Symbol.for(${JSON.stringify(
-              RSTEST_ENV_SYMBOL_KEY,
-            )})]`;
-            // Merge order: current config -> userConfig -> rstest required config (highest priority)
-            const merged = mergeEnvironmentConfig(
-              config,
-              {
-                ...userRsbuildConfig,
-                performance: buildCache
-                  ? {
-                      ...userRsbuildConfig.performance,
-                      buildCache,
-                    }
-                  : userRsbuildConfig.performance,
-              },
-              {
-                resolve: {
-                  alias: rstestInternalAliases,
-                },
-                source: {
-                  define: {
-                    'process.env': rstestEnvDefine,
-                    'import.meta.env': rstestEnvDefine,
-                  },
-                },
-                output: {
-                  target: 'web',
-                  // Enable source map for inline snapshot support
-                  sourceMap: {
-                    js: 'source-map',
-                  },
-                },
-                tools: {
-                  rspack: (rspackConfig) => {
-                    rspackConfig.mode = 'development';
-                    rspackConfig.lazyCompilation =
-                      createBrowserLazyCompilationConfig(setupFiles);
-                    rspackConfig.plugins = rspackConfig.plugins || [];
-                    rspackConfig.plugins.push(virtualManifestPlugin);
-
-                    applyDefaultWatchOptions(rspackConfig, isWatchMode);
-
-                    // Extract and merge sourcemaps from pre-built @rstest/core files
-                    // This preserves the sourcemap chain for inline snapshot support
-                    // See: https://rspack.dev/config/module-rules#rulesextractsourcemap
-                    const browserRuntimeDir = dirname(browserRuntimePath);
-                    rspackConfig.module = rspackConfig.module || {};
-                    rspackConfig.module.rules = rspackConfig.module.rules || [];
-                    rspackConfig.module.rules.unshift({
-                      test: /\.js$/,
-                      include: browserRuntimeDir,
-                      extractSourceMap: true,
-                    });
-
-                    if (isDebug()) {
-                      logger.log(
-                        `[rstest:browser] extractSourceMap rule added for: ${browserRuntimeDir}`,
-                      );
-                    }
-                  },
-                },
-              },
-            );
-
-            // Completely overwrite entry to prevent Rsbuild default entry detection from taking effect.
-            // In browser mode, entry is fully controlled by rstest (not user's src/index.ts).
-            // This must be done after mergeEnvironmentConfig to ensure highest priority.
-            merged.source = merged.source || {};
-            merged.source.entry = {
-              runner: resolveBrowserFile('client/entry.ts'),
-            };
-
-            return merged;
-          },
-          // Execute after all other plugins to ensure rstest's entry config has the highest priority
-          order: 'post',
-        });
-      },
-    },
-  ]);
-
-  // Register watch plugin if in watch mode
-  if (isWatchMode && onTriggerRerun) {
-    rsbuildInstance.addPlugins([
-      {
-        name: 'rstest:browser-watch',
-        setup(api) {
-          api.onBeforeDevCompile(() => {
-            if (!watchContext.hooksEnabled) {
-              return;
-            }
-            logger.log(color.cyan('\nFile changed, re-running tests...\n'));
-          });
-
-          api.onAfterDevCompile(async ({ stats }) => {
-            // Collect hashes even during initial build to establish baseline
-            if (stats) {
-              const projectEntries = await collectProjectEntries(context);
-              const entryTestFiles = new Set<string>(
-                collectWatchTestFiles(projectEntries).map(
-                  (file) => file.testPath,
-                ),
-              );
-
-              const statsJson = stats.toJson({ all: true });
-              const affected = getAffectedTestFiles(
-                statsJson.chunks,
-                entryTestFiles,
-              );
-              watchContext.affectedTestFiles = affected;
-
-              if (affected.length > 0) {
-                logger.debug(
-                  `[Watch] Affected test files: ${affected.join(', ')}`,
-                );
-              }
-            }
-
-            if (!watchContext.hooksEnabled) {
-              return;
-            }
-
-            await onTriggerRerun();
-          });
-        },
-      },
-    ]);
-  }
-
-  // Register coverage plugin for browser mode
-  const coverage = browserProjects.find(
-    (project) => project.normalizedConfig.coverage?.enabled,
-  )?.normalizedConfig.coverage;
-  if (coverage?.enabled && context.command !== 'list') {
-    const { pluginCoverage } = await loadCoverageProvider(
-      coverage,
-      context.rootPath,
-    );
-    rsbuildInstance.addPlugins([pluginCoverage(coverage)]);
-  }
-
-  const devServer = await rsbuildInstance.createDevServer({
-    getPortSilently: true,
-  });
-
-  if (isDebug()) {
-    await rsbuildInstance.inspectConfig({
-      writeToDisk: true,
-      extraConfigs: {
-        rstest: {
-          ...context.normalizedConfig,
-          projects: browserProjects.map((p) => p.normalizedConfig),
-        },
-      },
-    });
-  }
-
-  // Serve prebuilt container assets (SPA) via sirv
+  // Serve prebuilt container assets (SPA) via sirv (container origin only)
   const serveContainer = containerDistPath
     ? sirv(containerDistPath, {
         dev: false,
@@ -1675,13 +1483,7 @@ const createBrowserRuntime = async ({
       let html = await response.text();
       html = html.replace(OPTIONS_PLACEHOLDER, serializedOptions);
 
-      res.statusCode = response.status;
-      response.headers.forEach((value, key) => {
-        if (key.toLowerCase() === 'content-length') {
-          return;
-        }
-        res.setHeader(key, value);
-      });
+      copyProxyResponseHeaders(response, res);
       res.setHeader('Content-Type', 'text/html');
       res.end(html);
       return true;
@@ -1709,13 +1511,7 @@ const createBrowserRuntime = async ({
       }
 
       const buffer = Buffer.from(await response.arrayBuffer());
-      res.statusCode = response.status;
-      response.headers.forEach((value, key) => {
-        if (key.toLowerCase() === 'content-length') {
-          return;
-        }
-        res.setHeader(key, value);
-      });
+      copyProxyResponseHeaders(response, res);
       res.end(buffer);
       return true;
     } catch (error) {
@@ -1726,75 +1522,356 @@ const createBrowserRuntime = async ({
     }
   };
 
-  devServer.middlewares.use(
-    async (req: IncomingMessage, res: ServerResponse, next: () => void) => {
-      if (!req.url) {
-        next();
-        return;
-      }
-      const url = new URL(req.url, 'http://localhost');
-      if (url.pathname === '/__open-in-editor') {
-        const file = url.searchParams.get('file');
-        if (!file) {
-          res.statusCode = 400;
-          res.end('Missing file');
-          return;
-        }
-        try {
-          await openEditor([{ file }]);
-          res.statusCode = 204;
-          res.end();
-        } catch (error) {
-          logger.debug(`[Browser UI] Failed to open editor: ${String(error)}`);
-          res.statusCode = 500;
-          res.end('Failed to open editor');
-        }
-        return;
-      }
-      if (url.pathname === '/') {
-        if (await respondWithDevServerHtml(url, res)) {
-          return;
-        }
-
-        const html =
-          injectedContainerHtml ||
-          containerHtmlTemplate?.replace(OPTIONS_PLACEHOLDER, 'null');
-
-        if (html) {
-          res.setHeader('Content-Type', 'text/html');
-          res.end(html);
-          return;
-        }
-
-        res.statusCode = 502;
-        res.end('Container UI is not available.');
-        return;
-      }
-      if (url.pathname.startsWith('/container-static/')) {
-        if (await proxyDevServerAsset(req, res)) {
-          return;
-        }
-
-        if (serveContainer) {
-          serveContainer(req, res, next);
-          return;
-        }
-
-        res.statusCode = 502;
-        res.end('Container assets are not available.');
-        return;
-      }
-      if (url.pathname === '/runner.html') {
-        res.setHeader('Content-Type', 'text/html');
-        res.end(htmlTemplate);
-        return;
-      }
-      next();
-    },
+  const entryByEnvironmentName = new Map(
+    projectEntries.map((entry) => [entry.project.environmentName, entry]),
   );
 
-  const { port: listenPort } = await devServer.listen();
-  const port = resolveListenPort(listenPort, devServer.httpServer);
+  // ---- Build one isolated rsbuild instance + dev server per project ----
+  const buildProjectServer = async (
+    project: ProjectContext,
+    isContainerServer: boolean,
+  ): Promise<BrowserProjectServer> => {
+    const manifestPath = join(
+      tempDir,
+      toSafeVarName(project.environmentName),
+      VIRTUAL_MANIFEST_FILENAME,
+    );
+    const entry = entryByEnvironmentName.get(project.environmentName);
+    const manifestSource = generateManifestModule({
+      manifestPath,
+      entries: [
+        {
+          project,
+          testFiles: entry?.testFiles ?? [],
+          setupFiles: entry?.setupFiles ?? [],
+        },
+      ],
+    });
+    const virtualManifestPlugin = new rspack.experiments.VirtualModulesPlugin({
+      [manifestPath]: manifestSource,
+    });
+
+    const rstestInternalAliases = {
+      '@rstest/browser-manifest': manifestPath,
+      ...staticRstestAliases,
+    };
+
+    const rsbuildInstance = await createRsbuild({
+      callerName: 'rstest-browser',
+      rsbuildConfig: {
+        root: context.rootPath,
+        mode: 'development',
+        plugins: project.normalizedConfig.plugins || [],
+        server: {
+          printUrls: false,
+          // Each project gets its own dev server. Honor an explicitly
+          // configured port; otherwise keep the historical 4000 default for the
+          // container server and let the OS assign free ports for the rest, so
+          // multiple projects never collide on one port.
+          port:
+            project.normalizedConfig.browser.port ??
+            (isContainerServer ? 4000 : 0),
+          strictPort: project.normalizedConfig.browser.strictPort,
+        },
+        dev: createBrowserRsbuildDevConfig(isWatchMode),
+        environments: {
+          [project.environmentName]: {},
+        },
+      },
+    });
+
+    // Add plugin to merge user Rsbuild config with rstest required config
+    rsbuildInstance.addPlugins([
+      {
+        name: 'rstest:browser-user-config',
+        setup(api) {
+          // Internal extension entry: register host dispatch handlers without
+          // coupling scheduling to individual capability implementations.
+          (api as { expose?: (name: string, value: unknown) => void }).expose?.(
+            'rstest:browser',
+            {
+              registerDispatchHandler: (
+                namespace: string,
+                handler: BrowserDispatchHandler,
+              ) => {
+                dispatchHandlers.set(namespace, handler);
+              },
+            },
+          );
+
+          api.modifyEnvironmentConfig({
+            handler: (config, { mergeEnvironmentConfig, name }) => {
+              if (name !== project.environmentName) {
+                return config;
+              }
+
+              const userRsbuildConfig = project.normalizedConfig;
+              const buildCache = resolveProjectBuildCache({
+                context,
+                project,
+              });
+              const setupFiles = Object.values(
+                getSetupFiles(
+                  project.normalizedConfig.setupFiles,
+                  project.rootPath,
+                ),
+              );
+              // Merge order: current config -> userConfig -> rstest required config (highest priority)
+              const merged = mergeEnvironmentConfig(
+                config,
+                {
+                  ...userRsbuildConfig,
+                  performance: buildCache
+                    ? {
+                        ...userRsbuildConfig.performance,
+                        buildCache,
+                      }
+                    : userRsbuildConfig.performance,
+                },
+                {
+                  resolve: {
+                    alias: rstestInternalAliases,
+                  },
+                  source: {
+                    define: {
+                      'process.env': rstestEnvDefine,
+                      'import.meta.env': rstestEnvDefine,
+                    },
+                  },
+                  output: {
+                    target: 'web',
+                    // Enable source map for inline snapshot support
+                    sourceMap: {
+                      js: 'source-map',
+                    },
+                  },
+                  tools: {
+                    rspack: (rspackConfig) => {
+                      rspackConfig.mode = 'development';
+                      rspackConfig.lazyCompilation =
+                        createBrowserLazyCompilationConfig(setupFiles);
+                      rspackConfig.plugins = rspackConfig.plugins || [];
+                      rspackConfig.plugins.push(virtualManifestPlugin);
+
+                      applyDefaultWatchOptions(rspackConfig, isWatchMode);
+
+                      // Extract and merge sourcemaps from pre-built @rstest/core files
+                      // This preserves the sourcemap chain for inline snapshot support
+                      // See: https://rspack.dev/config/module-rules#rulesextractsourcemap
+                      const browserRuntimeDir = dirname(browserRuntimePath);
+                      rspackConfig.module = rspackConfig.module || {};
+                      rspackConfig.module.rules =
+                        rspackConfig.module.rules || [];
+                      rspackConfig.module.rules.unshift({
+                        test: /\.js$/,
+                        include: browserRuntimeDir,
+                        extractSourceMap: true,
+                      });
+
+                      if (isDebug()) {
+                        logger.log(
+                          `[rstest:browser] extractSourceMap rule added for: ${browserRuntimeDir}`,
+                        );
+                      }
+                    },
+                  },
+                },
+              );
+
+              // Completely overwrite entry to prevent Rsbuild default entry detection from taking effect.
+              // In browser mode, entry is fully controlled by rstest (not user's src/index.ts).
+              // This must be done after mergeEnvironmentConfig to ensure highest priority.
+              merged.source = merged.source || {};
+              merged.source.entry = {
+                runner: resolveBrowserFile('client/entry.ts'),
+              };
+
+              return merged;
+            },
+            // Execute after all other plugins to ensure rstest's entry config has the highest priority
+            order: 'post',
+          });
+        },
+      },
+    ]);
+
+    // Register watch plugin if in watch mode
+    if (isWatchMode && onTriggerRerun) {
+      rsbuildInstance.addPlugins([
+        {
+          name: 'rstest:browser-watch',
+          setup(api) {
+            api.onBeforeDevCompile(() => {
+              if (!watchContext.hooksEnabled) {
+                return;
+              }
+              logger.log(color.cyan('\nFile changed, re-running tests...\n'));
+            });
+
+            api.onAfterDevCompile(async ({ stats }) => {
+              // Collect hashes even during initial build to establish baseline
+              if (stats) {
+                const allProjectEntries = await collectProjectEntries(context);
+                const entryTestFiles = new Set<string>(
+                  collectWatchTestFiles(allProjectEntries).map(
+                    (file) => file.testPath,
+                  ),
+                );
+
+                const statsJson = stats.toJson({ all: true });
+                const affected = getAffectedTestFiles(
+                  statsJson.chunks,
+                  entryTestFiles,
+                );
+                watchContext.affectedTestFiles = affected;
+
+                if (affected.length > 0) {
+                  logger.debug(
+                    `[Watch] Affected test files: ${affected.join(', ')}`,
+                  );
+                }
+              }
+
+              if (!watchContext.hooksEnabled) {
+                return;
+              }
+
+              await onTriggerRerun();
+            });
+          },
+        },
+      ]);
+    }
+
+    // Register coverage plugin if this project enables coverage
+    const coverage = project.normalizedConfig.coverage;
+    if (coverage?.enabled && context.command !== 'list') {
+      const { pluginCoverage } = await loadCoverageProvider(
+        coverage,
+        context.rootPath,
+      );
+      rsbuildInstance.addPlugins([pluginCoverage(coverage)]);
+    }
+
+    const devServer = await rsbuildInstance.createDevServer({
+      getPortSilently: true,
+    });
+
+    if (isDebug()) {
+      await rsbuildInstance.inspectConfig({
+        writeToDisk: true,
+        extraConfigs: {
+          rstest: {
+            ...context.normalizedConfig,
+            projects: [project.normalizedConfig],
+          },
+        },
+      });
+    }
+
+    devServer.middlewares.use(
+      async (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+        if (!req.url) {
+          next();
+          return;
+        }
+        const url = new URL(req.url, 'http://localhost');
+        if (url.pathname === '/__open-in-editor') {
+          const file = url.searchParams.get('file');
+          if (!file) {
+            res.statusCode = 400;
+            res.end('Missing file');
+            return;
+          }
+          try {
+            await openEditor([{ file }]);
+            res.statusCode = 204;
+            res.end();
+          } catch (error) {
+            logger.debug(
+              `[Browser UI] Failed to open editor: ${String(error)}`,
+            );
+            res.statusCode = 500;
+            res.end('Failed to open editor');
+          }
+          return;
+        }
+        // Container UI HTML + static assets are served by the container origin
+        // only. Per-project runner servers expose just /runner.html + assets.
+        if (isContainerServer) {
+          if (url.pathname === '/') {
+            if (await respondWithDevServerHtml(url, res)) {
+              return;
+            }
+
+            const html =
+              injectedContainerHtml ||
+              containerHtmlTemplate?.replace(OPTIONS_PLACEHOLDER, 'null');
+
+            if (html) {
+              res.setHeader('Content-Type', 'text/html');
+              res.end(html);
+              return;
+            }
+
+            res.statusCode = 502;
+            res.end('Container UI is not available.');
+            return;
+          }
+          if (url.pathname.startsWith('/container-static/')) {
+            if (await proxyDevServerAsset(req, res)) {
+              return;
+            }
+
+            if (serveContainer) {
+              serveContainer(req, res, next);
+              return;
+            }
+
+            res.statusCode = 502;
+            res.end('Container assets are not available.');
+            return;
+          }
+        }
+        if (url.pathname === '/runner.html') {
+          res.setHeader('Content-Type', 'text/html');
+          res.end(htmlTemplate);
+          return;
+        }
+        next();
+      },
+    );
+
+    const { port: listenPort } = await devServer.listen();
+    const port = resolveListenPort(listenPort, devServer.httpServer);
+
+    return {
+      projectName: project.name,
+      environmentName: project.environmentName,
+      rsbuildInstance,
+      devServer,
+      port,
+      manifestPath,
+    };
+  };
+
+  // Build each project's server sequentially. Servers must bind ports one at a
+  // time: projects may share a configured port and rely on strictPort:false
+  // bumping to the next free one, which races under concurrent listen().
+  const projectServers = new Map<string, BrowserProjectServer>();
+  try {
+    for (const [index, project] of browserProjects.entries()) {
+      const server = await buildProjectServer(project, index === 0);
+      projectServers.set(server.projectName, server);
+    }
+  } catch (error) {
+    await closeAllProjectServers(projectServers.values());
+    throw error;
+  }
+
+  // browserProjects is non-empty (ensureConsistentBrowserLaunchOptions throws
+  // otherwise) and index 0 is the designated container origin.
+  const containerServer = projectServers.get(browserProjects[0]!.name)!;
 
   // Create WebSocket server on an available port
   // Using port: 0 lets the OS assign an available port, avoiding conflicts
@@ -1818,22 +1895,19 @@ const createBrowserRuntime = async ({
       providerOptions: browserLaunchOptions.providerOptions,
     });
     return {
-      rsbuildInstance,
-      devServer,
+      projectServers,
+      containerServer,
       browser: runtime.browser,
       browserLaunchOptions,
-      port,
       wsPort,
-      manifestPath,
       tempDir,
-      manifestPlugin: virtualManifestPlugin,
       setContainerOptions,
       dispatchHandlers,
       wss,
     };
   } catch (error) {
     wss.close();
-    await devServer.close();
+    await closeAllProjectServers(projectServers.values());
     throw error;
   }
 };
@@ -2159,12 +2233,6 @@ export const runBrowserController = async (
             Date.now().toString(),
           );
 
-  const manifestPath = join(tempDir, VIRTUAL_MANIFEST_FILENAME);
-  const manifestSource = generateManifestModule({
-    manifestPath,
-    entries: projectEntries,
-  });
-
   // Track initial test files for watch mode
   if (isWatchMode) {
     watchContext.lastTestFiles = collectWatchTestFiles(projectEntries);
@@ -2179,8 +2247,7 @@ export const runBrowserController = async (
     try {
       runtime = await createBrowserRuntime({
         context,
-        manifestPath,
-        manifestSource,
+        projectEntries,
         tempDir,
         isWatchMode,
         onTriggerRerun: isWatchMode
@@ -2209,7 +2276,7 @@ export const runBrowserController = async (
     }
   }
 
-  const { browser, browserLaunchOptions, port, wsPort, wss } = runtime;
+  const { browser, browserLaunchOptions, wsPort, wss } = runtime;
   const buildTime = Date.now() - buildStart;
 
   // Collect all test files from project entries with project info
@@ -2240,13 +2307,22 @@ export const runBrowserController = async (
     ),
   );
 
+  const projectRunnerUrls = Object.fromEntries(
+    [...runtime.projectServers].map(([name, server]) => [
+      name,
+      `http://localhost:${server.port}`,
+    ]),
+  );
+
   const hostOptions: BrowserHostConfig = {
     rootPath: normalize(context.rootPath),
     projects: projectRuntimeConfigs,
     snapshot: {
       updateSnapshot: context.snapshotManager.options.updateSnapshot,
     },
-    runnerUrl: `http://localhost:${port}`,
+    // Container origin (fallback). Per-project runner origins below.
+    runnerUrl: `http://localhost:${runtime.containerServer.port}`,
+    projectRunnerUrls,
     wsPort,
     debug: isDebug(),
     rpcTimeout: maxTestTimeoutForRpc,
@@ -2907,7 +2983,13 @@ export const runBrowserController = async (
           `window.__RSTEST_BROWSER_OPTIONS__ = ${serializedOptions};`,
         );
 
-        await page.goto(`http://localhost:${port}/runner.html`, {
+        const projectServer = runtime.projectServers.get(file.projectName);
+        if (!projectServer) {
+          throw new Error(
+            `No browser dev server for project "${file.projectName}" (test file: ${file.testPath}).`,
+          );
+        }
+        await page.goto(`http://localhost:${projectServer.port}/runner.html`, {
           waitUntil: 'load',
         });
 
@@ -3554,13 +3636,14 @@ export const runBrowserController = async (
   // Only navigate on first creation
   if (isNewPage) {
     const pagePath = '/';
-    await containerPage.goto(`http://localhost:${port}${pagePath}`, {
+    const containerPort = runtime.containerServer.port;
+    await containerPage.goto(`http://localhost:${containerPort}${pagePath}`, {
       waitUntil: 'load',
     });
 
     logger.log(
       color.cyan(
-        `\nBrowser mode opened at http://localhost:${port}${pagePath}\n`,
+        `\nBrowser mode opened at http://localhost:${containerPort}${pagePath}\n`,
       ),
     );
   }
@@ -3792,11 +3875,6 @@ export const listBrowserTests = async (
     `list-${Date.now()}`,
   );
 
-  const manifestPath = join(tempDir, VIRTUAL_MANIFEST_FILENAME);
-  const manifestSource = generateManifestModule({
-    manifestPath,
-    entries: projectEntries,
-  });
   const browserProjects = getBrowserProjects(context);
 
   // Create a simplified browser runtime for collect mode
@@ -3804,8 +3882,7 @@ export const listBrowserTests = async (
   try {
     runtime = await createBrowserRuntime({
       context,
-      manifestPath,
-      manifestSource,
+      projectEntries,
       tempDir,
       isWatchMode: false,
       containerDistPath: undefined,
@@ -3827,7 +3904,7 @@ export const listBrowserTests = async (
     throw error;
   }
 
-  const { browser, browserLaunchOptions, port } = runtime;
+  const { browser, browserLaunchOptions } = runtime;
 
   // Get browser projects for runtime config
   // Normalize projectRoot to posix format for cross-platform compatibility
@@ -3861,105 +3938,122 @@ export const listBrowserTests = async (
 
   runtime.setContainerOptions(hostOptions);
 
-  // Collect results
-  const collectResults: ListCommandResult[] = [];
-  let fatalError: Error | null = null;
-  let collectCompleted = false;
-
-  // Promise that resolves when collection is complete
-  let resolveCollect: (() => void) | undefined;
-  const collectPromise = new Promise<void>((resolve) => {
-    resolveCollect = resolve;
-  });
-
-  // Create a headless page to run collection
+  // Collect results across every project's isolated dev server. Each server
+  // serves only its own project's manifest, so collection navigates one page
+  // per project; each page returns its own results, aggregated afterwards.
   const browserContext = await browser.newContext({
     providerOptions: browserLaunchOptions.providerOptions,
     viewport: null,
   });
-  const page = await browserContext.newPage();
 
-  // Expose dispatch function for browser client to send messages
-  await page.exposeFunction(
-    DISPATCH_MESSAGE_TYPE,
-    (message: { type: string; payload?: unknown }) => {
-      switch (message.type) {
-        case 'collect-result': {
-          const payload = message.payload as {
-            testPath: string;
-            project: string;
-            tests: Test[];
-          };
-          collectResults.push({
-            testPath: payload.testPath,
-            project: payload.project,
-            tests: payload.tests,
-          });
-          break;
-        }
-        case 'collect-complete':
-          collectCompleted = true;
-          resolveCollect?.();
-          break;
-        case 'fatal': {
-          const payload = message.payload as {
-            message: string;
-            stack?: string;
-          };
-          fatalError = new Error(payload.message);
-          fatalError.stack = payload.stack;
-          resolveCollect?.();
-          break;
-        }
-        case 'ready':
-        case 'log':
-          // Ignore these messages during collection
-          break;
-        default:
-          // Log unexpected messages for debugging
-          logger.debug(`[List] Unexpected message: ${message.type}`);
-      }
-    },
-  );
-
-  // Inject host options before navigation so the runner can access them
   const serializedOptions = serializeForInlineScript(hostOptions);
-  await page.addInitScript(
-    `window.__RSTEST_BROWSER_OPTIONS__ = ${serializedOptions};`,
+
+  const collectFromServer = async (
+    server: BrowserProjectServer,
+  ): Promise<{ results: ListCommandResult[]; error: Error | null }> => {
+    const results: ListCommandResult[] = [];
+    let error: Error | null = null;
+    let collectCompleted = false;
+    let resolveCollect: (() => void) | undefined;
+    const collectPromise = new Promise<void>((resolve) => {
+      resolveCollect = resolve;
+    });
+
+    const page = await browserContext.newPage();
+
+    // Expose dispatch function for browser client to send messages
+    await page.exposeFunction(
+      DISPATCH_MESSAGE_TYPE,
+      (message: { type: string; payload?: unknown }) => {
+        switch (message.type) {
+          case 'collect-result': {
+            const payload = message.payload as {
+              testPath: string;
+              project: string;
+              tests: Test[];
+            };
+            results.push({
+              testPath: payload.testPath,
+              project: payload.project,
+              tests: payload.tests,
+            });
+            break;
+          }
+          case 'collect-complete':
+            collectCompleted = true;
+            resolveCollect?.();
+            break;
+          case 'fatal': {
+            const payload = message.payload as {
+              message: string;
+              stack?: string;
+            };
+            error = new Error(payload.message);
+            error.stack = payload.stack;
+            resolveCollect?.();
+            break;
+          }
+          case 'ready':
+          case 'log':
+            // Ignore these messages during collection
+            break;
+          default:
+            // Log unexpected messages for debugging
+            logger.debug(`[List] Unexpected message: ${message.type}`);
+        }
+      },
+    );
+
+    // Inject host options before navigation so the runner can access them
+    await page.addInitScript(
+      `window.__RSTEST_BROWSER_OPTIONS__ = ${serializedOptions};`,
+    );
+
+    // Navigate to this project's runner page
+    await page.goto(`http://localhost:${server.port}/runner.html`, {
+      waitUntil: 'load',
+    });
+
+    // Wait for collection to complete with timeout
+    const timeoutMs = 30000;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(() => {
+        if (!collectCompleted) {
+          logger.warn(
+            color.yellow(
+              `[List] Browser test collection timed out after ${timeoutMs}ms`,
+            ),
+          );
+        }
+        resolve();
+      }, timeoutMs);
+    });
+
+    await Promise.race([collectPromise, timeoutPromise]);
+
+    // Clear timeout to prevent Node.js from waiting for it
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    await page.close().catch(() => {});
+    return { results, error };
+  };
+
+  // Collect every project concurrently — each navigates its own page against
+  // its own dev server and returns its own results.
+  const collected = await Promise.all(
+    [...runtime.projectServers.values()].map((server) =>
+      collectFromServer(server),
+    ),
   );
-
-  // Navigate to runner page
-  await page.goto(`http://localhost:${port}/runner.html`, {
-    waitUntil: 'load',
-  });
-
-  // Wait for collection to complete with timeout
-  const timeoutMs = 30000;
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<void>((resolve) => {
-    timeoutId = setTimeout(() => {
-      if (!collectCompleted) {
-        logger.warn(
-          color.yellow(
-            `[List] Browser test collection timed out after ${timeoutMs}ms`,
-          ),
-        );
-      }
-      resolve();
-    }, timeoutMs);
-  });
-
-  await Promise.race([collectPromise, timeoutPromise]);
-
-  // Clear timeout to prevent Node.js from waiting for it
-  if (timeoutId) {
-    clearTimeout(timeoutId);
-  }
+  const collectResults = collected.flatMap((entry) => entry.results);
+  const fatalError = collected.find((entry) => entry.error)?.error ?? null;
 
   // Cleanup
   const cleanup = async () => {
     try {
-      await page.close();
       await browserContext.close();
     } catch {
       // ignore
@@ -3977,8 +4071,8 @@ export const listBrowserTests = async (
       errors: [
         {
           name: 'BrowserCollectError',
-          message: (fatalError as Error).message,
-          stack: (fatalError as Error).stack,
+          message: fatalError.message,
+          stack: fatalError.stack,
         } as FormattedError,
       ],
     };

--- a/packages/browser/src/protocol.ts
+++ b/packages/browser/src/protocol.ts
@@ -91,9 +91,16 @@ export type BrowserHostConfig = {
    */
   runId?: string;
   /**
-   * Base URL for runner (iframe) pages.
+   * Base URL for runner (iframe) pages. Container origin; used as a fallback
+   * when a project has no entry in `projectRunnerUrls`.
    */
   runnerUrl?: string;
+  /**
+   * Per-project runner origin base URLs, keyed by project name. Each browser
+   * project runs on its own dev server, so the container must load each test
+   * file's iframe from that project's own origin.
+   */
+  projectRunnerUrls?: Record<string, string>;
   /**
    * WebSocket port for container RPC.
    */


### PR DESCRIPTION
## Summary

In multi-project browser mode, every browser project shared one rsbuild instance, one dev server and one virtual `@rstest/browser-manifest`. The shared manifest compiled every project's test files into every environment while applying only that environment's own resolve config. So a project with divergent per-project config (e.g. a project-only `resolve.alias`) failed to resolve when compiled inside another project's environment, surfaced as "Module not found", and hung the whole run (#1473).

Each browser project now gets its **own isolated rsbuild instance + dev server (own port) + single-project manifest + runner**, eliminating cross-project compilation and shared-dev-server collisions by construction:

- The first project's server doubles as the container server. The shared Playwright browser and WebSocket server are unchanged; dispatch routes on `testPath`/`sessionId`, not port.
- Headless navigates each test file to its own project's port.
- The headed container UI picks each iframe origin by project via a new `projectRunnerUrls` map in `BrowserHostConfig` (`resolveRunnerBase`); the existing single `runnerUrl` stays as a fallback.

Regression coverage reuses the existing `multi-project-config` e2e fixture: project-b gains a divergent `@only-b` alias (and a test that imports it), plus a case that runs both browser projects together with no file filter — which deterministically reproduced the hang before this change.

## Related Links

- Closes https://github.com/web-infra-dev/rstest/issues/1473

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
