### PR TITLE
feat(adapter-rslib): support inline rslib config

### DIFF
--- a/packages/adapter-rslib/src/index.ts
+++ b/packages/adapter-rslib/src/index.ts
@@ -45,7 +45,7 @@ export function withRslibConfig(
     } = options;
 
     let rslibConfig: RslibConfig;
-    let filePath: string | null | undefined;
+    let filePath: string | undefined;
 
     if (inlineConfig) {
       rslibConfig = inlineConfig;
@@ -61,7 +61,9 @@ export function withRslibConfig(
         path: configPath,
       });
       rslibConfig = loadedConfig.content;
-      filePath = loadedConfig.filePath;
+      if (loadedConfig.filePath) {
+        filePath = loadedConfig.filePath;
+      }
     }
 
     if (!filePath && !inlineConfig) {
@@ -152,7 +154,7 @@ export function withRslibConfig(
       performance: {
         buildCache: resolveBuildCache({
           buildCache,
-          configPath: filePath || undefined,
+          configPath: filePath,
           root: finalLibConfig.root,
         }),
       },

--- a/packages/adapter-rslib/src/index.ts
+++ b/packages/adapter-rslib/src/index.ts
@@ -1,9 +1,15 @@
-import { normalize } from 'node:path';
+import { isAbsolute, join, normalize } from 'node:path';
 import { loadConfig, type RslibConfig, mergeRslibConfig } from '@rslib/core';
 import type { ExtendConfig, ExtendConfigFn } from '@rstest/core';
 import { resolveBuildCache } from '@rstest/core/internal/adapter';
 
 export interface WithRslibConfigOptions {
+  /**
+   * Rslib config object to convert directly.
+   * When provided, `configPath` is only used as file metadata.
+   * @default undefined
+   */
+  config?: RslibConfig;
   /**
    * `cwd` passed to loadConfig of Rslib
    * @default process.cwd()
@@ -30,20 +36,39 @@ export function withRslibConfig(
   options: WithRslibConfigOptions = {},
 ): ExtendConfigFn {
   return async (userConfig) => {
-    const { configPath, modifyLibConfig, libId, cwd = process.cwd() } = options;
-
-    // Load rslib config
     const {
-      content: { lib, ...rawLibConfig },
-      filePath,
-    } = await loadConfig({
-      cwd,
-      path: configPath,
-    });
+      config: inlineConfig,
+      configPath,
+      modifyLibConfig,
+      libId,
+      cwd = process.cwd(),
+    } = options;
 
-    if (!filePath) {
+    let rslibConfig: RslibConfig;
+    let filePath: string | null | undefined;
+
+    if (inlineConfig) {
+      rslibConfig = inlineConfig;
+      if (configPath) {
+        filePath = configPath;
+        if (!isAbsolute(configPath)) {
+          filePath = join(cwd, configPath);
+        }
+      }
+    } else {
+      const loadedConfig = await loadConfig({
+        cwd,
+        path: configPath,
+      });
+      rslibConfig = loadedConfig.content;
+      filePath = loadedConfig.filePath;
+    }
+
+    if (!filePath && !inlineConfig) {
       return {};
     }
+
+    const { lib, ...rawLibConfig } = rslibConfig;
 
     const libConfig =
       libId && Array.isArray(lib) ? lib.find((l) => l.id === libId) || {} : {};
@@ -56,14 +81,14 @@ export function withRslibConfig(
       resolve: libConfig.resolve,
     };
 
-    const rslibConfig = Array.isArray(lib)
+    const mergedRslibConfig = Array.isArray(lib)
       ? (mergeRslibConfig(
           rawLibConfig as RslibConfig,
           libTestConfig as RslibConfig,
         ) as RslibConfig)
       : (rawLibConfig as RslibConfig);
 
-    let libDecoratorsVersion = rslibConfig.source?.decorators?.version;
+    let libDecoratorsVersion = mergedRslibConfig.source?.decorators?.version;
 
     if (
       !userConfig.source?.tsconfigPath &&
@@ -74,7 +99,7 @@ export function withRslibConfig(
       const { loadTsconfig } = await import('./tsconfig');
       const tsconfig = await loadTsconfig(
         cwd,
-        rslibConfig.source?.tsconfigPath,
+        mergedRslibConfig.source?.tsconfigPath,
       );
 
       if (tsconfig.compilerOptions?.experimentalDecorators) {
@@ -84,8 +109,8 @@ export function withRslibConfig(
 
     // Allow modification of rslib config
     const finalLibConfig = modifyLibConfig
-      ? modifyLibConfig(rslibConfig)
-      : rslibConfig;
+      ? modifyLibConfig(mergedRslibConfig)
+      : mergedRslibConfig;
 
     const { rspack, swc, bundlerChain } = finalLibConfig.tools || {};
     const { buildCache } = finalLibConfig.performance || {};
@@ -105,7 +130,7 @@ export function withRslibConfig(
       // Copy over compatible configurations
       root: finalLibConfig.root,
       name: libId,
-      forceRerunTriggers: [normalize(filePath)],
+      forceRerunTriggers: filePath ? [normalize(filePath)] : undefined,
       plugins: finalLibConfig.plugins,
       source: {
         assetsInclude,
@@ -127,7 +152,7 @@ export function withRslibConfig(
       performance: {
         buildCache: resolveBuildCache({
           buildCache,
-          configPath: filePath,
+          configPath: filePath || undefined,
           root: finalLibConfig.root,
         }),
       },

--- a/packages/adapter-rslib/tests/index.test.ts
+++ b/packages/adapter-rslib/tests/index.test.ts
@@ -128,6 +128,32 @@ export default defineConfig({
     });
   });
 
+  it('should use inline rslib config before configPath', async () => {
+    const inlineConfigPath = join(__dirname, 'missing-inline-rslib.config.ts');
+    const config = await withRslibConfig({
+      configPath: inlineConfigPath,
+      config: {
+        lib: [{ format: 'esm' }],
+        performance: {
+          buildCache: true,
+        },
+        source: {
+          define: {
+            INLINE_CONFIG: '"inline"',
+          },
+        },
+      },
+    })({});
+
+    expect(config.source?.define).toEqual({
+      INLINE_CONFIG: '"inline"',
+    });
+    expect(config.forceRerunTriggers).toEqual([inlineConfigPath]);
+    expect((config as any).performance?.buildCache).toEqual({
+      buildDependencies: [inlineConfigPath],
+    });
+  });
+
   it('should throw error when config file not found', async () => {
     await expect(() =>
       withRslibConfig({

--- a/website/docs/en/guide/integration/rslib.mdx
+++ b/website/docs/en/guide/integration/rslib.mdx
@@ -2,6 +2,8 @@
 description: This guide covers how to integrate Rstest with Rslib for seamless testing in your Rslib projects.
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Rslib
 
 This guide covers how to integrate Rstest with [Rslib](https://rslib.rs) for seamless testing in your Rslib projects.
@@ -108,6 +110,8 @@ If both `config` and `configPath` are provided, `config` takes precedence as the
 :::
 
 #### `config`
+
+<ApiMeta addedVersion="0.11.0" />
 
 - **Type:** `RslibConfig`
 - **Default:** `undefined`

--- a/website/docs/en/guide/integration/rslib.mdx
+++ b/website/docs/en/guide/integration/rslib.mdx
@@ -71,13 +71,13 @@ export default defineConfig({
 
 The adapter does not reuse the entire Rslib config as-is. It keeps the parts that matter for test execution, such as module resolution, transforms, CSS Modules, decorator-related settings, static asset handling, and `target`, and automatically drops unmapped fields like `dev`, `server`, and `html`, along with other options that only exist for dev server, page entry, or build output.
 
-By default, the adapter uses `process.cwd()` to resolve the Rslib config. If your config lives elsewhere, you can use the `cwd` option. See [API](#api) for more details.
+By default, the adapter uses `process.cwd()` to resolve the Rslib config. If your config lives elsewhere, you can use the `cwd` option. You can also pass a Rslib config object directly with the `config` option. See [API](#api) for more details.
 
 ## API
 
 ### `withRslibConfig(options)`
 
-Returns a configuration function that loads Rslib config and converts it to Rstest configuration.
+Returns a configuration function that loads or accepts Rslib config and converts it to Rstest configuration.
 
 #### `cwd`
 
@@ -102,6 +102,35 @@ export default defineConfig({
 - **Default:** `'./rslib.config.ts'`
 
 Path to rslib config file.
+
+:::tip
+If both `config` and `configPath` are provided, `config` takes precedence as the config content.
+:::
+
+#### `config`
+
+- **Type:** `RslibConfig`
+- **Default:** `undefined`
+
+The inline Rslib config object to convert directly. When `config` is provided, the adapter does not call Rslib's `loadConfig`.
+
+If `configPath` is also provided, the adapter uses it as config file metadata for [`forceRerunTriggers`](/config/test/force-rerun-triggers) and build cache dependency resolution, but the inline `config` still takes precedence as the config content.
+
+```ts
+import { defineConfig as defineRslibConfig } from '@rslib/core';
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+
+const rslibConfig = defineRslibConfig({
+  lib: [{ format: 'esm' }],
+});
+
+export default defineConfig({
+  extends: withRslibConfig({
+    config: rslibConfig,
+  }),
+});
+```
 
 #### `libId`
 

--- a/website/docs/zh/guide/integration/rslib.mdx
+++ b/website/docs/zh/guide/integration/rslib.mdx
@@ -71,13 +71,13 @@ export default defineConfig({
 
 适配器不会原样复用整份 Rslib 配置，而是只保留测试运行需要的部分，例如模块解析、代码转换、CSS Modules、装饰器相关配置、静态资源处理和 `target`。像 `dev`、`server`、`html` 等未映射字段，以及其他仅用于开发服务器、页面入口或构建产物的配置，会在转换时自动裁剪掉。
 
-默认情况下，适配器使用 `process.cwd()` 来解析 Rslib 配置。如果配置文件在其他目录，可以使用 `cwd` 选项。更多详情请参阅 [API](#api)。
+默认情况下，适配器使用 `process.cwd()` 来解析 Rslib 配置。如果配置文件在其他目录，可以使用 `cwd` 选项。你也可以通过 `config` 选项直接传入 Rslib 配置对象。更多详情请参阅 [API](#api)。
 
 ## API
 
 ### `withRslibConfig(options)`
 
-返回一个加载 Rslib 配置并将其转换为 Rstest 配置的函数。
+返回一个加载或接收 Rslib 配置并将其转换为 Rstest 配置的函数。
 
 #### `cwd`
 
@@ -102,6 +102,35 @@ export default defineConfig({
 - **默认值：** `'./rslib.config.ts'`
 
 Rslib 配置文件的路径。
+
+:::tip
+如果同时提供 `config` 和 `configPath`，配置内容以 `config` 为准。
+:::
+
+#### `config`
+
+- **类型：** `RslibConfig`
+- **默认值：** `undefined`
+
+要直接转换的内联 Rslib 配置对象。提供 `config` 后，适配器不会调用 Rslib 的 `loadConfig`。
+
+如果同时提供了 `configPath`，适配器会将它作为配置文件元信息，用于 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 和 build cache 依赖解析，但配置内容仍以传入的 `config` 为准。
+
+```ts
+import { defineConfig as defineRslibConfig } from '@rslib/core';
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+
+const rslibConfig = defineRslibConfig({
+  lib: [{ format: 'esm' }],
+});
+
+export default defineConfig({
+  extends: withRslibConfig({
+    config: rslibConfig,
+  }),
+});
+```
 
 #### `libId`
 

--- a/website/docs/zh/guide/integration/rslib.mdx
+++ b/website/docs/zh/guide/integration/rslib.mdx
@@ -2,6 +2,8 @@
 description: 本指南介绍如何将 Rstest 集成到 Rslib 项目中，为你的 Rslib 项目提供无缝的测试体验。
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Rslib
 
 本指南介绍如何将 Rstest 集成到 [Rslib](https://rslib.rs) 项目中，为你的 Rslib 项目提供无缝的测试体验。
@@ -108,6 +110,8 @@ Rslib 配置文件的路径。
 :::
 
 #### `config`
+
+<ApiMeta addedVersion="0.11.0" />
 
 - **类型：** `RslibConfig`
 - **默认值：** `undefined`


### PR DESCRIPTION
## Summary

This PR adds an inline `config` option to `withRslibConfig` so callers can pass a Rslib config object directly instead of loading `rslib.config.*`.

When `configPath` is also provided, `config` supplies the config content while `configPath` remains file metadata for force-rerun triggers and build cache dependency resolution. 
## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).