### PR TITLE
fix(core): narrow return type of waitUntil to truthy values

### DIFF
--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeConfig,
   WaitForOptions,
   WaitUntilOptions,
+  Truthy,
 } from '../../types';
 import { RSTEST_ENV_SYMBOL_KEY } from '../../utils/constants';
 import { fileContext } from '../fileContext';
@@ -599,7 +600,7 @@ const buildRstestUtilities = async (): Promise<{
             throw createWaitUntilTimeoutError(timeout);
           }
           if (value) {
-            return value;
+            return value as Truthy<typeof value>;
           }
 
           if (timedOut) {

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -2,7 +2,7 @@ import type {
   Clock as FakeTimerClock,
   Config as FakeTimerInstallOpts,
 } from '@sinonjs/fake-timers';
-import type { FunctionLike, MaybePromise } from './utils';
+import type { FunctionLike, MaybePromise, Truthy } from './utils';
 import type { RuntimeConfig } from './worker';
 
 type FakeTimerTickTime = Parameters<FakeTimerClock['tick']>[0];
@@ -600,5 +600,5 @@ export interface RstestUtilities {
   waitUntil: <T>(
     callback: () => MaybePromise<T>,
     options?: number | WaitUntilOptions,
-  ) => Promise<T>;
+  ) => Promise<Truthy<Awaited<T>>>;
 }

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -9,3 +9,6 @@ export type TestPath = string;
 
 /** The stdio stream a console log was written to */
 export type ConsoleStreamType = 'stdout' | 'stderr';
+
+export type Falsy = false | 0 | -0 | 0n | '' | null | undefined;
+export type Truthy<T> = T extends Falsy ? never : T;

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -10,5 +10,5 @@ export type TestPath = string;
 /** The stdio stream a console log was written to */
 export type ConsoleStreamType = 'stdout' | 'stderr';
 
-export type Falsy = false | 0 | -0 | 0n | '' | null | undefined;
-export type Truthy<T> = T extends Falsy ? never : T;
+export type Falsy = false | 0 | 0n | '' | null | undefined;
+export type Truthy<T> = Exclude<T, Falsy>;


### PR DESCRIPTION
## Summary

Removes any explicitly falsy types from the return type of `waitUntil`, as we know it won't return them.

before:
<img width="626" height="71" alt="image" src="https://github.com/user-attachments/assets/7e792200-f8c7-4b41-981d-e7b6063a59e0" />

after:
<img width="629" height="75" alt="image" src="https://github.com/user-attachments/assets/d2e6ab79-7c6c-4c10-b785-82ba26ad5bfb" />

I don't think there are any type tests at the moment, if there are let me know and I'll add one :)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
