### PR TITLE
fix(browser): gate HMR/lazyCompilation to headed watch only

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -601,8 +601,24 @@ export const createBrowserLazyCompilationConfig = (
   };
 };
 
-export const createBrowserRsbuildDevConfig = (
+/**
+ * HMR — and the lazyCompilation transport it carries — is wired only for headed
+ * watch, the sole path that reuses a persistent page and applies module updates
+ * in place. Headless always loads each test file in a fresh page (pulling the
+ * latest incrementally-built chunks over HTTP), and one-shot runs never rerun,
+ * so pushing HMR updates there is dead weight that only races factory
+ * registration for chunk-split node_modules (rspack#11922) and lets
+ * lazyCompilation's accept-chain walk abort the next spec when no boundary
+ * exists (#1472). Disabling HMR does not make watch rebuilds any less
+ * incremental — HMR is only the client push transport.
+ */
+export const shouldEnableBrowserHmr = (
   isWatchMode: boolean,
+  isHeadless: boolean,
+): boolean => isWatchMode && !isHeadless;
+
+export const createBrowserRsbuildDevConfig = (
+  enableHmr: boolean,
 ): {
   writeToDisk: boolean;
   hmr: boolean;
@@ -612,12 +628,10 @@ export const createBrowserRsbuildDevConfig = (
 } => {
   return {
     writeToDisk: isDebug(),
-    // HMR is only wired in watch mode. One-shot runs load each test file in a
-    // fresh page against a persistent dev server; leaving HMR on makes the
-    // server push chunk updates into a page that is still resolving its module
-    // graph, which races factory registration for chunk-split node_modules
-    // (many-small-files packages like lodash-es) — see rspack#11922.
-    hmr: isWatchMode,
+    // `enableHmr` is gated to headed watch by `shouldEnableBrowserHmr` — the one
+    // path that reuses a page. See that helper for why fresh-page runs (headless,
+    // or any one-shot) must not receive HMR pushes.
+    hmr: enableHmr,
     client: {
       logLevel: 'error' as const,
     },
@@ -1264,7 +1278,10 @@ const generateManifestModule = ({
 
     if (isWatchMode) {
       // Watch mode keeps the include-glob context so newly added files are
-      // picked up on rebuild (and pairs with lazyCompilation to stay cheap).
+      // picked up on rebuild via `keys()` without regenerating the manifest.
+      // `mode: 'lazy'` is plain code-splitting (async chunks over HTTP), so it
+      // works with or without lazyCompilation; headed watch additionally layers
+      // lazyCompilation on top to keep the initial build cheap.
       const includeRegExp = globPatternsToRegExp(
         project.normalizedConfig.include,
       );
@@ -1609,6 +1626,10 @@ const createBrowserRuntime = async ({
       ...staticRstestAliases,
     };
 
+    const isHeadless =
+      forceHeadless || project.normalizedConfig.browser.headless;
+    const enableHmr = shouldEnableBrowserHmr(isWatchMode, isHeadless);
+
     const rsbuildInstance = await createRsbuild({
       callerName: 'rstest-browser',
       rsbuildConfig: {
@@ -1626,7 +1647,7 @@ const createBrowserRuntime = async ({
             (isContainerServer ? 4000 : 0),
           strictPort: project.normalizedConfig.browser.strictPort,
         },
-        dev: createBrowserRsbuildDevConfig(isWatchMode),
+        dev: createBrowserRsbuildDevConfig(enableHmr),
         environments: {
           [project.environmentName]: {},
         },
@@ -1701,11 +1722,11 @@ const createBrowserRuntime = async ({
                   tools: {
                     rspack: (rspackConfig) => {
                       rspackConfig.mode = 'development';
-                      // lazyCompilation relies on the HMR runtime to deliver
-                      // on-demand modules, so it is only safe in watch mode.
-                      // One-shot runs compile eagerly to avoid the HMR chunk
-                      // registration race (see createBrowserRsbuildDevConfig).
-                      rspackConfig.lazyCompilation = isWatchMode
+                      // lazyCompilation's only delivery transport is the HMR
+                      // runtime, so it follows the same gate as HMR (see
+                      // `shouldEnableBrowserHmr`): headed watch only, everything
+                      // else compiles eagerly.
+                      rspackConfig.lazyCompilation = enableHmr
                         ? createBrowserLazyCompilationConfig(setupFiles)
                         : false;
                       rspackConfig.plugins = rspackConfig.plugins || [];

--- a/packages/browser/tests/hostController.test.ts
+++ b/packages/browser/tests/hostController.test.ts
@@ -5,6 +5,7 @@ import {
   createBrowserRsbuildDevConfig,
   createBrowserContextExcludeRegExp,
   resolveListenPort,
+  shouldEnableBrowserHmr,
   toContextKey,
 } from '../src/hostController';
 
@@ -107,18 +108,29 @@ describe('browser config resolution', () => {
     expect(browserConfig.strictPort).toBe(true);
   });
 
-  it('should disable HMR in non-watch mode and keep error-only client log', () => {
+  it('should disable HMR when enableHmr is false and keep error-only client log', () => {
     const devConfig = createBrowserRsbuildDevConfig(false);
 
     expect(devConfig.hmr).toBe(false);
     expect(devConfig.client.logLevel).toBe('error');
   });
 
-  it('should enable HMR in watch mode', () => {
+  it('should enable HMR when enableHmr is true', () => {
     const devConfig = createBrowserRsbuildDevConfig(true);
 
     expect(devConfig.hmr).toBe(true);
     expect(devConfig.client.logLevel).toBe('error');
+  });
+
+  it('should only enable HMR for headed watch', () => {
+    // Headless never reuses a page, so it never consumes HMR — enabling it only
+    // exposes the #11922 factory race and the #1472 accept-chain throw. One-shot
+    // runs never rerun. So HMR (and the lazyCompilation transport it carries) is
+    // gated to headed watch alone.
+    expect(shouldEnableBrowserHmr(true, false)).toBe(true); // headed watch
+    expect(shouldEnableBrowserHmr(true, true)).toBe(false); // headless watch
+    expect(shouldEnableBrowserHmr(false, false)).toBe(false); // headed one-shot
+    expect(shouldEnableBrowserHmr(false, true)).toBe(false); // headless one-shot
   });
 
   it('should derive the non-watch import-map key like the runtime toContextKey', () => {


### PR DESCRIPTION
## Summary

Browser-mode headless runs load each test file in a fresh page against a persistent dev server and never consume in-page HMR updates, yet HMR was left on whenever `isWatchMode` was true. In headless watch that lets the dev server push chunk updates into a page still resolving its module graph, which:

- races factory registration for chunk-split `node_modules` — `RuntimeError: factory is undefined` (rspack#11922), and
- when no HMR accept boundary exists (e.g. React Fast Refresh disabled), lets `lazyCompilation`'s accept-chain walk abort the next spec, which then silently reports zero tests (#1472).

#1493 already removed this for one-shot runs; this extends the fix to headless watch by moving the gate from "watch" to **headed watch only** — the sole path that reuses a persistent page and actually applies HMR updates.

- Introduce `shouldEnableBrowserHmr(isWatchMode, isHeadless) = isWatchMode && !isHeadless` and drive both the `dev.hmr` flag and `rspackConfig.lazyCompilation` through it.
- The watch manifest keeps its glob `webpackContext` (plain code-splitting, independent of `lazyCompilation`), so newly added test files are still picked up on rebuild. Disabling HMR does not make rebuilds any less incremental — HMR is only the client push transport.

Known follow-up: headed watch + Fast Refresh disabled + multiple specs can still hit the accept-chain throw, since headed genuinely needs HMR; containing that would require the runner to install its own accept boundary and is left out of scope here.

## Related Links

- Closes #1472
- Follow-up to #1493

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).