### PR TITLE
fix(browser): avoid HMR factory race in headless one-shot runs

### DIFF
--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -284,10 +284,16 @@ const toContextKey = (absolutePath: string, projectRoot: string): string => {
   const normalizedAbsolute = normalize(absolutePath);
   const normalizedRoot = normalize(projectRoot);
 
-  let relative = normalizedAbsolute;
-  if (normalizedAbsolute.startsWith(normalizedRoot)) {
-    relative = normalizedAbsolute.slice(normalizedRoot.length);
-  }
+  // Only strip the root at a path boundary: a bare `startsWith` would mangle a
+  // sibling like `/repo/pkg-extra/a.test.ts` under root `/repo/pkg`. Must stay
+  // in sync with the host `toContextKey` (hostController.ts) so the non-watch
+  // import-map keys resolve.
+  const withinRoot =
+    normalizedAbsolute === normalizedRoot ||
+    normalizedAbsolute.startsWith(`${normalizedRoot}/`);
+  const relative = withinRoot
+    ? normalizedAbsolute.slice(normalizedRoot.length)
+    : normalizedAbsolute;
   return relative.startsWith('/') ? `.${relative}` : `./${relative}`;
 };
 

--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -291,9 +291,12 @@ const toContextKey = (absolutePath: string, projectRoot: string): string => {
   const withinRoot =
     normalizedAbsolute === normalizedRoot ||
     normalizedAbsolute.startsWith(`${normalizedRoot}/`);
-  const relative = withinRoot
-    ? normalizedAbsolute.slice(normalizedRoot.length)
-    : normalizedAbsolute;
+  if (!withinRoot) {
+    // Test file outside the project root: keep the absolute path as the key so
+    // `toAbsolutePath` round-trips it instead of re-rooting under projectRoot.
+    return normalizedAbsolute;
+  }
+  const relative = normalizedAbsolute.slice(normalizedRoot.length);
   return relative.startsWith('/') ? `.${relative}` : `./${relative}`;
 };
 
