### PR TITLE
docs(adapter-rsbuild): document toRstestConfig API

### DIFF
--- a/website/docs/en/guide/integration/rsbuild.mdx
+++ b/website/docs/en/guide/integration/rsbuild.mdx
@@ -205,7 +205,7 @@ The Rsbuild config object to convert.
 - **Type:** `string`
 - **Default:** `undefined`
 
-Source file path for the provided `rsbuildConfig`; it does not load config from this path. The adapter uses it only to add the file to [`forceRerunTriggers`](/config/test/force-rerun-triggers) and resolve relative `performance.buildCache.buildDependencies`.
+Source file path for the provided `rsbuildConfig`; it does not load config from this path. The adapter uses it only to add the file to [`forceRerunTriggers`](/config/test/force-rerun-triggers) and [`performance.buildCache.buildDependencies`](https://rsbuild.rs/config/performance/build-cache#builddependencies).
 
 #### `environmentName`
 

--- a/website/docs/en/guide/integration/rsbuild.mdx
+++ b/website/docs/en/guide/integration/rsbuild.mdx
@@ -170,6 +170,57 @@ export default defineConfig({
 });
 ```
 
+### `toRstestConfig(options)`
+
+Converts an Rsbuild config object to Rstest configuration without loading a config file. Use this when your project or framework already creates an Rsbuild config object in memory.
+
+```ts
+import type { RsbuildConfig } from '@rsbuild/core';
+import { defineConfig } from '@rstest/core';
+import { toRstestConfig } from '@rstest/adapter-rsbuild';
+
+const rsbuildConfig: RsbuildConfig = {
+  resolve: {
+    alias: {
+      '@': './src',
+    },
+  },
+};
+
+export default defineConfig({
+  extends: toRstestConfig({
+    rsbuildConfig,
+  }),
+});
+```
+
+#### `rsbuildConfig`
+
+- **Type:** `RsbuildConfig`
+
+The Rsbuild config object to convert.
+
+#### `configPath`
+
+- **Type:** `string`
+- **Default:** `undefined`
+
+Source file path for the provided `rsbuildConfig`; it does not load config from this path. The adapter uses it only to add the file to [`forceRerunTriggers`](/config/test/force-rerun-triggers) and resolve relative `performance.buildCache.buildDependencies`.
+
+#### `environmentName`
+
+- **Type:** `string`
+- **Default:** `undefined`
+
+The environment name in the `environments` field to merge with the common config.
+
+#### `modifyRsbuildConfig`
+
+- **Type:** `(config: RsbuildConfig) => RsbuildConfig`
+- **Default:** `undefined`
+
+Modify the merged Rsbuild config object before it gets converted to Rstest config.
+
 ## Configuration mapping
 
 The adapter automatically maps these Rsbuild options to Rstest:

--- a/website/docs/zh/guide/integration/rsbuild.mdx
+++ b/website/docs/zh/guide/integration/rsbuild.mdx
@@ -170,6 +170,57 @@ export default defineConfig({
 });
 ```
 
+### `toRstestConfig(options)`
+
+将已有的 Rsbuild 配置对象转换为 Rstest 配置，而不会加载配置文件。
+
+```ts
+import type { RsbuildConfig } from '@rsbuild/core';
+import { defineConfig } from '@rstest/core';
+import { toRstestConfig } from '@rstest/adapter-rsbuild';
+
+const rsbuildConfig: RsbuildConfig = {
+  resolve: {
+    alias: {
+      '@': './src',
+    },
+  },
+};
+
+export default defineConfig({
+  extends: toRstestConfig({
+    rsbuildConfig,
+  }),
+});
+```
+
+#### `rsbuildConfig`
+
+- **类型：** `RsbuildConfig`
+
+要转换的 Rsbuild 配置对象。
+
+#### `configPath`
+
+- **类型：** `string`
+- **默认值：** `undefined`
+
+传入的 `rsbuildConfig` 对应的来源文件路径；它不会从该路径加载配置。适配器只用它将该文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，并解析相对路径的 `performance.buildCache.buildDependencies`。
+
+#### `environmentName`
+
+- **类型：** `string`
+- **默认值：** `undefined`
+
+要从 `environments` 字段中合并到通用配置的环境名称。
+
+#### `modifyRsbuildConfig`
+
+- **类型：** `(config: RsbuildConfig) => RsbuildConfig`
+- **默认值：** `undefined`
+
+在将合并后的 Rsbuild 配置对象转换为 Rstest 配置之前对其进行修改。
+
 ## 配置映射
 
 适配器会自动将这些 Rsbuild 选项映射到 Rstest：

--- a/website/docs/zh/guide/integration/rsbuild.mdx
+++ b/website/docs/zh/guide/integration/rsbuild.mdx
@@ -205,7 +205,7 @@ export default defineConfig({
 - **类型：** `string`
 - **默认值：** `undefined`
 
-传入的 `rsbuildConfig` 对应的来源文件路径；它不会从该路径加载配置。适配器只用它将该文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，并解析相对路径的 `performance.buildCache.buildDependencies`。
+传入的 `rsbuildConfig` 对应的来源文件路径；它不会从该路径加载配置。适配器只用它将该文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 和 [performance.buildCache.buildDependencies](https://rsbuild.rs/zh/config/performance/build-cache#builddependencies)。
 
 #### `environmentName`
 


### PR DESCRIPTION
## Summary

This PR documents `toRstestConfig(options)` in the Rsbuild integration guide for users who already have an Rsbuild config object. It adds English and Chinese examples, lists the supported options, and clarifies that `configPath` is a source file path used for rerun triggers and build cache dependency resolution, not for loading config.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).