### PR TITLE
feat(adapter-rsbuild): support inline config

### DIFF
--- a/packages/adapter-rsbuild/src/index.ts
+++ b/packages/adapter-rsbuild/src/index.ts
@@ -1,8 +1,15 @@
+import { isAbsolute, join } from 'node:path';
 import { loadConfig, type RsbuildConfig } from '@rsbuild/core';
 import type { ExtendConfigFn } from '@rstest/core';
 import { toRstestConfig } from './toRstestConfig';
 
 export interface WithRsbuildConfigOptions {
+  /**
+   * Rsbuild config object to convert directly.
+   * When provided, `configPath` is only used as file metadata.
+   * @default undefined
+   */
+  config?: RsbuildConfig;
   /**
    * `cwd` passed to loadConfig of Rsbuild
    * @default process.cwd()
@@ -30,19 +37,36 @@ export function withRsbuildConfig(
 ): ExtendConfigFn {
   return async () => {
     const {
+      config: inlineConfig,
       configPath,
       modifyRsbuildConfig,
       environmentName,
       cwd = process.cwd(),
     } = options;
 
-    // Load rsbuild config
-    const { content: rsbuildConfig, filePath } = await loadConfig({
-      cwd,
-      path: configPath,
-    });
+    let rsbuildConfig: RsbuildConfig;
+    let filePath: string | undefined;
 
-    if (!filePath) {
+    if (inlineConfig) {
+      rsbuildConfig = inlineConfig;
+      if (configPath) {
+        filePath = configPath;
+        if (!isAbsolute(configPath)) {
+          filePath = join(cwd, configPath);
+        }
+      }
+    } else {
+      const loadedConfig = await loadConfig({
+        cwd,
+        path: configPath,
+      });
+      rsbuildConfig = loadedConfig.content;
+      if (loadedConfig.filePath) {
+        filePath = loadedConfig.filePath;
+      }
+    }
+
+    if (!filePath && !inlineConfig) {
       return {};
     }
 

--- a/packages/adapter-rsbuild/tests/index.test.ts
+++ b/packages/adapter-rsbuild/tests/index.test.ts
@@ -134,6 +134,34 @@ export default defineConfig({
     });
   });
 
+  it('should use inline rsbuild config before configPath', async () => {
+    const inlineConfigPath = join(
+      __dirname,
+      'missing-inline-rsbuild.config.ts',
+    );
+    const config = await withRsbuildConfig({
+      configPath: inlineConfigPath,
+      config: {
+        performance: {
+          buildCache: true,
+        },
+        source: {
+          define: {
+            INLINE_CONFIG: '"inline"',
+          },
+        },
+      },
+    })({});
+
+    expect(config.source?.define).toEqual({
+      INLINE_CONFIG: '"inline"',
+    });
+    expect(config.forceRerunTriggers).toEqual([inlineConfigPath]);
+    expect(config.performance?.buildCache).toEqual({
+      buildDependencies: [inlineConfigPath],
+    });
+  });
+
   it('should throw error when config file not found', async () => {
     await expect(() =>
       withRsbuildConfig({

--- a/website/docs/en/guide/integration/rsbuild.mdx
+++ b/website/docs/en/guide/integration/rsbuild.mdx
@@ -2,6 +2,8 @@
 description: This guide covers how to integrate Rstest with Rsbuild for seamless testing in your Rsbuild projects.
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Rsbuild
 
 This guide covers how to integrate Rstest with [Rsbuild](https://rsbuild.dev) for seamless testing in your Rsbuild projects.
@@ -55,13 +57,13 @@ This will automatically:
 
 The adapter does not reuse the entire Rsbuild config as-is. It keeps the parts that matter for test execution, such as module resolution, transforms, CSS Modules, static asset handling, and `target`, and automatically drops options like `dev`, `server`, and `html` that are specific to the dev server, page entry, or production output.
 
-By default, the adapter uses `process.cwd()` to resolve the Rsbuild config. If your config lives elsewhere, you can use the `cwd` option. See [API](#api) for more details.
+By default, the adapter uses `process.cwd()` to resolve the Rsbuild config. If your config lives elsewhere, you can use the `cwd` option. You can also pass an Rsbuild config object directly with the `config` option. See [API](#api) for more details.
 
 ## API
 
 ### `withRsbuildConfig(options)`
 
-Returns a configuration function that loads Rsbuild config and converts it to Rstest configuration.
+Returns a configuration function that loads or accepts Rsbuild config and converts it to Rstest configuration.
 
 #### `cwd`
 
@@ -86,6 +88,41 @@ export default defineConfig({
 - **Default:** `'./rsbuild.config.ts'`
 
 Path to rsbuild config file.
+
+:::tip
+If both `config` and `configPath` are provided, `config` takes precedence as the config content.
+:::
+
+#### `config`
+
+<ApiMeta addedVersion="0.11.0" />
+
+- **Type:** `RsbuildConfig`
+- **Default:** `undefined`
+
+The inline Rsbuild config object to convert directly. When `config` is provided, the adapter does not call Rsbuild's `loadConfig`.
+
+If `configPath` is also provided, the adapter uses it as config file metadata for [`forceRerunTriggers`](/config/test/force-rerun-triggers) and build cache dependency resolution, but the inline `config` still takes precedence as the config content.
+
+```ts
+import { defineConfig as defineRsbuildConfig } from '@rsbuild/core';
+import { defineConfig } from '@rstest/core';
+import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
+
+const rsbuildConfig = defineRsbuildConfig({
+  source: {
+    define: {
+      __DEV__: 'true',
+    },
+  },
+});
+
+export default defineConfig({
+  extends: withRsbuildConfig({
+    config: rsbuildConfig,
+  }),
+});
+```
 
 #### `environmentName`
 

--- a/website/docs/zh/guide/integration/rsbuild.mdx
+++ b/website/docs/zh/guide/integration/rsbuild.mdx
@@ -2,6 +2,8 @@
 description: 本指南介绍了如何将 Rstest 与 Rsbuild 集成，以便在你的 Rsbuild 项目中进行无缝测试。
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # Rsbuild
 
 本指南介绍了如何将 Rstest 与 [Rsbuild](https://rsbuild.dev) 集成，以便在你的 Rsbuild 项目中进行无缝测试。
@@ -55,13 +57,13 @@ export default defineConfig({
 
 适配器不会原样复用整份 Rsbuild 配置，而是只保留测试运行需要的部分，例如模块解析、代码转换、CSS Modules、静态资源处理和 `target`。像 `dev`、`server`、`html` 这类面向开发服务器、页面入口或产物输出的配置，会在转换时自动裁剪掉，避免把测试无关配置带入 Rstest。
 
-默认情况下，适配器使用 `process.cwd()` 来解析 Rsbuild 配置。如果你的配置文件在其他地方，你可以使用 `cwd` 选项。更多详情请参阅 [API](#api) 部分。
+默认情况下，适配器使用 `process.cwd()` 来解析 Rsbuild 配置。如果配置文件在其他目录，可以使用 `cwd` 选项。你也可以通过 `config` 选项直接传入 Rsbuild 配置对象。更多详情请参阅 [API](#api)。
 
 ## API
 
 ### `withRsbuildConfig(options)`
 
-返回一个配置函数，该函数加载 Rsbuild 配置并将其转换为 Rstest 配置。
+返回一个配置函数，该函数加载或接收 Rsbuild 配置并将其转换为 Rstest 配置。
 
 #### `cwd`
 
@@ -86,6 +88,41 @@ export default defineConfig({
 - **默认值：** `'./rsbuild.config.ts'`
 
 Rsbuild 配置文件的路径。
+
+:::tip
+如果同时提供 `config` 和 `configPath`，配置内容以 `config` 为准。
+:::
+
+#### `config`
+
+<ApiMeta addedVersion="0.11.0" />
+
+- **类型：** `RsbuildConfig`
+- **默认值：** `undefined`
+
+要直接转换的内联 Rsbuild 配置对象。提供 `config` 后，适配器不会调用 Rsbuild 的 `loadConfig`。
+
+如果同时提供了 `configPath`，适配器会将它作为配置文件元信息，用于 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 和 build cache 依赖解析，但配置内容仍以传入的 `config` 为准。
+
+```ts
+import { defineConfig as defineRsbuildConfig } from '@rsbuild/core';
+import { defineConfig } from '@rstest/core';
+import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
+
+const rsbuildConfig = defineRsbuildConfig({
+  source: {
+    define: {
+      __DEV__: 'true',
+    },
+  },
+});
+
+export default defineConfig({
+  extends: withRsbuildConfig({
+    config: rsbuildConfig,
+  }),
+});
+```
 
 #### `environmentName`
 


### PR DESCRIPTION
## Summary

This PR adds inline config support to `withRsbuildConfig`, matching the Rslib adapter behavior. Passing `config` now skips Rsbuild's `loadConfig`, while `configPath` remains file metadata for force rerun triggers and build cache dependency resolution. It also documents the new option in the Rsbuild integration guide and covers `config` precedence with a unit test.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).