### PR TITLE
feat(core)!: apply rs.mock to non-literal dynamic import()

### DIFF
--- a/e2e/mock/fixtures/nonLiteralDynamic/asyncDep.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/asyncDep.mjs
@@ -1,0 +1,4 @@
+// Mocked with an ASYNC factory. The synchronous native load hook cannot produce
+// async exports, so a natively-loaded importer must fall through to THIS real
+// module (not an empty synthetic one). See mockNonLiteralDynamicImport.test.ts.
+export const value = 'REAL_ASYNC';

--- a/e2e/mock/fixtures/nonLiteralDynamic/callableDep.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/callableDep.mjs
@@ -1,0 +1,3 @@
+export default function real() {
+  return 'REAL_CALLABLE';
+}

--- a/e2e/mock/fixtures/nonLiteralDynamic/cjsRequirer.cjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/cjsRequirer.cjs
@@ -1,0 +1,3 @@
+const os = require('node:os');
+
+module.exports = { probe: () => os.hostname() };

--- a/e2e/mock/fixtures/nonLiteralDynamic/classDep.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/classDep.mjs
@@ -1,0 +1,8 @@
+// Imported by targetVarClass.mjs (loaded natively via a variable import). Mocked
+// with a factory that returns a different class — the synthetic native-mock
+// module must keep the export constructible (`new Service()`).
+export class Service {
+  greet() {
+    return 'REAL';
+  }
+}

--- a/e2e/mock/fixtures/nonLiteralDynamic/esmShapedDep.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/esmShapedDep.mjs
@@ -1,0 +1,1 @@
+export const tag = 'REAL_ESM';

--- a/e2e/mock/fixtures/nonLiteralDynamic/sideEffectDep.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/sideEffectDep.mjs
@@ -1,0 +1,4 @@
+// Mocked with a function factory that has an observable side effect, to prove
+// the factory runs LAZILY (only when this module is imported natively), not
+// eagerly at rs.mock registration time. See mockNonLiteralDynamicImport.test.ts.
+export const value = 'REAL_FX';

--- a/e2e/mock/fixtures/nonLiteralDynamic/target.mts
+++ b/e2e/mock/fixtures/nonLiteralDynamic/target.mts
@@ -1,0 +1,3 @@
+import { hostname } from 'node:os';
+
+export const probe = (): string => hostname();

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVar.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVar.mjs
@@ -1,0 +1,8 @@
+// Imported ONLY via a non-literal `import(variable)` (see
+// mockNonLiteralDynamicImport.test.ts) so it stays out of the bundle and is
+// loaded by Node's loader — the #1454 off-graph case. Kept separate from
+// `target.mjs` (which a literal import compiles into the bundle) so the two
+// tests exercise distinct paths.
+import { hostname } from 'node:os';
+
+export const probe = () => hostname();

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarAsyncFactory.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarAsyncFactory.mjs
@@ -1,0 +1,6 @@
+// Loaded natively via a non-literal `import(variable)`; imports a module mocked
+// with an async factory, which the native path cannot serve — so it resolves to
+// the real module.
+import { value } from './asyncDep.mjs';
+
+export const probe = () => value;

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarCallable.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarCallable.mjs
@@ -1,0 +1,3 @@
+import fn from './callableDep.mjs';
+
+export const probe = () => fn();

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarClass.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarClass.mjs
@@ -1,0 +1,6 @@
+// Loaded natively via a non-literal `import(variable)`. Constructs a class
+// imported from a mocked module — exercises that the synthetic native-mock
+// module re-exports the class itself (not a non-constructible call wrapper).
+import { Service } from './classDep.mjs';
+
+export const probe = () => new Service().greet();

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarEsmShaped.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarEsmShaped.mjs
@@ -1,0 +1,4 @@
+import * as ns from './esmShapedDep.mjs';
+
+export const probe = () => ns.tag;
+export const hasDefault = () => 'default' in ns;

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarManualMock.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarManualMock.mjs
@@ -1,0 +1,6 @@
+// Loaded natively via a non-literal `import(variable)`. Imports a builtin that
+// is replaced by a manual mock (`__mocks__/dns.ts`) — exercises that a manual
+// mock is published to the native registry, not only factory/option mocks.
+import dns from 'node:dns';
+
+export const probe = () => dns?.__tag;

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarNpm.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarNpm.mjs
@@ -1,0 +1,7 @@
+// Imported ONLY via a non-literal `import(variable)`, so Node loads it natively.
+// Its bare `strip-ansi` import exercises the registerHooks NON-builtin branch
+// (real resolution via `nextResolve`, keyed by the resolved URL) — distinct from
+// the builtin (`node:os`) path.
+import stripAnsi from 'strip-ansi';
+
+export const probe = () => stripAnsi('x');

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarSideEffect.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarSideEffect.mjs
@@ -1,0 +1,5 @@
+// Loaded natively via a non-literal `import(variable)`; imports the mocked
+// side-effect module so the native load hook must evaluate the mock factory.
+import { value } from './sideEffectDep.mjs';
+
+export const probe = () => value;

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarThenExport.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarThenExport.mjs
@@ -1,0 +1,3 @@
+import { then } from './thenExportDep.mjs';
+
+export const probe = () => then();

--- a/e2e/mock/fixtures/nonLiteralDynamic/targetVarThrowingFactory.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/targetVarThrowingFactory.mjs
@@ -1,0 +1,3 @@
+import { value } from './throwingDep.mjs';
+
+export const probe = () => value;

--- a/e2e/mock/fixtures/nonLiteralDynamic/thenExportDep.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/thenExportDep.mjs
@@ -1,0 +1,2 @@
+export const then = () => 'REAL_THEN';
+export const value = 0;

--- a/e2e/mock/fixtures/nonLiteralDynamic/throwingDep.mjs
+++ b/e2e/mock/fixtures/nonLiteralDynamic/throwingDep.mjs
@@ -1,0 +1,1 @@
+export const value = 'REAL_THROW';

--- a/e2e/mock/fixtures/resolvedFirst/a/foo.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/a/foo.mjs
@@ -1,0 +1,1 @@
+export const from = 'A_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/a/importer.mts
+++ b/e2e/mock/fixtures/resolvedFirst/a/importer.mts
@@ -1,0 +1,6 @@
+// Non-literal relative import: the specifier resolves against THIS module's
+// directory (rspack-injected origin), not the test file's.
+export const loadFoo = (): Promise<{ from: string }> => {
+  const spec = './foo.mjs';
+  return import(spec);
+};

--- a/e2e/mock/fixtures/resolvedFirst/aliasDep.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/aliasDep.mjs
@@ -1,0 +1,1 @@
+export const tag = 'ALIAS_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/b/foo.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/b/foo.mjs
@@ -1,0 +1,1 @@
+export const from = 'B_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/b/importer.mts
+++ b/e2e/mock/fixtures/resolvedFirst/b/importer.mts
@@ -1,0 +1,6 @@
+// Same shape as a/importer.mts, one directory over — its './foo.mjs' names a
+// DIFFERENT module than a/'s.
+export const loadFoo = (): Promise<{ from: string }> => {
+  const spec = './foo.mjs';
+  return import(spec);
+};

--- a/e2e/mock/fixtures/resolvedFirst/helper/helperDep.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/helper/helperDep.mjs
@@ -1,0 +1,1 @@
+export const tag = 'HELPER_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/helper/mockFromHelper.mts
+++ b/e2e/mock/fixtures/resolvedFirst/helper/mockFromHelper.mts
@@ -1,0 +1,11 @@
+// A module mock declared OUTSIDE the test file: the relative request must
+// resolve against THIS helper's directory (the declaring module, `info.o`),
+// not the test file that imports the helper.
+import { rs } from '@rstest/core';
+
+rs.mock('./helperDep.mjs', () => ({ tag: 'MOCKED_FROM_HELPER' }));
+
+export const loadDep = (): Promise<{ tag: string }> => {
+  const spec = './helperDep.mjs';
+  return import(spec);
+};

--- a/e2e/mock/tests/mockDynamicImportResolvedFirst.test.ts
+++ b/e2e/mock/tests/mockDynamicImportResolvedFirst.test.ts
@@ -1,0 +1,64 @@
+import { fileURLToPath } from 'node:url';
+import { expect, it, rs } from '@rstest/core';
+
+// Resolved-first matching for non-literal dynamic `import(variable)`: the
+// bundle keys a relative mock only by its build-resolved absolute target
+// (`info.r`), and on a raw-spelling miss the worker resolves a relative
+// runtime specifier against its importing module's directory. These pins
+// cover the spellings that meet the absolute keys — relative
+// (per-directory), absolute, and `file://` — plus the raw-key match for an
+// alias spelling (aliases are matched verbatim, never expanded at runtime).
+
+rs.mock('../fixtures/resolvedFirst/a/foo.mjs', () => ({ from: 'A_MOCKED' }));
+// Declared via the alias spelling; the build resolves it to aliasDep.mjs.
+rs.mock('@e2e/mock-alias-dep', () => ({ tag: 'ALIAS_MOCKED' }));
+
+it('a relative variable import only hits the mock declared for ITS directory', async () => {
+  // a/ and b/ both variable-import './foo.mjs'; only a/foo.mjs is mocked. A
+  // raw request key could not tell them apart — the absolute key must.
+  const a = await import('../fixtures/resolvedFirst/a/importer.mts');
+  const b = await import('../fixtures/resolvedFirst/b/importer.mts');
+  expect((await a.loadFoo()).from).toBe('A_MOCKED');
+  expect((await b.loadFoo()).from).toBe('B_REAL');
+});
+
+it('a relative variable import from the test file resolves against the test dir', async () => {
+  const spec = '../fixtures/resolvedFirst/a/foo.mjs';
+  const mod = await import(spec);
+  expect(mod.from).toBe('A_MOCKED');
+});
+
+it('an absolute-path variable import hits the mock', async () => {
+  const abs = fileURLToPath(
+    new URL('../fixtures/resolvedFirst/a/foo.mjs', import.meta.url),
+  );
+  const mod = await import(abs);
+  expect(mod.from).toBe('A_MOCKED');
+});
+
+it('a file:// href variable import hits the mock', async () => {
+  const href = new URL('../fixtures/resolvedFirst/a/foo.mjs', import.meta.url)
+    .href;
+  const mod = await import(href);
+  expect(mod.from).toBe('A_MOCKED');
+});
+
+it('an alias variable import hits a mock declared with the same alias', async () => {
+  const spec = '@e2e/mock-alias-dep';
+  const mod = await import(spec);
+  expect(mod.tag).toBe('ALIAS_MOCKED');
+});
+
+it('a relative variable import hits a mock declared via its ALIAS spelling', async () => {
+  // Cross-spelling: declared as '@e2e/mock-alias-dep', imported relatively —
+  // both resolve to the same absolute target.
+  const spec = '../fixtures/resolvedFirst/aliasDep.mjs';
+  const mod = await import(spec);
+  expect(mod.tag).toBe('ALIAS_MOCKED');
+});
+
+it('a relative mock declared in a helper file resolves against the helper (info.o)', async () => {
+  const helper =
+    await import('../fixtures/resolvedFirst/helper/mockFromHelper.mts');
+  expect((await helper.loadDep()).tag).toBe('MOCKED_FROM_HELPER');
+});

--- a/e2e/mock/tests/mockNonLiteralDynamicImport.test.ts
+++ b/e2e/mock/tests/mockNonLiteralDynamicImport.test.ts
@@ -1,0 +1,214 @@
+import nodeModule from 'node:module';
+import { describe, expect, it, rs } from '@rstest/core';
+
+// Regression for #1454: rs.mock must reach the inner imports of a module loaded
+// via a NON-LITERAL dynamic `import(variable)`. rspack cannot statically include
+// such a target, so Node loads it outside the bundle; only the in-thread
+// `module.registerHooks` path (Node >= 22.15 / >= 23.5) can redirect the
+// target's `import 'node:os'` to the mock. The literal-import control compiles
+// the target into the bundle and is mock-aware on all Node.
+const HAS_REGISTER_HOOKS =
+  typeof (nodeModule as { registerHooks?: unknown }).registerHooks ===
+  'function';
+
+rs.mock('node:os', () => ({ hostname: () => 'MOCKED' }));
+rs.mock('strip-ansi', () => ({ default: () => 'MOCKED_STRIP' }));
+// Manual mock from `__mocks__/dns.ts` (no factory) — exercises that a manual
+// mock is published to the native registry too.
+rs.mock('node:dns');
+// Factory returning a class — exercises that the synthetic native-mock module
+// keeps the export constructible.
+rs.mock('../fixtures/nonLiteralDynamic/classDep.mjs', () => {
+  class Service {
+    greet() {
+      return 'MOCKED_CLASS';
+    }
+  }
+  return { Service };
+});
+// Function factory with an observable side effect — proves the factory runs
+// LAZILY (only when a natively-loaded module imports it), not eagerly at
+// registration time. The counter lives on the shared globalThis (same object in
+// the bundle and worker realms), so both sides increment/read the same value.
+const fxCounter = globalThis as { __rstestFxCalls?: number };
+rs.mock('../fixtures/nonLiteralDynamic/sideEffectDep.mjs', () => {
+  fxCounter.__rstestFxCalls = (fxCounter.__rstestFxCalls ?? 0) + 1;
+  return { value: 'MOCKED_FX' };
+});
+// Async factory: the synchronous native load hook can't produce its exports, so
+// a natively-loaded importer falls through to the real module.
+rs.mock('../fixtures/nonLiteralDynamic/asyncDep.mjs', async () => ({
+  value: 'MOCKED_ASYNC',
+}));
+// Throwing factory: the error must surface on the native path (fail the import)
+// rather than silently fall through to the real module, matching the bundled path.
+rs.mock('../fixtures/nonLiteralDynamic/throwingDep.mjs', () => {
+  throw new Error('boom mock factory');
+});
+// Callable result: a factory whose exports ARE a function (a default-function /
+// CommonJS-style module) must still be served natively as the default export,
+// not rejected as "not an object".
+rs.mock(
+  '../fixtures/nonLiteralDynamic/callableDep.mjs',
+  () => () => 'MOCKED_CALLABLE',
+);
+// ESM-shaped mock (`__esModule` true, no `default`): the native path must NOT
+// synthesize a whole-object default, matching the bundled interop.
+rs.mock('../fixtures/nonLiteralDynamic/esmShapedDep.mjs', () => ({
+  __esModule: true,
+  tag: 'MOCKED_ESM',
+}));
+// A legitimate function-valued `then` export must not be mistaken for an async
+// (thenable) factory result and dropped.
+rs.mock('../fixtures/nonLiteralDynamic/thenExportDep.mjs', () => ({
+  then: () => 'MOCKED_THEN',
+  value: 1,
+}));
+
+it('dynamic import with a string LITERAL applies the mock (control)', async () => {
+  const mod = await import('../fixtures/nonLiteralDynamic/target.mts');
+  expect(mod.probe()).toBe('MOCKED');
+});
+
+it('non-literal import where the variable IS a mocked builtin applies the mock (all Node)', async () => {
+  // The specifier resolves to the mocked module itself — fixed by the request-key
+  // bridge in the runtime router (no registerHooks needed), so this is ungated.
+  const spec = ['node', 'os'].join(':');
+  const os = (await import(spec)) as unknown as { hostname: () => string };
+  expect(os.hostname()).toBe('MOCKED');
+});
+
+it('non-literal import of the other builtin spelling applies the mock (all Node)', async () => {
+  // Mocked as `node:os`; imported via the bare `os` spelling. The request-key
+  // bridge canonicalizes builtin spellings, so this matches without registerHooks.
+  const id = ['o', 's'].join('');
+  const os = (await import(id)) as unknown as { hostname: () => string };
+  expect(os.hostname()).toBe('MOCKED');
+});
+
+it('a non-literal importActual of a mocked builtin returns the REAL module', async () => {
+  // `importActual` carries the internal `with: { rstest }` attribute; the mock
+  // router must NOT serve the mock for it, even when the specifier is non-literal
+  // and names a mocked builtin. Without that gate, this returns 'MOCKED'.
+  const id = ['node', 'os'].join(':');
+  const real = (await import(id, {
+    with: { rstest: 'importActual' },
+  })) as unknown as { hostname: () => string };
+  expect(real.hostname()).not.toBe('MOCKED');
+  expect(typeof real.hostname()).toBe('string');
+});
+
+it('unmock clears both builtin spellings (mock node:, unmock bare) (all Node)', async () => {
+  // The dynamic-import resolver treats `querystring` and `node:querystring` as
+  // equivalent, so an unmock with either spelling must clear both — otherwise the
+  // stale alias under the original key would still be served.
+  rs.doMock('node:querystring', () => ({ escape: () => 'MOCKED_QS' }));
+  const bare = ['query', 'string'].join('');
+  const mocked = (await import(bare)) as unknown as { escape: () => string };
+  expect(mocked.escape()).toBe('MOCKED_QS');
+
+  // Unmock via the bare spelling although the mock was registered as `node:`.
+  rs.doUnmock('querystring');
+  const prefixed = ['node', 'querystring'].join(':');
+  const real = (await import(prefixed)) as unknown as {
+    escape: (s: string) => string;
+  };
+  expect(real.escape('a b')).toBe('a%20b');
+});
+
+describe.skipIf(!HAS_REGISTER_HOOKS)('non-literal specifier (#1454)', () => {
+  it('dynamic import with a VARIABLE applies the mock (builtin)', async () => {
+    const specifier = '../fixtures/nonLiteralDynamic/targetVar.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('MOCKED');
+  });
+
+  it('dynamic import of a module that imports a mocked npm package sees the mock', async () => {
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarNpm.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('MOCKED_STRIP');
+  });
+
+  it('a manual mock (__mocks__) applies to a natively loaded module', async () => {
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarManualMock.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('MOCKED_DNS');
+  });
+
+  it('a mocked class export stays constructible in a natively loaded module', async () => {
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarClass.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('MOCKED_CLASS');
+  });
+
+  it('evaluates a function-factory mock lazily — once, at native-import time', async () => {
+    // Flushing the publish microtask must NOT run the factory: it runs only when
+    // a natively-loaded module actually imports the mock (lazy producer), so a
+    // factory with side effects keeps its lazy semantics.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fxCounter.__rstestFxCalls ?? 0).toBe(0);
+
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarSideEffect.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('MOCKED_FX');
+    expect(fxCounter.__rstestFxCalls).toBe(1);
+  });
+
+  it('an async factory mock is not served natively — falls through to the real module', async () => {
+    // The sync load hook can't produce async exports; the resolve hook must fall
+    // through to the real module rather than serve an empty synthetic one.
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarAsyncFactory.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('REAL_ASYNC');
+  });
+
+  it('a throwing factory surfaces its error on the native path (not silent real)', async () => {
+    // The factory throws when produced; the resolve hook must propagate that so
+    // the import fails, rather than swallowing it and serving the real module.
+    const specifier =
+      '../fixtures/nonLiteralDynamic/targetVarThrowingFactory.mjs';
+    await expect(import(specifier)).rejects.toThrow('boom mock factory');
+  });
+
+  it('a callable (default-function) mock is served natively', async () => {
+    // The mock's exports are a bare function; it must be served as the default
+    // export rather than rejected for not being a plain object.
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarCallable.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('MOCKED_CALLABLE');
+  });
+
+  it('an __esModule mock without a default synthesizes no default natively', async () => {
+    // Named exports are served, but no whole-object default is invented — the
+    // bundled interop only adds a default for non-__esModule shapes.
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarEsmShaped.mjs';
+    const mod = (await import(specifier)) as {
+      probe: () => string;
+      hasDefault: () => boolean;
+    };
+    expect(mod.probe()).toBe('MOCKED_ESM');
+    expect(mod.hasDefault()).toBe(false);
+  });
+
+  it('a mock exporting a function-valued `then` is served natively', async () => {
+    // `{ then: fn }` is a valid export shape, not an async factory result, so it
+    // must be served rather than dropped as thenable.
+    const specifier = '../fixtures/nonLiteralDynamic/targetVarThenExport.mjs';
+    const mod = (await import(specifier)) as { probe: () => string };
+    expect(mod.probe()).toBe('MOCKED_THEN');
+  });
+
+  it('a CJS require of a mocked module is not redirected to the ESM synthetic', async () => {
+    // `registerHooks` also fires for `require()`, but the synthetic mock module
+    // is ESM. The resolve hook must leave require resolutions to Node, so the CJS
+    // module receives the real `node:os` (not the mock, and not a load error).
+    const specifier = '../fixtures/nonLiteralDynamic/cjsRequirer.cjs';
+    const ns = (await import(specifier)) as {
+      default?: { probe: () => string };
+      probe?: () => string;
+    };
+    const probe = (ns.default ?? ns).probe!;
+    expect(probe()).not.toBe('MOCKED');
+  });
+});

