### PR TITLE
docs: enable Rspress anchor check

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     'Rstest is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.',
   markdown: {
     link: {
+      checkAnchors: true,
       checkDeadLinks: true,
     },
   },


### PR DESCRIPTION
## Summary

Enable Rspress `markdown.link.checkAnchors` for the documentation site so broken heading fragments are caught during website builds. The website already uses Rspress v2.0.15, which includes this option, so no dependency upgrade is needed.

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v2.0.15