### PR TITLE
perf(coverage-v8): resolve raw coverage in main process

### DIFF
--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -739,8 +739,6 @@ export async function runTests(context: Rstest): Promise<void> {
     testStart ??= buildStart;
     const buildTime = testStart - buildStart;
 
-    const testTime = Date.now() - testStart;
-
     // Wait for browser tests to complete if running in parallel
     const browserResult = browserResultPromise
       ? await browserResultPromise
@@ -780,21 +778,6 @@ export async function runTests(context: Rstest): Promise<void> {
       // are merging browser coverage into `mergedCoverageMap` and stripping it
       // from the browser results to avoid reporter/state cache bloat (mirrors
       // the node-side pool layer's `delete result.coverage`).
-
-      // When unifying reporter output, combine browser and node durations
-      const duration: Duration =
-        shouldUnifyReporter && browserResult
-          ? {
-              totalTime:
-                testTime + buildTime + browserResult.duration.totalTime,
-              buildTime: buildTime + browserResult.duration.buildTime,
-              testTime: testTime + browserResult.duration.testTime,
-            }
-          : {
-              totalTime: testTime + buildTime,
-              buildTime,
-              testTime,
-            };
 
       const results = returns.flatMap((r) => r.results);
       const testResults = returns.flatMap((r) => r.testResults);
@@ -836,6 +819,21 @@ export async function runTests(context: Rstest): Promise<void> {
           mergedCoverageMap?.merge(rawCoverageMap);
         }
       }
+
+      const testTime = Date.now() - testStart;
+      const duration: Duration =
+        shouldUnifyReporter && browserResult
+          ? {
+              totalTime:
+                testTime + buildTime + browserResult.duration.totalTime,
+              buildTime: buildTime + browserResult.duration.buildTime,
+              testTime: testTime + browserResult.duration.testTime,
+            }
+          : {
+              totalTime: testTime + buildTime,
+              buildTime,
+              testTime,
+            };
 
       // Check for failures including browser results when unified
       const nodeHasFailure =

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -160,12 +160,38 @@ const notifyReportersOnTestRunEnd = async ({
 
 const isLifecycleDebugEnabled = isDebug();
 
+type LifecycleStepOptions = {
+  slowAfter?: number;
+  slowMessage?: string;
+  slowDoneMessage?: string;
+};
+
 const runLifecycleStep = async <T>(
   label: string,
   fn: () => Promise<T>,
+  options?: LifecycleStepOptions,
 ): Promise<T> => {
+  const { slowAfter, slowMessage, slowDoneMessage } = options ?? {};
+  let didShowSlowMessage = false;
+  const slowTimer = slowMessage
+    ? setTimeout(() => {
+        didShowSlowMessage = true;
+        logger.info(slowMessage);
+      }, slowAfter ?? 1000)
+    : undefined;
+
   if (!isLifecycleDebugEnabled) {
-    return fn();
+    try {
+      const result = await fn();
+      if (didShowSlowMessage && slowDoneMessage) {
+        logger.info(slowDoneMessage);
+      }
+      return result;
+    } finally {
+      if (slowTimer) {
+        clearTimeout(slowTimer);
+      }
+    }
   }
 
   const startTime = Date.now();
@@ -174,10 +200,17 @@ const runLifecycleStep = async <T>(
   try {
     const result = await fn();
     logger.debug(`lifecycle: finish ${label} (${Date.now() - startTime}ms)`);
+    if (didShowSlowMessage && slowDoneMessage) {
+      logger.info(slowDoneMessage);
+    }
     return result;
   } catch (error) {
     logger.debug(`lifecycle: fail ${label} (${Date.now() - startTime}ms)`);
     throw error;
+  } finally {
+    if (slowTimer) {
+      clearTimeout(slowTimer);
+    }
   }
 };
 
@@ -573,6 +606,7 @@ export async function runTests(context: Rstest): Promise<void> {
     const mergedCoverageMap: CoverageMap | undefined = coverageProvider
       ? coverageProvider.createCoverageMap()
       : undefined;
+    const rawCoverageResults: unknown[] = [];
 
     // Adopt the pre-allocated buffer (set above `runTests` or at the end of
     // the previous rerun's `finalize`) so browser events emitted before
@@ -688,6 +722,7 @@ export async function runTests(context: Rstest): Promise<void> {
           buildId,
           updateSnapshot: context.snapshotManager.options.updateSnapshot,
           onCoverageResult: (coverage) => mergedCoverageMap?.merge(coverage),
+          onRawCoverageResult: (coverage) => rawCoverageResults.push(coverage),
           onTraceEvents: traceRun.onEvents,
           traceSpan: span,
         });
@@ -784,6 +819,22 @@ export async function runTests(context: Rstest): Promise<void> {
       }
       if (shouldUnifyReporter && browserResult?.unhandledErrors) {
         errors.push(...browserResult.unhandledErrors);
+      }
+
+      const resolveRawCoverage =
+        coverageProvider?.resolveRawCoverage?.bind(coverageProvider);
+      if (rawCoverageResults.length && resolveRawCoverage) {
+        const rawCoverageMap = await runLifecycleStep(
+          'coverage collect',
+          async () => resolveRawCoverage(rawCoverageResults),
+          {
+            slowMessage: 'processing coverage results...',
+            slowDoneMessage: 'coverage results processed.',
+          },
+        );
+        if (rawCoverageMap) {
+          mergedCoverageMap?.merge(rawCoverageMap);
+        }
       }
 
       // Check for failures including browser results when unified

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -1,5 +1,9 @@
 import { constants as osConstants } from 'node:os';
-import { cleanCoverageReports, createCoverageProvider } from '../coverage';
+import {
+  cleanCoverageReports,
+  createCoverageProvider,
+  resolveAndMergeRawCoverage,
+} from '../coverage';
 import { ensureRunDependencies } from './dependencies';
 import { createPool } from '../pool';
 import type {
@@ -804,21 +808,12 @@ export async function runTests(context: Rstest): Promise<void> {
         errors.push(...browserResult.unhandledErrors);
       }
 
-      const resolveRawCoverage =
-        coverageProvider?.resolveRawCoverage?.bind(coverageProvider);
-      if (rawCoverageResults.length && resolveRawCoverage) {
-        const rawCoverageMap = await runLifecycleStep(
-          'coverage collect',
-          async () => resolveRawCoverage(rawCoverageResults),
-          {
-            slowMessage: 'processing coverage results...',
-            slowDoneMessage: 'coverage results processed.',
-          },
-        );
-        if (rawCoverageMap) {
-          mergedCoverageMap?.merge(rawCoverageMap);
-        }
-      }
+      await resolveAndMergeRawCoverage({
+        coverageProvider,
+        mergedCoverageMap,
+        rawCoverageResults,
+        runCoverageStep: runLifecycleStep,
+      });
 
       const testTime = Date.now() - testStart;
       const duration: Duration =

--- a/packages/core/src/coverage/index.ts
+++ b/packages/core/src/coverage/index.ts
@@ -13,6 +13,7 @@ import {
   getCoverageProviderModuleName,
 } from './install';
 export { ensureCoverageProviderInstalled } from './install';
+export { resolveAndMergeRawCoverage } from './resolveRawCoverage';
 
 export const loadCoverageProvider = async (
   options: CoverageOptions,

--- a/packages/core/src/coverage/resolveRawCoverage.ts
+++ b/packages/core/src/coverage/resolveRawCoverage.ts
@@ -1,0 +1,40 @@
+import type { CoverageMap, CoverageProvider } from '../types/coverage';
+
+type RunCoverageStep = <T>(
+  label: string,
+  fn: () => Promise<T>,
+  options?: {
+    slowMessage?: string;
+    slowDoneMessage?: string;
+  },
+) => Promise<T>;
+
+export const resolveAndMergeRawCoverage = async ({
+  coverageProvider,
+  mergedCoverageMap,
+  rawCoverageResults,
+  runCoverageStep,
+}: {
+  coverageProvider: CoverageProvider | null;
+  mergedCoverageMap?: CoverageMap;
+  rawCoverageResults: unknown[];
+  runCoverageStep: RunCoverageStep;
+}): Promise<void> => {
+  const resolveRawCoverage =
+    coverageProvider?.resolveRawCoverage?.bind(coverageProvider);
+  if (!rawCoverageResults.length || !resolveRawCoverage) {
+    return;
+  }
+
+  const rawCoverageMap = await runCoverageStep(
+    'coverage collect',
+    async () => resolveRawCoverage(rawCoverageResults),
+    {
+      slowMessage: 'processing coverage results...',
+      slowDoneMessage: 'coverage results processed.',
+    },
+  );
+  if (rawCoverageMap) {
+    mergedCoverageMap?.merge(rawCoverageMap);
+  }
+};

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -540,7 +540,7 @@ export const createPool = async ({
             onCoverageResult?.(result.coverage);
             delete result.coverage;
           }
-          if (result.coverageRaw) {
+          if (result.coverageRaw != null) {
             onRawCoverageResult?.(result.coverageRaw);
             delete result.coverageRaw;
           }

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -284,6 +284,7 @@ export const createPool = async ({
     buildId?: number;
     /** When provided, coverage data is passed to this callback immediately for caller-owned merging. */
     onCoverageResult?: (coverage: CoverageMapData) => void;
+    onRawCoverageResult?: (coverage: unknown) => void;
     /** Perfetto trace events forwarded for caller-owned dumping. */
     onTraceEvents?: (events: TraceEvent[]) => void;
     /** Records host-side pool slices in the caller-owned Perfetto trace. */
@@ -479,6 +480,7 @@ export const createPool = async ({
       updateSnapshot,
       buildId,
       onCoverageResult,
+      onRawCoverageResult,
       onTraceEvents,
       traceSpan,
     }) => {
@@ -537,6 +539,10 @@ export const createPool = async ({
           if (result.coverage) {
             onCoverageResult?.(result.coverage);
             delete result.coverage;
+          }
+          if (result.coverageRaw) {
+            onRawCoverageResult?.(result.coverageRaw);
+            delete result.coverageRaw;
           }
           if (result.traceEvents) {
             onTraceEvents?.(result.traceEvents);

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -686,17 +686,16 @@ export const runInPool = async (
 
     // Collect coverage data after test file completes
     if (coverageProvider) {
+      const provider = coverageProvider;
       tracker.transition('coverage');
       const collectOptions = {
         assetFiles,
         sourceMaps,
         outputModule: options.context.outputModule,
       };
-      const rawCoverage = await coverageProvider.collectRaw?.(collectOptions);
-      if (rawCoverage) {
-        results.coverageRaw = rawCoverage;
-      } else {
-        const coverageMap = await coverageProvider.collect(collectOptions);
+
+      const collectCoverage = async () => {
+        const coverageMap = await provider.collect(collectOptions);
         if (coverageMap) {
           results.coverage = {};
           Object.entries(coverageMap.toJSON()).forEach(([key, value]) => {
@@ -705,6 +704,17 @@ export const runInPool = async (
             else results.coverage![key] = value;
           });
         }
+      };
+
+      if (provider.collectRaw && provider.resolveRawCoverage) {
+        const rawCoverage = await provider.collectRaw(collectOptions);
+        if (rawCoverage != null) {
+          results.coverageRaw = rawCoverage;
+        } else {
+          await collectCoverage();
+        }
+      } else {
+        await collectCoverage();
       }
     }
 

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -687,19 +687,24 @@ export const runInPool = async (
     // Collect coverage data after test file completes
     if (coverageProvider) {
       tracker.transition('coverage');
-      const coverageMap = await coverageProvider.collect({
+      const collectOptions = {
         assetFiles,
         sourceMaps,
         outputModule: options.context.outputModule,
-      });
-      if (coverageMap) {
-        // Attach coverage data to test result
-        results.coverage = {};
-        Object.entries(coverageMap.toJSON()).forEach(([key, value]) => {
-          if ('toJSON' in value)
-            results.coverage![key] = value.toJSON() as FileCoverageData;
-          else results.coverage![key] = value;
-        });
+      };
+      const rawCoverage = await coverageProvider.collectRaw?.(collectOptions);
+      if (rawCoverage) {
+        results.coverageRaw = rawCoverage;
+      } else {
+        const coverageMap = await coverageProvider.collect(collectOptions);
+        if (coverageMap) {
+          results.coverage = {};
+          Object.entries(coverageMap.toJSON()).forEach(([key, value]) => {
+            if ('toJSON' in value)
+              results.coverage![key] = value.toJSON() as FileCoverageData;
+            else results.coverage![key] = value;
+          });
+        }
       }
     }
 

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -173,10 +173,26 @@ export declare class CoverageProvider {
     options?: CoverageCollectOptions,
   ): CoverageMap | null | Promise<CoverageMap | null>;
 
+  /**
+   * Collect lightweight, serializable raw coverage payloads in workers.
+   *
+   * Providers may implement this with `resolveRawCoverage` to defer expensive
+   * conversion work to the main process. Return `null` to indicate that no raw
+   * coverage was collected and the runner should not call `resolveRawCoverage`
+   * for that worker result.
+   */
   collectRaw?(
     options?: CoverageCollectOptions,
   ): unknown | null | Promise<unknown | null>;
 
+  /**
+   * Resolve raw payloads produced by `collectRaw` into an Istanbul coverage map.
+   *
+   * The runner passes only non-null payloads returned by the same provider.
+   * Implementations should ignore malformed payloads only when they can still
+   * produce a valid partial report; otherwise they may reject to fail coverage
+   * finalization.
+   */
   resolveRawCoverage?(
     payloads: unknown[],
   ): CoverageMap | null | Promise<CoverageMap | null>;

--- a/packages/core/src/types/coverage.ts
+++ b/packages/core/src/types/coverage.ts
@@ -153,6 +153,12 @@ export type NormalizedCoverageOptions = Required<
   changed?: boolean | string;
 };
 
+export type CoverageCollectOptions = {
+  assetFiles?: Record<string, string>;
+  sourceMaps?: Record<string, string>;
+  outputModule?: boolean;
+};
+
 export declare class CoverageProvider {
   constructor(options: NormalizedCoverageOptions, root?: string);
   /**
@@ -161,13 +167,19 @@ export declare class CoverageProvider {
   init(): void | Promise<void>;
 
   /**
-   * Collect coverage data from global coverage object
+   * Collect coverage data into an Istanbul coverage map.
    */
-  collect(options?: {
-    assetFiles?: Record<string, string>;
-    sourceMaps?: Record<string, string>;
-    outputModule?: boolean;
-  }): CoverageMap | null | Promise<CoverageMap | null>;
+  collect(
+    options?: CoverageCollectOptions,
+  ): CoverageMap | null | Promise<CoverageMap | null>;
+
+  collectRaw?(
+    options?: CoverageCollectOptions,
+  ): unknown | null | Promise<unknown | null>;
+
+  resolveRawCoverage?(
+    payloads: unknown[],
+  ): CoverageMap | null | Promise<CoverageMap | null>;
 
   /**
    * Create a new coverage map

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -182,6 +182,12 @@ export type TestFileResult = TestResult & {
   results: TestResult[];
   snapshotResult?: SnapshotResult;
   coverage?: Record<string, FileCoverageData>;
+  /**
+   * Raw coverage payload used internally between workers and the pool.
+   * Stripped at the pool boundary before results are exposed to reporters.
+   *
+   * @internal
+   */
   coverageRaw?: unknown;
   /**
    * Perfetto-compatible trace events. Stripped at the pool boundary.

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -182,6 +182,7 @@ export type TestFileResult = TestResult & {
   results: TestResult[];
   snapshotResult?: SnapshotResult;
   coverage?: Record<string, FileCoverageData>;
+  coverageRaw?: unknown;
   /**
    * Perfetto-compatible trace events. Stripped at the pool boundary.
    *

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -42,11 +42,9 @@ type CoverageEntry = inspector.Profiler.ScriptCoverage & {
   filePath: string;
 };
 
-type CollectOptions = {
-  assetFiles?: Record<string, string>;
-  sourceMaps?: Record<string, string>;
-  outputModule?: boolean;
-};
+type CollectOptions = NonNullable<
+  Parameters<RstestCoverageProvider['collect']>[0]
+>;
 
 type TransformedSource = {
   code: string;
@@ -544,12 +542,12 @@ export class CoverageProvider implements RstestCoverageProvider {
 
     for (const entry of entries) {
       const assetSource = this.findInDict(options.assetFiles, entry.filePath);
-      if (assetSource) {
+      if (assetSource !== undefined) {
         assetFiles[entry.filePath] = assetSource;
       }
 
       const sourceMap = this.findInDict(options.sourceMaps, entry.filePath);
-      if (sourceMap) {
+      if (sourceMap !== undefined) {
         sourceMaps[entry.filePath] = sourceMap;
       }
     }

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -42,6 +42,24 @@ type CoverageEntry = inspector.Profiler.ScriptCoverage & {
   filePath: string;
 };
 
+type CollectOptions = {
+  assetFiles?: Record<string, string>;
+  sourceMaps?: Record<string, string>;
+  outputModule?: boolean;
+};
+
+type TransformedSource = {
+  code: string;
+  sourceMap?: SourceMapLike;
+  sourceMapStr?: string;
+  sourceMapUrl?: string;
+};
+
+type RawCoveragePayload = {
+  entries: CoverageEntry[];
+  options?: CollectOptions;
+};
+
 export class CoverageProvider implements RstestCoverageProvider {
   private session: inspector.Session | null = null;
   private isMatch: (filePath: string) => boolean;
@@ -307,16 +325,8 @@ export class CoverageProvider implements RstestCoverageProvider {
 
   private async getTransformedSource(
     filePath: string,
-    options?: {
-      assetFiles?: Record<string, string>;
-      sourceMaps?: Record<string, string>;
-    },
-  ): Promise<{
-    code: string;
-    sourceMap?: SourceMapLike;
-    sourceMapStr?: string;
-    sourceMapUrl?: string;
-  }> {
+    options?: Pick<CollectOptions, 'assetFiles' | 'sourceMaps'>,
+  ): Promise<TransformedSource> {
     const assetSource = this.findInDict(options?.assetFiles, filePath);
     const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
     const code = assetSource ?? (await fs.readFile(filePath, 'utf-8'));
@@ -366,14 +376,11 @@ export class CoverageProvider implements RstestCoverageProvider {
   private async convertWithAst(
     filePath: string,
     entry: inspector.Profiler.ScriptCoverage,
-    options?: {
-      assetFiles?: Record<string, string>;
-      sourceMaps?: Record<string, string>;
-      outputModule?: boolean;
-    },
+    options?: CollectOptions,
+    transformedSource?: TransformedSource,
   ): Promise<Record<string, FileCoverageData>> {
     const { code, sourceMap, sourceMapStr, sourceMapUrl } =
-      await this.getTransformedSource(filePath, options);
+      transformedSource ?? (await this.getTransformedSource(filePath, options));
 
     if (this.shouldSkipSourceMapEntry(sourceMap)) {
       return {};
@@ -469,12 +476,63 @@ export class CoverageProvider implements RstestCoverageProvider {
     });
   }
 
-  collect(options?: {
-    assetFiles?: Record<string, string>;
-    sourceMaps?: Record<string, string>;
-    outputModule?: boolean;
-  }): Promise<CoverageMap | null> {
+  collect(options?: CollectOptions): Promise<CoverageMap | null> {
     return this.collectImpl(options);
+  }
+
+  resolveRawCoverage(payloads: unknown[]): Promise<CoverageMap | null> {
+    return this.collectRawPayloads(payloads as RawCoveragePayload[]);
+  }
+
+  async collectRaw(
+    options?: CollectOptions,
+  ): Promise<RawCoveragePayload | null> {
+    if (!this.session) return null;
+
+    let entries: CoverageEntry[];
+    try {
+      entries = await this.takeRawCoverage();
+    } finally {
+      await this.stopCoverage();
+    }
+
+    const filteredEntries = await this.filterRawCoverageEntries(
+      entries,
+      options,
+    );
+
+    return {
+      entries: filteredEntries,
+      options: this.pickRawCoverageOptions(filteredEntries, options),
+    };
+  }
+
+  private pickRawCoverageOptions(
+    entries: CoverageEntry[],
+    options?: CollectOptions,
+  ): CollectOptions | undefined {
+    if (!options) return undefined;
+
+    const assetFiles: Record<string, string> = {};
+    const sourceMaps: Record<string, string> = {};
+
+    for (const entry of entries) {
+      const assetSource = this.findInDict(options.assetFiles, entry.filePath);
+      if (assetSource) {
+        assetFiles[entry.filePath] = assetSource;
+      }
+
+      const sourceMap = this.findInDict(options.sourceMaps, entry.filePath);
+      if (sourceMap) {
+        sourceMaps[entry.filePath] = sourceMap;
+      }
+    }
+
+    return {
+      ...(Object.keys(assetFiles).length ? { assetFiles } : {}),
+      ...(Object.keys(sourceMaps).length ? { sourceMaps } : {}),
+      outputModule: options.outputModule,
+    };
   }
 
   private async takeRawCoverage(): Promise<CoverageEntry[]> {
@@ -497,10 +555,7 @@ export class CoverageProvider implements RstestCoverageProvider {
 
   private async filterRawCoverageEntries(
     entries: CoverageEntry[],
-    options?: {
-      assetFiles?: Record<string, string>;
-      sourceMaps?: Record<string, string>;
-    },
+    options?: Pick<CollectOptions, 'assetFiles' | 'sourceMaps'>,
   ): Promise<CoverageEntry[]> {
     const filtered: CoverageEntry[] = [];
 
@@ -515,10 +570,7 @@ export class CoverageProvider implements RstestCoverageProvider {
 
   private async shouldKeepRawCoverageEntry(
     entry: CoverageEntry,
-    options?: {
-      assetFiles?: Record<string, string>;
-      sourceMaps?: Record<string, string>;
-    },
+    options?: Pick<CollectOptions, 'assetFiles' | 'sourceMaps'>,
   ): Promise<boolean> {
     const { filePath } = entry;
     const sourceMapStr = this.findInDict(options?.sourceMaps, filePath);
@@ -545,23 +597,16 @@ export class CoverageProvider implements RstestCoverageProvider {
     return assetSource === undefined && this.hasSourceMapOnDisk(filePath);
   }
 
-  private async collectImpl(options?: {
-    assetFiles?: Record<string, string>;
-    sourceMaps?: Record<string, string>;
-    outputModule?: boolean;
-  }): Promise<CoverageMap | null> {
+  private async collectImpl(
+    options?: CollectOptions,
+  ): Promise<CoverageMap | null> {
     if (!this.session) return null;
 
     let entries: CoverageEntry[];
     try {
       entries = await this.takeRawCoverage();
     } finally {
-      try {
-        await this.session.post('Profiler.stopPreciseCoverage');
-        await this.session.post('Profiler.disable');
-      } catch (_err) {
-        // Ignore teardown errors to prevent masking original errors
-      }
+      await this.stopCoverage();
     }
 
     const filteredEntries = await this.filterRawCoverageEntries(
@@ -589,6 +634,161 @@ export class CoverageProvider implements RstestCoverageProvider {
     );
 
     return coverageMap;
+  }
+
+  private async collectRawPayloads(
+    payloads: RawCoveragePayload[],
+  ): Promise<CoverageMap | null> {
+    const coverageMap = this.createCoverageMap();
+    const groups = new Map<
+      string,
+      { entries: CoverageEntry[]; options?: CollectOptions }
+    >();
+
+    for (const payload of payloads) {
+      for (const entry of payload.entries) {
+        const outputModule = payload.options?.outputModule ?? true;
+        const key = `${entry.filePath}\0${outputModule ? 'module' : 'script'}`;
+        this.mergeIntoCoverageEntries(groups, key, entry, payload.options);
+      }
+    }
+
+    await Promise.all(
+      Array.from(groups.values()).map(async ({ entries, options }) => {
+        const transformedSource = await this.getTransformedSource(
+          entries[0]!.filePath,
+          options,
+        );
+
+        await Promise.all(
+          entries.map(async (entry) => {
+            try {
+              const istanbulData = await this.convertWithAst(
+                entry.filePath,
+                entry,
+                options,
+                transformedSource,
+              );
+
+              this.filterCoverageData(istanbulData);
+              coverageMap.merge(istanbulData);
+            } catch (e) {
+              console.error(`Failed to process coverage for ${entry.url}:`, e);
+              process.exitCode = 1;
+            }
+          }),
+        );
+      }),
+    );
+
+    return coverageMap;
+  }
+
+  private async stopCoverage(): Promise<void> {
+    if (!this.session) return;
+
+    try {
+      await this.session.post('Profiler.stopPreciseCoverage');
+      await this.session.post('Profiler.disable');
+    } catch (_err) {
+      // Ignore teardown errors to prevent masking original errors
+    }
+  }
+
+  private mergeIntoCoverageEntries(
+    groups: Map<string, { entries: CoverageEntry[]; options?: CollectOptions }>,
+    key: string,
+    entry: CoverageEntry,
+    options?: CollectOptions,
+  ): void {
+    let group = groups.get(key);
+    if (!group) {
+      group = { entries: [], options };
+      groups.set(key, group);
+    } else if (options) {
+      group.options = {
+        assetFiles: { ...group.options?.assetFiles, ...options.assetFiles },
+        sourceMaps: { ...group.options?.sourceMaps, ...options.sourceMaps },
+        outputModule: group.options?.outputModule ?? options.outputModule,
+      };
+    }
+
+    for (const target of group.entries) {
+      if (this.tryMergeCoverageEntry(target, entry)) {
+        return;
+      }
+    }
+
+    group.entries.push(this.cloneCoverageEntry(entry));
+  }
+
+  private tryMergeCoverageEntry(
+    target: CoverageEntry,
+    incoming: CoverageEntry,
+  ): boolean {
+    if (target.functions.length !== incoming.functions.length) {
+      return false;
+    }
+
+    for (
+      let functionIndex = 0;
+      functionIndex < target.functions.length;
+      functionIndex++
+    ) {
+      const targetFunction = target.functions[functionIndex]!;
+      const incomingFunction = incoming.functions[functionIndex]!;
+      if (
+        targetFunction.functionName !== incomingFunction.functionName ||
+        targetFunction.isBlockCoverage !== incomingFunction.isBlockCoverage ||
+        targetFunction.ranges.length !== incomingFunction.ranges.length
+      ) {
+        return false;
+      }
+
+      for (
+        let rangeIndex = 0;
+        rangeIndex < targetFunction.ranges.length;
+        rangeIndex++
+      ) {
+        const targetRange = targetFunction.ranges[rangeIndex]!;
+        const incomingRange = incomingFunction.ranges[rangeIndex]!;
+        if (
+          targetRange.startOffset !== incomingRange.startOffset ||
+          targetRange.endOffset !== incomingRange.endOffset
+        ) {
+          return false;
+        }
+      }
+    }
+
+    for (
+      let functionIndex = 0;
+      functionIndex < target.functions.length;
+      functionIndex++
+    ) {
+      const targetFunction = target.functions[functionIndex]!;
+      const incomingFunction = incoming.functions[functionIndex]!;
+      for (
+        let rangeIndex = 0;
+        rangeIndex < targetFunction.ranges.length;
+        rangeIndex++
+      ) {
+        targetFunction.ranges[rangeIndex]!.count +=
+          incomingFunction.ranges[rangeIndex]!.count;
+      }
+    }
+
+    return true;
+  }
+
+  private cloneCoverageEntry(entry: CoverageEntry): CoverageEntry {
+    return {
+      ...entry,
+      functions: entry.functions.map((fn) => ({
+        ...fn,
+        ranges: fn.ranges.map((range) => ({ ...range })),
+      })),
+    };
   }
 
   createCoverageMap(): CoverageMap {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -58,6 +58,13 @@ type TransformedSource = {
 type RawCoveragePayload = {
   entries: CoverageEntry[];
   options?: CollectOptions;
+  root?: string;
+};
+
+type CoverageEntryGroup = {
+  entries: CoverageEntry[];
+  options?: CollectOptions;
+  root?: string;
 };
 
 export class CoverageProvider implements RstestCoverageProvider {
@@ -103,25 +110,32 @@ export class CoverageProvider implements RstestCoverageProvider {
     return posix.isAbsolute(filePath) || win32.isAbsolute(filePath);
   }
 
-  private toProjectRelativePath(filePath: string): string {
+  private toProjectRelativePath(filePath: string, root = this.root): string {
     const normalizedFilePath = this.normalizeSlashes(filePath);
 
-    if (!this.root || !this.isAbsolutePath(normalizedFilePath)) {
+    if (!root || !this.isAbsolutePath(normalizedFilePath)) {
       return normalizedFilePath;
     }
 
+    const normalizedRoot = this.normalizeSlashes(root);
+
     if (
       this.normalizeForMatching(normalizedFilePath) ===
-      this.normalizeForMatching(this.root)
+      this.normalizeForMatching(normalizedRoot)
     ) {
       return '';
     }
 
-    if (win32.isAbsolute(normalizedFilePath) || win32.isAbsolute(this.root)) {
-      return win32.relative(this.root, normalizedFilePath).replace(/\\/g, '/');
+    if (
+      win32.isAbsolute(normalizedFilePath) ||
+      win32.isAbsolute(normalizedRoot)
+    ) {
+      return win32
+        .relative(normalizedRoot, normalizedFilePath)
+        .replace(/\\/g, '/');
     }
 
-    return posix.relative(this.root, normalizedFilePath);
+    return posix.relative(normalizedRoot, normalizedFilePath);
   }
 
   private findInDict(
@@ -182,18 +196,19 @@ export class CoverageProvider implements RstestCoverageProvider {
     );
   }
 
-  private shouldProcessEntry(filePath: string): boolean {
+  private shouldProcessEntry(filePath: string, root = this.root): boolean {
     const normalizedFilePath = this.normalizeForMatching(filePath);
-    const normalizedRoot = this.root
-      ? this.normalizeForMatching(this.root)
-      : undefined;
+    const normalizedRoot = root ? this.normalizeForMatching(root) : undefined;
 
     if (this.shouldIgnoreTransformedFile(normalizedFilePath)) {
       return false;
     }
 
     if (!this.options.allowExternal && normalizedRoot) {
-      const relativeFilePath = this.toProjectRelativePath(normalizedFilePath);
+      const relativeFilePath = this.toProjectRelativePath(
+        normalizedFilePath,
+        normalizedRoot,
+      );
       if (
         this.isAbsolutePath(relativeFilePath) ||
         relativeFilePath.startsWith('../')
@@ -226,14 +241,17 @@ export class CoverageProvider implements RstestCoverageProvider {
     );
   }
 
-  private shouldKeepOriginalSource(filePath: string): boolean {
+  private shouldKeepOriginalSource(
+    filePath: string,
+    root = this.root,
+  ): boolean {
     const normalizedKey = filePath.replace(/\\/g, '/');
 
     if (this.shouldIgnoreTransformedFile(normalizedKey)) {
       return false;
     }
 
-    const originalTestPath = this.toProjectRelativePath(normalizedKey);
+    const originalTestPath = this.toProjectRelativePath(normalizedKey, root);
     return (
       !this.isExcluded(originalTestPath) && this.isIncluded(originalTestPath)
     );
@@ -378,6 +396,7 @@ export class CoverageProvider implements RstestCoverageProvider {
     entry: inspector.Profiler.ScriptCoverage,
     options?: CollectOptions,
     transformedSource?: TransformedSource,
+    root = this.root,
   ): Promise<Record<string, FileCoverageData>> {
     const { code, sourceMap, sourceMapStr, sourceMapUrl } =
       transformedSource ?? (await this.getTransformedSource(filePath, options));
@@ -400,6 +419,7 @@ export class CoverageProvider implements RstestCoverageProvider {
       codeHash,
       sourceMapStr,
       outputModule,
+      root,
     );
     const ast = this.parseAst(code, outputModule, astCacheKey);
 
@@ -407,7 +427,8 @@ export class CoverageProvider implements RstestCoverageProvider {
       ast,
       cacheKey: converterCacheKey,
       code,
-      sourceFilter: (sourcePath) => this.shouldKeepOriginalSource(sourcePath),
+      sourceFilter: (sourcePath) =>
+        this.shouldKeepOriginalSource(sourcePath, root),
       sourceMap,
       sourceMapUrl,
       coverage: {
@@ -423,12 +444,13 @@ export class CoverageProvider implements RstestCoverageProvider {
     codeHash: number,
     sourceMapStr: string | undefined,
     outputModule: boolean,
+    root: string | undefined,
   ): string {
     return [
       this.getAstCacheKey(filePath, code, codeHash, outputModule),
       sourceMapStr?.length ?? 0,
       sourceMapStr ? this.hashString(sourceMapStr) : 0,
-      this.root ?? '',
+      root ?? '',
       this.options.allowExternal ? 'external' : 'root-only',
       this.options.include?.join('\n') ?? '',
       this.options.exclude.join('\n'),
@@ -457,9 +479,12 @@ export class CoverageProvider implements RstestCoverageProvider {
     return hash >>> 0;
   }
 
-  private filterCoverageData(istanbulData: Record<string, FileCoverageData>) {
+  private filterCoverageData(
+    istanbulData: Record<string, FileCoverageData>,
+    root = this.root,
+  ) {
     for (const key of Object.keys(istanbulData)) {
-      if (!this.shouldKeepOriginalSource(key)) {
+      if (!this.shouldKeepOriginalSource(key, root)) {
         delete istanbulData[key];
         continue;
       }
@@ -504,6 +529,7 @@ export class CoverageProvider implements RstestCoverageProvider {
     return {
       entries: filteredEntries,
       options: this.pickRawCoverageOptions(filteredEntries, options),
+      root: this.root,
     };
   }
 
@@ -640,44 +666,63 @@ export class CoverageProvider implements RstestCoverageProvider {
     payloads: RawCoveragePayload[],
   ): Promise<CoverageMap | null> {
     const coverageMap = this.createCoverageMap();
-    const groups = new Map<
-      string,
-      { entries: CoverageEntry[]; options?: CollectOptions }
-    >();
+    const groups = new Map<string, CoverageEntryGroup>();
 
     for (const payload of payloads) {
       for (const entry of payload.entries) {
         const outputModule = payload.options?.outputModule ?? true;
-        const key = `${entry.filePath}\0${outputModule ? 'module' : 'script'}`;
-        this.mergeIntoCoverageEntries(groups, key, entry, payload.options);
+        const key = [
+          payload.root ?? '',
+          entry.filePath,
+          outputModule ? 'module' : 'script',
+        ].join('\0');
+        this.mergeIntoCoverageEntries(
+          groups,
+          key,
+          entry,
+          payload.options,
+          payload.root,
+        );
       }
     }
 
     await Promise.all(
-      Array.from(groups.values()).map(async ({ entries, options }) => {
-        const transformedSource = await this.getTransformedSource(
-          entries[0]!.filePath,
-          options,
-        );
+      Array.from(groups.values()).map(async ({ entries, options, root }) => {
+        try {
+          const transformedSource = await this.getTransformedSource(
+            entries[0]!.filePath,
+            options,
+          );
 
-        await Promise.all(
-          entries.map(async (entry) => {
-            try {
-              const istanbulData = await this.convertWithAst(
-                entry.filePath,
-                entry,
-                options,
-                transformedSource,
-              );
+          await Promise.all(
+            entries.map(async (entry) => {
+              try {
+                const istanbulData = await this.convertWithAst(
+                  entry.filePath,
+                  entry,
+                  options,
+                  transformedSource,
+                  root,
+                );
 
-              this.filterCoverageData(istanbulData);
-              coverageMap.merge(istanbulData);
-            } catch (e) {
-              console.error(`Failed to process coverage for ${entry.url}:`, e);
-              process.exitCode = 1;
-            }
-          }),
-        );
+                this.filterCoverageData(istanbulData, root);
+                coverageMap.merge(istanbulData);
+              } catch (e) {
+                console.error(
+                  `Failed to process coverage for ${entry.url}:`,
+                  e,
+                );
+                process.exitCode = 1;
+              }
+            }),
+          );
+        } catch (e) {
+          console.error(
+            `Failed to process coverage for ${entries[0]!.url}:`,
+            e,
+          );
+          process.exitCode = 1;
+        }
       }),
     );
 
@@ -696,14 +741,15 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   private mergeIntoCoverageEntries(
-    groups: Map<string, { entries: CoverageEntry[]; options?: CollectOptions }>,
+    groups: Map<string, CoverageEntryGroup>,
     key: string,
     entry: CoverageEntry,
     options?: CollectOptions,
+    root?: string,
   ): void {
     let group = groups.get(key);
     if (!group) {
-      group = { entries: [], options };
+      group = { entries: [], options, root };
       groups.set(key, group);
     } else if (options) {
       group.options = {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -65,6 +65,51 @@ type CoverageEntryGroup = {
   root?: string;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object';
+
+const isStringDict = (value: unknown): value is Record<string, string> =>
+  isRecord(value) &&
+  Object.values(value).every((item) => typeof item === 'string');
+
+const isCollectOptions = (value: unknown): value is CollectOptions =>
+  isRecord(value) &&
+  (value.assetFiles === undefined || isStringDict(value.assetFiles)) &&
+  (value.sourceMaps === undefined || isStringDict(value.sourceMaps)) &&
+  (value.outputModule === undefined || typeof value.outputModule === 'boolean');
+
+const isCoverageRange = (
+  value: unknown,
+): value is inspector.Profiler.CoverageRange =>
+  isRecord(value) &&
+  typeof value.startOffset === 'number' &&
+  typeof value.endOffset === 'number' &&
+  typeof value.count === 'number';
+
+const isFunctionCoverage = (
+  value: unknown,
+): value is inspector.Profiler.FunctionCoverage =>
+  isRecord(value) &&
+  typeof value.functionName === 'string' &&
+  typeof value.isBlockCoverage === 'boolean' &&
+  Array.isArray(value.ranges) &&
+  value.ranges.every(isCoverageRange);
+
+const isCoverageEntry = (value: unknown): value is CoverageEntry =>
+  isRecord(value) &&
+  typeof value.url === 'string' &&
+  typeof value.scriptId === 'string' &&
+  typeof value.filePath === 'string' &&
+  Array.isArray(value.functions) &&
+  value.functions.every(isFunctionCoverage);
+
+const isRawCoveragePayload = (value: unknown): value is RawCoveragePayload =>
+  isRecord(value) &&
+  Array.isArray(value.entries) &&
+  value.entries.every(isCoverageEntry) &&
+  (value.options === undefined || isCollectOptions(value.options)) &&
+  (value.root === undefined || typeof value.root === 'string');
+
 export class CoverageProvider implements RstestCoverageProvider {
   private session: inspector.Session | null = null;
   private isMatch: (filePath: string) => boolean;
@@ -141,7 +186,7 @@ export class CoverageProvider implements RstestCoverageProvider {
     filePath: string,
   ): string | undefined {
     if (!dict) return undefined;
-    if (dict[filePath]) return dict[filePath];
+    if (dict[filePath] !== undefined) return dict[filePath];
 
     let lookup = this.dictLookupCache.get(dict);
     if (!lookup) {
@@ -162,11 +207,11 @@ export class CoverageProvider implements RstestCoverageProvider {
 
     const normalizedPath = filePath.replace(/\\/g, '/');
     const directMatch = lookup.get(normalizedPath);
-    if (directMatch) return directMatch;
+    if (directMatch !== undefined) return directMatch;
 
     if (filePath.startsWith('/private/')) {
       const privateMatch = lookup.get(filePath.slice('/private'.length));
-      if (privateMatch) return privateMatch;
+      if (privateMatch !== undefined) return privateMatch;
     }
 
     return lookup.get(normalizedPath.toLowerCase());
@@ -504,7 +549,22 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   resolveRawCoverage(payloads: unknown[]): Promise<CoverageMap | null> {
-    return this.collectRawPayloads(payloads as RawCoveragePayload[]);
+    const validPayloads: RawCoveragePayload[] = [];
+
+    for (const payload of payloads) {
+      if (isRawCoveragePayload(payload)) {
+        validPayloads.push(payload);
+      } else {
+        console.error('Failed to resolve malformed raw V8 coverage payload.');
+        process.exitCode = 1;
+      }
+    }
+
+    if (!validPayloads.length) {
+      return Promise.resolve(null);
+    }
+
+    return this.collectRawPayloads(validPayloads);
   }
 
   async collectRaw(
@@ -665,15 +725,15 @@ export class CoverageProvider implements RstestCoverageProvider {
   ): Promise<CoverageMap | null> {
     const coverageMap = this.createCoverageMap();
     const groups = new Map<string, CoverageEntryGroup>();
+    const sourceIdentityIds = new Map<string, number>();
 
     for (const payload of payloads) {
       for (const entry of payload.entries) {
-        const outputModule = payload.options?.outputModule ?? true;
-        const key = [
-          payload.root ?? '',
-          entry.filePath,
-          outputModule ? 'module' : 'script',
-        ].join('\0');
+        const key = this.getRawCoverageGroupKey(
+          payload,
+          entry,
+          sourceIdentityIds,
+        );
         this.mergeIntoCoverageEntries(
           groups,
           key,
@@ -725,6 +785,45 @@ export class CoverageProvider implements RstestCoverageProvider {
     );
 
     return coverageMap;
+  }
+
+  private getRawCoverageGroupKey(
+    payload: RawCoveragePayload,
+    entry: CoverageEntry,
+    sourceIdentityIds: Map<string, number>,
+  ): string {
+    const outputModule = payload.options?.outputModule ?? true;
+    const assetSource = this.findInDict(
+      payload.options?.assetFiles,
+      entry.filePath,
+    );
+    const sourceMap = this.findInDict(
+      payload.options?.sourceMaps,
+      entry.filePath,
+    );
+
+    return [
+      payload.root ?? '',
+      entry.filePath,
+      outputModule ? 'module' : 'script',
+      this.getStringIdentity(assetSource, sourceIdentityIds),
+      this.getStringIdentity(sourceMap, sourceIdentityIds),
+    ].join('\0');
+  }
+
+  private getStringIdentity(
+    value: string | undefined,
+    sourceIdentityIds: Map<string, number>,
+  ): string {
+    if (value === undefined) return 'missing';
+
+    let id = sourceIdentityIds.get(value);
+    if (id === undefined) {
+      id = sourceIdentityIds.size;
+      sourceIdentityIds.set(value, id);
+    }
+
+    return String(id);
   }
 
   private async stopCoverage(): Promise<void> {

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -99,6 +99,7 @@ type ProviderInternals = CoverageProvider & {
       sourceMaps?: Record<string, string>;
       outputModule?: boolean;
     },
+    transformedSource?: { code: string },
   ) => Promise<Record<string, FileCoverageData>>;
   takeRawCoverage: () => Promise<unknown[]>;
 };
@@ -1081,6 +1082,73 @@ export default class CustomCoverageReporter {
     }
   });
 
+  it('keeps raw coverage groups separate when source identity differs', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-raw-source-identity');
+    const file = join(root, 'dist', 'covered.js');
+    const firstCode = 'function covered() { return 1; }\ncovered();';
+    const secondCode = 'function covered() { return 2; }\ncovered();';
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    const convertedCodes: string[] = [];
+    const convertedCounts: number[] = [];
+
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async (
+        _filePath: string,
+        entry: { functions: { ranges: { count: number }[] }[] },
+        _options: unknown,
+        transformedSource?: { code: string },
+      ) => {
+        const count = entry.functions[0]!.ranges[0]!.count;
+        convertedCodes.push(transformedSource!.code);
+        convertedCounts.push(count);
+        return {
+          [file]: {
+            ...createFileCoverage(file),
+            s: { 0: count },
+            f: { 0: count },
+            b: { 0: [count, count] },
+          },
+        };
+      },
+    });
+
+    try {
+      const createEntry = (count: number, code: string) => ({
+        url: pathToFileURL(file).href,
+        filePath: file,
+        scriptId: String(count),
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count }],
+          },
+        ],
+      });
+
+      const coverageMap = await provider.resolveRawCoverage([
+        {
+          entries: [createEntry(1, firstCode)],
+          options: { assetFiles: { [file]: firstCode }, outputModule: true },
+        },
+        {
+          entries: [createEntry(2, secondCode)],
+          options: { assetFiles: { [file]: secondCode }, outputModule: true },
+        },
+      ]);
+
+      expect(convertedCodes).toEqual([firstCode, secondCode]);
+      expect(convertedCounts).toEqual([1, 2]);
+      expect(
+        coverageMap?.fileCoverageFor(file).toSummary().statements.pct,
+      ).toBe(100);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('continues resolving raw coverage when a source lookup fails', async () => {
     const root = join(tmpdir(), 'rstest-coverage-v8-raw-source-error');
     const missingFile = join(root, 'missing.js');
@@ -1137,6 +1205,85 @@ export default class CustomCoverageReporter {
       console.error = originalError;
       process.exitCode = originalExitCode;
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips malformed raw coverage payloads during main-process resolution', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-raw-malformed');
+    const file = join(root, 'valid.js');
+    const code = 'function covered() { return 1; }\ncovered();';
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    const originalError = console.error;
+    const originalExitCode = process.exitCode;
+    let hasError = false;
+
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async (filePath: string) => ({
+        [filePath]: createFileCoverage(filePath),
+      }),
+    });
+
+    console.error = () => {
+      hasError = true;
+    };
+
+    try {
+      const coverageMap = await provider.resolveRawCoverage([
+        { entries: [{ filePath: file }] },
+        {
+          entries: [
+            {
+              url: pathToFileURL(file).href,
+              filePath: file,
+              scriptId: 'valid',
+              functions: [
+                {
+                  functionName: '',
+                  isBlockCoverage: true,
+                  ranges: [
+                    { startOffset: 0, endOffset: code.length, count: 1 },
+                  ],
+                },
+              ],
+            },
+          ],
+          options: { assetFiles: { [file]: code }, outputModule: true },
+        },
+      ]);
+
+      expect(coverageMap?.files()).toEqual([file]);
+      expect(hasError).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      console.error = originalError;
+      process.exitCode = originalExitCode;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when all raw coverage payloads are malformed', async () => {
+    const provider = new CoverageProvider(createOptions());
+    const originalError = console.error;
+    const originalExitCode = process.exitCode;
+    let hasError = false;
+
+    console.error = () => {
+      hasError = true;
+    };
+
+    try {
+      await expect(
+        provider.resolveRawCoverage([
+          { entries: [{ filePath: 'invalid.js' }] },
+        ]),
+      ).resolves.toBeNull();
+      expect(hasError).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      console.error = originalError;
+      process.exitCode = originalExitCode;
     }
   });
 

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -1020,6 +1020,67 @@ export default class CustomCoverageReporter {
     }
   });
 
+  it('collects raw v8 coverage before converting to Istanbul coverage', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-raw-merge');
+    const file = join(root, 'src', 'covered.js');
+    const code = 'function covered() { return 1; }\ncovered();';
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    const convertedCounts: number[] = [];
+
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async (
+        _filePath: string,
+        entry: { functions: { ranges: { count: number }[] }[] },
+      ) => {
+        const count = entry.functions[0]!.ranges[0]!.count;
+        convertedCounts.push(count);
+        return {
+          [file]: {
+            ...createFileCoverage(file),
+            s: { 0: count },
+            f: { 0: count },
+            b: { 0: [count, count] },
+          },
+        };
+      },
+    });
+
+    try {
+      const createEntry = (count: number) => ({
+        url: pathToFileURL(file).href,
+        filePath: file,
+        scriptId: String(count),
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count }],
+          },
+        ],
+      });
+
+      const coverageMap = await provider.resolveRawCoverage([
+        {
+          entries: [createEntry(1)],
+          options: { assetFiles: { [file]: code }, outputModule: true },
+        },
+        {
+          entries: [createEntry(2)],
+          options: { assetFiles: { [file]: code }, outputModule: true },
+        },
+      ]);
+
+      expect(convertedCounts).toEqual([3]);
+      expect(
+        coverageMap?.fileCoverageFor(file).toSummary().statements.pct,
+      ).toBe(100);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps excluded asset files with inline source maps for remapping', async () => {
     const root = join(tmpdir(), 'rstest-coverage-v8-inline-asset-map');
     const file = join(root, 'dist', 'bundle.js');

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -1081,6 +1081,108 @@ export default class CustomCoverageReporter {
     }
   });
 
+  it('continues resolving raw coverage when a source lookup fails', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-raw-source-error');
+    const missingFile = join(root, 'missing.js');
+    const validFile = join(root, 'valid.js');
+    const code = 'function covered() { return 1; }\ncovered();';
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    const originalError = console.error;
+    const originalExitCode = process.exitCode;
+    let hasError = false;
+
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async (filePath: string) => ({
+        [filePath]: createFileCoverage(filePath),
+      }),
+    });
+
+    console.error = () => {
+      hasError = true;
+    };
+
+    try {
+      mkdirSync(root, { recursive: true });
+
+      const createEntry = (filePath: string) => ({
+        url: pathToFileURL(filePath).href,
+        filePath,
+        scriptId: filePath,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      });
+
+      const coverageMap = await provider.resolveRawCoverage([
+        {
+          entries: [createEntry(missingFile)],
+          options: { outputModule: true },
+        },
+        {
+          entries: [createEntry(validFile)],
+          options: { assetFiles: { [validFile]: code }, outputModule: true },
+        },
+      ]);
+
+      expect(coverageMap?.files()).toEqual([validFile]);
+      expect(hasError).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      console.error = originalError;
+      process.exitCode = originalExitCode;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('uses raw coverage project root for include matching', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-raw-project-root');
+    const projectRoot = join(root, 'packages', 'app');
+    const generatedFile = join(projectRoot, 'dist', 'counter.js');
+    const originalFile = join(projectRoot, 'src', 'counter.ts');
+    const code = 'function double(value) { return value * 2; }';
+    const provider = new CoverageProvider(
+      createOptions({ include: ['src/**/*.ts'] }),
+      root,
+    );
+    const providerInternals = getProviderInternals(provider);
+
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async () => ({
+        [originalFile]: createFileCoverage(originalFile),
+      }),
+    });
+
+    const coverageMap = await provider.resolveRawCoverage([
+      {
+        entries: [
+          {
+            url: pathToFileURL(generatedFile).href,
+            filePath: generatedFile,
+            scriptId: generatedFile,
+            functions: [
+              {
+                functionName: '',
+                isBlockCoverage: true,
+                ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+              },
+            ],
+          },
+        ],
+        options: { assetFiles: { [generatedFile]: code }, outputModule: true },
+        root: projectRoot,
+      },
+    ]);
+
+    expect(coverageMap?.files()).toEqual([originalFile]);
+  });
+
   it('keeps excluded asset files with inline source maps for remapping', async () => {
     const root = join(tmpdir(), 'rstest-coverage-v8-inline-asset-map');
     const file = join(root, 'dist', 'bundle.js');


### PR DESCRIPTION
## Summary

This PR optimizes V8 coverage finalization on top of the existing AST converter and raw-entry filtering path. Workers now return lightweight raw coverage payloads through `collectRaw()`, the pool forwards those payloads separately from normal test results, and the main process resolves all raw payloads once through `resolveRawCoverage()` before report generation. Istanbul keeps the existing worker-side `collect()` fallback, and slow coverage finalization now shows a processing hint when it takes more than 1s.

Performance on `rsbuild` with `time pnpm test --coverage --coverage.provider v8 --coverage.reporters=json-summary` (5-run median):

- Wall time: `4.35s -> 3.82s` (-12.2%, 1.14x faster)
- Rstest total: `3192ms -> 1581ms` (-50.5%, 2.02x faster)
- User CPU: `29.95s -> 12.87s` (-57.0%)
- Sys CPU: `5.20s -> 3.28s` (-36.9%)
- Coverage summary stayed equivalent: `31.67/21.45/31.79/32.32 -> 31.65/21.45/31.67/32.32`

## Related Links

https://github.com/web-infra-dev/rstest/pull/1490

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).