--- a/e2e/mock/tests/mockNonLiteralDynamicImport.test.ts
+++ b/e2e/mock/tests/mockNonLiteralDynamicImport.test.ts
@@ -78,6 +78,15 @@ it('non-literal import where the variable IS a mocked builtin applies the mock (
   expect(os.hostname()).toBe('MOCKED');
 });
 
+it('LITERAL dynamic import of the other builtin spelling applies the mock (all Node)', async () => {
+  // Mocked as `node:os`, imported as a literal `import('os')`. The external
+  // dynamic import routes through `rstest_dynamic_require`, keyed by the raw
+  // request — its alt-spelling lookup must find the `node:` registration.
+  // Regression pin: this lookup used to miss, serving the REAL module.
+  const os = (await import('os')) as unknown as { hostname: () => string };
+  expect(os.hostname()).toBe('MOCKED');
+});
+
 it('non-literal import of the other builtin spelling applies the mock (all Node)', async () => {
   // Mocked as `node:os`; imported via the bare `os` spelling. The request-key
   // bridge canonicalizes builtin spellings, so this matches without registerHooks.

--- a/e2e/mock/tests/mockUnmockNativeRace.test.ts
+++ b/e2e/mock/tests/mockUnmockNativeRace.test.ts
@@ -1,0 +1,23 @@
+import nodeModule from 'node:module';
+import { describe, expect, it, rs } from '@rstest/core';
+
+// #1485 (Codex P2): `rs.unmock()` defers the native-registry removal on a
+// microtask (to preserve mock→unmock ordering). This checks the claimed race —
+// that a non-literal `import()` of the just-unmocked module in the same turn
+// could still see the stale native mock. The deferred unpublish is queued at
+// `rs.unmock()` time, before the async `import()` resolution begins, so it runs
+// before Node's registerHooks resolve hook; the real module must win.
+const HAS_REGISTER_HOOKS =
+  typeof (nodeModule as { registerHooks?: unknown }).registerHooks ===
+  'function';
+
+rs.mock('node:os', () => ({ hostname: () => 'MOCKED' }));
+
+describe.skipIf(!HAS_REGISTER_HOOKS)('unmock then non-literal import', () => {
+  it('sees the real module, not a stale native mock', async () => {
+    rs.unmock('node:os');
+    const spec = ['node', 'os'].join(':');
+    const os = (await import(spec)) as unknown as { hostname: () => string };
+    expect(os.hostname()).not.toBe('MOCKED');
+  });
+});

--- a/e2e/rstest.config.mts
+++ b/e2e/rstest.config.mts
@@ -51,6 +51,11 @@ export default defineConfig({
       '@e2e/wasm-glue': fileURLToPath(
         new URL('./wasm-imports/src/alias-glue.js', import.meta.url),
       ),
+      // Fixture-only: an alias spelling for the dynamic-import mock gate's
+      // raw-key + resolved-key matching (mock/tests/mockDynamicImportResolvedFirst).
+      '@e2e/mock-alias-dep': fileURLToPath(
+        new URL('./mock/fixtures/resolvedFirst/aliasDep.mjs', import.meta.url),
+      ),
     },
   },
   pool: {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -147,11 +147,6 @@ export default defineConfig({
         entry: {
           index: './src/browserRuntime.ts',
         },
-        // Strip the Node-only native-mock bridge (import.meta.resolve /
-        // pathToFileURL) from the browser bundle via dead-code elimination.
-        define: {
-          RSTEST_TARGET_BROWSER: JSON.stringify(true),
-        },
       },
       output: {
         target: 'web',
@@ -196,9 +191,6 @@ export default defineConfig({
     define: {
       RSTEST_VERSION: JSON.stringify(version),
       PLAYWRIGHT_VERSION: JSON.stringify(peerDependencies.playwright),
-      // Node builds keep the native-mock bridge; the `browser_runtime` entry
-      // overrides this to `true` so that code is stripped from the web bundle.
-      RSTEST_TARGET_BROWSER: JSON.stringify(false),
     },
   },
   tools: {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -147,6 +147,11 @@ export default defineConfig({
         entry: {
           index: './src/browserRuntime.ts',
         },
+        // Strip the Node-only native-mock bridge (import.meta.resolve /
+        // pathToFileURL) from the browser bundle via dead-code elimination.
+        define: {
+          RSTEST_TARGET_BROWSER: JSON.stringify(true),
+        },
       },
       output: {
         target: 'web',
@@ -191,6 +196,9 @@ export default defineConfig({
     define: {
       RSTEST_VERSION: JSON.stringify(version),
       PLAYWRIGHT_VERSION: JSON.stringify(peerDependencies.playwright),
+      // Node builds keep the native-mock bridge; the `browser_runtime` entry
+      // overrides this to `true` so that code is stripped from the web bundle.
+      RSTEST_TARGET_BROWSER: JSON.stringify(false),
     },
   },
   tools: {

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -146,12 +146,6 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 injectDynamicImportOrigin: {
                   functionName: dynamicImportCallee,
                 },
-                // Newer rspack appends the build-resolved mock identity
-                // `{o, r}` to generated `rstest_mock`/`rstest_unmock` calls;
-                // the pinned rspack ignores this unknown field, and the
-                // runtime feature-detects the extra argument, so the option
-                // is safe to pass unconditionally.
-                emitMockResolvedInfo: true,
                 // The runtime hook below resolves relative require.resolve
                 // specifiers against the source module that produced the
                 // call, instead of the test entry, fixing #848.

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -115,16 +115,16 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
               config.mode = isProd ? 'production' : 'development';
               config.output ??= {};
               config.output.iife = false;
-              // polyfill interop
-              // TODO: if we ever expose `output.importFunctionName` as a user
-              // option, rspack#13849's rewrite still reads it directly to pick
-              // the callee for non-string-literal `import()`. Either bind the
-              // runtime helper under the user-configured name as well, or move
-              // the dynamic-import-origin rewrite onto a dedicated rspack
-              // option so the two concerns stop sharing one identifier.
-              config.output.importFunctionName = outputModule
+              // Callee for the dynamic-import runtime hook, assigned to BOTH
+              // `output.importFunctionName` (external/dynamic import codegen —
+              // polyfills interop) and `injectDynamicImportOrigin.functionName`
+              // (the non-string-literal `import()` rewrite). Pinning the
+              // rewrite explicitly means exposing `output.importFunctionName`
+              // as a user option would not break it.
+              const dynamicImportCallee = outputModule
                 ? importMetaHook(RSTEST_DYNAMIC_IMPORT_HOOK)
                 : RSTEST_DYNAMIC_IMPORT_HOOK;
+              config.output.importFunctionName = dynamicImportCallee;
               config.output.devtoolModuleFilenameTemplate =
                 '[absolute-resource-path]';
 
@@ -143,7 +143,15 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 // The runtime hook below resolves relative dynamic-import
                 // specifiers against the source module that produced the
                 // call, instead of the test entry, fixing #1207.
-                injectDynamicImportOrigin: true,
+                injectDynamicImportOrigin: {
+                  functionName: dynamicImportCallee,
+                },
+                // Newer rspack appends the build-resolved mock identity
+                // `{o, r}` to generated `rstest_mock`/`rstest_unmock` calls;
+                // the pinned rspack ignores this unknown field, and the
+                // runtime feature-detects the extra argument, so the option
+                // is safe to pass unconditionally.
+                emitMockResolvedInfo: true,
                 // The runtime hook below resolves relative require.resolve
                 // specifiers against the source module that produced the
                 // call, instead of the test entry, fixing #848.

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -50,7 +50,10 @@ const hasOwn = (target, property) => Object.hasOwn(target, property);
 const altBuiltinSpelling = (request) =>
   request.startsWith('node:') ? request.slice(5) : `node:${request}`;
 
-const isPromise = (value) => value instanceof Promise;
+// Realm-safe (a cross-realm Promise fails `instanceof`), matching the worker
+// registry's async detection in `mockRegistry.getNativeMock`.
+const isPromise = (value) =>
+  Object.prototype.toString.call(value) === '[object Promise]';
 
 // Restore a module id to its captured original factory and drop its cache
 // entry — undoing a mock.
@@ -107,8 +110,7 @@ const createMockedModule = (originalModule, isSpy) => {
 // NATIVELY by Node — a true-external `A` (a node_modules package), or a local
 // module reached via a non-literal `import(variable)` (loaded outside the
 // bundle) — that internally imports this mocked module. Routed over the existing
-// RSTEST_API channel (same as `mockObject`). `request` is `undefined` under an
-// older @rspack/core that omits the request literal — skip then.
+// RSTEST_API channel (same as `mockObject`).
 //
 // `produce` yields the mock's exports: the already-built mocked module for the
 // spy/mock-option path (the SAME instance bundle consumers see, via its getters),
@@ -129,9 +131,6 @@ const createMockedModule = (originalModule, isSpy) => {
 // object-returning factories (the #1454 repro) and the spy/mock-option path are
 // unaffected.
 const publishNativeMock = (request, produce) => {
-  if (request === undefined) {
-    return;
-  }
   const api = globalThis.RSTEST_API?.rstest;
   if (!api || typeof api.__setNativeMock !== 'function') {
     return;
@@ -146,9 +145,6 @@ const publishNativeMock = (request, produce) => {
 // microtask, which would then re-add a stale entry. Queuing both keeps the last
 // operation winning (`rs.mock` then `rs.unmock` ⇒ removed).
 const unpublishNativeMock = (request) => {
-  if (request === undefined) {
-    return;
-  }
   queueMicrotask(() => {
     const api = globalThis.RSTEST_API?.rstest;
     if (api && typeof api.__unsetNativeMock === 'function') {
@@ -161,15 +157,11 @@ const unpublishNativeMock = (request) => {
 __webpack_require__.rstest_unmock = (id, request) => {
   restoreOriginalFactory(id);
 
-  // `request` is `undefined` under an older @rspack/core that omits the request
-  // literal; the guard can be dropped once the minimum @rspack/core always emits it.
-  if (request !== undefined) {
-    const map = __webpack_require__.rstest_mocked_ids_by_request;
-    delete map[request];
-    // `os` and `node:os` are equivalent, so an unmock with either spelling must
-    // clear both (mirrors the resolver's read-side alt lookup).
-    delete map[altBuiltinSpelling(request)];
-  }
+  const map = __webpack_require__.rstest_mocked_ids_by_request;
+  delete map[request];
+  // `os` and `node:os` are equivalent, so an unmock with either spelling must
+  // clear both (mirrors the resolver's read-side alt lookup).
+  delete map[altBuiltinSpelling(request)];
   unpublishNativeMock(request);
 };
 //#endregion
@@ -213,12 +205,9 @@ const getMockImplementation = (mockType = 'mock') => {
   // The mock and mockRequire will resolve to different module ids when the module is a dual package.
   return (id, modFactory, request) => {
     // Point a dynamic `import(request)` — which carries a different external
-    // module id — at this mocked id, so `rstest_dynamic_require` resolves it
-    // here. No-ops under an older @rspack/core that omits the request literal.
+    // module id — at this mocked id, so `rstest_dynamic_require` resolves it here.
     const registerRequestAlias = () => {
-      if (request !== undefined) {
-        __webpack_require__.rstest_mocked_ids_by_request[request] = id;
-      }
+      __webpack_require__.rstest_mocked_ids_by_request[request] = id;
     };
 
     // Swap in a mock factory: install it, drop the stale cache entry, and

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -44,9 +44,10 @@ __webpack_require__.rstest_mocked_ids_by_request = Object.create(null);
 
 const hasOwn = (target, property) => Object.hasOwn(target, property);
 
-// The other builtin spelling of a request (`os` <-> `node:os`). Used to treat
-// both spellings as one mock: the resolver reads under either, and unmock clears
-// both. A non-builtin's toggled key is never in the map, so it's a harmless miss.
+// The other builtin spelling of a request (`os` <-> `node:os`). Both spellings
+// are one mock: `registerRequestAlias` registers BOTH at mock time so every
+// lookup stays a plain single read, and unmock deletes both. A non-builtin's
+// toggled key (e.g. `node:./dep.js`) is junk no lookup ever queries — harmless.
 const altBuiltinSpelling = (request) =>
   request.startsWith('node:') ? request.slice(5) : `node:${request}`;
 
@@ -121,7 +122,7 @@ const createMockedModule = (originalModule, isSpy) => {
 // imports not yet evaluated when the hoisted `rs.mock` runs, never runs at
 // registration time and never runs at all when no natively-loaded module imports
 // the mock. Still queued on a microtask so publish/unpublish stay ordered (see
-// `unpublishNativeMock`).
+// `queueNativeMockCall`).
 //
 // LIMITATION (function factory only): the factory runs a second time on the
 // worker side (at native-import time), so the native-realm mock is a SEPARATE
@@ -130,39 +131,38 @@ const createMockedModule = (originalModule, isSpy) => {
 // handle — calls made via the natively-loaded module will not see them. Sync
 // object-returning factories (the #1454 repro) and the spy/mock-option path are
 // unaffected.
-const publishNativeMock = (request, produce) => {
-  const api = globalThis.RSTEST_API?.rstest;
-  if (!api || typeof api.__setNativeMock !== 'function') {
-    return;
-  }
-  queueMicrotask(() => {
-    api.__setNativeMock(request, produce);
-  });
-};
-
-// Deferred on a microtask like `publishNativeMock` so install→uninstall order is
-// preserved: a synchronous unpublish would run BEFORE the deferred publish
-// microtask, which would then re-add a stale entry. Queuing both keeps the last
-// operation winning (`rs.mock` then `rs.unmock` ⇒ removed).
-const unpublishNativeMock = (request) => {
+// Publish and unpublish are BOTH deferred on a microtask so install→uninstall
+// order is preserved: a synchronous unpublish would run BEFORE a deferred
+// publish, which would then re-add a stale entry. Queuing both keeps the last
+// operation winning (`rs.mock` then `rs.unmock` ⇒ removed). The API is
+// feature-detected inside the tick, one shape for both directions.
+const queueNativeMockCall = (method, ...args) => {
   queueMicrotask(() => {
     const api = globalThis.RSTEST_API?.rstest;
-    if (api && typeof api.__unsetNativeMock === 'function') {
-      api.__unsetNativeMock(request);
+    if (api && typeof api[method] === 'function') {
+      api[method](...args);
     }
   });
 };
 
+const publishNativeMock = (request, produce, info) =>
+  queueNativeMockCall('__setNativeMock', request, produce, info);
+
+const unpublishNativeMock = (request, info) =>
+  queueNativeMockCall('__unsetNativeMock', request, info);
+
 //#region rs.unmock
-__webpack_require__.rstest_unmock = (id, request) => {
+__webpack_require__.rstest_unmock = (id, request, info) => {
   restoreOriginalFactory(id);
 
+  // Delete the same alias set `registerRequestAlias` writes.
   const map = __webpack_require__.rstest_mocked_ids_by_request;
   delete map[request];
-  // `os` and `node:os` are equivalent, so an unmock with either spelling must
-  // clear both (mirrors the resolver's read-side alt lookup).
   delete map[altBuiltinSpelling(request)];
-  unpublishNativeMock(request);
+  if (info && typeof info.r === 'string') {
+    delete map[info.r];
+  }
+  unpublishNativeMock(request, info);
 };
 //#endregion
 
@@ -203,11 +203,24 @@ const getMockImplementation = (mockType = 'mock') => {
     mockType === 'mockRequire' || mockType === 'doMockRequire';
 
   // The mock and mockRequire will resolve to different module ids when the module is a dual package.
-  return (id, modFactory, request) => {
+  // `info` is the build-resolved mock identity `{o: <declaring file>, r:
+  // <resolved target | null>}` appended by newer rspack when
+  // `emitMockResolvedInfo` is on; absent on older rspack, so every consumer
+  // treats it as optional (feature-detect by argument presence, never version).
+  return (id, modFactory, request, info) => {
     // Point a dynamic `import(request)` — which carries a different external
-    // module id — at this mocked id, so `rstest_dynamic_require` resolves it here.
+    // module id — at this mocked id, so `rstest_dynamic_require` resolves it
+    // here. Every spelling the import might carry is registered at this ONE
+    // write point — the raw request, its other builtin spelling, and the
+    // build-resolved target from newer rspack (`info.r`, e.g. an absolute
+    // path) — so every reader is a plain single lookup.
     const registerRequestAlias = () => {
-      __webpack_require__.rstest_mocked_ids_by_request[request] = id;
+      const map = __webpack_require__.rstest_mocked_ids_by_request;
+      map[request] = id;
+      map[altBuiltinSpelling(request)] = id;
+      if (info && typeof info.r === 'string') {
+        map[info.r] = id;
+      }
     };
 
     // Swap in a mock factory: install it, drop the stale cache entry, and
@@ -294,7 +307,7 @@ const getMockImplementation = (mockType = 'mock') => {
       };
 
       installFactory(finalModFactory);
-      publishNativeMock(request, () => mockedModule);
+      publishNativeMock(request, () => mockedModule, info);
       return;
     }
 
@@ -313,7 +326,7 @@ const getMockImplementation = (mockType = 'mock') => {
       // natively-loaded module that imports this mocked module sees it too.
       // `__webpack_require__(modFactory)` is cache-safe (same call as the factory
       // above), so there is no separate-instance divergence here.
-      publishNativeMock(request, () => __webpack_require__(modFactory));
+      publishNativeMock(request, () => __webpack_require__(modFactory), info);
     } else if (typeof modFactory === 'function') {
       const finalModFactory = function (
         __webpack_module__,
@@ -343,7 +356,7 @@ const getMockImplementation = (mockType = 'mock') => {
       };
 
       installFactory(finalModFactory);
-      publishNativeMock(request, modFactory);
+      publishNativeMock(request, modFactory, info);
     }
   };
 };
@@ -391,13 +404,7 @@ __webpack_require__.rstest_dynamic_require = (id, request) => {
  * mocked, so the hook performs its normal native import.
  */
 globalThis.__rstest_resolve_mocked_dynamic_request__ = (request) => {
-  const map = __webpack_require__.rstest_mocked_ids_by_request;
-  let mockedId = map[request];
-  if (mockedId === undefined) {
-    // A builtin may be mocked under its other spelling (`os` vs `node:os`),
-    // mirroring the native hook's builtin canonicalization.
-    mockedId = map[altBuiltinSpelling(request)];
-  }
+  const mockedId = __webpack_require__.rstest_mocked_ids_by_request[request];
   return mockedId !== undefined ? __webpack_require__(mockedId) : undefined;
 };
 //#endregion

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -45,11 +45,45 @@ __webpack_require__.rstest_mocked_ids_by_request = Object.create(null);
 const hasOwn = (target, property) => Object.hasOwn(target, property);
 
 // The other builtin spelling of a request (`os` <-> `node:os`). Both spellings
-// are one mock: `registerRequestAlias` registers BOTH at mock time so every
-// lookup stays a plain single read, and unmock deletes both. A non-builtin's
-// toggled key (e.g. `node:./dep.js`) is junk no lookup ever queries — harmless.
+// are one mock: `requestAliasKeys` yields BOTH at mock time so every lookup
+// stays a plain single read, and unmock deletes both. A non-builtin's toggled
+// key (e.g. `node:some-pkg`) is junk no lookup ever queries — harmless.
 const altBuiltinSpelling = (request) =>
   request.startsWith('node:') ? request.slice(5) : `node:${request}`;
+
+const isRelativeRequest = (request) =>
+  request.startsWith('./') || request.startsWith('../');
+
+// Every generated `rstest_mock`/`rstest_unmock` call must carry the
+// build-resolved identity `{o, r}` (`o`: declaring module's absolute path,
+// `r`: resolved target — absolute path, external request, or null). Emitted
+// unconditionally by @rspack/core >= 2.1.3; absence means the build ran on an
+// older rspack, where the identity-keyed mock paths below would silently miss.
+const requireResolvedInfo = (info, method) => {
+  if (!info || typeof info.o !== 'string') {
+    throw new Error(
+      `[Rstest] rs.${method}() did not receive its build-resolved identity. ` +
+        'Module mocking requires @rspack/core >= 2.1.3 — upgrade the ' +
+        '@rspack/core (or @rsbuild/core) dependency compiling the tests.',
+    );
+  }
+};
+
+// Every spelling `rstest_mocked_ids_by_request` keys this mock under. A
+// RELATIVE request is NOT keyed raw — `./foo` names different modules from
+// different directories, so it is only reachable through its build-resolved
+// absolute target (`info.r`; the worker resolves a runtime specifier to the
+// same absolute path before querying). Bare/builtin/absolute spellings stay
+// raw, builtins under both spellings.
+const requestAliasKeys = (request, info) => {
+  const keys = isRelativeRequest(request)
+    ? []
+    : [request, altBuiltinSpelling(request)];
+  if (typeof info.r === 'string' && !keys.includes(info.r)) {
+    keys.push(info.r);
+  }
+  return keys;
+};
 
 // Realm-safe (a cross-realm Promise fails `instanceof`), matching the worker
 // registry's async detection in `mockRegistry.getNativeMock`.
@@ -153,14 +187,13 @@ const unpublishNativeMock = (request, info) =>
 
 //#region rs.unmock
 __webpack_require__.rstest_unmock = (id, request, info) => {
+  requireResolvedInfo(info, 'unmock');
   restoreOriginalFactory(id);
 
   // Delete the same alias set `registerRequestAlias` writes.
   const map = __webpack_require__.rstest_mocked_ids_by_request;
-  delete map[request];
-  delete map[altBuiltinSpelling(request)];
-  if (info && typeof info.r === 'string') {
-    delete map[info.r];
+  for (const key of requestAliasKeys(request, info)) {
+    delete map[key];
   }
   unpublishNativeMock(request, info);
 };
@@ -203,23 +236,18 @@ const getMockImplementation = (mockType = 'mock') => {
     mockType === 'mockRequire' || mockType === 'doMockRequire';
 
   // The mock and mockRequire will resolve to different module ids when the module is a dual package.
-  // `info` is the build-resolved mock identity `{o: <declaring file>, r:
-  // <resolved target | null>}` appended by newer rspack when
-  // `emitMockResolvedInfo` is on; absent on older rspack, so every consumer
-  // treats it as optional (feature-detect by argument presence, never version).
   return (id, modFactory, request, info) => {
+    requireResolvedInfo(info, mockType);
+
     // Point a dynamic `import(request)` — which carries a different external
     // module id — at this mocked id, so `rstest_dynamic_require` resolves it
     // here. Every spelling the import might carry is registered at this ONE
-    // write point — the raw request, its other builtin spelling, and the
-    // build-resolved target from newer rspack (`info.r`, e.g. an absolute
-    // path) — so every reader is a plain single lookup.
+    // write point (`requestAliasKeys`), so every reader is a plain single
+    // lookup.
     const registerRequestAlias = () => {
       const map = __webpack_require__.rstest_mocked_ids_by_request;
-      map[request] = id;
-      map[altBuiltinSpelling(request)] = id;
-      if (info && typeof info.r === 'string') {
-        map[info.r] = id;
+      for (const key of requestAliasKeys(request, info)) {
+        map[key] = id;
       }
     };
 
@@ -402,9 +430,29 @@ __webpack_require__.rstest_dynamic_require = (id, request) => {
  * loading the real one. Published on the shared `globalThis` because the worker
  * hook has no `__webpack_require__`; returns `undefined` when the request isn't
  * mocked, so the hook performs its normal native import.
+ *
+ * Resolved-first retry: a raw miss does not settle it — relative requests are
+ * not keyed raw (`requestAliasKeys`). `resolveToPath` (provided by the worker)
+ * resolves the specifier against its importing module's directory, and the
+ * lookup retries by that absolute path (the `info.r` key). Invoked only when
+ * at least one mock is registered.
  */
-globalThis.__rstest_resolve_mocked_dynamic_request__ = (request) => {
-  const mockedId = __webpack_require__.rstest_mocked_ids_by_request[request];
+globalThis.__rstest_resolve_mocked_dynamic_request__ = (
+  request,
+  resolveToPath,
+) => {
+  const map = __webpack_require__.rstest_mocked_ids_by_request;
+  let mockedId = map[request];
+  if (
+    mockedId === undefined &&
+    typeof resolveToPath === 'function' &&
+    Object.keys(map).length > 0
+  ) {
+    const resolved = resolveToPath(request);
+    if (typeof resolved === 'string') {
+      mockedId = map[resolved];
+    }
+  }
   return mockedId !== undefined ? __webpack_require__(mockedId) : undefined;
 };
 //#endregion

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -44,6 +44,12 @@ __webpack_require__.rstest_mocked_ids_by_request = Object.create(null);
 
 const hasOwn = (target, property) => Object.hasOwn(target, property);
 
+// The other builtin spelling of a request (`os` <-> `node:os`). Used to treat
+// both spellings as one mock: the resolver reads under either, and unmock clears
+// both. A non-builtin's toggled key is never in the map, so it's a harmless miss.
+const altBuiltinSpelling = (request) =>
+  request.startsWith('node:') ? request.slice(5) : `node:${request}`;
+
 const isPromise = (value) => value instanceof Promise;
 
 // Restore a module id to its captured original factory and drop its cache
@@ -96,6 +102,61 @@ const createMockedModule = (originalModule, isSpy) => {
   );
 };
 
+// #1454: register a mock's exports PRODUCER with the worker-realm native-mock
+// registry so a Node `registerHooks` load hook can serve them to a module loaded
+// NATIVELY by Node — a true-external `A` (a node_modules package), or a local
+// module reached via a non-literal `import(variable)` (loaded outside the
+// bundle) — that internally imports this mocked module. Routed over the existing
+// RSTEST_API channel (same as `mockObject`). `request` is `undefined` under an
+// older @rspack/core that omits the request literal — skip then.
+//
+// `produce` yields the mock's exports: the already-built mocked module for the
+// spy/mock-option path (the SAME instance bundle consumers see, via its getters),
+// or the raw factory for a function mock. It is NOT run here — only the thunk is
+// handed to the worker, which runs it LAZILY (once, memoized) the first time the
+// load hook actually serves this mock. This preserves `rs.mock`/`doMock` lazy
+// factory semantics: a factory with side effects, or one referencing module-level
+// imports not yet evaluated when the hoisted `rs.mock` runs, never runs at
+// registration time and never runs at all when no natively-loaded module imports
+// the mock. Still queued on a microtask so publish/unpublish stay ordered (see
+// `unpublishNativeMock`).
+//
+// LIMITATION (function factory only): the factory runs a second time on the
+// worker side (at native-import time), so the native-realm mock is a SEPARATE
+// instance from the bundle's. A spy created inside the factory (`rs.fn()`) is
+// therefore a different object on each side, so asserting — through the bundle
+// handle — calls made via the natively-loaded module will not see them. Sync
+// object-returning factories (the #1454 repro) and the spy/mock-option path are
+// unaffected.
+const publishNativeMock = (request, produce) => {
+  if (request === undefined) {
+    return;
+  }
+  const api = globalThis.RSTEST_API?.rstest;
+  if (!api || typeof api.__setNativeMock !== 'function') {
+    return;
+  }
+  queueMicrotask(() => {
+    api.__setNativeMock(request, produce);
+  });
+};
+
+// Deferred on a microtask like `publishNativeMock` so install→uninstall order is
+// preserved: a synchronous unpublish would run BEFORE the deferred publish
+// microtask, which would then re-add a stale entry. Queuing both keeps the last
+// operation winning (`rs.mock` then `rs.unmock` ⇒ removed).
+const unpublishNativeMock = (request) => {
+  if (request === undefined) {
+    return;
+  }
+  queueMicrotask(() => {
+    const api = globalThis.RSTEST_API?.rstest;
+    if (api && typeof api.__unsetNativeMock === 'function') {
+      api.__unsetNativeMock(request);
+    }
+  });
+};
+
 //#region rs.unmock
 __webpack_require__.rstest_unmock = (id, request) => {
   restoreOriginalFactory(id);
@@ -103,8 +164,13 @@ __webpack_require__.rstest_unmock = (id, request) => {
   // `request` is `undefined` under an older @rspack/core that omits the request
   // literal; the guard can be dropped once the minimum @rspack/core always emits it.
   if (request !== undefined) {
-    delete __webpack_require__.rstest_mocked_ids_by_request[request];
+    const map = __webpack_require__.rstest_mocked_ids_by_request;
+    delete map[request];
+    // `os` and `node:os` are equivalent, so an unmock with either spelling must
+    // clear both (mirrors the resolver's read-side alt lookup).
+    delete map[altBuiltinSpelling(request)];
   }
+  unpublishNativeMock(request);
 };
 //#endregion
 
@@ -239,6 +305,7 @@ const getMockImplementation = (mockType = 'mock') => {
       };
 
       installFactory(finalModFactory);
+      publishNativeMock(request, () => mockedModule);
       return;
     }
 
@@ -253,6 +320,11 @@ const getMockImplementation = (mockType = 'mock') => {
       };
 
       installFactory(finalModFactory);
+      // Manual mock (`__mocks__`) — publish the SAME bundled instance so a
+      // natively-loaded module that imports this mocked module sees it too.
+      // `__webpack_require__(modFactory)` is cache-safe (same call as the factory
+      // above), so there is no separate-instance divergence here.
+      publishNativeMock(request, () => __webpack_require__(modFactory));
     } else if (typeof modFactory === 'function') {
       const finalModFactory = function (
         __webpack_module__,
@@ -282,6 +354,7 @@ const getMockImplementation = (mockType = 'mock') => {
       };
 
       installFactory(finalModFactory);
+      publishNativeMock(request, modFactory);
     }
   };
 };
@@ -315,6 +388,28 @@ __webpack_require__.rstest_do_mock_require =
 __webpack_require__.rstest_dynamic_require = (id, request) => {
   const mockedId = __webpack_require__.rstest_mocked_ids_by_request[request];
   return __webpack_require__(mockedId !== undefined ? mockedId : id);
+};
+//#endregion
+
+//#region non-literal dynamic import() mock resolution
+/**
+ * Expose the mocked instance for a clean `request` to the worker's native import
+ * hook (loadEsModule/loadModule `defineRstestDynamicImport`), which handles a
+ * non-literal `import(variable)` outside the webpack runtime. `const s='node:os';
+ * import(s)` then resolves `s` to the mocked module here instead of natively
+ * loading the real one. Published on the shared `globalThis` because the worker
+ * hook has no `__webpack_require__`; returns `undefined` when the request isn't
+ * mocked, so the hook performs its normal native import.
+ */
+globalThis.__rstest_resolve_mocked_dynamic_request__ = (request) => {
+  const map = __webpack_require__.rstest_mocked_ids_by_request;
+  let mockedId = map[request];
+  if (mockedId === undefined) {
+    // A builtin may be mocked under its other spelling (`os` vs `node:os`),
+    // mirroring the native hook's builtin canonicalization.
+    mockedId = map[altBuiltinSpelling(request)];
+  }
+  return mockedId !== undefined ? __webpack_require__(mockedId) : undefined;
 };
 //#endregion
 

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -3,6 +3,10 @@
 declare const RSTEST_VERSION: string;
 declare const RSTEST_SELF_CI: boolean;
 declare const PLAYWRIGHT_VERSION: string;
+// `true` only in the `browser_runtime` build; lets the shared runtime
+// dead-code-eliminate the Node-only native-mock bridge out of the browser
+// bundle (its `import.meta.resolve`/`pathToFileURL` use crashes in the browser).
+declare const RSTEST_TARGET_BROWSER: boolean;
 
 declare module '@rstest/browser/package.json' {
   const content: {

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -3,10 +3,6 @@
 declare const RSTEST_VERSION: string;
 declare const RSTEST_SELF_CI: boolean;
 declare const PLAYWRIGHT_VERSION: string;
-// `true` only in the `browser_runtime` build; lets the shared runtime
-// dead-code-eliminate the Node-only native-mock bridge out of the browser
-// bundle (its `import.meta.resolve`/`pathToFileURL` use crashes in the browser).
-declare const RSTEST_TARGET_BROWSER: boolean;
 
 declare module '@rstest/browser/package.json' {
   const content: {

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -13,14 +13,13 @@ import { getRealTimers } from '../util';
 import type { FakeTimerInstallOpts, FakeTimersSnapshot } from './fakeTimers';
 import {
   getNativeMock,
+  type NativeMockResolvedInfo,
+  resolveNativeMockKeys,
   setNativeMock,
   unsetNativeMock,
 } from '../worker/mockRegistry';
 import { mockObject as mockObjectImpl } from './mockObject';
 import { initSpy } from './spy';
-// Browser-safe path/URL helpers (no `node:url`/`node:path`); keeps this shared
-// module linkable in the browser runtime build.
-import { pathToFileURL } from 'url-extras';
 
 const DEFAULT_WAIT_TIMEOUT = 1000;
 const DEFAULT_WAIT_INTERVAL = 50;
@@ -133,36 +132,6 @@ let utilitiesPromise:
  * per-file `useRealTimers`, unchanged.
  * See https://github.com/web-infra-dev/rstest/issues/1376.
  */
-// #1454: browser-safe key computation for the native-mock bridge.
-// Mirrors the Node-only hook key (nativeMockHooks.ts) but imports nothing from
-// `node:url` / `node:module`, so this shared module stays linkable in the
-// browser runtime build. `import.meta.resolve` is undefined in browser mode, so
-// only the trivial `node:` short-circuit survives there (native mocks are
-// meaningless without Node's loader anyway).
-const nativeImportMetaResolve = RSTEST_TARGET_BROWSER
-  ? undefined
-  : import.meta.resolve?.bind(import.meta);
-
-const resolveNativeMockKey = (
-  request: string,
-  base: string,
-): string | undefined => {
-  // `import.meta.resolve` returns the `node:`-prefixed form for bare builtins
-  // ('os' → 'node:os'), matching `toNodeBuiltin` on the hook side; an explicit
-  // `node:` specifier needs no resolution.
-  if (request.startsWith('node:')) {
-    return request;
-  }
-  if (!nativeImportMetaResolve) {
-    return undefined;
-  }
-  try {
-    return nativeImportMetaResolve(request, pathToFileURL(base).href);
-  } catch {
-    return undefined;
-  }
-};
-
 export const createRstestUtilities = async (): Promise<RstestUtilities> => {
   utilitiesPromise ??= buildRstestUtilities();
   const bound = await utilitiesPromise;
@@ -675,49 +644,44 @@ const buildRstestUtilities = async (): Promise<{
   // #1454: bridge the bundle's mock runtime to the worker-realm `mockRegistry`
   // that the Node `registerHooks` load hook reads. Called from
   // `mockRuntimeCode.js` at rs.mock/unmock time over the existing RSTEST_API
-  // channel (the same one `mockObject` uses). Keyed by the specifier resolved
-  // against the test file so a natively-loaded module's internal `import 'B'` —
-  // resolved by Node against that module's own URL — lands on the same key for
-  // builtins and same-realpath npm deps.
-  // Node-only: `registerHooks`, the synthetic mock module, and native ESM
-  // loading don't exist in the browser, and this bridge's key resolution uses
-  // `import.meta.resolve`/`pathToFileURL`, which crash there. The build strips
-  // this whole block from the `browser_runtime` bundle via `RSTEST_TARGET_BROWSER`.
-  if (!RSTEST_TARGET_BROWSER) {
-    const bridge = rstest as RstestUtilities & {
-      __setNativeMock?: (request: string, produce: () => unknown) => void;
-      __unsetNativeMock?: (request: string) => void;
-      // Bundler retention anchor, not runtime API — see the assignment below.
-      __getNativeMock?: typeof getNativeMock;
-    };
-    // Bundler anchor (never invoked): the synthetic mock module the Node load
-    // hook generates does `import { getNativeMock } from <REGISTRY_URL>` at
-    // RUNTIME, so the registry chunk must keep `getNativeMock` as a NAMED
-    // export. mockRegistry and nativeMockHooks share one chunk, so their
-    // internal use is inlined and does NOT retain the export; this assignment
-    // from the api chunk is a real cross-chunk consumer, which forces the
-    // bundler to keep it. (Verified: drop it and the synthetic import fails to
-    // link — `does not provide an export`.)
-    bridge.__getNativeMock = getNativeMock;
-    bridge.__setNativeMock = (request, produce) => {
-      const key = resolveNativeMockKey(
-        request,
-        fileContext().workerState.testPath,
-      );
-      if (key !== undefined && typeof produce === 'function') {
-        setNativeMock(key, produce);
-      }
-    };
-    bridge.__unsetNativeMock = (request) => {
-      const key = resolveNativeMockKey(
-        request,
-        fileContext().workerState.testPath,
-      );
-      if (key !== undefined) {
-        unsetNativeMock(key);
-      }
-    };
-  }
+  // channel (the same one `mockObject` uses). Key derivation lives with the
+  // hook (nativeMockHooks.ts, reached through the registry's injected
+  // resolver), so the write-side keys and the hook's read-side keys stay in
+  // one module; in the browser build no resolver is ever injected, keys
+  // resolve to none, and every registration is a no-op.
+  const bridge = rstest as RstestUtilities & {
+    __setNativeMock?: (
+      request: string,
+      produce: () => unknown,
+      info?: NativeMockResolvedInfo,
+    ) => void;
+    __unsetNativeMock?: (
+      request: string,
+      info?: NativeMockResolvedInfo,
+    ) => void;
+    // Bundler retention anchor, not runtime API — see the assignment below.
+    __getNativeMock?: typeof getNativeMock;
+  };
+  // Bundler anchor (never invoked): the synthetic mock module the Node load
+  // hook generates does `import { getNativeMock } from <REGISTRY_URL>` at
+  // RUNTIME, so the registry chunk must keep `getNativeMock` as a NAMED
+  // export. mockRegistry and nativeMockHooks share one chunk, so their
+  // internal use is inlined and does NOT retain the export; this assignment
+  // from the api chunk is a real cross-chunk consumer, which forces the
+  // bundler to keep it. (Verified: drop it and the synthetic import fails to
+  // link — `does not provide an export`.)
+  bridge.__getNativeMock = getNativeMock;
+  bridge.__setNativeMock = (request, produce, info) => {
+    setNativeMock(
+      resolveNativeMockKeys(request, info, fileContext().workerState.testPath),
+      produce,
+    );
+  };
+  bridge.__unsetNativeMock = (request, info) => {
+    unsetNativeMock(
+      resolveNativeMockKeys(request, info, fileContext().workerState.testPath),
+    );
+  };
 
   return { rstest, resetForFile };
 };

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -11,8 +11,16 @@ import { RSTEST_ENV_SYMBOL_KEY } from '../../utils/constants';
 import { fileContext } from '../fileContext';
 import { getRealTimers } from '../util';
 import type { FakeTimerInstallOpts, FakeTimersSnapshot } from './fakeTimers';
+import {
+  getNativeMock,
+  setNativeMock,
+  unsetNativeMock,
+} from '../worker/mockRegistry';
 import { mockObject as mockObjectImpl } from './mockObject';
 import { initSpy } from './spy';
+// Browser-safe path/URL helpers (no `node:url`/`node:path`); keeps this shared
+// module linkable in the browser runtime build.
+import { pathToFileURL } from 'url-extras';
 
 const DEFAULT_WAIT_TIMEOUT = 1000;
 const DEFAULT_WAIT_INTERVAL = 50;
@@ -125,6 +133,36 @@ let utilitiesPromise:
  * per-file `useRealTimers`, unchanged.
  * See https://github.com/web-infra-dev/rstest/issues/1376.
  */
+// #1454: browser-safe key computation for the native-mock bridge.
+// Mirrors the Node-only hook key (nativeMockHooks.ts) but imports nothing from
+// `node:url` / `node:module`, so this shared module stays linkable in the
+// browser runtime build. `import.meta.resolve` is undefined in browser mode, so
+// only the trivial `node:` short-circuit survives there (native mocks are
+// meaningless without Node's loader anyway).
+const nativeImportMetaResolve = RSTEST_TARGET_BROWSER
+  ? undefined
+  : import.meta.resolve?.bind(import.meta);
+
+const resolveNativeMockKey = (
+  request: string,
+  base: string,
+): string | undefined => {
+  // `import.meta.resolve` returns the `node:`-prefixed form for bare builtins
+  // ('os' → 'node:os'), matching `toNodeBuiltin` on the hook side; an explicit
+  // `node:` specifier needs no resolution.
+  if (request.startsWith('node:')) {
+    return request;
+  }
+  if (!nativeImportMetaResolve) {
+    return undefined;
+  }
+  try {
+    return nativeImportMetaResolve(request, pathToFileURL(base).href);
+  } catch {
+    return undefined;
+  }
+};
+
 export const createRstestUtilities = async (): Promise<RstestUtilities> => {
   utilitiesPromise ??= buildRstestUtilities();
   const bound = await utilitiesPromise;
@@ -633,6 +671,53 @@ const buildRstestUtilities = async (): Promise<{
     originalConfig = undefined;
     currentFakeTimersConfig = undefined;
   };
+
+  // #1454: bridge the bundle's mock runtime to the worker-realm `mockRegistry`
+  // that the Node `registerHooks` load hook reads. Called from
+  // `mockRuntimeCode.js` at rs.mock/unmock time over the existing RSTEST_API
+  // channel (the same one `mockObject` uses). Keyed by the specifier resolved
+  // against the test file so a natively-loaded module's internal `import 'B'` —
+  // resolved by Node against that module's own URL — lands on the same key for
+  // builtins and same-realpath npm deps.
+  // Node-only: `registerHooks`, the synthetic mock module, and native ESM
+  // loading don't exist in the browser, and this bridge's key resolution uses
+  // `import.meta.resolve`/`pathToFileURL`, which crash there. The build strips
+  // this whole block from the `browser_runtime` bundle via `RSTEST_TARGET_BROWSER`.
+  if (!RSTEST_TARGET_BROWSER) {
+    const bridge = rstest as RstestUtilities & {
+      __setNativeMock?: (request: string, produce: () => unknown) => void;
+      __unsetNativeMock?: (request: string) => void;
+      // Bundler retention anchor, not runtime API — see the assignment below.
+      __getNativeMock?: typeof getNativeMock;
+    };
+    // Bundler anchor (never invoked): the synthetic mock module the Node load
+    // hook generates does `import { getNativeMock } from <REGISTRY_URL>` at
+    // RUNTIME, so the registry chunk must keep `getNativeMock` as a NAMED
+    // export. mockRegistry and nativeMockHooks share one chunk, so their
+    // internal use is inlined and does NOT retain the export; this assignment
+    // from the api chunk is a real cross-chunk consumer, which forces the
+    // bundler to keep it. (Verified: drop it and the synthetic import fails to
+    // link — `does not provide an export`.)
+    bridge.__getNativeMock = getNativeMock;
+    bridge.__setNativeMock = (request, produce) => {
+      const key = resolveNativeMockKey(
+        request,
+        fileContext().workerState.testPath,
+      );
+      if (key !== undefined && typeof produce === 'function') {
+        setNativeMock(key, produce);
+      }
+    };
+    bridge.__unsetNativeMock = (request) => {
+      const key = resolveNativeMockKey(
+        request,
+        fileContext().workerState.testPath,
+      );
+      if (key !== undefined) {
+        unsetNativeMock(key);
+      }
+    };
+  }
 
   return { rstest, resetForFile };
 };

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -653,12 +653,9 @@ const buildRstestUtilities = async (): Promise<{
     __setNativeMock?: (
       request: string,
       produce: () => unknown,
-      info?: NativeMockResolvedInfo,
+      info: NativeMockResolvedInfo,
     ) => void;
-    __unsetNativeMock?: (
-      request: string,
-      info?: NativeMockResolvedInfo,
-    ) => void;
+    __unsetNativeMock?: (request: string, info: NativeMockResolvedInfo) => void;
     // Bundler retention anchor, not runtime API — see the assignment below.
     __getNativeMock?: typeof getNativeMock;
   };
@@ -672,15 +669,10 @@ const buildRstestUtilities = async (): Promise<{
   // link — `does not provide an export`.)
   bridge.__getNativeMock = getNativeMock;
   bridge.__setNativeMock = (request, produce, info) => {
-    setNativeMock(
-      resolveNativeMockKeys(request, info, fileContext().workerState.testPath),
-      produce,
-    );
+    setNativeMock(resolveNativeMockKeys(request, info), produce);
   };
   bridge.__unsetNativeMock = (request, info) => {
-    unsetNativeMock(
-      resolveNativeMockKeys(request, info, fileContext().workerState.testPath),
-    );
+    unsetNativeMock(resolveNativeMockKeys(request, info));
   };
 
   return { rstest, resetForFile };

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -9,6 +9,7 @@ import {
   finalizeDynamicImport,
   loadWasm,
   resolveImportSpecifier,
+  maybeResolveMockedDynamicImport,
 } from './resolveDynamicImport';
 import {
   RSTEST_DYNAMIC_IMPORT_HOOK,
@@ -105,6 +106,17 @@ const defineRstestDynamicImport =
     importAttributes: ImportCallOptions,
     origin?: string,
   ) => {
+    // #1454: route `import(variable)` of a mocked module to the bundle's mock
+    // instance before any native load (policy in resolveDynamicImport.ts).
+    const mocked = maybeResolveMockedDynamicImport(
+      specifier,
+      returnModule,
+      importAttributes,
+    );
+    if (mocked !== undefined) {
+      return mocked;
+    }
+
     const currentDirectory = path.dirname(distPath);
 
     const joinedPath = isRelativePath(specifier)

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -112,6 +112,7 @@ const defineRstestDynamicImport =
       specifier,
       returnModule,
       importAttributes,
+      origin ?? testPath,
     );
     if (mocked !== undefined) {
       return mocked;

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -9,6 +9,7 @@ import {
   finalizeDynamicImport,
   loadWasm,
   resolveImportSpecifier,
+  maybeResolveMockedDynamicImport,
 } from './resolveDynamicImport';
 import {
   RSTEST_DYNAMIC_IMPORT_HOOK,
@@ -126,6 +127,17 @@ const defineRstestDynamicImport =
     importAttributes: ImportCallOptions,
     origin?: string,
   ) => {
+    // #1454: route `import(variable)` of a mocked module to the bundle's mock
+    // instance before any native load (policy in resolveDynamicImport.ts).
+    const mocked = maybeResolveMockedDynamicImport(
+      specifier,
+      returnModule,
+      importAttributes,
+    );
+    if (mocked !== undefined) {
+      return mocked;
+    }
+
     const modulePath = resolveImportSpecifier({ specifier, origin, testPath });
 
     // `.wasm` always resolves to an on-disk source file (wasmLoader.mjs rewrites

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -133,6 +133,7 @@ const defineRstestDynamicImport =
       specifier,
       returnModule,
       importAttributes,
+      origin ?? testPath,
     );
     if (mocked !== undefined) {
       return mocked;

--- a/packages/core/src/runtime/worker/mockRegistry.ts
+++ b/packages/core/src/runtime/worker/mockRegistry.ts
@@ -35,9 +35,9 @@ type NativeMockEntry = {
   error: unknown;
   /** Every registry key this entry is registered under. One mock may be keyed
    * by several equivalent spellings of the same module (the build-resolved
-   * path from the rspack plugin, the Node-resolved URL, the legacy
-   * testPath-based resolution), so registration and removal operate on the
-   * whole alias group — an unmock computed from ANY spelling clears them all. */
+   * path from the rspack plugin, the Node-resolved URL), so registration and
+   * removal operate on the whole alias group — an unmock computed from ANY
+   * spelling clears them all. */
   aliases: readonly string[];
 };
 
@@ -59,17 +59,17 @@ export const setNativeMockInstaller = (install: () => void): void => {
   installHooks = install;
 };
 
-/** Build-resolved mock identity appended by newer rspack (see
- * `emitMockResolvedInfo` in `core/plugins/basic.ts`): `o` is the absolute path
- * of the module declaring the `rs.mock` call, `r` the build-resolved target —
- * an absolute file path, an external request (e.g. a builtin spelling), or
- * `null` when the build could not resolve it. Absent entirely on older rspack. */
-export type NativeMockResolvedInfo = { o?: string; r?: string | null };
+/** Build-resolved mock identity appended to every generated `rstest_mock`/
+ * `rstest_unmock` call (hard contract, enforced by `mockRuntimeCode.js` —
+ * requires @rspack/core >= 2.1.3): `o` is the absolute path of the module
+ * declaring the `rs.mock` call, `r` the build-resolved target — an absolute
+ * file path, an external request (e.g. a builtin spelling), or `null` when
+ * the build could not resolve it. */
+export type NativeMockResolvedInfo = { o: string; r: string | null };
 
 type NativeMockKeyResolver = (
   request: string,
-  info: NativeMockResolvedInfo | undefined,
-  testPath: string,
+  info: NativeMockResolvedInfo,
 ) => string[];
 
 // Node-only registry-key derivation, injected by nativeMockHooks at load time
@@ -86,11 +86,8 @@ export const setNativeMockKeyResolver = (
   keyResolver = resolve;
 };
 
-export const resolveNativeMockKeys: NativeMockKeyResolver = (
-  request,
-  info,
-  testPath,
-) => keyResolver?.(request, info, testPath) ?? [];
+export const resolveNativeMockKeys: NativeMockKeyResolver = (request, info) =>
+  keyResolver?.(request, info) ?? [];
 
 // Delete every alias of any entry reachable through `keys`; returns whether
 // the registry changed. Removal always operates on the WHOLE alias group so

--- a/packages/core/src/runtime/worker/mockRegistry.ts
+++ b/packages/core/src/runtime/worker/mockRegistry.ts
@@ -33,6 +33,12 @@ type NativeMockEntry = {
   status: 'pending' | 'resolved' | 'errored';
   exports: Record<string, unknown> | undefined;
   error: unknown;
+  /** Every registry key this entry is registered under. One mock may be keyed
+   * by several equivalent spellings of the same module (the build-resolved
+   * path from the rspack plugin, the Node-resolved URL, the legacy
+   * testPath-based resolution), so registration and removal operate on the
+   * whole alias group — an unmock computed from ANY spelling clears them all. */
+  aliases: readonly string[];
 };
 
 const registry = new Map<string, NativeMockEntry>();
@@ -53,7 +59,62 @@ export const setNativeMockInstaller = (install: () => void): void => {
   installHooks = install;
 };
 
-export const setNativeMock = (key: string, produce: () => unknown): void => {
+/** Build-resolved mock identity appended by newer rspack (see
+ * `emitMockResolvedInfo` in `core/plugins/basic.ts`): `o` is the absolute path
+ * of the module declaring the `rs.mock` call, `r` the build-resolved target —
+ * an absolute file path, an external request (e.g. a builtin spelling), or
+ * `null` when the build could not resolve it. Absent entirely on older rspack. */
+export type NativeMockResolvedInfo = { o?: string; r?: string | null };
+
+type NativeMockKeyResolver = (
+  request: string,
+  info: NativeMockResolvedInfo | undefined,
+  testPath: string,
+) => string[];
+
+// Node-only registry-key derivation, injected by nativeMockHooks at load time
+// (the same inversion as `setNativeMockInstaller`) so the WRITE-side keying
+// lives in the same module as the READ-side resolve hook that consumes the
+// keys. Stays `undefined` in the browser build, where key resolution — and
+// with it every registration — degrades to a no-op.
+let keyResolver: NativeMockKeyResolver | undefined;
+
+/** Register the key derivation; called by nativeMockHooks at load time. */
+export const setNativeMockKeyResolver = (
+  resolve: NativeMockKeyResolver,
+): void => {
+  keyResolver = resolve;
+};
+
+export const resolveNativeMockKeys: NativeMockKeyResolver = (
+  request,
+  info,
+  testPath,
+) => keyResolver?.(request, info, testPath) ?? [];
+
+// Delete every alias of any entry reachable through `keys`; returns whether
+// the registry changed. Removal always operates on the WHOLE alias group so
+// an unmock computed from any spelling clears them all.
+const deleteAliasGroups = (keys: readonly string[]): boolean => {
+  let changed = false;
+  for (const key of keys) {
+    const entry = registry.get(key);
+    if (entry) {
+      for (const alias of entry.aliases) {
+        changed = registry.delete(alias) || changed;
+      }
+    }
+  }
+  return changed;
+};
+
+export const setNativeMock = (
+  keys: readonly string[],
+  produce: () => unknown,
+): void => {
+  if (keys.length === 0) {
+    return;
+  }
   // Install the loader hooks on the first published mock, then null the
   // installer: later mocks skip it, and an unsupported-Node attempt is not
   // retried (the install is a no-op there).
@@ -61,17 +122,24 @@ export const setNativeMock = (key: string, produce: () => unknown): void => {
     installHooks();
     installHooks = undefined;
   }
-  registry.set(key, {
+  // Evict any entry reachable through the new keys first, so a re-mock whose
+  // alias group shrank leaves no stale key serving the previous mock.
+  deleteAliasGroups(keys);
+  const entry: NativeMockEntry = {
     produce,
     status: 'pending',
     exports: undefined,
     error: undefined,
-  });
+    aliases: keys,
+  };
+  for (const key of keys) {
+    registry.set(key, entry);
+  }
   version++;
 };
 
-export const unsetNativeMock = (key: string): void => {
-  if (registry.delete(key)) {
+export const unsetNativeMock = (keys: readonly string[]): void => {
+  if (deleteAliasGroups(keys)) {
     version++;
   }
 };

--- a/packages/core/src/runtime/worker/mockRegistry.ts
+++ b/packages/core/src/runtime/worker/mockRegistry.ts
@@ -1,0 +1,122 @@
+/**
+ * #1454: worker-realm registry of mocks that must be served to
+ * modules loaded NATIVELY by Node (true externals). The webpack-runtime mock
+ * path only covers bundled modules; when a true-external `A` internally imports
+ * a mocked `B`, `A`'s import of `B` is resolved by Node's loader, outside the
+ * bundle. A Node `module.registerHooks` resolve/load pair (in
+ * `nativeMockHooks.ts`, installed lazily on the first native mock) reads THIS
+ * module-scoped map to redirect such imports to the mock.
+ *
+ * This is plain module-scoped state reached by a normal `import` — NOT a
+ * `globalThis` bridge. It is shared between the worker runtime and the synthetic
+ * mock modules the load hook generates because both import this file by the same
+ * resolved URL (Node dedupes ESM by URL), so there is a single instance.
+ */
+
+/** This module's own resolved URL, baked into generated synthetic modules so
+ * they re-export from the exact same instance the worker writes to. */
+export const REGISTRY_URL: string = import.meta.url;
+
+/**
+ * A registered native mock. `produce` yields the mock's exports (the already
+ * built mocked module, or a user factory); it is run LAZILY — at most once, and
+ * only when the load hook actually serves this mock to a natively-loaded module
+ * — so an `rs.mock`/`doMock` factory with side effects keeps its lazy semantics and
+ * never runs at registration time. `status` guards that single evaluation: it
+ * flips to `resolved` even when the factory yields nothing usable (async/primitive
+ * → `exports` `undefined`), or to `errored` when the factory throws (`error` is
+ * memoized and re-thrown so a broken factory surfaces on the native path, matching
+ * the bundled path).
+ */
+type NativeMockEntry = {
+  produce: () => unknown;
+  status: 'pending' | 'resolved' | 'errored';
+  exports: Record<string, unknown> | undefined;
+  error: unknown;
+};
+
+const registry = new Map<string, NativeMockEntry>();
+
+/** Bumped on every mutation; folded into the synthetic module's virtual URL so a
+ * re-mock/unmock busts Node's ESM cache for that specifier. */
+let version = 0;
+
+// Lazily-installed Node loader hooks (nativeMockHooks.ts). Registered once at
+// worker bootstrap and invoked on the first published mock, so a run with no
+// module mocks never touches Node's module loader. Stays `undefined` in the
+// browser build (nativeMockHooks is node-only and never imported there), where
+// native mocks are meaningless.
+let installHooks: (() => void) | undefined;
+
+/** Register the lazy hook installer; called by nativeMockHooks at load time. */
+export const setNativeMockInstaller = (install: () => void): void => {
+  installHooks = install;
+};
+
+export const setNativeMock = (key: string, produce: () => unknown): void => {
+  // Install the loader hooks on the first published mock, then null the
+  // installer: later mocks skip it, and an unsupported-Node attempt is not
+  // retried (the install is a no-op there).
+  if (installHooks) {
+    installHooks();
+    installHooks = undefined;
+  }
+  registry.set(key, {
+    produce,
+    status: 'pending',
+    exports: undefined,
+    error: undefined,
+  });
+  version++;
+};
+
+export const unsetNativeMock = (key: string): void => {
+  if (registry.delete(key)) {
+    version++;
+  }
+};
+
+export const getNativeMock = (
+  key: string,
+): Record<string, unknown> | undefined => {
+  const entry = registry.get(key);
+  if (!entry) {
+    return undefined;
+  }
+  // Evaluate the producer on first use and memoize, so a factory runs exactly
+  // once (the resolve hook reads this to decide whether a servable mock exists,
+  // then the load hook reads it to list export names and read their values). A
+  // callable is servable too (a default-function / CommonJS module export), so
+  // only a primitive or a Promise (an async factory) settles to `undefined` — the
+  // resolve hook then falls through to the real module (the async-factory
+  // limitation in nativeMockHooks). A `Promise` is matched by its toString tag,
+  // not a duck-typed `.then`, so a mock that legitimately exports a `then`
+  // function is still served. A factory that THROWS is memoized and re-thrown on
+  // every access, so a broken mock surfaces the error on the native path instead
+  // of silently serving the real module — matching how the bundled path fails a
+  // throwing factory.
+  if (entry.status === 'pending') {
+    // Mark non-pending before producing so a re-entrant call can't re-run it.
+    entry.status = 'resolved';
+    try {
+      const res = entry.produce();
+      entry.exports =
+        res !== null &&
+        (typeof res === 'object' || typeof res === 'function') &&
+        Object.prototype.toString.call(res) !== '[object Promise]'
+          ? (res as Record<string, unknown>)
+          : undefined;
+    } catch (error) {
+      entry.status = 'errored';
+      entry.error = error;
+    }
+  }
+  if (entry.status === 'errored') {
+    throw entry.error;
+  }
+  return entry.exports;
+};
+
+export const isRegistryEmpty = (): boolean => registry.size === 0;
+
+export const getRegistryVersion = (): number => version;

--- a/packages/core/src/runtime/worker/nativeMockHooks.ts
+++ b/packages/core/src/runtime/worker/nativeMockHooks.ts
@@ -70,22 +70,20 @@ const deriveKey = (request: string, base: string): string | undefined => {
 
 /**
  * Registry-key derivation for one native mock (the write side of the resolve
- * hook's read-side keying below). Several derivations may disagree on spelling
+ * hook's read-side keying below). Two derivations may disagree on spelling
  * for the same module (pnpm realpath, exports conditions, extension aliases),
  * so every derivation that succeeds is registered as an alias of the same
  * entry, best-first:
  * 1. the build-resolved target from the rspack plugin (`info.r`) — exact,
  *    no runtime re-resolution;
  * 2. `request` resolved against the DECLARING module (`info.o`) — correct
- *    base for a relative `rs.mock` living in a helper file;
- * 3. `request` resolved against the test file — the pre-info behavior, kept
- *    as the old-rspack fallback and divergence absorber (skipped when `info.o`
- *    IS the test file, where it could only repeat derivation 2).
+ *    base for a relative `rs.mock` living in a helper file, and the
+ *    divergence absorber when Node's runtime resolution disagrees with the
+ *    build's.
  */
 const deriveNativeMockKeys = (
   request: string,
-  info: NativeMockResolvedInfo | undefined,
-  testPath: string,
+  info: NativeMockResolvedInfo,
 ): string[] => {
   const keys: string[] = [];
   const add = (key: string | undefined) => {
@@ -93,7 +91,7 @@ const deriveNativeMockKeys = (
       keys.push(key);
     }
   };
-  const resolved = info?.r;
+  const resolved = info.r;
   if (typeof resolved === 'string') {
     if (isAbsolute(resolved)) {
       // The resolve hook keys non-builtins by their resolved URL.
@@ -102,16 +100,11 @@ const deriveNativeMockKeys = (
       // External request: a `node:` builtin spelling is the hook's canonical
       // key already; a bare spelling ('os', or an uninstalled package rstest
       // externalized by raw request) is registered verbatim — the canonical
-      // form comes from derivations 2/3 below.
+      // form comes from derivation 2 below.
       add(resolved);
     }
   }
-  if (info?.o !== undefined) {
-    add(deriveKey(request, info.o));
-  }
-  if (info?.o !== testPath) {
-    add(deriveKey(request, testPath));
-  }
+  add(deriveKey(request, info.o));
   return keys;
 };
 

--- a/packages/core/src/runtime/worker/nativeMockHooks.ts
+++ b/packages/core/src/runtime/worker/nativeMockHooks.ts
@@ -1,0 +1,151 @@
+// Default import (not `{ registerHooks }`): on Node < 22.15 / < 23.5 the named
+// export does not exist and a named import would fail at link time. The default
+// export (the `Module` class) carries `registerHooks` as a static when present,
+// so a property read feature-detects safely.
+import nodeModule from 'node:module';
+import {
+  getNativeMock,
+  getRegistryVersion,
+  isRegistryEmpty,
+  REGISTRY_URL,
+  setNativeMockInstaller,
+} from './mockRegistry';
+import { isBuiltinSpecifier, toNodeBuiltin } from './resolveDynamicImport';
+
+const VIRTUAL_PREFIX = 'rstest-mock:';
+
+// Export names that are valid JS identifiers — only these can be re-emitted as
+// `export const <name>` in the synthetic module the load hook generates.
+const IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// rstest's own runtime lives in the same directory as this module's compiled
+// chunk. Imports originating from there (including the synthetic mock module's
+// `import { getNativeMock } from <REGISTRY_URL>`, which pulls in this dist chunk
+// and its `node:` imports) must NEVER be redirected: doing so would (a) wrongly
+// mock builtins for rstest's own internals and (b) form a circular
+// synthetic → dist chunk → mocked builtin → synthetic load. Gate the hook on the
+// importer being OUTSIDE this directory.
+const RSTEST_DIST_DIR = REGISTRY_URL.slice(
+  0,
+  REGISTRY_URL.lastIndexOf('/') + 1,
+);
+
+/**
+ * #1454: install the Node `module.registerHooks` resolve/load pair that makes
+ * `rs.mock` reach a mocked module imported INSIDE a natively-loaded module —
+ * both a true-external `A` (a node_modules package rstest externalizes) and a
+ * local module reached via a non-literal `import(variable)` (which rstest loads
+ * through Node's loader, outside the bundle). The webpack-runtime mock path only
+ * covers bundled modules; such a module's internal `import 'B'` is resolved by
+ * Node's loader. Node's IN-THREAD synchronous `module.registerHooks` runs in
+ * this same worker realm, so its resolve/load pair can consult the
+ * module-scoped `mockRegistry` directly (no thread bridge, no structuredClone,
+ * no globalThis) and redirect such imports to the mock.
+ *
+ * Installed LAZILY — `mockRegistry.setNativeMock` triggers it on the first
+ * published mock and then nulls its installer, so this runs exactly once and a
+ * run with no module mocks never registers anything on Node's module loader.
+ * Feature-detected: `registerHooks` requires Node >= 22.15 / >= 23.5; on older
+ * Node this is a no-op and the natively-loaded-internal case stays unmocked
+ * exactly as before (graceful fallback, never a crash).
+ *
+ * Known limitation: an ASYNC mock factory is not applied to a natively-loaded
+ * module — the resolve/load hooks are synchronous, so a factory whose exports
+ * settle on a promise yields no servable exports and the import resolves to the
+ * REAL module. Synchronous factories (the common case, and #1454's repro) are
+ * unaffected.
+ */
+export const installNativeMockHooks = (): void => {
+  if (typeof nodeModule.registerHooks !== 'function') {
+    return;
+  }
+  nodeModule.registerHooks({
+    resolve(specifier, context, nextResolve) {
+      // Hot path: fires on EVERY native resolution. Bail before any work while
+      // no mock is active (also covers the worker's own bootstrap imports), or
+      // when the importer is rstest's own runtime (see RSTEST_DIST_DIR).
+      if (isRegistryEmpty() || context.parentURL?.startsWith(RSTEST_DIST_DIR)) {
+        return nextResolve(specifier, context);
+      }
+      // `registerHooks` also fires for `require()`, but the load hook only serves
+      // an ESM synthetic (`format: 'module'`) the CommonJS loader can't require.
+      // Leave require resolutions to Node so a natively-loaded CJS module gets the
+      // real module instead of a format mismatch — native mocks reach ESM inner
+      // imports only.
+      if (context.conditions?.includes('require')) {
+        return nextResolve(specifier, context);
+      }
+      const virtual = (key: string) => ({
+        url: `${VIRTUAL_PREFIX}${encodeURIComponent(key)}?v=${getRegistryVersion()}`,
+        shortCircuit: true,
+      });
+      // `getNativeMock` (not a bare presence check) so we only short-circuit when
+      // the mock yields SERVABLE exports: an async producer settles to `undefined`
+      // here and the resolution falls through to the real module rather than an
+      // empty synthetic one, while a producer that THROWS propagates its error so
+      // a broken mock surfaces instead of silently serving the real module.
+      //
+      // Builtins key by their canonical `node:` id without resolving — and
+      // CRUCIALLY without calling `import.meta.resolve`, which would re-enter
+      // this very hook and recurse. The bare/prefixed spellings collapse to one
+      // key so `rs.mock('node:os')` matches an external's `import 'os'`.
+      if (isBuiltinSpecifier(specifier)) {
+        const key = toNodeBuiltin(specifier);
+        return getNativeMock(key) !== undefined
+          ? virtual(key)
+          : nextResolve(specifier, context);
+      }
+      // Everything else: let the hook chain perform the real resolution (this is
+      // the resolution we would do on passthrough anyway, so no extra cost and
+      // no recursion), then key by the resolved URL.
+      const resolved = nextResolve(specifier, context);
+      if (resolved?.url && getNativeMock(resolved.url) !== undefined) {
+        return virtual(resolved.url);
+      }
+      return resolved;
+    },
+    load(url, context, nextLoad) {
+      if (!url.startsWith(VIRTUAL_PREFIX)) {
+        return nextLoad(url, context);
+      }
+      const key = decodeURIComponent(
+        url.slice(VIRTUAL_PREFIX.length).split('?')[0]!,
+      );
+      const mock = getNativeMock(key) ?? {};
+      const names = Object.keys(mock).filter(
+        (name) => name !== 'default' && IDENT_RE.test(name),
+      );
+      // Re-export each known export from the live registry entry by the exact
+      // same instance the worker writes to (same REGISTRY_URL). Re-export the
+      // value directly — NOT a call wrapper — so a class export stays
+      // constructible (`new X()`) and `this`/identity are preserved. Equivalent
+      // to the prior per-call wrapper for liveness: `__m` is fixed for a given
+      // mock version, and a re-mock bumps the synthetic module's `?v=` URL so
+      // `__m` is re-read on the next load.
+      const keyLit = JSON.stringify(key);
+      const body = names
+        .map((name) => `export const ${name} = __m[${JSON.stringify(name)}];`)
+        .join('\n');
+      // Mirror `defineExportsWithCjsInterop`: re-export an explicit `default`;
+      // otherwise synthesize the whole object as the default ONLY for a
+      // CJS-shaped mock (no `__esModule`). An `__esModule` mock without a
+      // default provides no default export, exactly as the bundled path does.
+      const defaultLine =
+        'default' in mock
+          ? 'export default __m.default;'
+          : (mock as { __esModule?: unknown }).__esModule
+            ? ''
+            : 'export default __m;';
+      const source =
+        `import { getNativeMock } from ${JSON.stringify(REGISTRY_URL)};\n` +
+        `const __m = getNativeMock(${keyLit}) ?? {};\n` +
+        `${body}\n` +
+        `${defaultLine}\n`;
+      return { format: 'module', source, shortCircuit: true };
+    },
+  });
+};
+
+// Registered at worker bootstrap (this module is side-effect imported by
+// `setup.ts`); `mockRegistry.setNativeMock` invokes it on the first published mock.
+setNativeMockInstaller(installNativeMockHooks);

--- a/packages/core/src/runtime/worker/nativeMockHooks.ts
+++ b/packages/core/src/runtime/worker/nativeMockHooks.ts
@@ -3,16 +3,25 @@
 // export (the `Module` class) carries `registerHooks` as a static when present,
 // so a property read feature-detects safely.
 import nodeModule from 'node:module';
+import { isAbsolute } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   getNativeMock,
   getRegistryVersion,
   isRegistryEmpty,
+  type NativeMockResolvedInfo,
   REGISTRY_URL,
   setNativeMockInstaller,
+  setNativeMockKeyResolver,
 } from './mockRegistry';
 import { isBuiltinSpecifier, toNodeBuiltin } from './resolveDynamicImport';
 
 const VIRTUAL_PREFIX = 'rstest-mock:';
+
+const virtual = (key: string) => ({
+  url: `${VIRTUAL_PREFIX}${encodeURIComponent(key)}?v=${getRegistryVersion()}`,
+  shortCircuit: true,
+});
 
 // Export names that are valid JS identifiers — only these can be re-emitted as
 // `export const <name>` in the synthetic module the load hook generates.
@@ -29,6 +38,82 @@ const RSTEST_DIST_DIR = REGISTRY_URL.slice(
   0,
   REGISTRY_URL.lastIndexOf('/') + 1,
 );
+
+const importMetaResolve = import.meta.resolve?.bind(import.meta);
+
+// True while `deriveKey` runs `import.meta.resolve`, whose resolution passes
+// through the resolve hook below once it is installed. The hook passes straight
+// through then: key derivation must observe the REAL resolution — an already
+// mocked module would otherwise resolve to its virtual URL and a re-mock/unmock
+// would be keyed by that virtual URL instead of the module's. Keying and hook
+// live in this one module precisely so they can coordinate like this.
+let derivingKey = false;
+
+const deriveKey = (request: string, base: string): string | undefined => {
+  // Builtins key by their canonical `node:` id — the same `toNodeBuiltin` the
+  // resolve hook uses on the read side — without any resolution work.
+  if (isBuiltinSpecifier(request)) {
+    return toNodeBuiltin(request);
+  }
+  if (!importMetaResolve) {
+    return undefined;
+  }
+  derivingKey = true;
+  try {
+    return importMetaResolve(request, pathToFileURL(base).href);
+  } catch {
+    return undefined;
+  } finally {
+    derivingKey = false;
+  }
+};
+
+/**
+ * Registry-key derivation for one native mock (the write side of the resolve
+ * hook's read-side keying below). Several derivations may disagree on spelling
+ * for the same module (pnpm realpath, exports conditions, extension aliases),
+ * so every derivation that succeeds is registered as an alias of the same
+ * entry, best-first:
+ * 1. the build-resolved target from the rspack plugin (`info.r`) — exact,
+ *    no runtime re-resolution;
+ * 2. `request` resolved against the DECLARING module (`info.o`) — correct
+ *    base for a relative `rs.mock` living in a helper file;
+ * 3. `request` resolved against the test file — the pre-info behavior, kept
+ *    as the old-rspack fallback and divergence absorber (skipped when `info.o`
+ *    IS the test file, where it could only repeat derivation 2).
+ */
+const deriveNativeMockKeys = (
+  request: string,
+  info: NativeMockResolvedInfo | undefined,
+  testPath: string,
+): string[] => {
+  const keys: string[] = [];
+  const add = (key: string | undefined) => {
+    if (key !== undefined && !keys.includes(key)) {
+      keys.push(key);
+    }
+  };
+  const resolved = info?.r;
+  if (typeof resolved === 'string') {
+    if (isAbsolute(resolved)) {
+      // The resolve hook keys non-builtins by their resolved URL.
+      add(pathToFileURL(resolved).href);
+    } else {
+      // External request: a `node:` builtin spelling is the hook's canonical
+      // key already; a bare spelling ('os', or an uninstalled package rstest
+      // externalized by raw request) is registered verbatim — the canonical
+      // form comes from derivations 2/3 below.
+      add(resolved);
+    }
+  }
+  if (info?.o !== undefined) {
+    add(deriveKey(request, info.o));
+  }
+  if (info?.o !== testPath) {
+    add(deriveKey(request, testPath));
+  }
+  return keys;
+};
 
 /**
  * #1454: install the Node `module.registerHooks` resolve/load pair that makes
@@ -62,9 +147,14 @@ export const installNativeMockHooks = (): void => {
   nodeModule.registerHooks({
     resolve(specifier, context, nextResolve) {
       // Hot path: fires on EVERY native resolution. Bail before any work while
-      // no mock is active (also covers the worker's own bootstrap imports), or
-      // when the importer is rstest's own runtime (see RSTEST_DIST_DIR).
-      if (isRegistryEmpty() || context.parentURL?.startsWith(RSTEST_DIST_DIR)) {
+      // no mock is active (also covers the worker's own bootstrap imports),
+      // when this resolution IS a key derivation (see `derivingKey`), or when
+      // the importer is rstest's own runtime (see RSTEST_DIST_DIR).
+      if (
+        isRegistryEmpty() ||
+        derivingKey ||
+        context.parentURL?.startsWith(RSTEST_DIST_DIR)
+      ) {
         return nextResolve(specifier, context);
       }
       // `registerHooks` also fires for `require()`, but the load hook only serves
@@ -75,10 +165,6 @@ export const installNativeMockHooks = (): void => {
       if (context.conditions?.includes('require')) {
         return nextResolve(specifier, context);
       }
-      const virtual = (key: string) => ({
-        url: `${VIRTUAL_PREFIX}${encodeURIComponent(key)}?v=${getRegistryVersion()}`,
-        shortCircuit: true,
-      });
       // `getNativeMock` (not a bare presence check) so we only short-circuit when
       // the mock yields SERVABLE exports: an async producer settles to `undefined`
       // here and the resolution falls through to the real module rather than an
@@ -147,5 +233,8 @@ export const installNativeMockHooks = (): void => {
 };
 
 // Registered at worker bootstrap (this module is side-effect imported by
-// `setup.ts`); `mockRegistry.setNativeMock` invokes it on the first published mock.
+// `setup.ts`); `mockRegistry.setNativeMock` invokes the installer on the first
+// published mock, and the RSTEST_API bridge (`api/utilities.ts`) reaches the
+// key derivation through `mockRegistry.resolveNativeMockKeys`.
 setNativeMockInstaller(installNativeMockHooks);
+setNativeMockKeyResolver(deriveNativeMockKeys);

--- a/packages/core/src/runtime/worker/resolveDynamicImport.ts
+++ b/packages/core/src/runtime/worker/resolveDynamicImport.ts
@@ -26,8 +26,12 @@ import {
 
 const importMetaResolve = import.meta.resolve?.bind(import.meta);
 
+// Set, not array scan: `isBuiltinSpecifier` sits on the native-mock resolve
+// hook's per-resolution hot path (nativeMockHooks.ts).
+const BUILTIN_MODULES = new Set(builtinModules);
+
 export const isBuiltinSpecifier = (specifier: string): boolean =>
-  specifier.startsWith('node:') || builtinModules.includes(specifier);
+  specifier.startsWith('node:') || BUILTIN_MODULES.has(specifier);
 
 /**
  * Normalize a builtin specifier to its `node:` canonical form. Node treats the

--- a/packages/core/src/runtime/worker/resolveDynamicImport.ts
+++ b/packages/core/src/runtime/worker/resolveDynamicImport.ts
@@ -3,8 +3,8 @@ import {
   builtinModules,
   createRequire as createNativeRequire,
 } from 'node:module';
-import { isAbsolute } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   asModule,
   createInteropProxy,
@@ -112,21 +112,57 @@ export const resolveImportSpecifier = ({
  * Returns `undefined` (caller falls through to a real native import) for a static
  * import, an `importActual`, or an unmocked request. Both loaders share this
  * single policy rather than re-implementing the gate at each call site.
+ *
+ * Lookup is RESOLVED-FIRST: the bundle map keys relative mocks only by their
+ * build-resolved absolute target (a raw `./foo` means different modules from
+ * different directories), so on a raw miss the bundle calls back into
+ * `resolveToPath`, which resolves a relative specifier against the importing
+ * module's directory (`resolveBase`, the rspack-injected origin) — the
+ * relative, absolute, and `file://` spellings then meet the map's absolute
+ * keys. Alias / tsconfig-paths spellings are NOT expanded (that would need the
+ * build's resolve config at runtime); they match only when the mock was
+ * declared with the same spelling — and Node cannot natively load such a
+ * specifier anyway, so an unmocked one fails loudly rather than silently
+ * loading something else. The callback only runs when at least one mock is
+ * registered.
  */
 export const maybeResolveMockedDynamicImport = (
   specifier: string,
   returnModule: boolean | undefined,
-  importAttributes?: ImportCallOptions,
+  importAttributes: ImportCallOptions | undefined,
+  resolveBase: string,
 ): unknown => {
   if (returnModule || importAttributes?.with?.rstest) {
     return undefined;
   }
   const resolver = (
     globalThis as {
-      __rstest_resolve_mocked_dynamic_request__?: (request: string) => unknown;
+      __rstest_resolve_mocked_dynamic_request__?: (
+        request: string,
+        resolveToPath?: (request: string) => string | undefined,
+      ) => unknown;
     }
   ).__rstest_resolve_mocked_dynamic_request__;
-  return typeof resolver === 'function' ? resolver(specifier) : undefined;
+  if (typeof resolver !== 'function') {
+    return undefined;
+  }
+  const resolveToPath = (request: string): string | undefined => {
+    // Builtins are fully covered by raw keys (both spellings registered).
+    if (isBuiltinSpecifier(request)) {
+      return undefined;
+    }
+    // A `file://` spelling of an absolute target only needs normalizing to
+    // the plain-path form the map keys carry.
+    if (request.startsWith('file:')) {
+      return fileURLToPath(request);
+    }
+    if (request.startsWith('./') || request.startsWith('../')) {
+      return resolve(dirname(resolveBase), request);
+    }
+    // Bare/alias spellings: raw-key matches only (see the doc block above).
+    return undefined;
+  };
+  return resolver(specifier, resolveToPath);
 };
 
 /**

--- a/packages/core/src/runtime/worker/resolveDynamicImport.ts
+++ b/packages/core/src/runtime/worker/resolveDynamicImport.ts
@@ -26,7 +26,7 @@ import {
 
 const importMetaResolve = import.meta.resolve?.bind(import.meta);
 
-const isBuiltinSpecifier = (specifier: string): boolean =>
+export const isBuiltinSpecifier = (specifier: string): boolean =>
   specifier.startsWith('node:') || builtinModules.includes(specifier);
 
 /**
@@ -37,7 +37,7 @@ const isBuiltinSpecifier = (specifier: string): boolean =>
  * module instances. Every `builtinModules` entry is importable with the `node:`
  * prefix, so prefixing is always safe.
  */
-const toNodeBuiltin = (specifier: string): string =>
+export const toNodeBuiltin = (specifier: string): string =>
   specifier.startsWith('node:') ? specifier : `node:${specifier}`;
 
 const resolveModule = (specifier: string, resolveBase: string): string => {
@@ -89,6 +89,40 @@ export const resolveImportSpecifier = ({
     : isBuiltinSpecifier(specifier)
       ? toNodeBuiltin(specifier)
       : resolveModule(specifier, resolveBase);
+};
+
+/**
+ * #1454: a non-literal `import(request)` is routed to this worker's native
+ * import hook, which loads outside the webpack runtime and so bypasses
+ * `rs.mock`. When the `request` itself names a mocked module (e.g.
+ * `const s = 'node:os'; import(s)`), the bundle's mock runtime publishes a
+ * resolver on the shared global that maps the clean request to the
+ * already-installed mocked instance. Consulting it before the native import
+ * keeps `import(variable)` of a mocked module mock-aware on every Node version.
+ *
+ * Gated on `returnModule` being false: only the `import()` call site can reach a
+ * mocked request — static imports are mock-rewritten in the bundle and never
+ * hit the loaders. Also skipped for `importActual` (carried as the internal
+ * `with: { rstest }` attribute), which must reach the REAL module — so
+ * `rs.importActual(variable)` of a mocked module is never served the mock.
+ * Returns `undefined` (caller falls through to a real native import) for a static
+ * import, an `importActual`, or an unmocked request. Both loaders share this
+ * single policy rather than re-implementing the gate at each call site.
+ */
+export const maybeResolveMockedDynamicImport = (
+  specifier: string,
+  returnModule: boolean | undefined,
+  importAttributes?: ImportCallOptions,
+): unknown => {
+  if (returnModule || importAttributes?.with?.rstest) {
+    return undefined;
+  }
+  const resolver = (
+    globalThis as {
+      __rstest_resolve_mocked_dynamic_request__?: (request: string) => unknown;
+    }
+  ).__rstest_resolve_mocked_dynamic_request__;
+  return typeof resolver === 'function' ? resolver(specifier) : undefined;
 };
 
 /**

--- a/packages/core/src/runtime/worker/setup.ts
+++ b/packages/core/src/runtime/worker/setup.ts
@@ -1,3 +1,8 @@
+// Register the #1454 native-mock loader hooks (installed lazily, on the first
+// native mock — see nativeMockHooks.ts). Node-only; this bootstrap runs only in
+// the worker, never in the browser build.
+import './nativeMockHooks';
+
 const gracefulExit: boolean = process.execArgv.some(
   (execArg) =>
     execArg.startsWith('--perf') ||

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -517,9 +517,12 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
     RstestPlugin {
       "_args": [
         {
+          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
-          "injectDynamicImportOrigin": true,
+          "injectDynamicImportOrigin": {
+            "functionName": "import.meta.__rstest_dynamic_import__",
+          },
           "injectModulePathName": true,
           "injectRequireResolveOrigin": {
             "functionName": "import.meta.__rstest_require_resolve__",
@@ -1111,9 +1114,12 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
     RstestPlugin {
       "_args": [
         {
+          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
-          "injectDynamicImportOrigin": true,
+          "injectDynamicImportOrigin": {
+            "functionName": "__rstest_dynamic_import__",
+          },
           "injectModulePathName": true,
           "injectRequireResolveOrigin": {
             "functionName": "__rstest_require_resolve__",
@@ -1691,9 +1697,12 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
     RstestPlugin {
       "_args": [
         {
+          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
-          "injectDynamicImportOrigin": true,
+          "injectDynamicImportOrigin": {
+            "functionName": "__rstest_dynamic_import__",
+          },
           "injectModulePathName": true,
           "injectRequireResolveOrigin": {
             "functionName": "__rstest_require_resolve__",
@@ -2273,9 +2282,12 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
     RstestPlugin {
       "_args": [
         {
+          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
-          "injectDynamicImportOrigin": true,
+          "injectDynamicImportOrigin": {
+            "functionName": "__rstest_dynamic_import__",
+          },
           "injectModulePathName": true,
           "injectRequireResolveOrigin": {
             "functionName": "__rstest_require_resolve__",
@@ -3184,9 +3196,12 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
     RstestPlugin {
       "_args": [
         {
+          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
-          "injectDynamicImportOrigin": true,
+          "injectDynamicImportOrigin": {
+            "functionName": "__rstest_dynamic_import__",
+          },
           "injectModulePathName": true,
           "injectRequireResolveOrigin": {
             "functionName": "__rstest_require_resolve__",
@@ -3765,9 +3780,12 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
     RstestPlugin {
       "_args": [
         {
+          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
-          "injectDynamicImportOrigin": true,
+          "injectDynamicImportOrigin": {
+            "functionName": "__rstest_dynamic_import__",
+          },
           "injectModulePathName": true,
           "injectRequireResolveOrigin": {
             "functionName": "__rstest_require_resolve__",

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -517,7 +517,6 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -1114,7 +1113,6 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -1697,7 +1695,6 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -2282,7 +2279,6 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -3196,7 +3192,6 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -3780,7 +3775,6 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {

--- a/packages/core/tests/runtime/worker/mockRegistry.test.ts
+++ b/packages/core/tests/runtime/worker/mockRegistry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  getNativeMock,
+  getRegistryVersion,
+  setNativeMock,
+  unsetNativeMock,
+} from '../../../src/runtime/worker/mockRegistry';
+
+describe('mockRegistry alias groups', () => {
+  it('serves one entry under every alias and clears the whole group from any alias', () => {
+    setNativeMock(['group:a', 'group:b'], () => ({ tag: 'A' }));
+
+    expect(getNativeMock('group:a')).toEqual({ tag: 'A' });
+    // Same entry (memoized produce), not a re-run.
+    expect(getNativeMock('group:b')).toBe(getNativeMock('group:a'));
+
+    // Unmock computed from the OTHER spelling clears both.
+    unsetNativeMock(['group:b']);
+    expect(getNativeMock('group:a')).toBeUndefined();
+    expect(getNativeMock('group:b')).toBeUndefined();
+  });
+
+  it('evicts every stale alias when a re-mock registers a smaller group', () => {
+    setNativeMock(['re:a', 're:b'], () => ({ tag: 'old' }));
+    setNativeMock(['re:a'], () => ({ tag: 'new' }));
+
+    expect(getNativeMock('re:a')).toEqual({ tag: 'new' });
+    // 're:b' must not keep serving the previous mock.
+    expect(getNativeMock('re:b')).toBeUndefined();
+
+    unsetNativeMock(['re:a']);
+  });
+
+  it('runs the producer lazily and at most once across aliases', () => {
+    let calls = 0;
+    setNativeMock(['lazy:a', 'lazy:b'], () => {
+      calls++;
+      return { tag: 'lazy' };
+    });
+    expect(calls).toBe(0);
+
+    getNativeMock('lazy:a');
+    getNativeMock('lazy:b');
+    expect(calls).toBe(1);
+
+    unsetNativeMock(['lazy:a']);
+  });
+
+  it('bumps the version on set and on effective unset only', () => {
+    const before = getRegistryVersion();
+    setNativeMock(['ver:a'], () => ({}));
+    expect(getRegistryVersion()).toBe(before + 1);
+
+    unsetNativeMock(['ver:missing']);
+    expect(getRegistryVersion()).toBe(before + 1);
+
+    unsetNativeMock(['ver:a']);
+    expect(getRegistryVersion()).toBe(before + 2);
+  });
+
+  it('ignores an empty key group', () => {
+    const before = getRegistryVersion();
+    setNativeMock([], () => ({}));
+    expect(getRegistryVersion()).toBe(before);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  '@rspack/core': npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+
 packageExtensionsChecksum: sha256-/oXUNlAVRCvDfhpsbH+E7MlrA1cfGnTrmqgmHjY2sMM=
 
 importers:
@@ -12,7 +15,7 @@ importers:
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.16
-        version: 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+        version: 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@rslint/core':
         specifier: ^0.6.3
         version: 0.6.3(jiti@2.7.0)
@@ -99,7 +102,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.23.1
         version: 0.23.1(@microsoft/api-extractor@7.58.9(@types/node@22.18.6))(typescript@6.0.3)
@@ -223,7 +226,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -312,7 +315,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -372,7 +375,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -406,7 +409,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -434,7 +437,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -468,7 +471,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -518,7 +521,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -588,7 +591,7 @@ importers:
         version: 2.0.0(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
         version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.1.1)
@@ -622,7 +625,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -674,7 +677,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -714,7 +717,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -751,19 +754,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rspack/cli':
         specifier: ~2.1.1
-        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))
+        version: 2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))
       '@rspack/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@swc/helpers@0.5.23)
+        specifier: npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+        version: '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@rspack/dev-server':
         specifier: ~2.1.0
-        version: 2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rspack/plugin-react-refresh':
         specifier: ~2.0.2
-        version: 2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+        version: 2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -806,16 +809,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: ~2.1.1
-        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))
+        version: 2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))
       '@rspack/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@swc/helpers@0.5.23)
+        specifier: npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+        version: '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@rspack/dev-server':
         specifier: ~2.1.0
-        version: 2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rspack/plugin-react-refresh':
         specifier: ~2.0.2
-        version: 2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+        version: 2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -879,7 +882,7 @@ importers:
         version: 2.0.0(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
         version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.1.1)
@@ -936,16 +939,17 @@ importers:
         version: 6.0.3
 
   packages/adapter-rspack:
+    dependencies:
+      '@rspack/core':
+        specifier: npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+        version: '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
     devDependencies:
       '@rslib/core':
         specifier: 0.23.1
         version: 0.23.1(@microsoft/api-extractor@7.58.9(@types/node@22.18.6))(typescript@6.0.3)
       '@rspack/cli':
         specifier: ~2.1.1
-        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))
-      '@rspack/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@swc/helpers@0.5.23)
+        version: 2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1058,10 +1062,10 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.4
-        version: 2.0.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.0.4(@rsbuild/core@2.1.1)(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ^4.3.1
         version: 4.3.1
@@ -1104,7 +1108,7 @@ importers:
         version: 7.58.9(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
         version: 1.4.6(@rsbuild/core@2.1.1)
@@ -1232,7 +1236,7 @@ importers:
         version: 3.0.1
       istanbul-lib-source-maps:
         specifier: ^5.0.6
-        version: 5.0.6
+        version: 5.0.6(supports-color@8.1.1)
       istanbul-reports:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1360,10 +1364,10 @@ importers:
         version: 0.0.15
       '@vscode/test-electron':
         specifier: ^2.5.2
-        version: 2.5.2
+        version: 2.5.2(supports-color@8.1.1)
       '@vscode/vsce':
         specifier: 3.9.2
-        version: 3.9.2
+        version: 3.9.2(supports-color@8.1.1)
       birpc:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1404,13 +1408,13 @@ importers:
         version: 2.0.0(@rsbuild/core@2.1.1)
       '@rspress/core':
         specifier: 2.0.15
-        version: 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.15
-        version: 2.0.15(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 2.0.15(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rstack-dev/doc-ui':
         specifier: 1.14.5
-        version: 1.14.5(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.14.5(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1437,7 +1441,7 @@ importers:
         version: 1.1.3(@rsbuild/core@2.1.1)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
-        version: 1.0.4(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.0.4(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
       rspress-plugin-sitemap:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2122,6 +2126,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -3046,11 +3056,6 @@ packages:
 
   '@rsdoctor/rspack-plugin@1.5.16':
     resolution: {integrity: sha512-CoFLPpJF+XU96sVZ8EWbbQh4ZjihmZAv3hlyQzrn+HO8VBa0BRI/k+oyRAPwg7fI0/Uc1OHDtgL7D8IST3vbTw==}
-    peerDependencies:
-      '@rspack/core': '*'
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
 
   '@rsdoctor/sdk@1.5.16':
     resolution: {integrity: sha512-t2ghEUCUKFwP12QeeLX3VvI5b+Z+SI9rwUiE8VHa+gOFi8oHkceEi0rlBf1k9BexMpQf3zP3RNTZtzo09mxpCw==}
@@ -3058,11 +3063,8 @@ packages:
   '@rsdoctor/types@1.5.16':
     resolution: {integrity: sha512-J9yqQu1VNFgLJpkgzAucjA1AkVnrg6kRyMhAzj05uYyPM6FQgFmi3NlQFDxRPLAfTuwSXC72xhSi7LYd6MuVvA==}
     peerDependencies:
-      '@rspack/core': '*'
       webpack: 5.x
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -3135,73 +3137,85 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.1.1':
-    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
+  '@rspack-canary/binding-darwin-arm64@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-eU5seMbeQsNGo5hQ4ZJvufWSeWvpAAIOv+jYLBjowA5eQptgaIB4zoqZ5AWWDRKMPoKRuFu3j24UeKdvfBggOA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.1':
-    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
+  '@rspack-canary/binding-darwin-x64@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-EFrSPxeYCbHBf7yRVZ5H5Een+VSjrRFa2lbGLLpzCdo9d//jZHJAXrFlipByDPky3fzXNAoeg2CNklEH6q8Eyw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
-    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-ls6J9O43d44rNCRT8v1Gt3ONfewAc2giG1p+HkTfNYBt+GhpKceh84kVKy+KZF1wmvjd+ieyReifq/QK52t9Uw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
-    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
+  '@rspack-canary/binding-linux-arm64-musl@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-ZlQ9WSAqq2DmVmaEubDWaSrBSlbeUaNjBAZI5Icl/rfnO9SXpKZR5EzL7xSXl+H+3zqThDCu1C5NchJ1fjzUYg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-v4hdbXWuFLUwveXrF8RkUeNhGmRgrKR9atvmIaJlOnKReZZjaNSIMthzIq+VcKMhifTX7ZRJuGnOW/tSWDYoaw==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
-    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-aTDQH5hydOtNGYjv1ZcpHkGSkhl6dwgyihzd0DI1XTKXqwlI01It16/ZdqDfMJPQwpTiSbC2Ciy/J+dAVeLHsA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.1.1':
-    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
+  '@rspack-canary/binding-linux-x64-gnu@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-Een2lCrQF1y6H4XFasF8JrUZQ8Y0B5WiWnIlLgoloP2yTBfzEU1sp8IVuY18nB86xFxXYE+8eFx+x4w7DVj5XA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.1.1':
-    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
+  '@rspack-canary/binding-linux-x64-musl@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-NqX7zRjMDA85GWsuLdywneRKHYNoykkLC/BSVirx0YYhnkzDVfEEL2mrytfG5UzMe+8Qbs6zwGSGx/sUr3zLjw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.1.1':
-    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
+  '@rspack-canary/binding-wasm32-wasi@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-EKU/AcfP0ZRT8zLbTo3ENj72GnZLoL6560kSY9/TdgIFdEQhISGBP0yyyVimoG9T+JTpAaXV7WdHhPPxXDXzlA==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
-    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-FKSwtQXn8Xoxb5V1YApVAX3REUSr3oxfLmuCBZCu/yUe0EGJMDDCusaKzd0c8VgwlF2tlqU7skJsz3GMsS66xA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
-    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-G58E6vCUixbFLHwvpUu+45e62hTSK+O7r1GOSoGdTzKcoqGiHfCjr6cQ6wUv+yAWttYIDZKVZEn6RqxfOh6ytA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.1':
-    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
+  '@rspack-canary/binding-win32-x64-msvc@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-wQzp3Trh3OSSOBNgDOKPt6auFWGg/HvcZnrt6FgqbtyjrSsqTx4UjhwOfmfEyiRXugikzYcBC7vwGS+t0Bbtew==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.1.1':
-    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
+  '@rspack-canary/binding@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-7STI8EDhKDsVfAyFzQ48T8JUvKkkdLgfiP1Mjsf7kPgiK/+65tJljJSaWVR7pNjmLPyC6oSF+VVDe+BtVXuVJQ==}
+
+  '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-3gnI4OTtyfmrcCdWcPnbIbZQhIblWQlJ+Mzk4j/8JLuuF4HX3G+oYWfz/DtdAAfK7M9+pvi71LY4dr/t74bS/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
 
   '@rspack/cli@2.1.1':
     resolution: {integrity: sha512-zsJFurwCDesy0dud7cejObagbbXsvKcQ6j485nmnytBsXV17Uf6XfedQMxnOXBZeGIel+I7Jl/Jp3Sn08TsZuw==}
@@ -3211,18 +3225,6 @@ packages:
       '@rspack/dev-server': ^2.0.0-0
     peerDependenciesMeta:
       '@rspack/dev-server':
-        optional: true
-
-  '@rspack/core@2.1.1':
-    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
         optional: true
 
   '@rspack/dev-middleware@2.0.3':
@@ -3250,11 +3252,7 @@ packages:
   '@rspack/plugin-react-refresh@2.0.0':
     resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
     peerDependencies:
-      '@rspack/core': ^2.0.0-0
       react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
 
   '@rspack/plugin-react-refresh@2.0.2':
     resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
@@ -5895,12 +5893,9 @@ packages:
     resolution: {integrity: sha512-F0+ErFFDj3Pt+nVrCN6VlEGEzocv9s7x/aR9v2riI+WM83UAfTYBDBjGPJnT55lBLR6JSI4fmWblt+aA2JN6/w==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -7182,12 +7177,9 @@ packages:
   rspack-vue-loader@17.5.1:
     resolution: {integrity: sha512-1pXdeqYM95P0T8DO2ZcOCBnfMp62W5IG2c0RICn1rFYjHcja41IYSQLzcdc1uePEq0n4JZwvfR2lVs8wRZuwzA==}
     peerDependencies:
-      '@rspack/core': ^1.0.0 || ^2.0.0-0
       '@vue/compiler-sfc': '*'
       vue: '*'
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       '@vue/compiler-sfc':
         optional: true
       vue:
@@ -9142,6 +9134,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@node-rs/crc32-android-arm-eabi@1.10.6':
     optional: true
 
@@ -9808,7 +9807,7 @@ snapshots:
 
   '@rsbuild/core@2.1.1':
     dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9849,16 +9848,17 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.1
 
-  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.1)
+      less-loader: 12.3.3(@swc/helpers@0.5.23)(less@4.6.7)(webpack@5.108.1)
       reduce-configs: 2.0.1
     optionalDependencies:
       '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
   '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.1)':
@@ -9889,18 +9889,19 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.1
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@swc/helpers@0.5.23)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.1
@@ -9936,9 +9937,9 @@ snapshots:
       - sugarss
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.1.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
@@ -9962,25 +9963,26 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))':
+  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+      rspack-vue-loader: 17.5.1(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
     optionalDependencies:
       '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - '@vue/compiler-sfc'
       - vue
 
   '@rsdoctor/client@1.5.16': {}
 
-  '@rsdoctor/core@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/core@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.1)
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/sdk': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@rspack/resolver': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.47.1
@@ -9991,73 +9993,80 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
       - '@rsbuild/core'
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/graph@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       es-toolkit: 1.47.1
       path-browserify: 1.0.1
       source-map: 0.7.6
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/rspack-plugin@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
-      '@rsdoctor/core': 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-    optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rsdoctor/core': 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/sdk': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
       - '@rsbuild/core'
+      - '@swc/helpers'
       - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/sdk@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       '@rsdoctor/client': 1.5.16
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1
       tapable: 2.3.3
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/types@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       webpack: 5.108.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rsdoctor/utils@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/utils@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@types/estree': 1.0.5
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -10072,7 +10081,8 @@ snapshots:
       rslog: 2.1.3
       strip-ansi: 6.0.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
   '@rslib/core@0.23.1(@microsoft/api-extractor@7.58.9(@types/node@22.18.6))(typescript@6.0.3)':
@@ -10125,95 +10135,97 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.6.3':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.1':
+  '@rspack-canary/binding-darwin-arm64@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.1':
+  '@rspack-canary/binding-darwin-x64@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
+  '@rspack-canary/binding-linux-arm64-musl@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.1':
+  '@rspack-canary/binding-linux-x64-gnu@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.1':
+  '@rspack-canary/binding-linux-x64-musl@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.1':
+  '@rspack-canary/binding-wasm32-wasi@2.1.3-canary-7caa6eff-20260703032940':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.1':
+  '@rspack-canary/binding-win32-x64-msvc@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding@2.1.1':
+  '@rspack-canary/binding@2.1.3-canary-7caa6eff-20260703032940':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.1
-      '@rspack/binding-darwin-x64': 2.1.1
-      '@rspack/binding-linux-arm64-gnu': 2.1.1
-      '@rspack/binding-linux-arm64-musl': 2.1.1
-      '@rspack/binding-linux-riscv64-gnu': 2.1.1
-      '@rspack/binding-linux-riscv64-musl': 2.1.1
-      '@rspack/binding-linux-x64-gnu': 2.1.1
-      '@rspack/binding-linux-x64-musl': 2.1.1
-      '@rspack/binding-wasm32-wasi': 2.1.1
-      '@rspack/binding-win32-arm64-msvc': 2.1.1
-      '@rspack/binding-win32-ia32-msvc': 2.1.1
-      '@rspack/binding-win32-x64-msvc': 2.1.1
+      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-riscv64-gnu': '@rspack-canary/binding-linux-riscv64-gnu@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-riscv64-musl': '@rspack-canary/binding-linux-riscv64-musl@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.1.3-canary-7caa6eff-20260703032940'
 
-  '@rspack/cli@2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))':
+  '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-    optionalDependencies:
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))
-
-  '@rspack/core@2.1.1(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.1.1
+      '@rspack/binding': '@rspack-canary/binding@2.1.3-canary-7caa6eff-20260703032940'
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/dev-middleware@2.0.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
-    optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-
-  '@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rspack/cli@2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))':
     dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-      '@rspack/dev-middleware': 2.0.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
+    optionalDependencies:
+      '@rspack/dev-server': 2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
+
+  '@rspack/dev-middleware@2.0.3(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))':
+    optionalDependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
+
+  '@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
+      '@rspack/dev-middleware': 2.0.3(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@swc/helpers@0.5.23)(react-refresh@0.18.0)':
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       react-refresh: 0.18.0
-    optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -10266,12 +10278,12 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@rsbuild/core': 2.1.1
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)
       '@rspress/shared': 2.0.15
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -10308,7 +10320,7 @@ snapshots:
       unist-util-visit-children: 3.0.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@rspack/core'
+      - '@swc/helpers'
       - '@types/mdast'
       - '@types/react'
       - core-js
@@ -10316,11 +10328,11 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-algolia@2.0.15(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@rspress/plugin-algolia@2.0.15(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -10338,9 +10350,9 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
     optionalDependencies:
-      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rushstack/node-core-library@5.23.1(@types/node@22.18.6)':
     dependencies:
@@ -11006,8 +11018,8 @@ snapshots:
 
   '@typespec/ts-http-runtime@0.3.0':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -11061,10 +11073,10 @@ snapshots:
     transitivePeerDependencies:
       - monocart-coverage-reports
 
-  '@vscode/test-electron@2.5.2':
+  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.8.5
@@ -11110,7 +11122,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.5
       '@vscode/vsce-sign-win32-x64': 2.0.5
 
-  '@vscode/vsce@3.9.2':
+  '@vscode/vsce@3.9.2(supports-color@8.1.1)':
     dependencies:
       '@azure/identity': 4.12.0
       '@secretlint/node': 10.2.2
@@ -11133,7 +11145,7 @@ snapshots:
       minimatch: 10.2.5
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2
+      secretlint: 10.2.2(supports-color@8.1.1)
       semver: 7.8.5
       tmp: 0.2.3
       typed-rest-client: 1.8.11
@@ -12801,7 +12813,7 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -12817,7 +12829,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -12992,7 +13004,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       debug: 4.4.3(supports-color@8.1.1)
@@ -13254,12 +13266,15 @@ snapshots:
       lefthook-windows-arm64: 2.1.9
       lefthook-windows-x64: 2.1.9
 
-  less-loader@12.3.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.1):
+  less-loader@12.3.3(@swc/helpers@0.5.23)(less@4.6.7)(webpack@5.108.1):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       webpack: 5.108.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   less@4.6.7:
     dependencies:
@@ -14199,7 +14214,7 @@ snapshots:
 
   ovsx@1.0.2:
     dependencies:
-      '@vscode/vsce': 3.9.2
+      '@vscode/vsce': 3.9.2(supports-color@8.1.1)
       commander: 6.2.1
       follow-redirects: 1.16.0
       is-ci: 2.0.0
@@ -14856,17 +14871,20 @@ snapshots:
 
   rslog@2.1.3: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3)):
+  rspack-vue-loader@17.5.1(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3)):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       vue: 3.5.39(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
     dependencies:
-      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   rspress-plugin-sitemap@1.2.1: {}
 
@@ -15033,7 +15051,7 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  secretlint@10.2.2:
+  secretlint@10.2.2(supports-color@8.1.1):
     dependencies:
       '@secretlint/config-creator': 10.2.2
       '@secretlint/formatter': 10.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,10 @@ allowBuilds:
 
 autoInstallPeers: false
 
+# TEMP (do not commit): validate rspack canary with build-resolved mock info (PR web-infra-dev/rspack#14665)
+overrides:
+  '@rspack/core': 'npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940'
+
 # for vsce
 hoistPattern: ['@secretlint/*']
 
@@ -24,6 +28,7 @@ hoistPattern: ['@secretlint/*']
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@rspack/*'
+  - '@rspack-canary/*'
   - '@rsbuild/*'
   - '@rslib/*'
   - '@rspress/*'

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -188,6 +188,8 @@ const launch = await import(launchScriptPath);
 const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocked
 ```
 
+Before mock matching, a non-literal relative specifier is resolved against the **importing module's directory**. Relative paths, absolute paths, and `file://` URLs therefore all reach a mock declared for the same module — two `import('./foo')` calls from different directories are matched independently, and a relative `rs.mock('./dep')` declared in a shared helper resolves against the helper's own directory.
+
 :::warning Requirements and limitations
 
 Case 1 (the specifier resolves to the mocked module itself) works on every supported Node.js version. Cases 2 and 3 — where the **inner** import of a natively-loaded module must be mocked — additionally require:
@@ -200,7 +202,8 @@ Case 1 (the specifier resolves to the mocked module itself) works on every suppo
 - **`require()` on the native path**: a mocked module reached through `require()` inside a natively-loaded CommonJS module is not mocked — native mocks apply to ESM `import`, so the `require()` receives the real module.
 - **`isolate: false`**: a natively-loaded module is cached by Node's ESM loader across files, so a mock applied to it can persist into a later test file run by the same worker.
 - **`isolate: false` across projects**: the non-literal `import(variable)` mock resolver is published on a shared global, so when one worker runs multiple projects the resolver reflects whichever project's runtime executed last — a variable `import()` of a mocked module in an earlier project may then consult a later project's mocks. Static and literal imports are unaffected.
-- **Relative specifiers**: a relative mock is resolved against the **test file**. A relative `rs.mock('./dep')` declared in a setup file or shared helper, or a non-literal relative `import('./dep')` from a module in a different directory, may not reach the natively-loaded path. Mock such modules with an absolute or package specifier, or declare the mock in the test file.
+- **Rspack version**: module mocking requires the test build to run on `@rspack/core >= 2.1.3` — every generated mock call carries a build-resolved identity the runtime depends on. On an older rspack, `rs.mock()` fails at runtime with an upgrade hint instead of silently missing.
+- **Alias specifiers**: a non-literal `import(variable)` whose value uses a `resolve.alias` / tsconfig-paths spelling matches a mock only when the mock was declared with the **same spelling** — the alias is not expanded at runtime. An unmocked one fails loudly (Node's loader cannot resolve it natively either). Literal imports and static imports are unaffected — the build expands them.
 
 :::
 

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -169,6 +169,41 @@ Note that `rs.resetModules()` does not cancel module mocking. To cancel module m
 
 For the full API and more examples, see [Mock modules](/api/runtime-api/rstest/mock-modules).
 
+### Mock modules behind a dynamic `import()`
+
+`rs.mock()` also applies when a module is reached outside the bundle — through a dynamic `import()` whose specifier is **not a static string literal** (for example a variable), or through an externalized `node_modules` dependency that internally imports a mocked module:
+
+```ts
+rs.mock('node:os', () => ({ hostname: () => 'MOCKED' }));
+
+// 1. The variable specifier IS the mocked module:
+const id = 'node:os';
+const os = await import(id); // os.hostname() === 'MOCKED'
+
+// 2. The variable specifier resolves to a module that imports `node:os`:
+const launch = await import(launchScriptPath);
+// the loaded module's internal `os.hostname()` returns 'MOCKED'
+
+// 3. An externalized dependency imports the mocked module internally:
+const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocked
+```
+
+:::warning Requirements and limitations
+
+Case 1 (the specifier resolves to the mocked module itself) works on every supported Node.js version. Cases 2 and 3 — where the **inner** import of a natively-loaded module must be mocked — additionally require:
+
+- **Node.js version**: they rely on [`module.registerHooks`](https://nodejs.org/api/module.html#moduleregisterhooksoptions), available in Node.js `>= 22.15.0` and `>= 23.5.0`. On older versions the mock is silently not applied to natively-loaded modules (no error); literal `import()` and static `import` mocking is unchanged.
+- **Compiled languages**: a TypeScript/JSX module loaded natively by Node — a variable `import()` of a `.ts` file, or a TS dependency — is outside Rstest's compilation, so its imports are not rewritten. Use a static string literal specifier so the module is compiled into the bundle instead.
+- **Factory instance**: a function-factory mock (`rs.mock(id, () => ({ fn: rs.fn() }))`) backs the natively-loaded importer with a separate instance, so a spy created inside the factory is a different object from the one the bundle sees. Prefer a synchronous, plain-object factory; an async factory cannot be produced by the synchronous native load hook, so a natively-loaded importer of it falls through to the real module.
+- **Named-export identity**: the native path re-exports each of a mock's named exports by value at import time. A mutated spy is unaffected (the binding still points at the same object), but reassigning a named export binding after a natively-loaded module has imported it is not observed by that consumer.
+- **`mockRequire` is CommonJS-only**: `rs.mockRequire` targets `require()` / CJS entries. To mock a module that is loaded through `import()`, use `rs.mock`.
+- **`require()` on the native path**: a mocked module reached through `require()` inside a natively-loaded CommonJS module is not mocked — native mocks apply to ESM `import`, so the `require()` receives the real module.
+- **`isolate: false`**: a natively-loaded module is cached by Node's ESM loader across files, so a mock applied to it can persist into a later test file run by the same worker.
+- **`isolate: false` across projects**: the non-literal `import(variable)` mock resolver is published on a shared global, so when one worker runs multiple projects the resolver reflects whichever project's runtime executed last — a variable `import()` of a mocked module in an earlier project may then consult a later project's mocks. Static and literal imports are unaffected.
+- **Relative specifiers**: a relative mock is resolved against the **test file**. A relative `rs.mock('./dep')` declared in a setup file or shared helper, or a non-literal relative `import('./dep')` from a module in a different directory, may not reach the natively-loaded path. Mock such modules with an absolute or package specifier, or declare the mock in the test file.
+
+:::
+
 ## Mock functions
 
 If a dependency is passed in as a callback or injected implementation, you can use [rs.fn()](/api/runtime-api/rstest/mock-functions#rsfn) to create a mock function.

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -169,6 +169,41 @@ rs.mock('../src/api');
 
 关于完整 API 和更多示例，可以参考 [Mock modules](/api/runtime-api/rstest/mock-modules)。
 
+### Mock 通过动态 `import()` 加载的模块
+
+当模块在 bundle 之外被加载时——通过 specifier **不是静态字符串字面量**（例如变量）的动态 `import()`，或通过被 external 化的 `node_modules` 依赖在其内部 import 了被 mock 的模块——`rs.mock()` 同样会生效：
+
+```ts
+rs.mock('node:os', () => ({ hostname: () => 'MOCKED' }));
+
+// 1. The variable specifier IS the mocked module:
+const id = 'node:os';
+const os = await import(id); // os.hostname() === 'MOCKED'
+
+// 2. The variable specifier resolves to a module that imports `node:os`:
+const launch = await import(launchScriptPath);
+// the loaded module's internal `os.hostname()` returns 'MOCKED'
+
+// 3. An externalized dependency imports the mocked module internally:
+const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocked
+```
+
+:::warning 要求与限制
+
+情况 1（specifier 解析到被 mock 的模块本身）在所有受支持的 Node.js 版本上都生效。情况 2 和 3——需要 mock 一个由 Node 原生加载的模块的**内部** import——还需要满足：
+
+- **Node.js 版本**：依赖 [`module.registerHooks`](https://nodejs.org/api/module.html#moduleregisterhooksoptions)，仅在 Node.js `>= 22.15.0` 与 `>= 23.5.0` 上可用。在更低版本上，对原生加载模块的 mock 会被静默跳过（不会报错）；字面量 `import()` 与静态 `import` 的 mock 行为不变。
+- **编译型语言**：由 Node 原生加载的 TypeScript/JSX 模块——对 `.ts` 文件的变量 `import()`，或一个 TS 依赖——不在 Rstest 的编译范围内，因此其内部 import 不会被改写。请改用静态字符串字面量 specifier，让该模块被编译进 bundle。
+- **工厂实例**：以工厂函数形式创建的 mock（`rs.mock(id, () => ({ fn: rs.fn() }))`）为原生加载的引用方提供的是一个独立实例，因此在工厂内创建的 spy 与 bundle 看到的并非同一个对象。建议使用同步的、返回普通对象的工厂；异步工厂无法被同步的原生 load hook 产出，因此原生加载它的引用方会回退到真实模块。
+- **具名导出的标识**：原生路径在 import 时按值重新导出 mock 的每个具名导出。原地 mutate 的 spy 不受影响（binding 仍指向同一对象），但在原生加载的模块已经 import 之后再重新赋值某个具名导出 binding，该消费者不会观察到这次更新。
+- **`mockRequire` 仅适用于 CommonJS**：`rs.mockRequire` 针对 `require()` / CJS 入口。若要 mock 一个通过 `import()` 加载的模块，请使用 `rs.mock`。
+- **原生路径上的 `require()`**：在原生加载的 CommonJS 模块中通过 `require()` 访问的 mocked 模块不会被 mock——native mock 仅作用于 ESM `import`，因此该 `require()` 会拿到真实模块。
+- **`isolate: false`**：原生加载的模块会被 Node 的 ESM loader 跨文件缓存，因此对它应用的 mock 可能会保留到同一 worker 运行的后续测试文件中。
+- **跨项目的 `isolate: false`**：非字面量 `import(variable)` 的 mock 解析发布在共享全局上，因此当一个 worker 运行多个项目时，该解析器反映的是最后执行的那个项目的 runtime——较早项目中对 mocked 模块的变量 `import()` 可能会查到较晚项目的 mock。静态与字面量 import 不受影响。
+- **相对 specifier**：相对路径的 mock 以**测试文件**为基准解析。写在 setup 文件或共享 helper 中的相对 `rs.mock('./dep')`，或来自其他目录模块的非字面量相对 `import('./dep')`，可能无法命中原生加载路径。请改用绝对路径或包名 specifier，或将 mock 声明在测试文件中。
+
+:::
+
 ## Mock 函数
 
 如果依赖是以回调或注入实现的形式传入的，可以使用 [rs.fn()](/api/runtime-api/rstest/mock-functions#rsfn) 创建 mock 函数。

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -188,6 +188,8 @@ const launch = await import(launchScriptPath);
 const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocked
 ```
 
+在进行 mock 匹配之前，非字面量的相对 specifier 会以**发起 import 的模块所在目录**为基准进行解析。因此相对路径、绝对路径、`file://` URL 都能命中为同一模块声明的 mock——来自不同目录的两个 `import('./foo')` 会被独立匹配，写在共享 helper 中的相对 `rs.mock('./dep')` 也会以 helper 自身目录为基准解析。
+
 :::warning 要求与限制
 
 情况 1（specifier 解析到被 mock 的模块本身）在所有受支持的 Node.js 版本上都生效。情况 2 和 3——需要 mock 一个由 Node 原生加载的模块的**内部** import——还需要满足：
@@ -200,7 +202,8 @@ const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocke
 - **原生路径上的 `require()`**：在原生加载的 CommonJS 模块中通过 `require()` 访问的 mocked 模块不会被 mock——native mock 仅作用于 ESM `import`，因此该 `require()` 会拿到真实模块。
 - **`isolate: false`**：原生加载的模块会被 Node 的 ESM loader 跨文件缓存，因此对它应用的 mock 可能会保留到同一 worker 运行的后续测试文件中。
 - **跨项目的 `isolate: false`**：非字面量 `import(variable)` 的 mock 解析发布在共享全局上，因此当一个 worker 运行多个项目时，该解析器反映的是最后执行的那个项目的 runtime——较早项目中对 mocked 模块的变量 `import()` 可能会查到较晚项目的 mock。静态与字面量 import 不受影响。
-- **相对 specifier**：相对路径的 mock 以**测试文件**为基准解析。写在 setup 文件或共享 helper 中的相对 `rs.mock('./dep')`，或来自其他目录模块的非字面量相对 `import('./dep')`，可能无法命中原生加载路径。请改用绝对路径或包名 specifier，或将 mock 声明在测试文件中。
+- **Rspack 版本**：模块 mock 要求测试构建运行在 `@rspack/core >= 2.1.3` 上——每个生成的 mock 调用都携带 runtime 依赖的构建期解析标识。在更低版本的 rspack 上，`rs.mock()` 会在运行时报错并提示升级，而不是静默失效。
+- **Alias specifier**：值为 `resolve.alias` / tsconfig-paths 拼写的非字面量 `import(variable)`，只有当 mock 以**相同拼写**声明时才会命中——alias 不会在运行时被展开。未被 mock 时会显式报错（Node 的 loader 同样无法原生解析这类 specifier）。字面量 import 与静态 import 不受影响——它们由构建展开。
 
 :::
 


### PR DESCRIPTION
## Summary

A dynamic `import()` whose specifier is not a static string literal (e.g. a variable) is routed to the worker's native import hook and loaded by Node outside the webpack runtime, so `rs.mock()` was bypassed (#1454).

- **Direct case** — route a non-literal `import(request)` whose request names a mocked module to the bundle's mock instance via a shared-global resolver (all Node), fixing `const s = 'node:os'; import(s)`.
- **Inner-import case (the reported repro)** — install in-thread `module.registerHooks` (Node >= 22.15 / >= 23.5, feature-detected with silent fallback, installed lazily on the first mock) so a natively-loaded module's inner import of a mocked module is redirected to a worker-realm mock registry; this also covers externalized deps that import a mocked module.

### BREAKING: requires @rspack/core >= 2.1.3

Per the release plan (rspack ships first, no old-rspack compatibility): every generated `rstest_mock`/`rstest_unmock` call must carry the build-resolved identity `{o, r}`, emitted unconditionally by rspack since web-infra-dev/rspack#14665. On an older rspack, `rs.mock()` fails loudly at runtime with an upgrade hint instead of silently missing.

On top of the hard contract, non-literal `import(variable)` matching is **resolved-first**:

- relative mock requests are keyed only by their build-resolved absolute target (a raw `./foo` is ambiguous across directories); on a raw-spelling miss the worker resolves a relative runtime specifier against the importing module's directory (the rspack-injected origin) and retries by absolute path — relative, absolute, and `file://` spellings all match, two `import('./foo')` calls from different directories are matched independently, and a relative `rs.mock('./dep')` declared in a shared helper resolves against the helper's own directory (`info.o`);
- alias / tsconfig-paths spellings are matched verbatim only, never expanded at runtime; an unmocked one fails loudly (documented limitation).

Limitations are documented in the mock guide: rspack version floor, Node version floor, compiled (TS/JSX) native targets, function-factory instance divergence, alias spellings, and `isolate: false` ESM cache.

### Merge gate

The last commit pins the rspack canary (`2.1.3-canary-7caa6eff`) so CI runs against the emitting rspack. **Keep this PR draft until a stable @rspack/core release ships the emission and @rsbuild/core picks it up; then drop the pin commit and bump the dependency.**

## Related Links

- Closes #1454
- https://github.com/web-infra-dev/rspack/pull/14665

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).