### PR TITLE
feat(core): support custom runCLI argv

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1150,7 +1150,7 @@ export function createCli(): CAC {
   return cli;
 }
 
-export function setupCommands(): void {
+export function setupCommands(argv: string[]): void {
   const cli = createCli();
-  cli.parse(process.argv);
+  cli.parse(argv);
 }

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -4,11 +4,19 @@ import { prepareCli } from './prepare';
 
 export { initCli } from './init';
 
-export function runCLI(): void {
+export type RunCLIOptions = {
+  /**
+   * The command-line arguments to parse, matching the shape of Node.js `process.argv`
+   * @default process.argv
+   */
+  argv?: string[];
+};
+
+export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
   prepareCli();
 
   try {
-    setupCommands();
+    setupCommands(argv);
   } catch (err) {
     logger.error('Failed to start Rstest CLI.');
     logger.error(err);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ import type {
   RstestConfig,
 } from './types';
 
-export { initCli, runCLI } from './cli';
+export { initCli, runCLI, type RunCLIOptions } from './cli';
 export { loadConfig, mergeProjectConfig, mergeRstestConfig } from './config';
 export { createRstest } from './core';
 export * from './runtime/api/public';


### PR DESCRIPTION
## Summary

This PR adds a `RunCLIOptions` API so programmatic callers can pass a custom `argv` array to `runCLI`, matching the Node.js `process.argv` shape while preserving `process.argv` as the default behavior.

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).