### PR TITLE
perf(coverage-v8): optimize V8 AST coverage conversion

### DIFF
--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -32,11 +32,13 @@
     "test": "rstest"
   },
   "dependencies": {
+    "@jridgewell/trace-mapping": "^0.3.31",
     "acorn": "^8.17.0",
-    "ast-v8-to-istanbul": "^1.0.4",
+    "estree-walker": "^3.0.3",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.2.0",
+    "js-tokens": "^10.0.0",
     "picomatch": "^4.0.4",
     "v8-to-istanbul": "^9.3.0"
   },

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -32,7 +32,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@jridgewell/trace-mapping": "^0.3.31",
+    "@jridgewell/trace-mapping": "0.3.31",
     "acorn": "^8.17.0",
     "estree-walker": "^3.0.3",
     "istanbul-lib-coverage": "^3.2.2",

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import inspector from 'node:inspector/promises';
-import { isAbsolute, posix, resolve, win32 } from 'node:path';
+import { dirname, isAbsolute, posix, resolve, win32 } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type {
   NormalizedCoverageOptions,
@@ -31,8 +31,7 @@ type CoverageReporterConstructor = new (
 ) => ReportBase;
 
 const MAX_PARSED_AST_CACHE_SIZE = 50;
-const INLINE_SOURCE_MAP_PATTERN =
-  /[#@]\s*sourceMappingURL\s*=\s*data:application\/json(?:;[^'",\s]*)*,/i;
+const SOURCE_MAP_URL_PATTERN = /[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/m;
 const parsedAstCache = new Map<string, ReturnType<typeof Parser.parse>>();
 
 type CoverageEntry = inspector.Profiler.ScriptCoverage & {
@@ -48,7 +47,7 @@ export class CoverageProvider implements RstestCoverageProvider {
     Record<string, string>,
     Map<string, string>
   >();
-  private diskInlineSourceMapCache = new Map<string, Promise<boolean>>();
+  private diskSourceMapCache = new Map<string, Promise<boolean>>();
 
   constructor(
     public options: NormalizedCoverageOptions,
@@ -219,17 +218,65 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   private hasInlineSourceMap(code: string): boolean {
-    return INLINE_SOURCE_MAP_PATTERN.test(code);
+    const sourceMapUrl = this.getSourceMapUrl(code);
+    return (
+      sourceMapUrl !== undefined && this.isInlineSourceMapUrl(sourceMapUrl)
+    );
   }
 
-  private async hasInlineSourceMapOnDisk(filePath: string): Promise<boolean> {
-    let cached = this.diskInlineSourceMapCache.get(filePath);
+  private hasExternalSourceMap(code: string): boolean {
+    const sourceMapUrl = this.getSourceMapUrl(code);
+    return (
+      sourceMapUrl !== undefined && !this.isInlineSourceMapUrl(sourceMapUrl)
+    );
+  }
+
+  private getSourceMapUrl(code: string): string | undefined {
+    return code.match(SOURCE_MAP_URL_PATTERN)?.[1];
+  }
+
+  private isInlineSourceMapUrl(url: string): boolean {
+    return url.startsWith('data:');
+  }
+
+  private async loadExternalSourceMap(
+    filePath: string,
+    code: string,
+  ): Promise<{
+    sourceMap?: SourceMapLike;
+    sourceMapStr?: string;
+  }> {
+    const sourceMapUrl = this.getSourceMapUrl(code);
+    if (!sourceMapUrl || this.isInlineSourceMapUrl(sourceMapUrl)) {
+      return {};
+    }
+
+    try {
+      const sourceMapStr = await fs.readFile(
+        resolve(dirname(filePath), sourceMapUrl),
+        'utf-8',
+      );
+
+      return {
+        sourceMap: {
+          names: [],
+          ...(JSON.parse(sourceMapStr) as Partial<SourceMapLike>),
+        } as SourceMapLike,
+        sourceMapStr,
+      };
+    } catch {
+      return {};
+    }
+  }
+
+  private async hasSourceMapOnDisk(filePath: string): Promise<boolean> {
+    let cached = this.diskSourceMapCache.get(filePath);
     if (!cached) {
       cached = fs
         .readFile(filePath, 'utf-8')
-        .then((code) => this.hasInlineSourceMap(code))
+        .then((code) => this.getSourceMapUrl(code) !== undefined)
         .catch(() => false);
-      this.diskInlineSourceMapCache.set(filePath, cached);
+      this.diskSourceMapCache.set(filePath, cached);
     }
 
     return cached;
@@ -248,16 +295,22 @@ export class CoverageProvider implements RstestCoverageProvider {
   }> {
     const assetSource = this.findInDict(options?.assetFiles, filePath);
     const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
+    const code = assetSource ?? (await fs.readFile(filePath, 'utf-8'));
+
+    if (sourceMapStr) {
+      return {
+        code,
+        sourceMap: {
+          names: [],
+          ...(JSON.parse(sourceMapStr) as Partial<SourceMapLike>),
+        } as SourceMapLike,
+        sourceMapStr,
+      };
+    }
 
     return {
-      code: assetSource ?? (await fs.readFile(filePath, 'utf-8')),
-      sourceMap: sourceMapStr
-        ? ({
-            names: [],
-            ...(JSON.parse(sourceMapStr) as Partial<SourceMapLike>),
-          } as SourceMapLike)
-        : undefined,
-      sourceMapStr,
+      code,
+      ...(await this.loadExternalSourceMap(filePath, code)),
     };
   }
 
@@ -448,7 +501,14 @@ export class CoverageProvider implements RstestCoverageProvider {
     const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
     const assetSource = this.findInDict(options?.assetFiles, filePath);
 
-    if (sourceMapStr || (assetSource && this.hasInlineSourceMap(assetSource))) {
+    if (
+      sourceMapStr ||
+      (assetSource && this.hasExternalSourceMap(assetSource))
+    ) {
+      return true;
+    }
+
+    if (assetSource && this.hasInlineSourceMap(assetSource)) {
       return true;
     }
 
@@ -459,7 +519,7 @@ export class CoverageProvider implements RstestCoverageProvider {
       return true;
     }
 
-    return assetSource === undefined && this.hasInlineSourceMapOnDisk(filePath);
+    return assetSource === undefined && this.hasSourceMapOnDisk(filePath);
   }
 
   private async collectImpl(options?: {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -6,7 +6,6 @@ import type {
   NormalizedCoverageOptions,
   CoverageProvider as RstestCoverageProvider,
 } from '@rstest/core';
-import astV8ToIstanbul from 'ast-v8-to-istanbul';
 import { Parser } from 'acorn';
 import { type CoverageMap, type FileCoverageData } from 'istanbul-lib-coverage';
 import type { ReportBase } from 'istanbul-lib-report';
@@ -15,6 +14,7 @@ import reports from 'istanbul-reports';
 import picomatch from 'picomatch';
 import v8ToIstanbul from 'v8-to-istanbul';
 import { createFastCoverageMap } from './utils';
+import { convertV8CoverageWithAst } from './v8AstConverter';
 
 type SourceMapLike = {
   version: number;
@@ -30,6 +30,15 @@ type CoverageReporterConstructor = new (
   options: Record<string, unknown>,
 ) => ReportBase;
 
+const MAX_PARSED_AST_CACHE_SIZE = 50;
+const INLINE_SOURCE_MAP_PATTERN =
+  /[#@]\s*sourceMappingURL\s*=\s*data:application\/json(?:;[^'",\s]*)*,/i;
+const parsedAstCache = new Map<string, ReturnType<typeof Parser.parse>>();
+
+type CoverageEntry = inspector.Profiler.ScriptCoverage & {
+  filePath: string;
+};
+
 export class CoverageProvider implements RstestCoverageProvider {
   private session: inspector.Session | null = null;
   private isMatch: (filePath: string) => boolean;
@@ -39,6 +48,7 @@ export class CoverageProvider implements RstestCoverageProvider {
     Record<string, string>,
     Map<string, string>
   >();
+  private diskInlineSourceMapCache = new Map<string, Promise<boolean>>();
 
   constructor(
     public options: NormalizedCoverageOptions,
@@ -195,18 +205,34 @@ export class CoverageProvider implements RstestCoverageProvider {
     );
   }
 
-  private hasInlineSourceMap(code: string): boolean {
-    return /[#@]\s*sourceMappingURL\s*=\s*data:application\/json(?:;[^'",\s]*)*,/i.test(
-      code,
+  private shouldKeepOriginalSource(filePath: string): boolean {
+    const normalizedKey = filePath.replace(/\\/g, '/');
+
+    if (this.shouldIgnoreTransformedFile(normalizedKey)) {
+      return false;
+    }
+
+    const originalTestPath = this.toProjectRelativePath(normalizedKey);
+    return (
+      !this.isExcluded(originalTestPath) && this.isIncluded(originalTestPath)
     );
   }
 
+  private hasInlineSourceMap(code: string): boolean {
+    return INLINE_SOURCE_MAP_PATTERN.test(code);
+  }
+
   private async hasInlineSourceMapOnDisk(filePath: string): Promise<boolean> {
-    try {
-      return this.hasInlineSourceMap(await fs.readFile(filePath, 'utf-8'));
-    } catch (_err) {
-      return false;
+    let cached = this.diskInlineSourceMapCache.get(filePath);
+    if (!cached) {
+      cached = fs
+        .readFile(filePath, 'utf-8')
+        .then((code) => this.hasInlineSourceMap(code))
+        .catch(() => false);
+      this.diskInlineSourceMapCache.set(filePath, cached);
     }
+
+    return cached;
   }
 
   private async getTransformedSource(
@@ -218,6 +244,7 @@ export class CoverageProvider implements RstestCoverageProvider {
   ): Promise<{
     code: string;
     sourceMap?: SourceMapLike;
+    sourceMapStr?: string;
   }> {
     const assetSource = this.findInDict(options?.assetFiles, filePath);
     const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
@@ -230,16 +257,33 @@ export class CoverageProvider implements RstestCoverageProvider {
             ...(JSON.parse(sourceMapStr) as Partial<SourceMapLike>),
           } as SourceMapLike)
         : undefined,
+      sourceMapStr,
     };
   }
 
-  private parseAst(code: string, outputModule: boolean) {
-    return Parser.parse(code, {
+  private parseAst(code: string, outputModule: boolean, cacheKey: string) {
+    const cachedAst = parsedAstCache.get(cacheKey);
+    if (cachedAst) {
+      return cachedAst;
+    }
+
+    const ast = Parser.parse(code, {
       ecmaVersion: 'latest',
       locations: true,
       ranges: true,
       sourceType: outputModule ? 'module' : 'script',
     });
+
+    parsedAstCache.set(cacheKey, ast);
+
+    if (parsedAstCache.size > MAX_PARSED_AST_CACHE_SIZE) {
+      const firstKey = parsedAstCache.keys().next().value;
+      if (firstKey) {
+        parsedAstCache.delete(firstKey);
+      }
+    }
+
+    return ast;
   }
 
   private async convertWithAst(
@@ -251,7 +295,7 @@ export class CoverageProvider implements RstestCoverageProvider {
       outputModule?: boolean;
     },
   ): Promise<Record<string, FileCoverageData>> {
-    const { code, sourceMap } = await this.getTransformedSource(
+    const { code, sourceMap, sourceMapStr } = await this.getTransformedSource(
       filePath,
       options,
     );
@@ -260,37 +304,79 @@ export class CoverageProvider implements RstestCoverageProvider {
       return {};
     }
 
-    const ast = this.parseAst(code, options?.outputModule ?? true);
-
-    return (await astV8ToIstanbul({
-      ast,
+    const outputModule = options?.outputModule ?? true;
+    const codeHash = this.hashString(code);
+    const astCacheKey = this.getAstCacheKey(
+      filePath,
       code,
+      codeHash,
+      outputModule,
+    );
+    const converterCacheKey = this.getConverterCacheKey(
+      filePath,
+      code,
+      codeHash,
+      sourceMapStr,
+      outputModule,
+    );
+    const ast = this.parseAst(code, outputModule, astCacheKey);
+
+    return convertV8CoverageWithAst({
+      ast,
+      cacheKey: converterCacheKey,
+      code,
+      sourceFilter: (sourcePath) => this.shouldKeepOriginalSource(sourcePath),
       sourceMap,
       coverage: {
         url: entry.url,
         functions: entry.functions,
       },
-    })) as Record<string, FileCoverageData>;
+    });
+  }
+
+  private getConverterCacheKey(
+    filePath: string,
+    code: string,
+    codeHash: number,
+    sourceMapStr: string | undefined,
+    outputModule: boolean,
+  ): string {
+    return [
+      this.getAstCacheKey(filePath, code, codeHash, outputModule),
+      sourceMapStr?.length ?? 0,
+      sourceMapStr ? this.hashString(sourceMapStr) : 0,
+      this.root ?? '',
+      this.options.allowExternal ? 'external' : 'root-only',
+      this.options.include?.join('\n') ?? '',
+      this.options.exclude.join('\n'),
+    ].join('\0');
+  }
+
+  private getAstCacheKey(
+    filePath: string,
+    code: string,
+    codeHash: number,
+    outputModule: boolean,
+  ): string {
+    return [
+      filePath,
+      outputModule ? 'module' : 'script',
+      code.length,
+      codeHash,
+    ].join('\0');
+  }
+
+  private hashString(value: string): number {
+    let hash = 0;
+    for (let index = 0; index < value.length; index++) {
+      hash = Math.imul(31, hash) + value.charCodeAt(index);
+    }
+    return hash >>> 0;
   }
 
   private filterCoverageData(istanbulData: Record<string, FileCoverageData>) {
     for (const key of Object.keys(istanbulData)) {
-      const normalizedKey = key.replace(/\\/g, '/');
-
-      // AST remapping can emit original-source entries that differ from the
-      // executed script URL. Re-apply the same internal-file guard here so
-      // remapped dependency files do not leak into the final map.
-      if (this.shouldIgnoreTransformedFile(normalizedKey)) {
-        delete istanbulData[key];
-        continue;
-      }
-
-      const originalTestPath = this.toProjectRelativePath(normalizedKey);
-
-      if (
-        this.isExcluded(originalTestPath) ||
-        !this.isIncluded(originalTestPath)
-      ) {
+      if (!this.shouldKeepOriginalSource(key)) {
         delete istanbulData[key];
         continue;
       }
@@ -315,6 +401,67 @@ export class CoverageProvider implements RstestCoverageProvider {
     return this.collectImpl(options);
   }
 
+  private async takeRawCoverage(): Promise<CoverageEntry[]> {
+    if (!this.session) return [];
+
+    const coverage = await this.session.post('Profiler.takePreciseCoverage');
+    const entries: CoverageEntry[] = [];
+
+    for (const entry of coverage.result) {
+      if (!entry.url.startsWith('file://')) continue;
+
+      const filePath = fileURLToPath(entry.url).replace(/\\/g, '/');
+      if (!this.isMatch(filePath)) continue;
+
+      entries.push({ ...entry, filePath });
+    }
+
+    return entries;
+  }
+
+  private async filterRawCoverageEntries(
+    entries: CoverageEntry[],
+    options?: {
+      assetFiles?: Record<string, string>;
+      sourceMaps?: Record<string, string>;
+    },
+  ): Promise<CoverageEntry[]> {
+    const filtered: CoverageEntry[] = [];
+
+    for (const entry of entries) {
+      if (await this.shouldKeepRawCoverageEntry(entry, options)) {
+        filtered.push(entry);
+      }
+    }
+
+    return filtered;
+  }
+
+  private async shouldKeepRawCoverageEntry(
+    entry: CoverageEntry,
+    options?: {
+      assetFiles?: Record<string, string>;
+      sourceMaps?: Record<string, string>;
+    },
+  ): Promise<boolean> {
+    const { filePath } = entry;
+    const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
+    const assetSource = this.findInDict(options?.assetFiles, filePath);
+
+    if (sourceMapStr || (assetSource && this.hasInlineSourceMap(assetSource))) {
+      return true;
+    }
+
+    if (
+      this.shouldProcessEntry(filePath) &&
+      this.shouldKeepOriginalSource(filePath)
+    ) {
+      return true;
+    }
+
+    return assetSource === undefined && this.hasInlineSourceMapOnDisk(filePath);
+  }
+
   private async collectImpl(options?: {
     assetFiles?: Record<string, string>;
     sourceMaps?: Record<string, string>;
@@ -322,9 +469,9 @@ export class CoverageProvider implements RstestCoverageProvider {
   }): Promise<CoverageMap | null> {
     if (!this.session) return null;
 
-    let coverage: inspector.Profiler.TakePreciseCoverageReturnType;
+    let entries: CoverageEntry[];
     try {
-      coverage = await this.session.post('Profiler.takePreciseCoverage');
+      entries = await this.takeRawCoverage();
     } finally {
       try {
         await this.session.post('Profiler.stopPreciseCoverage');
@@ -334,41 +481,17 @@ export class CoverageProvider implements RstestCoverageProvider {
       }
     }
 
+    const filteredEntries = await this.filterRawCoverageEntries(
+      entries,
+      options,
+    );
     const coverageMap = this.createCoverageMap();
 
     await Promise.all(
-      coverage.result.map(async (entry) => {
-        if (!entry.url.startsWith('file://')) return;
-
-        const filePath = fileURLToPath(entry.url).replace(/\\/g, '/');
-
-        if (!this.isMatch(filePath)) return;
-
-        const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
-        const assetSource = this.findInDict(options?.assetFiles, filePath);
-        let hasSourceMap = Boolean(
-          sourceMapStr || (assetSource && this.hasInlineSourceMap(assetSource)),
-        );
-
-        if (!this.shouldProcessEntry(filePath) && !hasSourceMap) {
-          hasSourceMap = await this.hasInlineSourceMapOnDisk(filePath);
-          if (!hasSourceMap) return;
-        }
-
-        if (!hasSourceMap) {
-          const originalTestPath = this.toProjectRelativePath(filePath);
-          if (
-            this.isExcluded(originalTestPath) ||
-            !this.isIncluded(originalTestPath)
-          ) {
-            hasSourceMap = await this.hasInlineSourceMapOnDisk(filePath);
-            if (!hasSourceMap) return;
-          }
-        }
-
+      filteredEntries.map(async (entry) => {
         try {
           const istanbulData = await this.convertWithAst(
-            filePath,
+            entry.filePath,
             entry,
             options,
           );
@@ -495,14 +618,6 @@ export class CoverageProvider implements RstestCoverageProvider {
     return reporterName;
   }
 
-  private toImportSpecifier(reporterName: string): string {
-    if (isAbsolute(reporterName)) {
-      return pathToFileURL(reporterName).toString();
-    }
-
-    return reporterName;
-  }
-
   private isRequireEsmError(error: unknown): boolean {
     if (typeof error !== 'object' || error === null || !('code' in error)) {
       return false;
@@ -511,6 +626,13 @@ export class CoverageProvider implements RstestCoverageProvider {
     return error.code === 'ERR_REQUIRE_ESM';
   }
 
+  private toImportSpecifier(reporterName: string): string {
+    if (isAbsolute(reporterName)) {
+      return pathToFileURL(reporterName).toString();
+    }
+
+    return reporterName;
+  }
   cleanup(): void {
     this.session?.disconnect();
     this.session = null;

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -268,6 +268,7 @@ export class CoverageProvider implements RstestCoverageProvider {
   ): Promise<{
     sourceMap?: SourceMapLike;
     sourceMapStr?: string;
+    sourceMapUrl?: string;
   }> {
     const sourceMapUrl = this.getSourceMapUrl(code);
     if (!sourceMapUrl || this.isInlineSourceMapUrl(sourceMapUrl)) {
@@ -275,10 +276,8 @@ export class CoverageProvider implements RstestCoverageProvider {
     }
 
     try {
-      const sourceMapStr = await fs.readFile(
-        resolve(dirname(filePath), sourceMapUrl),
-        'utf-8',
-      );
+      const resolvedSourceMapUrl = resolve(dirname(filePath), sourceMapUrl);
+      const sourceMapStr = await fs.readFile(resolvedSourceMapUrl, 'utf-8');
 
       return {
         sourceMap: {
@@ -286,6 +285,7 @@ export class CoverageProvider implements RstestCoverageProvider {
           ...(JSON.parse(sourceMapStr) as Partial<SourceMapLike>),
         } as SourceMapLike,
         sourceMapStr,
+        sourceMapUrl: resolvedSourceMapUrl,
       };
     } catch {
       return {};
@@ -315,6 +315,7 @@ export class CoverageProvider implements RstestCoverageProvider {
     code: string;
     sourceMap?: SourceMapLike;
     sourceMapStr?: string;
+    sourceMapUrl?: string;
   }> {
     const assetSource = this.findInDict(options?.assetFiles, filePath);
     const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
@@ -371,10 +372,8 @@ export class CoverageProvider implements RstestCoverageProvider {
       outputModule?: boolean;
     },
   ): Promise<Record<string, FileCoverageData>> {
-    const { code, sourceMap, sourceMapStr } = await this.getTransformedSource(
-      filePath,
-      options,
-    );
+    const { code, sourceMap, sourceMapStr, sourceMapUrl } =
+      await this.getTransformedSource(filePath, options);
 
     if (this.shouldSkipSourceMapEntry(sourceMap)) {
       return {};
@@ -403,6 +402,7 @@ export class CoverageProvider implements RstestCoverageProvider {
       code,
       sourceFilter: (sourcePath) => this.shouldKeepOriginalSource(sourcePath),
       sourceMap,
+      sourceMapUrl,
       coverage: {
         url: entry.url,
         functions: entry.functions,

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -31,7 +31,11 @@ type CoverageReporterConstructor = new (
 ) => ReportBase;
 
 const MAX_PARSED_AST_CACHE_SIZE = 50;
-const SOURCE_MAP_URL_PATTERN = /[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/m;
+const SOURCE_MAP_INNER_PATTERN =
+  /\s*[#@]\s*sourceMappingURL\s*=\s*([^\s'"]*)\s*/;
+const SOURCE_MAP_URL_PATTERN = new RegExp(
+  `(?:/\\*(?:\\s*\\r?\\n(?://)?)?${SOURCE_MAP_INNER_PATTERN.source}\\s*\\*/|//${SOURCE_MAP_INNER_PATTERN.source})\\s*`,
+);
 const parsedAstCache = new Map<string, ReturnType<typeof Parser.parse>>();
 
 type CoverageEntry = inspector.Profiler.ScriptCoverage & {
@@ -232,7 +236,26 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   private getSourceMapUrl(code: string): string | undefined {
-    return code.match(SOURCE_MAP_URL_PATTERN)?.[1];
+    let searchIndex = code.lastIndexOf('sourceMappingURL');
+
+    while (searchIndex !== -1) {
+      const lineStart = code.lastIndexOf('\n', searchIndex);
+      const lineEnd = code.indexOf('\n', searchIndex);
+      const line = code.slice(
+        lineStart + 1,
+        lineEnd === -1 ? code.length : lineEnd,
+      );
+      const match = line.match(SOURCE_MAP_URL_PATTERN);
+
+      if (match) {
+        const sourceMapUrl = match[1] || match[2] || '';
+        return sourceMapUrl ? decodeURI(sourceMapUrl) : undefined;
+      }
+
+      searchIndex = code.lastIndexOf('sourceMappingURL', lineStart - 1);
+    }
+
+    return undefined;
   }
 
   private isInlineSourceMapUrl(url: string): boolean {

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -47,7 +47,9 @@ import type { FileCoverageData } from 'istanbul-lib-coverage';
 import jsTokens from 'js-tokens';
 import { walk } from 'estree-walker';
 
-type SourceMapLike = Omit<EncodedSourceMap, 'version'> & { version: number };
+type SourceMapLike = Omit<EncodedSourceMap | DecodedSourceMap, 'version'> & {
+  version: number;
+};
 type AstNode = {
   type: string;
   start: number;
@@ -347,7 +349,7 @@ async function prepareCoverage(
 
           if (hint === 'else' && alternate) {
             setSkipped(alternate);
-          } else if (hint !== 'if' && hint !== 'else') {
+          } else {
             branches.push(alternate);
           }
 
@@ -600,9 +602,11 @@ class CoverageBuilder {
       }
 
       const location = this.locator.getLoc(branch);
-      if (location !== null) {
-        locations.push(location);
+      if (location === null) {
+        continue;
       }
+
+      locations.push(location);
 
       const bias = branch.type === 'BlockStatement' ? 1 : 0;
       ranges.push({
@@ -815,7 +819,7 @@ function applyCoverage(
   }
 
   for (const descriptor of prepared.statements) {
-    data[descriptor.filename]!.s[descriptor.index] = getCount(
+    data[descriptor.filename]!.s[descriptor.index]! += getCount(
       descriptor,
       ranges,
     );
@@ -892,7 +896,7 @@ function normalizeWithCoverageArray(
   const hits = new Uint32Array(maxEnd + 1);
 
   for (const range of ranges) {
-    hits.fill(range.count, range.start, range.end + 1);
+    hits.fill(range.count, range.start, range.end);
   }
 
   const normalized: NormalizedRange[] = [];
@@ -930,7 +934,7 @@ function normalizeWithCoverageEvents(ranges: RawCoverageRange[]) {
 
   for (const range of ranges) {
     events.push({ offset: range.start, range, type: 'add' });
-    events.push({ offset: range.end + 1, range, type: 'remove' });
+    events.push({ offset: range.end, range, type: 'remove' });
   }
 
   events.sort((a, b) => a.offset - b.offset);

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -896,12 +896,11 @@ function normalizeWithCoverageArray(
   const normalized: NormalizedRange[] = [];
   let start = 0;
 
-  for (let end = 1; end <= hits.length; end++) {
-    const isLast = end === hits.length;
-    const current = isLast ? null : hits[end];
+  for (let end = 1; end < hits.length; end++) {
+    const current = hits[end];
     const previous = hits[start];
 
-    if (current !== previous || isLast) {
+    if (current !== previous) {
       normalized.push({
         start,
         end: end - 1,
@@ -910,6 +909,12 @@ function normalizeWithCoverageArray(
       start = end;
     }
   }
+
+  normalized.push({
+    start,
+    end: hits.length - 1,
+    count: hits[start] ?? 0,
+  });
 
   return normalized;
 }

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -29,7 +29,7 @@
 import fs from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   allGeneratedPositionsFor,
   LEAST_UPPER_BOUND,
@@ -169,7 +169,7 @@ async function prepareCoverage(
     sourceMapResult?.sourceMap || createEmptySourceMap(filename, options.code);
   const sourceMap = new TraceMap(
     mapInput as SourceMapInput,
-    sourceMapResult?.sourceMapUrl,
+    normalizeSourceMapUrl(sourceMapResult?.sourceMapUrl),
   );
   const locator = new Locator(sourceMap, options.code);
   const builder = new CoverageBuilder(
@@ -1254,6 +1254,18 @@ function resolveSourceFilename(source: string, directory: string) {
   }
 
   return resolve(directory, source);
+}
+
+function normalizeSourceMapUrl(sourceMapUrl: string | undefined) {
+  if (
+    !sourceMapUrl ||
+    (URL_SCHEME_PATTERN.test(sourceMapUrl) &&
+      !WINDOWS_ABSOLUTE_PATH_PATTERN.test(sourceMapUrl))
+  ) {
+    return sourceMapUrl;
+  }
+
+  return pathToFileURL(sourceMapUrl).href;
 }
 
 function getFunctionName(node: AstNode): string | undefined {

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -1,0 +1,1224 @@
+/*
+ * Portions of this file are derived from ast-v8-to-istanbul.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2026 Ari Perkkio
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import fs from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  allGeneratedPositionsFor,
+  LEAST_UPPER_BOUND,
+  originalPositionFor,
+  sourceContentFor,
+  TraceMap,
+  type DecodedSourceMap,
+  type EncodedSourceMap,
+  type Needle,
+  type SourceMapInput,
+  type SourceMapSegment,
+} from '@jridgewell/trace-mapping';
+import type { Profiler } from 'node:inspector';
+import type { FileCoverageData } from 'istanbul-lib-coverage';
+import jsTokens from 'js-tokens';
+import { walk } from 'estree-walker';
+
+type SourceMapLike = Omit<EncodedSourceMap, 'version'> & { version: number };
+type AstNode = {
+  type: string;
+  start: number;
+  end: number;
+  [key: string]: unknown;
+};
+
+type BranchType = 'if' | 'binary-expr' | 'cond-expr' | 'switch' | 'default-arg';
+type Position = Needle & { filename: string | null };
+type MappedLocation = { start: Position; end: Position };
+type IstanbulLocation = {
+  start: { line: number; column: number };
+  end: { line: number; column: number };
+};
+type PartialLocation = {
+  start: Partial<Needle>;
+  end: Partial<Needle>;
+};
+type IgnoreHint = {
+  type: 'if' | 'else' | 'next' | 'file';
+  loc: { start: number; end: number };
+};
+type NormalizedRange = { start: number; end: number; count: number };
+type RawCoverageRange = NormalizedRange & { area: number; order: number };
+type FileTemplate = Omit<FileCoverageData, 's' | 'f' | 'b'> & {
+  statementCount: number;
+  functionCount: number;
+  branchLengths: Record<string, number>;
+  seen: Record<string, number>;
+  fnNames: Map<string, number>;
+};
+type FunctionDescriptor = {
+  filename: string;
+  index: number;
+  startOffset: number;
+  endOffset: number;
+};
+type StatementDescriptor = FunctionDescriptor;
+type BranchRangeDescriptor = {
+  startOffset: number;
+  endOffset: number;
+  implicit?: boolean;
+};
+type BranchDescriptor = {
+  filename: string;
+  index: number;
+  ranges: BranchRangeDescriptor[];
+};
+type PreparedCoverage = {
+  files: Record<string, FileTemplate>;
+  functions: FunctionDescriptor[];
+  statements: StatementDescriptor[];
+  branches: BranchDescriptor[];
+};
+
+type ConvertOptions = {
+  ast: unknown;
+  cacheKey: string;
+  code: string;
+  coverage: Pick<Profiler.ScriptCoverage, 'functions' | 'url'>;
+  sourceMap?: SourceMapLike;
+  sourceFilter?: (filePath: string) => boolean;
+};
+
+const WORD_PATTERN = /(\w+|\s|[^\w\s])/g;
+const INLINE_MAP_PATTERN = /[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/m;
+const BASE_64_SOURCE_MAP_PATTERN =
+  /^data:application\/json(?:;[^,]*)?;base64,/i;
+const IGNORE_PATTERN =
+  /^\s*(?:istanbul|[cv]8|node:coverage)\s+ignore\s+(if|else|next|file)(?=\W|$)/;
+const IGNORE_LINES_PATTERN =
+  /\s*(?:istanbul|[cv]8|node:coverage)\s+ignore\s+(start|stop)(?=\W|$)/;
+const EOL_PATTERN = /\r?\n/g;
+const MAX_PREPARED_CACHE_SIZE = 50;
+
+const preparedCache = new Map<string, Promise<PreparedCoverage>>();
+
+export async function convertV8CoverageWithAst(
+  options: ConvertOptions,
+): Promise<Record<string, FileCoverageData>> {
+  const ignoreHints = getIgnoreHints(options.code);
+
+  if (ignoreHints.length === 1 && ignoreHints[0]?.type === 'file') {
+    return {};
+  }
+
+  let prepared = preparedCache.get(options.cacheKey);
+  if (!prepared) {
+    prepared = prepareCoverage(options, ignoreHints);
+    preparedCache.set(options.cacheKey, prepared);
+
+    if (preparedCache.size > MAX_PREPARED_CACHE_SIZE) {
+      const firstKey = preparedCache.keys().next().value;
+      if (firstKey) {
+        preparedCache.delete(firstKey);
+      }
+    }
+  }
+
+  return applyCoverage(await prepared, normalize(options.coverage));
+}
+
+async function prepareCoverage(
+  options: ConvertOptions,
+  ignoreHints: IgnoreHint[],
+): Promise<PreparedCoverage> {
+  const filename = fileURLToPath(options.coverage.url);
+  const directory = dirname(filename);
+  const mapInput =
+    options.sourceMap ||
+    (await getInlineSourceMap(filename, options.code)) ||
+    createEmptySourceMap(filename, options.code);
+  const sourceMap = new TraceMap(mapInput as SourceMapInput);
+  const locator = new Locator(sourceMap, options.code);
+  const builder = new CoverageBuilder(
+    filename,
+    sourceMap,
+    locator,
+    directory,
+    options.sourceFilter,
+  );
+  const skippedNodes = new WeakSet<AstNode>();
+  const coveredNodes = new WeakSet<AstNode>();
+  let nextIgnore: AstNode | false = false;
+
+  const getIgnoreHint = (node: AstNode) => {
+    for (const hint of ignoreHints) {
+      if (hint.loc.end === node.start) {
+        return hint.type;
+      }
+    }
+
+    return null;
+  };
+
+  const setSkipped = (node: AstNode | null | undefined) => {
+    if (node) {
+      skippedNodes.add(node);
+    }
+  };
+
+  const isSkipped = (node: AstNode | null | undefined) =>
+    Boolean(node && skippedNodes.has(node));
+
+  walk(options.ast as Parameters<typeof walk>[0], {
+    enter(node) {
+      const current = node as AstNode;
+      if (nextIgnore !== false) {
+        return;
+      }
+
+      const hint = getIgnoreHint(current);
+
+      if (hint === 'next') {
+        nextIgnore = current;
+        return;
+      }
+
+      if (isSkipped(current)) {
+        nextIgnore = current;
+        return;
+      }
+
+      switch (current.type) {
+        case 'FunctionDeclaration': {
+          const body = current.body as AstNode;
+          builder.addFunction(current, {
+            loc: body,
+            decl: (current.id as AstNode | null) || {
+              ...current,
+              end: current.start + 1,
+            },
+          });
+          return;
+        }
+        case 'FunctionExpression': {
+          if (coveredNodes.has(current)) {
+            return;
+          }
+
+          const body = current.body as AstNode;
+          builder.addFunction(current, {
+            loc: body,
+            decl: (current.id as AstNode | null) || {
+              ...current,
+              end: current.start + 1,
+            },
+          });
+          return;
+        }
+        case 'MethodDefinition': {
+          const value = current.value as AstNode;
+          if (value.type === 'FunctionExpression') {
+            coveredNodes.add(value);
+          }
+
+          builder.addFunction(current, {
+            loc: value.body as AstNode,
+            decl: current.key as AstNode,
+          });
+          return;
+        }
+        case 'Property': {
+          const value = current.value as AstNode;
+          if (value.type === 'FunctionExpression') {
+            coveredNodes.add(value);
+            builder.addFunction(current, {
+              loc: value.body as AstNode,
+              decl: current.key as AstNode,
+            });
+          }
+          return;
+        }
+        case 'ArrowFunctionExpression': {
+          let body = current.body as AstNode;
+          if (body.type === 'ParenthesizedExpression') {
+            body = body.expression as AstNode;
+            current.body = body;
+          }
+
+          builder.addFunction(current, {
+            loc: body,
+            decl: { ...current, end: current.start + 1 },
+          });
+
+          if (body.type !== 'BlockStatement') {
+            builder.addStatement(body, current);
+          }
+          return;
+        }
+        case 'ExpressionStatement': {
+          const expression = current.expression as AstNode & {
+            value?: unknown;
+          };
+          if (
+            expression.type !== 'Literal' ||
+            expression.value !== 'use strict'
+          ) {
+            builder.addStatement(current);
+          }
+          return;
+        }
+        case 'BreakStatement':
+        case 'ContinueStatement':
+        case 'DebuggerStatement':
+        case 'ReturnStatement':
+        case 'ThrowStatement':
+        case 'TryStatement':
+        case 'ForStatement':
+        case 'ForInStatement':
+        case 'ForOfStatement':
+        case 'WhileStatement':
+        case 'DoWhileStatement':
+        case 'WithStatement':
+        case 'LabeledStatement': {
+          builder.addStatement(current);
+          return;
+        }
+        case 'VariableDeclarator': {
+          if (current.init) {
+            builder.addStatement(current.init as AstNode, current);
+          }
+          return;
+        }
+        case 'ClassBody': {
+          const children = current.body as AstNode[];
+          for (const child of children) {
+            if (
+              (child.type === 'PropertyDefinition' ||
+                child.type === 'ClassProperty' ||
+                child.type === 'ClassPrivateProperty') &&
+              child.value
+            ) {
+              builder.addStatement(child.value as AstNode);
+            }
+          }
+          return;
+        }
+        case 'IfStatement': {
+          const branches: (AstNode | null | undefined)[] = [];
+          const consequent = toBlockStatement(current.consequent as AstNode);
+          current.consequent = consequent;
+          const alternate = current.alternate
+            ? toBlockStatement(current.alternate as AstNode)
+            : null;
+          current.alternate = alternate;
+
+          if (hint === 'if') {
+            setSkipped(consequent);
+          } else {
+            branches.push(consequent);
+          }
+
+          if (hint === 'else' && alternate) {
+            setSkipped(alternate);
+          } else if (hint !== 'if' && hint !== 'else') {
+            branches.push(alternate);
+          }
+
+          builder.addBranch('if', current, branches);
+          builder.addStatement(current);
+          return;
+        }
+        case 'SwitchStatement': {
+          const cases = (current.cases as AstNode[]).filter(
+            (switchCase) => getIgnoreHint(switchCase) !== 'next',
+          );
+          builder.addBranch('switch', current, cases);
+          builder.addStatement(current);
+          return;
+        }
+        case 'ConditionalExpression': {
+          let consequent = current.consequent as AstNode;
+          let alternate = current.alternate as AstNode;
+          const branches: AstNode[] = [];
+
+          if (consequent.type === 'ParenthesizedExpression') {
+            consequent = consequent.expression as AstNode;
+            current.consequent = consequent;
+          }
+          if (alternate.type === 'ParenthesizedExpression') {
+            alternate = alternate.expression as AstNode;
+            current.alternate = alternate;
+          }
+
+          if (getIgnoreHint(consequent) === 'next') {
+            setSkipped(consequent);
+          } else {
+            branches.push(consequent);
+          }
+
+          if (getIgnoreHint(alternate) === 'next') {
+            setSkipped(alternate);
+          } else {
+            branches.push(alternate);
+          }
+
+          builder.addBranch('cond-expr', current, branches);
+          return;
+        }
+        case 'LogicalExpression': {
+          if (isSkipped(current)) {
+            return;
+          }
+
+          const branches: AstNode[] = [];
+          const visit = (child: AstNode) => {
+            if (child.type === 'LogicalExpression') {
+              setSkipped(child);
+
+              if (getIgnoreHint(child) !== 'next') {
+                visit(child.left as AstNode);
+                visit(child.right as AstNode);
+                return;
+              }
+            }
+            branches.push(child);
+          };
+
+          visit(current);
+          builder.addBranch('binary-expr', current, branches);
+          return;
+        }
+        case 'AssignmentPattern': {
+          builder.addBranch('default-arg', current, [current.right as AstNode]);
+          return;
+        }
+      }
+    },
+    leave(node) {
+      if (node === nextIgnore) {
+        nextIgnore = false;
+      }
+    },
+  });
+
+  return builder.toPreparedCoverage();
+}
+
+function toBlockStatement(node: AstNode): AstNode {
+  if (node.type === 'BlockStatement') {
+    return node;
+  }
+
+  return {
+    type: 'BlockStatement',
+    body: [node],
+    start: node.start,
+    end: node.end,
+  };
+}
+
+class CoverageBuilder {
+  private files: Record<string, FileTemplate> = {};
+  private functions: FunctionDescriptor[] = [];
+  private statements: StatementDescriptor[] = [];
+  private branches: BranchDescriptor[] = [];
+
+  constructor(
+    filename: string,
+    sourceMap: TraceMap,
+    private locator: Locator,
+    private directory: string,
+    sourceFilter?: (filePath: string) => boolean,
+  ) {
+    const generatedDirectory = dirname(filename);
+
+    for (const source of sourceMap.resolvedSources) {
+      let filePath = filename;
+
+      if (source) {
+        filePath = source.startsWith('file://')
+          ? fileURLToPath(source)
+          : resolve(generatedDirectory, source);
+      }
+
+      if (sourceFilter && !sourceFilter(filePath)) {
+        continue;
+      }
+
+      this.files[filePath] = {
+        path: filePath,
+        statementMap: {},
+        fnMap: {},
+        branchMap: {},
+        statementCount: 0,
+        functionCount: 0,
+        branchLengths: {},
+        seen: {},
+        fnNames: new Map(),
+      };
+    }
+  }
+
+  addFunction(
+    node: AstNode,
+    positions: {
+      loc: Pick<AstNode, 'start' | 'end'>;
+      decl: Pick<AstNode, 'start' | 'end'>;
+    },
+  ) {
+    const loc = this.locator.getLoc(positions.loc);
+    if (loc === null) return;
+
+    const decl = this.locator.getLoc(positions.decl);
+    if (decl === null) return;
+
+    const filename = this.getSourceFilename(loc);
+    const fileCoverage = this.files[filename];
+    if (!fileCoverage) return;
+
+    const key = `f:${cacheKey(decl)}`;
+    let index = fileCoverage.seen[key];
+
+    if (index == null) {
+      index = fileCoverage.functionCount++;
+      fileCoverage.seen[key] = index;
+
+      let name = getFunctionName(node);
+      if (name) {
+        const base = name;
+        let count = (fileCoverage.fnNames.get(base) || 0) + 1;
+        name = count > 1 ? `${base}_${count}` : base;
+
+        while (fileCoverage.fnNames.has(name)) {
+          count++;
+          name = `${base}_${count}`;
+        }
+
+        fileCoverage.fnNames.set(base, count);
+
+        if (name !== base) {
+          fileCoverage.fnNames.set(name, 0);
+        }
+      }
+
+      fileCoverage.fnMap[index] = {
+        name: name || `(anonymous_${index})`,
+        decl: pickLocation(decl),
+        loc: pickLocation(loc),
+        line: loc.start.line,
+      };
+    }
+
+    this.functions.push({
+      filename,
+      index,
+      startOffset: node.start,
+      endOffset: node.end,
+    });
+  }
+
+  addStatement(node: AstNode, parent?: AstNode) {
+    const loc = this.locator.getLoc(node);
+    if (loc === null) return;
+
+    const filename = this.getSourceFilename(loc);
+    const fileCoverage = this.files[filename];
+    if (!fileCoverage) return;
+
+    const key = `s:${cacheKey(loc)}`;
+    let index = fileCoverage.seen[key];
+
+    if (index == null) {
+      index = fileCoverage.statementCount++;
+      fileCoverage.seen[key] = index;
+      fileCoverage.statementMap[index] = pickLocation(loc);
+    }
+
+    const coverageNode = parent || node;
+    this.statements.push({
+      filename,
+      index,
+      startOffset: coverageNode.start,
+      endOffset: coverageNode.end,
+    });
+  }
+
+  addBranch(
+    type: BranchType,
+    node: AstNode,
+    branches: (AstNode | null | undefined)[],
+  ) {
+    const loc = this.locator.getLoc(node);
+    if (loc === null) return;
+
+    const filename = this.getSourceFilename(loc);
+    const fileCoverage = this.files[filename];
+    if (!fileCoverage) return;
+
+    const locations: PartialLocation[] = [];
+    const ranges: BranchRangeDescriptor[] = [];
+
+    for (const branch of branches) {
+      if (!branch) {
+        locations.push({
+          start: { line: undefined, column: undefined },
+          end: { line: undefined, column: undefined },
+        });
+        ranges.push({
+          startOffset: node.start,
+          endOffset: node.end,
+          implicit: true,
+        });
+        continue;
+      }
+
+      const location = this.locator.getLoc(branch);
+      if (location !== null) {
+        locations.push(location);
+      }
+
+      const bias = branch.type === 'BlockStatement' ? 1 : 0;
+      ranges.push({
+        startOffset: branch.start + bias,
+        endOffset: branch.end - bias,
+      });
+    }
+
+    if (type === 'if' && locations.length > 0) {
+      locations[0] = loc;
+    }
+
+    if (locations.length === 0) {
+      return;
+    }
+
+    const key = ['b', ...locations.map(cacheKey)].join(':');
+    let index = fileCoverage.seen[key];
+
+    if (index == null) {
+      index = Object.keys(fileCoverage.branchMap).length;
+      fileCoverage.seen[key] = index;
+      fileCoverage.branchMap[index] = {
+        loc: pickLocation(loc),
+        type,
+        locations: locations.map((location) => pickLocation(location)),
+        line: loc.start.line,
+      };
+      fileCoverage.branchLengths[index] = locations.length;
+    }
+
+    this.branches.push({ filename, index, ranges });
+  }
+
+  toPreparedCoverage(): PreparedCoverage {
+    return {
+      files: this.files,
+      functions: this.functions,
+      statements: this.statements,
+      branches: this.branches,
+    };
+  }
+
+  private getSourceFilename(position: MappedLocation) {
+    const sourceFilename = position.start.filename || position.end.filename;
+
+    if (!sourceFilename) {
+      throw new Error(
+        `Missing original filename for ${JSON.stringify(position)}`,
+      );
+    }
+
+    if (sourceFilename.startsWith('file://')) {
+      return fileURLToPath(sourceFilename);
+    }
+
+    return resolve(this.directory, sourceFilename);
+  }
+}
+
+class Locator {
+  private cache = new Map<number, Needle>();
+  private ignoredLines = new Map<string, Set<number>>();
+  private lineStarts: number[] = [0];
+
+  constructor(
+    private sourceMap: TraceMap,
+    code: string,
+  ) {
+    for (let index = 0; index < code.length; index++) {
+      if (code.charCodeAt(index) === 10) {
+        this.lineStarts.push(index + 1);
+      }
+    }
+  }
+
+  offsetToNeedle(offset: number): Needle {
+    const cached = this.cache.get(offset);
+    if (cached) {
+      return { ...cached };
+    }
+
+    let low = 0;
+    let high = this.lineStarts.length - 1;
+
+    while (low <= high) {
+      const mid = (low + high) >> 1;
+      const lineStart = this.lineStarts[mid]!;
+
+      if (lineStart <= offset) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    const lineIndex = Math.max(0, high);
+    const needle = {
+      line: lineIndex + 1,
+      column: offset - this.lineStarts[lineIndex]!,
+    };
+    this.cache.set(offset, needle);
+    return { ...needle };
+  }
+
+  getLoc(node: Pick<AstNode, 'start' | 'end'>): MappedLocation | null {
+    const startNeedle = this.offsetToNeedle(node.start);
+    const start = getPosition(startNeedle, this.sourceMap);
+
+    if (start === null) {
+      return null;
+    }
+
+    const endNeedle = this.offsetToNeedle(node.end);
+    endNeedle.column -= 1;
+
+    let end = getPosition(endNeedle, this.sourceMap);
+
+    if (end === null) {
+      for (
+        let line = endNeedle.line;
+        line >= startNeedle.line && end === null;
+        line--
+      ) {
+        end = getPosition({ line, column: Infinity }, this.sourceMap);
+      }
+
+      if (end === null) return null;
+    }
+
+    const loc = { start, end };
+
+    if (!loc.end.filename) {
+      return null;
+    }
+
+    const afterEndMappings = allGeneratedPositionsFor(this.sourceMap, {
+      source: loc.end.filename,
+      line: loc.end.line,
+      column: loc.end.column + 1,
+      bias: LEAST_UPPER_BOUND,
+    });
+
+    if (afterEndMappings.length === 0) {
+      loc.end.column = Infinity;
+    } else {
+      for (const mapping of afterEndMappings) {
+        if (mapping.line === null) continue;
+
+        const original = originalPositionFor(this.sourceMap, mapping);
+        if (original.line === loc.end.line) {
+          loc.end = { ...original, filename: original.source };
+          break;
+        }
+      }
+    }
+
+    const filename = loc.start.filename;
+    if (!filename) {
+      return null;
+    }
+
+    let ignoredLines = this.ignoredLines.get(filename);
+
+    if (!ignoredLines) {
+      const sources = sourceContentFor(this.sourceMap, filename);
+      ignoredLines = getIgnoredLines(sources ?? tryReadFileSync(filename));
+      this.ignoredLines.set(filename, ignoredLines);
+    }
+
+    if (ignoredLines.has(loc.start.line)) {
+      return null;
+    }
+
+    return loc;
+  }
+}
+
+function applyCoverage(
+  prepared: PreparedCoverage,
+  ranges: NormalizedRange[],
+): Record<string, FileCoverageData> {
+  const data: Record<string, FileCoverageData> = {};
+
+  for (const [filename, template] of Object.entries(prepared.files)) {
+    const fileCoverage: FileCoverageData = {
+      path: template.path,
+      statementMap: template.statementMap,
+      fnMap: template.fnMap,
+      branchMap: template.branchMap,
+      s: {},
+      f: {},
+      b: {},
+    };
+
+    for (let index = 0; index < template.statementCount; index++) {
+      fileCoverage.s[index] = 0;
+    }
+    for (let index = 0; index < template.functionCount; index++) {
+      fileCoverage.f[index] = 0;
+    }
+    for (const [index, length] of Object.entries(template.branchLengths)) {
+      fileCoverage.b[index] = Array(length).fill(0);
+    }
+
+    data[filename] = fileCoverage;
+  }
+
+  for (const descriptor of prepared.functions) {
+    data[descriptor.filename]!.f[descriptor.index]! += getCount(
+      descriptor,
+      ranges,
+    );
+  }
+
+  for (const descriptor of prepared.statements) {
+    data[descriptor.filename]!.s[descriptor.index] = getCount(
+      descriptor,
+      ranges,
+    );
+  }
+
+  for (const descriptor of prepared.branches) {
+    const hits = data[descriptor.filename]!.b[descriptor.index]!;
+    const covered: number[] = [];
+
+    for (const range of descriptor.ranges) {
+      const count = getCount(range, ranges);
+      const hit = range.implicit ? count - (covered.at(-1) || 0) : count;
+      covered.push(hit);
+    }
+
+    for (let index = 0; index < hits.length; index++) {
+      hits[index] = hits[index]! + (covered[index] || 0);
+    }
+  }
+
+  return data;
+}
+
+function normalize(scriptCoverage: Pick<Profiler.ScriptCoverage, 'functions'>) {
+  const rawRanges = getSortedRawCoverageRanges(scriptCoverage);
+
+  if (rawRanges.length === 0) {
+    return [];
+  }
+
+  let maxEnd = 0;
+  for (const range of rawRanges) {
+    if (range.end > maxEnd) {
+      maxEnd = range.end;
+    }
+  }
+
+  if (maxEnd <= 2_000_000) {
+    return normalizeWithCoverageArray(rawRanges, maxEnd);
+  }
+
+  return normalizeWithCoverageEvents(rawRanges);
+}
+
+function getSortedRawCoverageRanges(
+  scriptCoverage: Pick<Profiler.ScriptCoverage, 'functions'>,
+) {
+  const ranges: RawCoverageRange[] = [];
+  let order = 0;
+
+  for (const fn of scriptCoverage.functions) {
+    for (const range of fn.ranges) {
+      ranges.push({
+        start: range.startOffset,
+        end: range.endOffset,
+        count: range.count,
+        area: range.endOffset - range.startOffset,
+        order: order++,
+      });
+    }
+  }
+
+  return ranges.sort((a, b) => {
+    const diff = b.area - a.area;
+    if (diff !== 0) return diff;
+    return a.end - b.end;
+  });
+}
+
+function normalizeWithCoverageArray(
+  ranges: RawCoverageRange[],
+  maxEnd: number,
+) {
+  const hits = new Uint32Array(maxEnd + 1);
+
+  for (const range of ranges) {
+    hits.fill(range.count, range.start, range.end + 1);
+  }
+
+  const normalized: NormalizedRange[] = [];
+  let start = 0;
+
+  for (let end = 1; end <= hits.length; end++) {
+    const isLast = end === hits.length;
+    const current = isLast ? null : hits[end];
+    const previous = hits[start];
+
+    if (current !== previous || isLast) {
+      normalized.push({
+        start,
+        end: end - 1,
+        count: previous ?? 0,
+      });
+      start = end;
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeWithCoverageEvents(ranges: RawCoverageRange[]) {
+  const events: {
+    offset: number;
+    range: RawCoverageRange;
+    type: 'add' | 'remove';
+  }[] = [];
+
+  for (const range of ranges) {
+    events.push({ offset: range.start, range, type: 'add' });
+    events.push({ offset: range.end + 1, range, type: 'remove' });
+  }
+
+  events.sort((a, b) => a.offset - b.offset);
+
+  const active: RawCoverageRange[] = [];
+  const normalized: NormalizedRange[] = [];
+  let cursor = events[0]!.offset;
+  let index = 0;
+
+  while (index < events.length) {
+    const offset = events[index]!.offset;
+
+    if (active.length > 0 && cursor < offset) {
+      const winner = getMostSpecificRange(active);
+      const previous = normalized.at(-1);
+
+      if (
+        previous &&
+        previous.end + 1 === cursor &&
+        previous.count === winner.count
+      ) {
+        previous.end = offset - 1;
+      } else {
+        normalized.push({
+          start: cursor,
+          end: offset - 1,
+          count: winner.count,
+        });
+      }
+    }
+
+    while (index < events.length && events[index]!.offset === offset) {
+      const event = events[index]!;
+      if (event.type === 'add') {
+        active.push(event.range);
+      } else {
+        const activeIndex = active.indexOf(event.range);
+        if (activeIndex !== -1) {
+          active.splice(activeIndex, 1);
+        }
+      }
+      index++;
+    }
+
+    cursor = offset;
+  }
+
+  return normalized;
+}
+
+function getMostSpecificRange(ranges: RawCoverageRange[]) {
+  let winner = ranges[0]!;
+
+  for (let index = 1; index < ranges.length; index++) {
+    const range = ranges[index]!;
+    if (
+      range.area < winner.area ||
+      (range.area === winner.area && range.end > winner.end) ||
+      (range.area === winner.area &&
+        range.end === winner.end &&
+        range.order > winner.order)
+    ) {
+      winner = range;
+    }
+  }
+
+  return winner;
+}
+
+function getCount(
+  offset: { startOffset: number; endOffset: number },
+  coverages: NormalizedRange[],
+) {
+  let count = 0;
+  let low = 0;
+  let high = coverages.length - 1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const coverage = coverages[mid]!;
+
+    if (
+      coverage.start <= offset.startOffset &&
+      offset.startOffset <= coverage.end
+    ) {
+      count = coverage.count;
+      low = mid + 1;
+      continue;
+    }
+
+    if (offset.startOffset < coverage.start) {
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return count;
+}
+
+function getPosition(needle: Needle, sourceMap: TraceMap): Position | null {
+  let position = originalPositionFor(sourceMap, needle);
+
+  if (position.source == null) {
+    position = originalPositionFor(sourceMap, {
+      column: needle.column,
+      line: needle.line,
+      bias: LEAST_UPPER_BOUND,
+    });
+  }
+
+  if (position.source == null) {
+    return null;
+  }
+
+  return {
+    line: position.line,
+    column: position.column,
+    filename: position.source,
+  };
+}
+
+function createEmptySourceMap(
+  filename: string,
+  code: string,
+): DecodedSourceMap {
+  const mappings: SourceMapSegment[][] = [];
+
+  for (const [line, content] of code.split('\n').entries()) {
+    const parts = content.match(WORD_PATTERN) || [];
+    const segments: SourceMapSegment[] = [];
+    let column = 0;
+
+    for (const part of parts) {
+      segments.push([column, 0, line, column]);
+      column += part.length;
+    }
+
+    mappings.push(segments);
+  }
+
+  return {
+    version: 3,
+    mappings,
+    file: filename,
+    sources: [filename],
+    sourcesContent: [code],
+    names: [],
+  };
+}
+
+async function getInlineSourceMap(filename: string, code: string) {
+  const matches = code.match(INLINE_MAP_PATTERN);
+  const match = matches?.[1];
+
+  if (!match) return null;
+
+  try {
+    if (BASE_64_SOURCE_MAP_PATTERN.test(match)) {
+      const encoded = match.replace(BASE_64_SOURCE_MAP_PATTERN, '');
+      const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+      return JSON.parse(decoded) as SourceMapLike;
+    }
+
+    const directory = dirname(filename);
+    const content = await fs.readFile(resolve(directory, match), 'utf-8');
+    return JSON.parse(content) as SourceMapLike;
+  } catch {
+    return null;
+  }
+}
+
+function getIgnoreHints(code: string): IgnoreHint[] {
+  const ignoreHints: IgnoreHint[] = [];
+  const tokens = jsTokens(code);
+  let current = 0;
+  let previousTokenWasIgnoreHint = false;
+
+  for (const token of tokens) {
+    if (
+      previousTokenWasIgnoreHint &&
+      token.type !== 'WhiteSpace' &&
+      token.type !== 'LineTerminatorSequence'
+    ) {
+      const previous = ignoreHints.at(-1);
+      if (previous) {
+        previous.loc.end = current;
+      }
+      previousTokenWasIgnoreHint = false;
+    }
+
+    if (
+      token.type === 'SingleLineComment' ||
+      token.type === 'MultiLineComment'
+    ) {
+      const loc = { start: current, end: current + token.value.length };
+      const comment = token.value
+        .replace(/^\/\*\*/, '')
+        .replace(/^\/\*/, '')
+        .replace(/\*\*\/$/, '')
+        .replace(/\*\/$/, '')
+        .replace(/^\/\//, '');
+      const groups = comment.match(IGNORE_PATTERN);
+      const type = groups?.[1];
+
+      if (type === 'file') {
+        return [{ type, loc: { start: 0, end: 0 } }];
+      }
+
+      if (type === 'if' || type === 'else' || type === 'next') {
+        ignoreHints.push({ type, loc });
+        previousTokenWasIgnoreHint = true;
+      }
+    }
+
+    current += token.value.length;
+  }
+
+  return ignoreHints;
+}
+
+function getIgnoredLines(text?: string): Set<number> {
+  if (!text) {
+    return new Set();
+  }
+
+  const ranges: { start: number; stop: number }[] = [];
+  let lineNumber = 0;
+
+  for (const line of text.split(EOL_PATTERN)) {
+    lineNumber++;
+    const match = line.match(IGNORE_LINES_PATTERN);
+
+    if (!match) {
+      continue;
+    }
+
+    const type = match[1];
+
+    if (type === 'stop') {
+      const previous = ranges.at(-1);
+
+      if (previous && previous.stop === Infinity) {
+        previous.stop = lineNumber;
+      }
+
+      continue;
+    }
+
+    ranges.push({ start: lineNumber, stop: Infinity });
+  }
+
+  const ignoredLines = new Set<number>();
+
+  for (const range of ranges) {
+    const stop = Math.min(range.stop, lineNumber);
+    for (let line = range.start; line <= stop; line++) {
+      ignoredLines.add(line);
+    }
+  }
+
+  return ignoredLines;
+}
+
+function tryReadFileSync(filename: string) {
+  try {
+    return readFileSync(filename, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function getFunctionName(node: AstNode): string | undefined {
+  if (node.type === 'Identifier') {
+    return node.name as string;
+  }
+
+  if (node.id) {
+    return getFunctionName(node.id as AstNode);
+  }
+
+  if (node.key) {
+    return getFunctionName(node.key as AstNode);
+  }
+
+  return undefined;
+}
+
+function pickLocation(loc: PartialLocation): IstanbulLocation {
+  return {
+    start: { line: loc.start.line!, column: loc.start.column! },
+    end: { line: loc.end.line!, column: loc.end.column! },
+  };
+}
+
+function cacheKey(loc: PartialLocation) {
+  return `${loc.start.line}:${loc.start.column}:${loc.end.line}:${loc.end.column}`;
+}

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -111,11 +111,12 @@ type ConvertOptions = {
   code: string;
   coverage: Pick<Profiler.ScriptCoverage, 'functions' | 'url'>;
   sourceMap?: SourceMapLike;
+  sourceMapUrl?: string;
   sourceFilter?: (filePath: string) => boolean;
 };
 
 const WORD_PATTERN = /(\w+|\s|[^\w\s])/g;
-const INLINE_MAP_PATTERN = /[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/m;
+const SOURCE_MAP_URL_PATTERN = /[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/gm;
 const DATA_SOURCE_MAP_PATTERN = /^data:application\/json(?:;[^,]*)?,/i;
 const BASE_64_SOURCE_MAP_PATTERN =
   /^data:application\/json(?:;[^,]*)?;base64,/i;
@@ -161,11 +162,15 @@ async function prepareCoverage(
 ): Promise<PreparedCoverage> {
   const filename = fileURLToPath(options.coverage.url);
   const directory = dirname(filename);
+  const sourceMapResult = options.sourceMap
+    ? { sourceMap: options.sourceMap, sourceMapUrl: options.sourceMapUrl }
+    : await getSourceMap(filename, options.code);
   const mapInput =
-    options.sourceMap ||
-    (await getInlineSourceMap(filename, options.code)) ||
-    createEmptySourceMap(filename, options.code);
-  const sourceMap = new TraceMap(mapInput as SourceMapInput);
+    sourceMapResult?.sourceMap || createEmptySourceMap(filename, options.code);
+  const sourceMap = new TraceMap(
+    mapInput as SourceMapInput,
+    sourceMapResult?.sourceMapUrl,
+  );
   const locator = new Locator(sourceMap, options.code);
   const builder = new CoverageBuilder(
     filename,
@@ -599,10 +604,7 @@ class CoverageBuilder {
 
     for (const branch of branches) {
       if (!branch) {
-        locations.push({
-          start: { line: undefined, column: undefined },
-          end: { line: undefined, column: undefined },
-        });
+        locations.push(loc);
         ranges.push({
           startOffset: node.start,
           endOffset: node.end,
@@ -1100,9 +1102,15 @@ function createEmptySourceMap(
   };
 }
 
-async function getInlineSourceMap(filename: string, code: string) {
-  const matches = code.match(INLINE_MAP_PATTERN);
-  const match = matches?.[1];
+async function getSourceMap(
+  filename: string,
+  code: string,
+): Promise<{ sourceMap: SourceMapLike; sourceMapUrl?: string } | null> {
+  let match: string | undefined;
+
+  for (const matches of code.matchAll(SOURCE_MAP_URL_PATTERN)) {
+    match = matches[1];
+  }
 
   if (!match) return null;
 
@@ -1110,17 +1118,20 @@ async function getInlineSourceMap(filename: string, code: string) {
     if (BASE_64_SOURCE_MAP_PATTERN.test(match)) {
       const encoded = match.replace(BASE_64_SOURCE_MAP_PATTERN, '');
       const decoded = Buffer.from(encoded, 'base64').toString('utf8');
-      return JSON.parse(decoded) as SourceMapLike;
+      return { sourceMap: JSON.parse(decoded) as SourceMapLike };
     }
 
     if (DATA_SOURCE_MAP_PATTERN.test(match)) {
       const encoded = match.replace(DATA_SOURCE_MAP_PATTERN, '');
-      return JSON.parse(decodeURIComponent(encoded)) as SourceMapLike;
+      return {
+        sourceMap: JSON.parse(decodeURIComponent(encoded)) as SourceMapLike,
+      };
     }
 
     const directory = dirname(filename);
-    const content = await fs.readFile(resolve(directory, match), 'utf-8');
-    return JSON.parse(content) as SourceMapLike;
+    const sourceMapUrl = resolve(directory, match);
+    const content = await fs.readFile(sourceMapUrl, 'utf-8');
+    return { sourceMap: JSON.parse(content) as SourceMapLike, sourceMapUrl };
   } catch {
     return null;
   }

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -24,6 +24,8 @@
  * SOFTWARE.
  */
 
+// cspell:ignore Perkkio
+
 import fs from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -347,9 +347,11 @@ async function prepareCoverage(
             branches.push(consequent);
           }
 
-          if (hint === 'else' && alternate) {
-            setSkipped(alternate);
-          } else {
+          if (hint === 'else') {
+            if (alternate) {
+              setSkipped(alternate);
+            }
+          } else if (alternate || hint !== 'if') {
             branches.push(alternate);
           }
 

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -183,6 +183,14 @@ async function prepareCoverage(
       if (hint.loc.end === node.start) {
         return hint.type;
       }
+
+      if (
+        hint.type === 'next' &&
+        hint.loc.end < node.start &&
+        isTernarySeparatorOnly(options.code.slice(hint.loc.end, node.start))
+      ) {
+        return hint.type;
+      }
     }
 
     return null;
@@ -1116,6 +1124,10 @@ async function getInlineSourceMap(filename: string, code: string) {
   } catch {
     return null;
   }
+}
+
+function isTernarySeparatorOnly(code: string): boolean {
+  return /^[?:\s]*$/.test(code);
 }
 
 function getIgnoreHints(code: string): IgnoreHint[] {

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -114,8 +114,11 @@ type ConvertOptions = {
 
 const WORD_PATTERN = /(\w+|\s|[^\w\s])/g;
 const INLINE_MAP_PATTERN = /[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/m;
+const DATA_SOURCE_MAP_PATTERN = /^data:application\/json(?:;[^,]*)?,/i;
 const BASE_64_SOURCE_MAP_PATTERN =
   /^data:application\/json(?:;[^,]*)?;base64,/i;
+const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[a-zA-Z]:[\\/]/;
 const IGNORE_PATTERN =
   /^\s*(?:istanbul|[cv]8|node:coverage)\s+ignore\s+(if|else|next|file)(?=\W|$)/;
 const IGNORE_LINES_PATTERN =
@@ -257,6 +260,7 @@ async function prepareCoverage(
             builder.addFunction(current, {
               loc: value.body as AstNode,
               decl: current.key as AstNode,
+              coverage: value,
             });
           }
           return;
@@ -459,9 +463,7 @@ class CoverageBuilder {
       let filePath = filename;
 
       if (source) {
-        filePath = source.startsWith('file://')
-          ? fileURLToPath(source)
-          : resolve(generatedDirectory, source);
+        filePath = resolveSourceFilename(source, generatedDirectory);
       }
 
       if (sourceFilter && !sourceFilter(filePath)) {
@@ -487,6 +489,7 @@ class CoverageBuilder {
     positions: {
       loc: Pick<AstNode, 'start' | 'end'>;
       decl: Pick<AstNode, 'start' | 'end'>;
+      coverage?: Pick<AstNode, 'start' | 'end'>;
     },
   ) {
     const loc = this.locator.getLoc(positions.loc);
@@ -532,11 +535,12 @@ class CoverageBuilder {
       };
     }
 
+    const coverage = positions.coverage || node;
     this.functions.push({
       filename,
       index,
-      startOffset: node.start,
-      endOffset: node.end,
+      startOffset: coverage.start,
+      endOffset: coverage.end,
     });
   }
 
@@ -651,11 +655,7 @@ class CoverageBuilder {
       );
     }
 
-    if (sourceFilename.startsWith('file://')) {
-      return fileURLToPath(sourceFilename);
-    }
-
-    return resolve(this.directory, sourceFilename);
+    return resolveSourceFilename(sourceFilename, this.directory);
   }
 }
 
@@ -715,7 +715,7 @@ class Locator {
     const endNeedle = this.offsetToNeedle(node.end);
     endNeedle.column -= 1;
 
-    let end = getPosition(endNeedle, this.sourceMap);
+    let end = getPosition(endNeedle, this.sourceMap, true);
 
     if (end === null) {
       for (
@@ -723,7 +723,7 @@ class Locator {
         line >= startNeedle.line && end === null;
         line--
       ) {
-        end = getPosition({ line, column: Infinity }, this.sourceMap);
+        end = getPosition({ line, column: Infinity }, this.sourceMap, true);
       }
 
       if (end === null) return null;
@@ -1031,10 +1031,14 @@ function getCount(
   return count;
 }
 
-function getPosition(needle: Needle, sourceMap: TraceMap): Position | null {
+function getPosition(
+  needle: Needle,
+  sourceMap: TraceMap,
+  allowNextMapping = false,
+): Position | null {
   let position = originalPositionFor(sourceMap, needle);
 
-  if (position.source == null) {
+  if (position.source == null && allowNextMapping) {
     position = originalPositionFor(sourceMap, {
       column: needle.column,
       line: needle.line,
@@ -1093,6 +1097,11 @@ async function getInlineSourceMap(filename: string, code: string) {
       const encoded = match.replace(BASE_64_SOURCE_MAP_PATTERN, '');
       const decoded = Buffer.from(encoded, 'base64').toString('utf8');
       return JSON.parse(decoded) as SourceMapLike;
+    }
+
+    if (DATA_SOURCE_MAP_PATTERN.test(match)) {
+      const encoded = match.replace(DATA_SOURCE_MAP_PATTERN, '');
+      return JSON.parse(decodeURIComponent(encoded)) as SourceMapLike;
     }
 
     const directory = dirname(filename);
@@ -1201,6 +1210,21 @@ function tryReadFileSync(filename: string) {
   } catch {
     return undefined;
   }
+}
+
+function resolveSourceFilename(source: string, directory: string) {
+  if (source.startsWith('file://')) {
+    return fileURLToPath(source);
+  }
+
+  if (
+    URL_SCHEME_PATTERN.test(source) &&
+    !WINDOWS_ABSOLUTE_PATH_PATTERN.test(source)
+  ) {
+    return source;
+  }
+
+  return resolve(directory, source);
 }
 
 function getFunctionName(node: AstNode): string | undefined {

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -352,6 +352,31 @@ describe('coverage-v8 provider', () => {
     expect(coverage[file]?.b[0]).toEqual([1]);
   });
 
+  it('honors ignore-next comments before ternary separators', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-ignore-ternary-next.js');
+    const code = "const os = flag ? 'OSX' /* v8 ignore next */ : 'Windows';";
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:ignore-ternary-next`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.branchMap[0]?.locations).toHaveLength(1);
+    expect(coverage[file]?.b[0]).toEqual([1]);
+  });
+
   it('invalidates prepared AST coverage when an external source map changes', async () => {
     const root = join(tmpdir(), 'rstest-coverage-v8-external-map-cache');
     const generatedFile = join(root, 'dist', 'bundle.js');
@@ -407,6 +432,64 @@ describe('coverage-v8 provider', () => {
 
       expect(Object.keys(firstCoverage)).toEqual([firstOriginalFile]);
       expect(Object.keys(secondCoverage)).toEqual([secondOriginalFile]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the final sourceMappingURL comment for external source maps', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-final-source-map-url');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const staleOriginalFile = join(root, 'src', 'stale.ts');
+    const finalOriginalFile = join(root, 'src', 'final.ts');
+    const code = [
+      'const value = 1;',
+      '//# sourceMappingURL=stale.js.map',
+      '//# sourceMappingURL=final.js.map',
+    ].join('\n');
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    const entry = {
+      url: pathToFileURL(generatedFile).href,
+      scriptId: '1',
+      functions: [
+        {
+          functionName: '',
+          isBlockCoverage: true,
+          ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+        },
+      ],
+    };
+
+    const createSourceMap = (source: string) =>
+      JSON.stringify({
+        version: 3,
+        file: generatedFile,
+        sources: [source],
+        sourcesContent: ['const value = 1;'],
+        names: [],
+        mappings: 'AAAA',
+      });
+
+    try {
+      mkdirSync(join(root, 'dist'), { recursive: true });
+      writeFileSync(generatedFile, code);
+      writeFileSync(
+        join(root, 'dist', 'stale.js.map'),
+        createSourceMap('../src/stale.ts'),
+      );
+      writeFileSync(
+        join(root, 'dist', 'final.js.map'),
+        createSourceMap('../src/final.ts'),
+      );
+
+      const coverage = await providerInternals.convertWithAst(
+        generatedFile,
+        entry,
+      );
+
+      expect(Object.keys(coverage)).toEqual([finalOriginalFile]);
+      expect(Object.keys(coverage)).not.toEqual([staleOriginalFile]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -300,6 +300,163 @@ describe('coverage-v8 provider', () => {
     });
   });
 
+  it('preserves the else branch when ignoring the if branch', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-ignore-if-else.js');
+    const code = `const flag = true;
+/* istanbul ignore if */ if (flag) { foo(); } else { bar(); }`;
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:ignore-if-else`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.branchMap[0]?.locations).toHaveLength(1);
+    expect(coverage[file]?.b[0]).toEqual([1]);
+  });
+
+  it('keeps branch counts aligned when an arm has no source mapping', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-branch-range-alignment');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const code = `if (flag)
+{
+  foo();
+}
+else { bar(); }`;
+    const ast = parseModule(code);
+    const consequentStart = code.indexOf('{');
+    const consequentEnd = code.indexOf('}') + 1;
+    const alternateStart = code.lastIndexOf('{');
+    const alternateEnd = code.lastIndexOf('}') + 1;
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:branch-range-alignment`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [
+              { startOffset: 0, endOffset: code.length, count: 1 },
+              {
+                startOffset: consequentStart,
+                endOffset: consequentEnd,
+                count: 0,
+              },
+              {
+                startOffset: alternateStart,
+                endOffset: alternateEnd,
+                count: 1,
+              },
+            ],
+          },
+        ],
+      },
+      sourceMap: {
+        version: 3,
+        sources: ['../src/original.ts'],
+        sourcesContent: ['if (flag) { bar(); }'],
+        names: [],
+        mappings: [[[0, 0, 0, 0]], [], [], [], [[0, 0, 0, 1]]],
+      },
+    });
+
+    expect(coverage[originalFile]?.branchMap[0]?.locations).toHaveLength(1);
+    expect(coverage[originalFile]?.b[0]).toEqual([1]);
+  });
+
+  it('treats V8 end offsets as exclusive for adjacent ranges', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-exclusive-end-offset.js');
+    const code = 'function f(){}g();';
+    const ast = parseModule(code);
+    const functionEnd = code.indexOf('g();');
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:exclusive-end-offset`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+          {
+            functionName: 'f',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: functionEnd, count: 0 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.s).toEqual({ 0: 1 });
+  });
+
+  it('accumulates duplicate statement hits from the same source mapping', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-duplicate-statement-hit');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const code = 'foo();\nbar();';
+    const ast = parseModule(code);
+    const secondStatementStart = code.indexOf('bar();');
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:duplicate-statement-hit`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [
+              { startOffset: 0, endOffset: code.length, count: 1 },
+              {
+                startOffset: secondStatementStart,
+                endOffset: code.length,
+                count: 0,
+              },
+            ],
+          },
+        ],
+      },
+      sourceMap: {
+        version: 3,
+        sources: ['../src/original.ts'],
+        sourcesContent: ['call();'],
+        names: [],
+        mappings: [[[0, 0, 0, 0]], [[0, 0, 0, 0]]],
+      },
+    });
+
+    expect(coverage[originalFile]?.statementMap).toEqual({
+      0: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: Number.POSITIVE_INFINITY },
+      },
+    });
+    expect(coverage[originalFile]?.s).toEqual({ 0: 1 });
+  });
+
   it('loads custom coverage reporters from relative config paths', async () => {
     const root = mkdtempSync(join(tmpdir(), 'rstest-coverage-reporter-'));
     const outputFile = join(root, 'custom-reporter-output.json');

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -109,6 +109,15 @@ function getProviderInternals(provider: CoverageProvider): ProviderInternals {
   return provider as unknown as ProviderInternals;
 }
 
+function parseModule(code: string) {
+  return Parser.parse(code, {
+    ecmaVersion: 'latest',
+    locations: true,
+    ranges: true,
+    sourceType: 'module',
+  });
+}
+
 describe('coverage-v8 provider', () => {
   it('reads charset base64 inline source maps in the AST converter', async () => {
     const root = join(tmpdir(), 'rstest-coverage-v8-inline-map-charset');
@@ -125,12 +134,7 @@ describe('coverage-v8 provider', () => {
     const code = `const value = 1;\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
       JSON.stringify(sourceMap),
     ).toString('base64')}`;
-    const ast = Parser.parse(code, {
-      ecmaVersion: 'latest',
-      locations: true,
-      ranges: true,
-      sourceType: 'module',
-    });
+    const ast = parseModule(code);
 
     const coverage = await convertV8CoverageWithAst({
       ast,
@@ -149,6 +153,151 @@ describe('coverage-v8 provider', () => {
     });
 
     expect(Object.keys(coverage)).toEqual([originalFile]);
+  });
+
+  it('reads non-base64 inline data source maps in the AST converter', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-inline-map-data-url');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const sourceMap = {
+      version: 3,
+      file: generatedFile,
+      sources: ['../src/original.ts'],
+      sourcesContent: ['const value = 1;'],
+      names: [],
+      mappings: 'AAAA',
+    };
+    const code = `const value = 1;\n//# sourceMappingURL=data:application/json;charset=UTF-8,${encodeURIComponent(
+      JSON.stringify(sourceMap),
+    )}`;
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:inline-data-url`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(Object.keys(coverage)).toEqual([originalFile]);
+  });
+
+  it('uses value offsets for object property function coverage', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-property-function.js');
+    const code = 'const o = { a: function () {} };\no.a;';
+    const functionStart = code.indexOf('function');
+    const functionEnd = functionStart + 'function () {}'.length;
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:property-function`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+          {
+            functionName: 'a',
+            isBlockCoverage: true,
+            ranges: [
+              { startOffset: functionStart, endOffset: functionEnd, count: 0 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const fileCoverage = coverage[file]!;
+    expect(fileCoverage.fnMap[0]?.name).toBe('a');
+    expect(fileCoverage.f).toEqual({ 0: 0 });
+  });
+
+  it('preserves non-file source map URLs as coverage filenames', async () => {
+    const generatedFile = join(
+      tmpdir(),
+      'rstest-coverage-v8-webpack-source.js',
+    );
+    const sourceUrl = 'webpack://rstest/src/original.ts';
+    const code = 'const value = 1;';
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:webpack-source`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+      sourceMap: {
+        version: 3,
+        sources: [sourceUrl],
+        sourcesContent: [code],
+        names: [],
+        mappings: 'AAAA',
+      },
+    });
+
+    expect(Object.keys(coverage)).toEqual([sourceUrl]);
+  });
+
+  it('does not remap unmapped wrapper statements to the next source', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-unmapped-wrapper');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const code = '(function(){})();\nconst value = 1;';
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:unmapped-wrapper`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+      sourceMap: {
+        version: 3,
+        sources: ['../src/original.ts'],
+        sourcesContent: ['const value = 1;'],
+        names: [],
+        mappings: ';AAAA',
+      },
+    });
+
+    expect(Object.keys(coverage)).toEqual([originalFile]);
+    expect(coverage[originalFile]?.statementMap).toEqual({
+      0: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: Number.POSITIVE_INFINITY },
+      },
+    });
   });
 
   it('loads custom coverage reporters from relative config paths', async () => {

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -191,6 +191,52 @@ describe('coverage-v8 provider', () => {
     expect(Object.keys(coverage)).toEqual([originalFile]);
   });
 
+  it('uses the final inline sourceMappingURL comment in the AST converter', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-final-inline-map');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const staleOriginalFile = join(root, 'src', 'stale.ts');
+    const finalOriginalFile = join(root, 'src', 'final.ts');
+    const createSourceMap = (source: string) => ({
+      version: 3,
+      file: generatedFile,
+      sources: [source],
+      sourcesContent: ['const value = 1;'],
+      names: [],
+      mappings: 'AAAA',
+    });
+    const staleMap = Buffer.from(
+      JSON.stringify(createSourceMap('../src/stale.ts')),
+    ).toString('base64');
+    const finalMap = Buffer.from(
+      JSON.stringify(createSourceMap('../src/final.ts')),
+    ).toString('base64');
+    const code = [
+      'const value = 1;',
+      `//# sourceMappingURL=data:application/json;base64,${staleMap}`,
+      `//# sourceMappingURL=data:application/json;base64,${finalMap}`,
+    ].join('\n');
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:final-inline-map`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(Object.keys(coverage)).toEqual([finalOriginalFile]);
+    expect(Object.keys(coverage)).not.toEqual([staleOriginalFile]);
+  });
+
   it('uses value offsets for object property function coverage', async () => {
     const file = join(tmpdir(), 'rstest-coverage-v8-property-function.js');
     const code = 'const o = { a: function () {} };\no.a;';
@@ -259,6 +305,40 @@ describe('coverage-v8 provider', () => {
     });
 
     expect(Object.keys(coverage)).toEqual([sourceUrl]);
+  });
+
+  it('resolves external source map sources relative to the map file', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-nested-external-map');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const code = 'const value = 1;';
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:nested-external-map`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+      sourceMap: {
+        version: 3,
+        sources: ['../../src/original.ts'],
+        sourcesContent: [code],
+        names: [],
+        mappings: 'AAAA',
+      },
+      sourceMapUrl: join(root, 'dist', 'maps', 'bundle.js.map'),
+    });
+
+    expect(Object.keys(coverage)).toEqual([originalFile]);
   });
 
   it('does not remap unmapped wrapper statements to the next source', async () => {
@@ -350,6 +430,39 @@ describe('coverage-v8 provider', () => {
 
     expect(coverage[file]?.branchMap[0]?.locations).toHaveLength(1);
     expect(coverage[file]?.b[0]).toEqual([1]);
+  });
+
+  it('gives implicit else branches numeric locations', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-implicit-else-location.js');
+    const code = 'if (flag) { foo(); }';
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:implicit-else-location`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.branchMap[0]?.locations).toEqual([
+      {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: Number.POSITIVE_INFINITY },
+      },
+      {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: Number.POSITIVE_INFINITY },
+      },
+    ]);
   });
 
   it('honors ignore-next comments before ternary separators', async () => {

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -326,6 +326,92 @@ describe('coverage-v8 provider', () => {
     expect(coverage[file]?.b[0]).toEqual([1]);
   });
 
+  it('does not add an implicit else branch when ignoring an absent else branch', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-ignore-implicit-else.js');
+    const code = `const flag = true;
+/* istanbul ignore else */ if (flag) { foo(); }`;
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:ignore-implicit-else`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.branchMap[0]?.locations).toHaveLength(1);
+    expect(coverage[file]?.b[0]).toEqual([1]);
+  });
+
+  it('invalidates prepared AST coverage when an external source map changes', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-external-map-cache');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const firstOriginalFile = join(root, 'src', 'first.ts');
+    const secondOriginalFile = join(root, 'src', 'second.ts');
+    const code = 'const value = 1;\n//# sourceMappingURL=bundle.js.map';
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    const entry = {
+      url: pathToFileURL(generatedFile).href,
+      scriptId: '1',
+      functions: [
+        {
+          functionName: '',
+          isBlockCoverage: true,
+          ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+        },
+      ],
+    };
+
+    const createSourceMap = (source: string) =>
+      JSON.stringify({
+        version: 3,
+        file: generatedFile,
+        sources: [source],
+        sourcesContent: ['const value = 1;'],
+        names: [],
+        mappings: 'AAAA',
+      });
+
+    try {
+      mkdirSync(join(root, 'dist'), { recursive: true });
+      writeFileSync(generatedFile, code);
+      writeFileSync(
+        join(root, 'dist', 'bundle.js.map'),
+        createSourceMap('../src/first.ts'),
+      );
+
+      const firstCoverage = await providerInternals.convertWithAst(
+        generatedFile,
+        entry,
+      );
+
+      writeFileSync(
+        join(root, 'dist', 'bundle.js.map'),
+        createSourceMap('../src/second.ts'),
+      );
+
+      const secondCoverage = await providerInternals.convertWithAst(
+        generatedFile,
+        entry,
+      );
+
+      expect(Object.keys(firstCoverage)).toEqual([firstOriginalFile]);
+      expect(Object.keys(secondCoverage)).toEqual([secondOriginalFile]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps branch counts aligned when an arm has no source mapping', async () => {
     const root = join(tmpdir(), 'rstest-coverage-v8-branch-range-alignment');
     const generatedFile = join(root, 'dist', 'bundle.js');

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -9,8 +9,10 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import type { NormalizedCoverageOptions } from '@rstest/core';
+import { Parser } from 'acorn';
 import type { FileCoverageData } from 'istanbul-lib-coverage';
 import { CoverageProvider } from '../src/provider';
+import { convertV8CoverageWithAst } from '../src/v8AstConverter';
 
 const createOptions = (
   overrides: Partial<NormalizedCoverageOptions> = {},
@@ -98,6 +100,7 @@ type ProviderInternals = CoverageProvider & {
       outputModule?: boolean;
     },
   ) => Promise<Record<string, FileCoverageData>>;
+  takeRawCoverage: () => Promise<unknown[]>;
 };
 
 function getProviderInternals(provider: CoverageProvider): ProviderInternals {
@@ -107,6 +110,47 @@ function getProviderInternals(provider: CoverageProvider): ProviderInternals {
 }
 
 describe('coverage-v8 provider', () => {
+  it('reads charset base64 inline source maps in the AST converter', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-inline-map-charset');
+    const generatedFile = join(root, 'dist', 'bundle.js');
+    const originalFile = join(root, 'src', 'original.ts');
+    const sourceMap = {
+      version: 3,
+      file: generatedFile,
+      sources: ['../src/original.ts'],
+      sourcesContent: ['const value = 1;'],
+      names: [],
+      mappings: 'AAAA',
+    };
+    const code = `const value = 1;\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
+      JSON.stringify(sourceMap),
+    ).toString('base64')}`;
+    const ast = Parser.parse(code, {
+      ecmaVersion: 'latest',
+      locations: true,
+      ranges: true,
+      sourceType: 'module',
+    });
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${generatedFile}:inline-charset`,
+      code,
+      coverage: {
+        url: pathToFileURL(generatedFile).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(Object.keys(coverage)).toEqual([originalFile]);
+  });
+
   it('loads custom coverage reporters from relative config paths', async () => {
     const root = mkdtempSync(join(tmpdir(), 'rstest-coverage-reporter-'));
     const outputFile = join(root, 'custom-reporter-output.json');
@@ -322,6 +366,68 @@ export default class CustomCoverageReporter {
     } finally {
       console.error = originalError;
       process.exitCode = originalExitCode;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('filters raw coverage entries before source lookup and conversion', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-raw-filter');
+    const includedFile = join(root, 'src', 'included.js');
+    const nodeModuleFile = join(root, 'node_modules', 'dep', 'index.js');
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    const fileCoverage = {
+      path: includedFile,
+      statementMap: {},
+      fnMap: {},
+      branchMap: {},
+      s: {},
+      f: {},
+      b: {},
+    } satisfies FileCoverageData;
+    const convertedFiles: string[] = [];
+
+    Object.defineProperty(providerInternals, 'takeRawCoverage', {
+      configurable: true,
+      value: async () => [
+        {
+          url: pathToFileURL(nodeModuleFile).href,
+          filePath: nodeModuleFile,
+          scriptId: '1',
+          functions: [],
+        },
+        {
+          url: pathToFileURL(includedFile).href,
+          filePath: includedFile,
+          scriptId: '2',
+          functions: [],
+        },
+      ],
+    });
+    Object.defineProperty(provider, 'session', {
+      configurable: true,
+      value: {},
+    });
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async (filePath: string) => {
+        convertedFiles.push(filePath);
+        return { [includedFile]: fileCoverage };
+      },
+    });
+
+    try {
+      const coverageMap = await provider.collect({
+        assetFiles: {
+          [includedFile]: 'value();',
+          [nodeModuleFile]: 'dep();',
+        },
+        sourceMaps: {},
+      });
+
+      expect(convertedFiles).toEqual([includedFile]);
+      expect(coverageMap?.files()).toEqual([includedFile]);
+    } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1269,7 +1269,7 @@ importers:
   packages/coverage-v8:
     dependencies:
       '@jridgewell/trace-mapping':
-        specifier: ^0.3.31
+        specifier: 0.3.31
         version: 0.3.31
       acorn:
         specifier: ^8.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,12 +1268,15 @@ importers:
 
   packages/coverage-v8:
     dependencies:
+      '@jridgewell/trace-mapping':
+        specifier: ^0.3.31
+        version: 0.3.31
       acorn:
         specifier: ^8.17.0
         version: 8.17.0
-      ast-v8-to-istanbul:
-        specifier: ^1.0.4
-        version: 1.0.4
+      estree-walker:
+        specifier: ^3.0.3
+        version: 3.0.3
       istanbul-lib-coverage:
         specifier: ^3.2.2
         version: 3.2.2
@@ -1283,6 +1286,9 @@ importers:
       istanbul-reports:
         specifier: ^3.2.0
         version: 3.2.0
+      js-tokens:
+        specifier: ^10.0.0
+        version: 10.0.0
       picomatch:
         specifier: ^4.0.4
         version: 4.0.4
@@ -4276,9 +4282,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  ast-v8-to-istanbul@1.0.4:
-    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -11436,12 +11439,6 @@ snapshots:
       util: 0.12.5
 
   assertion-error@2.0.1: {}
-
-  ast-v8-to-istanbul@1.0.4:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      estree-walker: 3.0.3
-      js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
 


### PR DESCRIPTION
## Summary

This PR improves V8 coverage conversion performance for bundled Rstest workloads. It replaces the generic `ast-v8-to-istanbul` runtime path with a local converter tailored for Rstest, filters raw V8 entries before source lookup/conversion, and keeps sourcemap remapping behavior for bundled assets.

Benchmark command in `/Users/bytedance/Desktop/projects/rsbuild`:

```bash
pnpm test --coverage --coverage.provider=v8
```

| Version | Trace | Wall span | Phase sum | Coverage phase | Collect |
| --- | --- | ---: | ---: | ---: | ---: |
| baseline (`ast-v8-to-istanbul`) | `trace-2026-06-30T07-27-13-436` | 6.05s | 60.11s | 42.728s | 2.713s |
| optimized AST converter | `trace-2026-06-30T07-31-08-298` | 3.83s | 31.68s | 14.845s | 2.828s |
| raw entry filtering + workflow | `trace-2026-06-30T07-27-27-444` | 1.81s | 10.28s | 0.014s | 3.135s |

Compared with baseline, the final version reduces wall span by 70.1% (3.34x faster) and phase sum by 82.9% (5.85x faster).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
