### PR TITLE
fix(browser): interpret console format specifiers when forwarding logs

### DIFF
--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -110,9 +110,6 @@ const ensureRuntimeEnv = (env: RuntimeConfig['env'] | undefined): void => {
   }
 };
 
-/**
- * Format an argument for console output.
- */
 const getFileTaskId = (testPath: string): string => {
   return `file:${testPath}`;
 };
@@ -147,7 +144,6 @@ const interceptConsole = (
       // Call original for browser DevTools
       originalConsole[level](...args);
 
-      // Format message
       const content = formatConsoleArgs(args);
       const currentTask = getCurrentTask();
 

--- a/packages/browser/src/client/entry.ts
+++ b/packages/browser/src/client/entry.ts
@@ -32,6 +32,7 @@ import {
   createRunnerLifecycleRequest,
   sendRunnerLifecycle,
 } from './dispatchTransport';
+import { formatConsoleArgs } from './formatConsole';
 import { BrowserSnapshotEnvironment } from './snapshot';
 import {
   findNewScriptUrl,
@@ -112,21 +113,6 @@ const ensureRuntimeEnv = (env: RuntimeConfig['env'] | undefined): void => {
 /**
  * Format an argument for console output.
  */
-const formatArg = (arg: unknown): string => {
-  if (arg === null) return 'null';
-  if (arg === undefined) return 'undefined';
-  if (typeof arg === 'string') return arg;
-  if (typeof arg === 'number' || typeof arg === 'boolean') return String(arg);
-  if (arg instanceof Error) {
-    return arg.stack || `${arg.name}: ${arg.message}`;
-  }
-  try {
-    return JSON.stringify(arg, null, 2);
-  } catch {
-    return String(arg);
-  }
-};
-
 const getFileTaskId = (testPath: string): string => {
   return `file:${testPath}`;
 };
@@ -162,7 +148,7 @@ const interceptConsole = (
       originalConsole[level](...args);
 
       // Format message
-      const content = args.map(formatArg).join(' ');
+      const content = formatConsoleArgs(args);
       const currentTask = getCurrentTask();
 
       // Send to host

--- a/packages/browser/src/client/formatConsole.ts
+++ b/packages/browser/src/client/formatConsole.ts
@@ -1,8 +1,4 @@
-/**
- * Format a single console argument to a string for terminal forwarding.
- * Objects are JSON-stringified; Errors keep their stack. This mirrors the
- * browser console's default stringification closely enough for log forwarding.
- */
+/** Stringify a single console argument for terminal forwarding. */
 export const formatArg = (arg: unknown): string => {
   if (arg === null) return 'null';
   if (arg === undefined) return 'undefined';
@@ -49,13 +45,13 @@ export const formatConsoleArgs = (args: unknown[]): string => {
   let next = 1;
   const substituted = first.replace(SPECIFIER, (spec) => {
     if (spec === '%%') return '%';
-    if (next >= args.length) return spec; // no argument left to consume
+    if (next >= args.length) return spec;
     const arg = args[next++];
     switch (spec) {
       case '%c':
         return ''; // CSS directive: swallow the style argument
       case '%s':
-        return typeof arg === 'string' ? arg : formatArg(arg);
+        return formatArg(arg);
       case '%d':
       case '%i': {
         // Match the browser console formatter (WHATWG): parseInt on the value,

--- a/packages/browser/src/client/formatConsole.ts
+++ b/packages/browser/src/client/formatConsole.ts
@@ -23,7 +23,7 @@ export const formatArg = (arg: unknown): string => {
 // and dropped (matching how Node's `util.format` handles it). `%%` is a literal
 // percent sign. Kept aligned with the browser console spec (no Node-only `%j`,
 // since these logs originate in the browser).
-// cspell:ignore sdifo
+// cspell:ignore sdifo WHATWG
 const HAS_SPECIFIER = /%[sdifoOc%]/;
 const SPECIFIER = /%[sdifoOc%]/g;
 
@@ -55,16 +55,15 @@ export const formatConsoleArgs = (args: unknown[]): string => {
         return typeof arg === 'string' ? arg : formatArg(arg);
       case '%d':
       case '%i': {
-        // `Number(symbol)` throws; a real console forwards NaN instead of
-        // letting the log call fail the test.
-        if (typeof arg === 'symbol') return 'NaN';
-        if (typeof arg === 'bigint') return String(arg);
-        const num = Number(arg);
-        return Number.isNaN(num) ? 'NaN' : String(Math.trunc(num));
+        // Match the browser console formatter (WHATWG): parseInt on the value,
+        // so unit-suffixed strings like '42px' format as 42 (not NaN).
+        // `String()` first keeps Symbol safe — a bare `parseInt(symbol)` throws
+        // via ToString, whereas the spec maps a Symbol to NaN.
+        const num = Number.parseInt(String(arg), 10);
+        return Number.isNaN(num) ? 'NaN' : String(num);
       }
       case '%f': {
-        if (typeof arg === 'symbol') return 'NaN';
-        const num = Number(arg);
+        const num = Number.parseFloat(String(arg));
         return Number.isNaN(num) ? 'NaN' : String(num);
       }
       default: // %o, %O

--- a/packages/browser/src/client/formatConsole.ts
+++ b/packages/browser/src/client/formatConsole.ts
@@ -8,6 +8,9 @@ export const formatArg = (arg: unknown): string => {
   if (arg === undefined) return 'undefined';
   if (typeof arg === 'string') return arg;
   if (typeof arg === 'number' || typeof arg === 'boolean') return String(arg);
+  // `JSON.stringify(symbol)` is `undefined`, so a symbol must be handled before
+  // the JSON path or it would forward as an empty/`undefined` log.
+  if (typeof arg === 'symbol') return arg.toString();
   if (arg instanceof Error) {
     return arg.stack || `${arg.name}: ${arg.message}`;
   }

--- a/packages/browser/src/client/formatConsole.ts
+++ b/packages/browser/src/client/formatConsole.ts
@@ -1,0 +1,75 @@
+/**
+ * Format a single console argument to a string for terminal forwarding.
+ * Objects are JSON-stringified; Errors keep their stack. This mirrors the
+ * browser console's default stringification closely enough for log forwarding.
+ */
+export const formatArg = (arg: unknown): string => {
+  if (arg === null) return 'null';
+  if (arg === undefined) return 'undefined';
+  if (typeof arg === 'string') return arg;
+  if (typeof arg === 'number' || typeof arg === 'boolean') return String(arg);
+  if (arg instanceof Error) {
+    return arg.stack || `${arg.name}: ${arg.message}`;
+  }
+  try {
+    return JSON.stringify(arg, null, 2);
+  } catch {
+    return String(arg);
+  }
+};
+
+// Format specifiers understood by the browser console. `%c` applies CSS in a
+// real console; forwarded to a terminal there is no styling, so it is consumed
+// and dropped (matching how Node's `util.format` handles it). `%%` is a literal
+// percent sign. Kept aligned with the browser console spec (no Node-only `%j`,
+// since these logs originate in the browser).
+// cspell:ignore sdifo
+const HAS_SPECIFIER = /%[sdifoOc%]/;
+const SPECIFIER = /%[sdifoOc%]/g;
+
+/**
+ * Join console arguments the way a console does. When the first argument is a
+ * string carrying `printf`-style specifiers, substitute the following arguments
+ * into it (consuming `%c` styles without emitting them), then append any
+ * leftover arguments. Otherwise fall back to a plain space-join.
+ *
+ * Without this, `console.info('%cText', 'font-weight:bold')` (e.g. React's
+ * DevTools notice) leaks the raw `%c` directive and its CSS argument into the
+ * forwarded terminal output.
+ */
+export const formatConsoleArgs = (args: unknown[]): string => {
+  const first = args[0];
+  if (typeof first !== 'string' || !HAS_SPECIFIER.test(first)) {
+    return args.map(formatArg).join(' ');
+  }
+
+  let next = 1;
+  const substituted = first.replace(SPECIFIER, (spec) => {
+    if (spec === '%%') return '%';
+    if (next >= args.length) return spec; // no argument left to consume
+    const arg = args[next++];
+    switch (spec) {
+      case '%c':
+        return ''; // CSS directive: swallow the style argument
+      case '%s':
+        return typeof arg === 'string' ? arg : formatArg(arg);
+      case '%d':
+      case '%i': {
+        if (typeof arg === 'bigint') return String(arg);
+        const num = Number(arg);
+        return Number.isNaN(num) ? 'NaN' : String(Math.trunc(num));
+      }
+      case '%f': {
+        const num = Number(arg);
+        return Number.isNaN(num) ? 'NaN' : String(num);
+      }
+      default: // %o, %O
+        return formatArg(arg);
+    }
+  });
+
+  if (next >= args.length) {
+    return substituted;
+  }
+  return [substituted, ...args.slice(next).map(formatArg)].join(' ');
+};

--- a/packages/browser/src/client/formatConsole.ts
+++ b/packages/browser/src/client/formatConsole.ts
@@ -55,11 +55,15 @@ export const formatConsoleArgs = (args: unknown[]): string => {
         return typeof arg === 'string' ? arg : formatArg(arg);
       case '%d':
       case '%i': {
+        // `Number(symbol)` throws; a real console forwards NaN instead of
+        // letting the log call fail the test.
+        if (typeof arg === 'symbol') return 'NaN';
         if (typeof arg === 'bigint') return String(arg);
         const num = Number(arg);
         return Number.isNaN(num) ? 'NaN' : String(Math.trunc(num));
       }
       case '%f': {
+        if (typeof arg === 'symbol') return 'NaN';
         const num = Number(arg);
         return Number.isNaN(num) ? 'NaN' : String(num);
       }

--- a/packages/browser/tests/formatConsole.test.ts
+++ b/packages/browser/tests/formatConsole.test.ts
@@ -31,6 +31,13 @@ describe('formatConsoleArgs', () => {
     expect(formatConsoleArgs(['%f', 3.5])).toBe('3.5');
   });
 
+  it('formats a Symbol under numeric specifiers as NaN without throwing', () => {
+    const sym = Symbol('id');
+    expect(formatConsoleArgs(['%d', sym])).toBe('NaN');
+    expect(formatConsoleArgs(['%i', sym])).toBe('NaN');
+    expect(formatConsoleArgs(['%f', sym])).toBe('NaN');
+  });
+
   it('renders %o / %O objects', () => {
     expect(formatConsoleArgs(['%o', { a: 1 }])).toBe('{\n  "a": 1\n}');
   });

--- a/packages/browser/tests/formatConsole.test.ts
+++ b/packages/browser/tests/formatConsole.test.ts
@@ -21,6 +21,12 @@ describe('formatConsoleArgs', () => {
     expect(formatConsoleArgs(['%s world', 'hello'])).toBe('hello world');
   });
 
+  it('stringifies a Symbol under %s and as a bare argument', () => {
+    const sym = Symbol('id');
+    expect(formatConsoleArgs(['%s', sym])).toBe('Symbol(id)');
+    expect(formatConsoleArgs([sym])).toBe('Symbol(id)');
+  });
+
   it('parses %d and %i as an integer like the browser console', () => {
     expect(formatConsoleArgs(['%d', 3.7])).toBe('3');
     expect(formatConsoleArgs(['%i things', 5.9])).toBe('5 things');

--- a/packages/browser/tests/formatConsole.test.ts
+++ b/packages/browser/tests/formatConsole.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from '@rstest/core';
+import { formatConsoleArgs } from '../src/client/formatConsole';
+
+describe('formatConsoleArgs', () => {
+  it('joins plain arguments with a space when there is no specifier', () => {
+    expect(formatConsoleArgs(['a', 'b', 1])).toBe('a b 1');
+  });
+
+  it('consumes %c and drops its style argument (React DevTools notice)', () => {
+    expect(
+      formatConsoleArgs([
+        '%cDownload the React DevTools: https://react.dev/link/react-devtools',
+        'font-weight:bold',
+      ]),
+    ).toBe(
+      'Download the React DevTools: https://react.dev/link/react-devtools',
+    );
+  });
+
+  it('substitutes %s with the following argument', () => {
+    expect(formatConsoleArgs(['%s world', 'hello'])).toBe('hello world');
+  });
+
+  it('truncates %d and %i to an integer', () => {
+    expect(formatConsoleArgs(['%d', 3.7])).toBe('3');
+    expect(formatConsoleArgs(['%i things', 5.9])).toBe('5 things');
+    expect(formatConsoleArgs(['%d', 'nope'])).toBe('NaN');
+  });
+
+  it('keeps %f as a float', () => {
+    expect(formatConsoleArgs(['%f', 3.5])).toBe('3.5');
+  });
+
+  it('renders %o / %O objects', () => {
+    expect(formatConsoleArgs(['%o', { a: 1 }])).toBe('{\n  "a": 1\n}');
+  });
+
+  it('turns %% into a literal percent sign without consuming an argument', () => {
+    expect(formatConsoleArgs(['100%% done', 'extra'])).toBe('100% done extra');
+  });
+
+  it('appends leftover arguments after substitution', () => {
+    expect(formatConsoleArgs(['%s', 'a', 'b', 'c'])).toBe('a b c');
+  });
+
+  it('keeps a specifier literal when no argument is left to consume', () => {
+    expect(formatConsoleArgs(['%s %s', 'a'])).toBe('a %s');
+  });
+
+  it('does not substitute when the first argument is not a string', () => {
+    expect(formatConsoleArgs([{ a: 1 }, '%s'])).toBe('{\n  "a": 1\n} %s');
+  });
+});

--- a/packages/browser/tests/formatConsole.test.ts
+++ b/packages/browser/tests/formatConsole.test.ts
@@ -21,14 +21,18 @@ describe('formatConsoleArgs', () => {
     expect(formatConsoleArgs(['%s world', 'hello'])).toBe('hello world');
   });
 
-  it('truncates %d and %i to an integer', () => {
+  it('parses %d and %i as an integer like the browser console', () => {
     expect(formatConsoleArgs(['%d', 3.7])).toBe('3');
     expect(formatConsoleArgs(['%i things', 5.9])).toBe('5 things');
     expect(formatConsoleArgs(['%d', 'nope'])).toBe('NaN');
+    // Unit-suffixed strings parse to their leading integer (parseInt), not NaN.
+    expect(formatConsoleArgs(['%i', '42px'])).toBe('42');
   });
 
-  it('keeps %f as a float', () => {
+  it('parses %f as a float like the browser console', () => {
     expect(formatConsoleArgs(['%f', 3.5])).toBe('3.5');
+    // Unit-suffixed strings parse to their leading float (parseFloat), not NaN.
+    expect(formatConsoleArgs(['%f', '3.5ms'])).toBe('3.5');
   });
 
   it('formats a Symbol under numeric specifiers as NaN without throwing', () => {


### PR DESCRIPTION
## Summary

In browser mode, forwarded console logs stringified each argument independently and space-joined them, so format specifiers were never interpreted. A call like `console.info('%cText', 'font-weight:bold')` — which React emits for its DevTools notice — leaked the raw `%c` directive and its CSS argument into the terminal:

```
info | tests/counter.test.tsx
%cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
```

This adds a `formatConsoleArgs` helper (new `src/client/formatConsole.ts`) that runs `printf`-style substitution over the leading format string (`%s %d %i %f %o %O %c %%`), consuming `%c` styles like a real console does, then appends any leftover arguments. The above now forwards as:

```
info | tests/counter.test.tsx
Download the React DevTools for a better development experience: https://react.dev/link/react-devtools
```

Node mode already formats logs correctly via `util.formatWithOptions` in `@rstest/core`'s custom console; this brings browser mode in line. The helper is extracted into its own module so it can be unit-tested without the browser-only client entry.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).