@@ -302,6 +305,11 @@ const toContextKey = (absolutePath: string, projectRoot: string): string => {
  * e.g., './src/foo.test.ts' -> '/project/src/foo.test.ts'
  */
 const toAbsolutePath = (key: string, projectRoot: string): string => {
+  // An absolute key (test file outside the project root, see `toContextKey`)
+  // round-trips as-is; only `./`-prefixed relative keys are re-rooted.
+  if (!key.startsWith('.')) {
+    return key;
+  }
   // key format: ./src/foo.test.ts
   // Ensure no double slashes by removing trailing slash from projectRoot
   const normalizedRoot = normalize(projectRoot).replace(/\/$/, '');

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1187,9 +1187,12 @@ export const toContextKey = (
   projectRootPosix: string,
 ): string => {
   const posixPath = normalize(filePath);
-  const rel = posixPath.startsWith(projectRootPosix)
-    ? posixPath.slice(projectRootPosix.length)
-    : posixPath;
+  // Only strip the root at a path boundary: a bare `startsWith` would mangle a
+  // sibling like `/repo/pkg-extra/a.test.ts` under root `/repo/pkg`.
+  const withinRoot =
+    posixPath === projectRootPosix ||
+    posixPath.startsWith(`${projectRootPosix}/`);
+  const rel = withinRoot ? posixPath.slice(projectRootPosix.length) : posixPath;
   return rel.startsWith('/') ? `.${rel}` : `./${rel}`;
 };
 

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -602,7 +602,7 @@ export const createBrowserLazyCompilationConfig = (
 };
 
 export const createBrowserRsbuildDevConfig = (
-  _isWatchMode: boolean,
+  isWatchMode: boolean,
 ): {
   writeToDisk: boolean;
   hmr: boolean;
@@ -612,9 +612,12 @@ export const createBrowserRsbuildDevConfig = (
 } => {
   return {
     writeToDisk: isDebug(),
-    // Keep HMR enabled in browser mode even for one-shot runs.
-    // lazyCompilation depends on HMR runtime wiring for async import chains.
-    hmr: true,
+    // HMR is only wired in watch mode. One-shot runs load each test file in a
+    // fresh page against a persistent dev server; leaving HMR on makes the
+    // server push chunk updates into a page that is still resolving its module
+    // graph, which races factory registration for chunk-split node_modules
+    // (many-small-files packages like lodash-es) — see rspack#11922.
+    hmr: isWatchMode,
     client: {
       logLevel: 'error' as const,
     },
@@ -1175,12 +1178,29 @@ const toSafeVarName = (name: string): string => {
   return name.replace(/[^a-zA-Z0-9_]/g, '_');
 };
 
+// Host-side mirror of the browser runtime's `toContextKey` (client/entry.ts):
+// `./<path-relative-to-project-root>` with forward slashes. The runtime derives
+// the same key from the target test file, so the non-watch import map below must
+// key by the identical form for `loadTest(key)` to resolve.
+export const toContextKey = (
+  filePath: string,
+  projectRootPosix: string,
+): string => {
+  const posixPath = normalize(filePath);
+  const rel = posixPath.startsWith(projectRootPosix)
+    ? posixPath.slice(projectRootPosix.length)
+    : posixPath;
+  return rel.startsWith('/') ? `.${rel}` : `./${rel}`;
+};
+
 const generateManifestModule = ({
   manifestPath,
   entries,
+  isWatchMode,
 }: {
   manifestPath: string;
   entries: BrowserProjectEntries[];
+  isWatchMode: boolean;
 }): string => {
   const manifestDirPosix = normalize(dirname(manifestPath));
 
@@ -1226,30 +1246,53 @@ const generateManifestModule = ({
   lines.push('};');
   lines.push('');
 
-  // 3. Test context for each project
+  // 3. Test context for each project. Both branches expose the same shape as a
+  // webpackContext (callable by key, plus `keys()`), consumed in section 4.
   lines.push('// Test context for each project');
-  for (const { project } of entries) {
+  for (const { project, testFiles } of entries) {
     const varName = `context_${toSafeVarName(project.environmentName)}`;
     const projectRootPosix = normalize(project.rootPath);
-    const includeRegExp = globPatternsToRegExp(
-      project.normalizedConfig.include,
-    );
-    const excludePatterns = project.normalizedConfig.exclude.patterns;
-    const excludeRegExp = createBrowserContextExcludeRegExp(
-      excludePatterns,
-      projectRootPosix,
-    );
 
-    lines.push(
-      `const ${varName} = import.meta.webpackContext(${JSON.stringify(projectRootPosix)}, {`,
-    );
-    lines.push('  recursive: true,');
-    lines.push(`  regExp: ${includeRegExp.toString()},`);
-    if (excludeRegExp) {
-      lines.push(`  exclude: ${excludeRegExp.toString()},`);
+    if (isWatchMode) {
+      // Watch mode keeps the include-glob context so newly added files are
+      // picked up on rebuild (and pairs with lazyCompilation to stay cheap).
+      const includeRegExp = globPatternsToRegExp(
+        project.normalizedConfig.include,
+      );
+      const excludeRegExp = createBrowserContextExcludeRegExp(
+        project.normalizedConfig.exclude.patterns,
+        projectRootPosix,
+      );
+      lines.push(
+        `const ${varName} = import.meta.webpackContext(${JSON.stringify(projectRootPosix)}, {`,
+      );
+      lines.push('  recursive: true,');
+      lines.push(`  regExp: ${includeRegExp.toString()},`);
+      if (excludeRegExp) {
+        lines.push(`  exclude: ${excludeRegExp.toString()},`);
+      }
+      lines.push("  mode: 'lazy',");
+      lines.push('});');
+    } else {
+      // One-shot runs: the file set is fixed and already filtered, so emit an
+      // explicit lazy-import map (one chunk per literal `import()`, like the
+      // setup loaders above). The eager, non-lazyCompilation build then compiles
+      // only the run set instead of every included test file.
+      lines.push(`const ${varName}_modules = {`);
+      for (const filePath of testFiles) {
+        const key = toContextKey(filePath, projectRootPosix);
+        const importPath = toRelativeImport(filePath);
+        lines.push(
+          `  ${JSON.stringify(key)}: () => import(${JSON.stringify(importPath)}),`,
+        );
+      }
+      lines.push('};');
+      lines.push(
+        `const ${varName} = Object.assign((key) => ${varName}_modules[key](), {`,
+      );
+      lines.push(`  keys: () => Object.keys(${varName}_modules),`);
+      lines.push('});');
     }
-    lines.push("  mode: 'lazy',");
-    lines.push('});');
     lines.push('');
   }
 
@@ -1546,6 +1589,7 @@ const createBrowserRuntime = async ({
           setupFiles: entry?.setupFiles ?? [],
         },
       ],
+      isWatchMode,
     });
     const virtualManifestPlugin = new rspack.experiments.VirtualModulesPlugin({
       [manifestPath]: manifestSource,
@@ -1648,8 +1692,13 @@ const createBrowserRuntime = async ({
                   tools: {
                     rspack: (rspackConfig) => {
                       rspackConfig.mode = 'development';
-                      rspackConfig.lazyCompilation =
-                        createBrowserLazyCompilationConfig(setupFiles);
+                      // lazyCompilation relies on the HMR runtime to deliver
+                      // on-demand modules, so it is only safe in watch mode.
+                      // One-shot runs compile eagerly to avoid the HMR chunk
+                      // registration race (see createBrowserRsbuildDevConfig).
+                      rspackConfig.lazyCompilation = isWatchMode
+                        ? createBrowserLazyCompilationConfig(setupFiles)
+                        : false;
                       rspackConfig.plugins = rspackConfig.plugins || [];
                       rspackConfig.plugins.push(virtualManifestPlugin);
 

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1192,7 +1192,13 @@ export const toContextKey = (
   const withinRoot =
     posixPath === projectRootPosix ||
     posixPath.startsWith(`${projectRootPosix}/`);
-  const rel = withinRoot ? posixPath.slice(projectRootPosix.length) : posixPath;
+  if (!withinRoot) {
+    // Test file outside the project root: use the absolute path as the key so
+    // the runtime `toAbsolutePath` can round-trip it. A `./`-prefixed relative
+    // key would be re-rooted under projectRoot and point at a nonexistent file.
+    return posixPath;
+  }
+  const rel = posixPath.slice(projectRootPosix.length);
   return rel.startsWith('/') ? `.${rel}` : `./${rel}`;
 };
 

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -131,6 +131,11 @@ describe('browser config resolution', () => {
     expect(toContextKey('/elsewhere/x.test.ts', '/project')).toBe(
       './elsewhere/x.test.ts',
     );
+    // A sibling that only shares a string prefix with the root is not stripped
+    // at a non-boundary (would otherwise mangle to `./-extra/a.test.ts`).
+    expect(toContextKey('/repo/pkg-extra/a.test.ts', '/repo/pkg')).toBe(
+      './repo/pkg-extra/a.test.ts',
+    );
   });
 
   it('should keep setup files out of lazy compilation', () => {

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -5,6 +5,7 @@ import {
   createBrowserRsbuildDevConfig,
   createBrowserContextExcludeRegExp,
   resolveListenPort,
+  toContextKey,
 } from '../src/hostController';
 
 /**
@@ -106,10 +107,10 @@ describe('browser config resolution', () => {
     expect(browserConfig.strictPort).toBe(true);
   });
 
-  it('should enable HMR in non-watch mode and keep error-only client log', () => {
+  it('should disable HMR in non-watch mode and keep error-only client log', () => {
     const devConfig = createBrowserRsbuildDevConfig(false);
 
-    expect(devConfig.hmr).toBe(true);
+    expect(devConfig.hmr).toBe(false);
     expect(devConfig.client.logLevel).toBe('error');
   });
 
@@ -118,6 +119,18 @@ describe('browser config resolution', () => {
 
     expect(devConfig.hmr).toBe(true);
     expect(devConfig.client.logLevel).toBe('error');
+  });
+
+  it('should derive the non-watch import-map key like the runtime toContextKey', () => {
+    // Keys must match the browser runtime's `toContextKey` so `loadTest(key)`
+    // resolves against the manifest import map.
+    expect(toContextKey('/project/tests/a.test.ts', '/project')).toBe(
+      './tests/a.test.ts',
+    );
+    // Paths outside the project root are left as-is with a `./` prefix.
+    expect(toContextKey('/elsewhere/x.test.ts', '/project')).toBe(
+      './elsewhere/x.test.ts',
+    );
   });
 
   it('should keep setup files out of lazy compilation', () => {

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -127,14 +127,16 @@ describe('browser config resolution', () => {
     expect(toContextKey('/project/tests/a.test.ts', '/project')).toBe(
       './tests/a.test.ts',
     );
-    // Paths outside the project root are left as-is with a `./` prefix.
+    // Paths outside the project root keep their absolute form so the runtime
+    // `toAbsolutePath` round-trips them instead of re-rooting under projectRoot.
     expect(toContextKey('/elsewhere/x.test.ts', '/project')).toBe(
-      './elsewhere/x.test.ts',
+      '/elsewhere/x.test.ts',
     );
     // A sibling that only shares a string prefix with the root is not stripped
-    // at a non-boundary (would otherwise mangle to `./-extra/a.test.ts`).
+    // at a non-boundary (would otherwise mangle to `./-extra/a.test.ts`); it is
+    // outside the root, so it is also kept absolute.
     expect(toContextKey('/repo/pkg-extra/a.test.ts', '/repo/pkg')).toBe(
-      './repo/pkg-extra/a.test.ts',
+      '/repo/pkg-extra/a.test.ts',
     );
   });
 


### PR DESCRIPTION
## Summary

Headless browser runs load each test file in a fresh page against a persistent dev server. Because `hmr: true` was forced on even for one-shot runs (lazyCompilation depends on the HMR runtime), the dev server could push chunk updates into a page that was still resolving its module graph, racing factory registration for chunk-split `node_modules` (many-small-files packages such as `lodash-es`) and surfacing `RuntimeError: factory is undefined` (rspack#11922). The failure is order/pressure dependent and reproduces most reliably in CI.

- Gate HMR **and** lazyCompilation to watch mode. One-shot runs now build eagerly with no HMR runtime, so the race cannot occur. Watch mode is unchanged.
- To avoid the eager build compiling every included test file when only a subset is run, the non-watch manifest emits an explicit lazy-import map of the resolved (already filtered) test files instead of a glob-based `webpackContext` — one lazy chunk per file, mirroring the existing setup-loader pattern.

Total walltime is neutral-to-faster across full and filtered runs; running a single file in a large suite now compiles only that file (measured ~2.5x faster on a 600-file suite, and dynamic-`import()` full runs ~2.9x faster since they no longer pay per-request HMR round-trips).

## Related Links

- Closes #1482
- https://github.com/web-infra-dev/rspack/issues/11922

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).