### PR TITLE
feat(core)!: resolve dynamic-import mock requests against their origin

### DIFF
--- a/e2e/mock/fixtures/resolvedFirst/a/foo.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/a/foo.mjs
@@ -1,0 +1,1 @@
+export const from = 'A_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/a/importer.mts
+++ b/e2e/mock/fixtures/resolvedFirst/a/importer.mts
@@ -1,0 +1,6 @@
+// Non-literal relative import: the specifier resolves against THIS module's
+// directory (rspack-injected origin), not the test file's.
+export const loadFoo = (): Promise<{ from: string }> => {
+  const spec = './foo.mjs';
+  return import(spec);
+};

--- a/e2e/mock/fixtures/resolvedFirst/aliasDep.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/aliasDep.mjs
@@ -1,0 +1,1 @@
+export const tag = 'ALIAS_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/b/foo.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/b/foo.mjs
@@ -1,0 +1,1 @@
+export const from = 'B_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/b/importer.mts
+++ b/e2e/mock/fixtures/resolvedFirst/b/importer.mts
@@ -1,0 +1,6 @@
+// Same shape as a/importer.mts, one directory over — its './foo.mjs' names a
+// DIFFERENT module than a/'s.
+export const loadFoo = (): Promise<{ from: string }> => {
+  const spec = './foo.mjs';
+  return import(spec);
+};

--- a/e2e/mock/fixtures/resolvedFirst/helper/helperDep.mjs
+++ b/e2e/mock/fixtures/resolvedFirst/helper/helperDep.mjs
@@ -1,0 +1,1 @@
+export const tag = 'HELPER_REAL';

--- a/e2e/mock/fixtures/resolvedFirst/helper/mockFromHelper.mts
+++ b/e2e/mock/fixtures/resolvedFirst/helper/mockFromHelper.mts
@@ -1,0 +1,11 @@
+// A module mock declared OUTSIDE the test file: the relative request must
+// resolve against THIS helper's directory (the declaring module, `info.o`),
+// not the test file that imports the helper.
+import { rs } from '@rstest/core';
+
+rs.mock('./helperDep.mjs', () => ({ tag: 'MOCKED_FROM_HELPER' }));
+
+export const loadDep = (): Promise<{ tag: string }> => {
+  const spec = './helperDep.mjs';
+  return import(spec);
+};

--- a/e2e/mock/tests/mockDynamicImportResolvedFirst.test.ts
+++ b/e2e/mock/tests/mockDynamicImportResolvedFirst.test.ts
@@ -1,0 +1,64 @@
+import { fileURLToPath } from 'node:url';
+import { expect, it, rs } from '@rstest/core';
+
+// Resolved-first matching for non-literal dynamic `import(variable)`: the
+// bundle keys a relative mock only by its build-resolved absolute target
+// (`info.r`), and on a raw-spelling miss the worker resolves a relative
+// runtime specifier against its importing module's directory. These pins
+// cover the spellings that meet the absolute keys — relative
+// (per-directory), absolute, and `file://` — plus the raw-key match for an
+// alias spelling (aliases are matched verbatim, never expanded at runtime).
+
+rs.mock('../fixtures/resolvedFirst/a/foo.mjs', () => ({ from: 'A_MOCKED' }));
+// Declared via the alias spelling; the build resolves it to aliasDep.mjs.
+rs.mock('@e2e/mock-alias-dep', () => ({ tag: 'ALIAS_MOCKED' }));
+
+it('a relative variable import only hits the mock declared for ITS directory', async () => {
+  // a/ and b/ both variable-import './foo.mjs'; only a/foo.mjs is mocked. A
+  // raw request key could not tell them apart — the absolute key must.
+  const a = await import('../fixtures/resolvedFirst/a/importer.mts');
+  const b = await import('../fixtures/resolvedFirst/b/importer.mts');
+  expect((await a.loadFoo()).from).toBe('A_MOCKED');
+  expect((await b.loadFoo()).from).toBe('B_REAL');
+});
+
+it('a relative variable import from the test file resolves against the test dir', async () => {
+  const spec = '../fixtures/resolvedFirst/a/foo.mjs';
+  const mod = await import(spec);
+  expect(mod.from).toBe('A_MOCKED');
+});
+
+it('an absolute-path variable import hits the mock', async () => {
+  const abs = fileURLToPath(
+    new URL('../fixtures/resolvedFirst/a/foo.mjs', import.meta.url),
+  );
+  const mod = await import(abs);
+  expect(mod.from).toBe('A_MOCKED');
+});
+
+it('a file:// href variable import hits the mock', async () => {
+  const href = new URL('../fixtures/resolvedFirst/a/foo.mjs', import.meta.url)
+    .href;
+  const mod = await import(href);
+  expect(mod.from).toBe('A_MOCKED');
+});
+
+it('an alias variable import hits a mock declared with the same alias', async () => {
+  const spec = '@e2e/mock-alias-dep';
+  const mod = await import(spec);
+  expect(mod.tag).toBe('ALIAS_MOCKED');
+});
+
+it('a relative variable import hits a mock declared via its ALIAS spelling', async () => {
+  // Cross-spelling: declared as '@e2e/mock-alias-dep', imported relatively —
+  // both resolve to the same absolute target.
+  const spec = '../fixtures/resolvedFirst/aliasDep.mjs';
+  const mod = await import(spec);
+  expect(mod.tag).toBe('ALIAS_MOCKED');
+});
+
+it('a relative mock declared in a helper file resolves against the helper (info.o)', async () => {
+  const helper =
+    await import('../fixtures/resolvedFirst/helper/mockFromHelper.mts');
+  expect((await helper.loadDep()).tag).toBe('MOCKED_FROM_HELPER');
+});

--- a/e2e/rstest.config.mts
+++ b/e2e/rstest.config.mts
@@ -51,6 +51,11 @@ export default defineConfig({
       '@e2e/wasm-glue': fileURLToPath(
         new URL('./wasm-imports/src/alias-glue.js', import.meta.url),
       ),
+      // Fixture-only: an alias spelling for the dynamic-import mock gate's
+      // raw-key + resolved-key matching (mock/tests/mockDynamicImportResolvedFirst).
+      '@e2e/mock-alias-dep': fileURLToPath(
+        new URL('./mock/fixtures/resolvedFirst/aliasDep.mjs', import.meta.url),
+      ),
     },
   },
   pool: {

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -146,12 +146,6 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 injectDynamicImportOrigin: {
                   functionName: dynamicImportCallee,
                 },
-                // Newer rspack appends the build-resolved mock identity
-                // `{o, r}` to generated `rstest_mock`/`rstest_unmock` calls;
-                // the pinned rspack ignores this unknown field, and the
-                // runtime feature-detects the extra argument, so the option
-                // is safe to pass unconditionally.
-                emitMockResolvedInfo: true,
                 // The runtime hook below resolves relative require.resolve
                 // specifiers against the source module that produced the
                 // call, instead of the test entry, fixing #848.

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -45,11 +45,45 @@ __webpack_require__.rstest_mocked_ids_by_request = Object.create(null);
 const hasOwn = (target, property) => Object.hasOwn(target, property);
 
 // The other builtin spelling of a request (`os` <-> `node:os`). Both spellings
-// are one mock: `registerRequestAlias` registers BOTH at mock time so every
-// lookup stays a plain single read, and unmock deletes both. A non-builtin's
-// toggled key (e.g. `node:./dep.js`) is junk no lookup ever queries — harmless.
+// are one mock: `requestAliasKeys` yields BOTH at mock time so every lookup
+// stays a plain single read, and unmock deletes both. A non-builtin's toggled
+// key (e.g. `node:some-pkg`) is junk no lookup ever queries — harmless.
 const altBuiltinSpelling = (request) =>
   request.startsWith('node:') ? request.slice(5) : `node:${request}`;
+
+const isRelativeRequest = (request) =>
+  request.startsWith('./') || request.startsWith('../');
+
+// Every generated `rstest_mock`/`rstest_unmock` call must carry the
+// build-resolved identity `{o, r}` (`o`: declaring module's absolute path,
+// `r`: resolved target — absolute path, external request, or null). Emitted
+// unconditionally by @rspack/core >= 2.1.3; absence means the build ran on an
+// older rspack, where the identity-keyed mock paths below would silently miss.
+const requireResolvedInfo = (info, method) => {
+  if (!info || typeof info.o !== 'string') {
+    throw new Error(
+      `[Rstest] rs.${method}() did not receive its build-resolved identity. ` +
+        'Module mocking requires @rspack/core >= 2.1.3 — upgrade the ' +
+        '@rspack/core (or @rsbuild/core) dependency compiling the tests.',
+    );
+  }
+};
+
+// Every spelling `rstest_mocked_ids_by_request` keys this mock under. A
+// RELATIVE request is NOT keyed raw — `./foo` names different modules from
+// different directories, so it is only reachable through its build-resolved
+// absolute target (`info.r`; the worker resolves a runtime specifier to the
+// same absolute path before querying). Bare/builtin/absolute spellings stay
+// raw, builtins under both spellings.
+const requestAliasKeys = (request, info) => {
+  const keys = isRelativeRequest(request)
+    ? []
+    : [request, altBuiltinSpelling(request)];
+  if (typeof info.r === 'string' && !keys.includes(info.r)) {
+    keys.push(info.r);
+  }
+  return keys;
+};
 
 // Realm-safe (a cross-realm Promise fails `instanceof`), matching the worker
 // registry's async detection in `mockRegistry.getNativeMock`.
@@ -153,14 +187,13 @@ const unpublishNativeMock = (request, info) =>
 
 //#region rs.unmock
 __webpack_require__.rstest_unmock = (id, request, info) => {
+  requireResolvedInfo(info, 'unmock');
   restoreOriginalFactory(id);
 
   // Delete the same alias set `registerRequestAlias` writes.
   const map = __webpack_require__.rstest_mocked_ids_by_request;
-  delete map[request];
-  delete map[altBuiltinSpelling(request)];
-  if (info && typeof info.r === 'string') {
-    delete map[info.r];
+  for (const key of requestAliasKeys(request, info)) {
+    delete map[key];
   }
   unpublishNativeMock(request, info);
 };
@@ -203,23 +236,18 @@ const getMockImplementation = (mockType = 'mock') => {
     mockType === 'mockRequire' || mockType === 'doMockRequire';
 
   // The mock and mockRequire will resolve to different module ids when the module is a dual package.
-  // `info` is the build-resolved mock identity `{o: <declaring file>, r:
-  // <resolved target | null>}` appended by newer rspack when
-  // `emitMockResolvedInfo` is on; absent on older rspack, so every consumer
-  // treats it as optional (feature-detect by argument presence, never version).
   return (id, modFactory, request, info) => {
+    requireResolvedInfo(info, mockType);
+
     // Point a dynamic `import(request)` — which carries a different external
     // module id — at this mocked id, so `rstest_dynamic_require` resolves it
     // here. Every spelling the import might carry is registered at this ONE
-    // write point — the raw request, its other builtin spelling, and the
-    // build-resolved target from newer rspack (`info.r`, e.g. an absolute
-    // path) — so every reader is a plain single lookup.
+    // write point (`requestAliasKeys`), so every reader is a plain single
+    // lookup.
     const registerRequestAlias = () => {
       const map = __webpack_require__.rstest_mocked_ids_by_request;
-      map[request] = id;
-      map[altBuiltinSpelling(request)] = id;
-      if (info && typeof info.r === 'string') {
-        map[info.r] = id;
+      for (const key of requestAliasKeys(request, info)) {
+        map[key] = id;
       }
     };
 
@@ -402,9 +430,29 @@ __webpack_require__.rstest_dynamic_require = (id, request) => {
  * loading the real one. Published on the shared `globalThis` because the worker
  * hook has no `__webpack_require__`; returns `undefined` when the request isn't
  * mocked, so the hook performs its normal native import.
+ *
+ * Resolved-first retry: a raw miss does not settle it — relative requests are
+ * not keyed raw (`requestAliasKeys`). `resolveToPath` (provided by the worker)
+ * resolves the specifier against its importing module's directory, and the
+ * lookup retries by that absolute path (the `info.r` key). Invoked only when
+ * at least one mock is registered.
  */
-globalThis.__rstest_resolve_mocked_dynamic_request__ = (request) => {
-  const mockedId = __webpack_require__.rstest_mocked_ids_by_request[request];
+globalThis.__rstest_resolve_mocked_dynamic_request__ = (
+  request,
+  resolveToPath,
+) => {
+  const map = __webpack_require__.rstest_mocked_ids_by_request;
+  let mockedId = map[request];
+  if (
+    mockedId === undefined &&
+    typeof resolveToPath === 'function' &&
+    Object.keys(map).length > 0
+  ) {
+    const resolved = resolveToPath(request);
+    if (typeof resolved === 'string') {
+      mockedId = map[resolved];
+    }
+  }
   return mockedId !== undefined ? __webpack_require__(mockedId) : undefined;
 };
 //#endregion

--- a/packages/core/src/runtime/api/utilities.ts
+++ b/packages/core/src/runtime/api/utilities.ts
@@ -653,12 +653,9 @@ const buildRstestUtilities = async (): Promise<{
     __setNativeMock?: (
       request: string,
       produce: () => unknown,
-      info?: NativeMockResolvedInfo,
+      info: NativeMockResolvedInfo,
     ) => void;
-    __unsetNativeMock?: (
-      request: string,
-      info?: NativeMockResolvedInfo,
-    ) => void;
+    __unsetNativeMock?: (request: string, info: NativeMockResolvedInfo) => void;
     // Bundler retention anchor, not runtime API — see the assignment below.
     __getNativeMock?: typeof getNativeMock;
   };
@@ -672,15 +669,10 @@ const buildRstestUtilities = async (): Promise<{
   // link — `does not provide an export`.)
   bridge.__getNativeMock = getNativeMock;
   bridge.__setNativeMock = (request, produce, info) => {
-    setNativeMock(
-      resolveNativeMockKeys(request, info, fileContext().workerState.testPath),
-      produce,
-    );
+    setNativeMock(resolveNativeMockKeys(request, info), produce);
   };
   bridge.__unsetNativeMock = (request, info) => {
-    unsetNativeMock(
-      resolveNativeMockKeys(request, info, fileContext().workerState.testPath),
-    );
+    unsetNativeMock(resolveNativeMockKeys(request, info));
   };
 
   return { rstest, resetForFile };

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -112,6 +112,7 @@ const defineRstestDynamicImport =
       specifier,
       returnModule,
       importAttributes,
+      origin ?? testPath,
     );
     if (mocked !== undefined) {
       return mocked;

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -133,6 +133,7 @@ const defineRstestDynamicImport =
       specifier,
       returnModule,
       importAttributes,
+      origin ?? testPath,
     );
     if (mocked !== undefined) {
       return mocked;

--- a/packages/core/src/runtime/worker/mockRegistry.ts
+++ b/packages/core/src/runtime/worker/mockRegistry.ts
@@ -35,9 +35,9 @@ type NativeMockEntry = {
   error: unknown;
   /** Every registry key this entry is registered under. One mock may be keyed
    * by several equivalent spellings of the same module (the build-resolved
-   * path from the rspack plugin, the Node-resolved URL, the legacy
-   * testPath-based resolution), so registration and removal operate on the
-   * whole alias group — an unmock computed from ANY spelling clears them all. */
+   * path from the rspack plugin, the Node-resolved URL), so registration and
+   * removal operate on the whole alias group — an unmock computed from ANY
+   * spelling clears them all. */
   aliases: readonly string[];
 };
 
@@ -59,17 +59,17 @@ export const setNativeMockInstaller = (install: () => void): void => {
   installHooks = install;
 };
 
-/** Build-resolved mock identity appended by newer rspack (see
- * `emitMockResolvedInfo` in `core/plugins/basic.ts`): `o` is the absolute path
- * of the module declaring the `rs.mock` call, `r` the build-resolved target —
- * an absolute file path, an external request (e.g. a builtin spelling), or
- * `null` when the build could not resolve it. Absent entirely on older rspack. */
-export type NativeMockResolvedInfo = { o?: string; r?: string | null };
+/** Build-resolved mock identity appended to every generated `rstest_mock`/
+ * `rstest_unmock` call (hard contract, enforced by `mockRuntimeCode.js` —
+ * requires @rspack/core >= 2.1.3): `o` is the absolute path of the module
+ * declaring the `rs.mock` call, `r` the build-resolved target — an absolute
+ * file path, an external request (e.g. a builtin spelling), or `null` when
+ * the build could not resolve it. */
+export type NativeMockResolvedInfo = { o: string; r: string | null };
 
 type NativeMockKeyResolver = (
   request: string,
-  info: NativeMockResolvedInfo | undefined,
-  testPath: string,
+  info: NativeMockResolvedInfo,
 ) => string[];
 
 // Node-only registry-key derivation, injected by nativeMockHooks at load time
@@ -86,11 +86,8 @@ export const setNativeMockKeyResolver = (
   keyResolver = resolve;
 };
 
-export const resolveNativeMockKeys: NativeMockKeyResolver = (
-  request,
-  info,
-  testPath,
-) => keyResolver?.(request, info, testPath) ?? [];
+export const resolveNativeMockKeys: NativeMockKeyResolver = (request, info) =>
+  keyResolver?.(request, info) ?? [];
 
 // Delete every alias of any entry reachable through `keys`; returns whether
 // the registry changed. Removal always operates on the WHOLE alias group so

--- a/packages/core/src/runtime/worker/nativeMockHooks.ts
+++ b/packages/core/src/runtime/worker/nativeMockHooks.ts
@@ -70,22 +70,20 @@ const deriveKey = (request: string, base: string): string | undefined => {
 
 /**
  * Registry-key derivation for one native mock (the write side of the resolve
- * hook's read-side keying below). Several derivations may disagree on spelling
+ * hook's read-side keying below). Two derivations may disagree on spelling
  * for the same module (pnpm realpath, exports conditions, extension aliases),
  * so every derivation that succeeds is registered as an alias of the same
  * entry, best-first:
  * 1. the build-resolved target from the rspack plugin (`info.r`) — exact,
  *    no runtime re-resolution;
  * 2. `request` resolved against the DECLARING module (`info.o`) — correct
- *    base for a relative `rs.mock` living in a helper file;
- * 3. `request` resolved against the test file — the pre-info behavior, kept
- *    as the old-rspack fallback and divergence absorber (skipped when `info.o`
- *    IS the test file, where it could only repeat derivation 2).
+ *    base for a relative `rs.mock` living in a helper file, and the
+ *    divergence absorber when Node's runtime resolution disagrees with the
+ *    build's.
  */
 const deriveNativeMockKeys = (
   request: string,
-  info: NativeMockResolvedInfo | undefined,
-  testPath: string,
+  info: NativeMockResolvedInfo,
 ): string[] => {
   const keys: string[] = [];
   const add = (key: string | undefined) => {
@@ -93,7 +91,7 @@ const deriveNativeMockKeys = (
       keys.push(key);
     }
   };
-  const resolved = info?.r;
+  const resolved = info.r;
   if (typeof resolved === 'string') {
     if (isAbsolute(resolved)) {
       // The resolve hook keys non-builtins by their resolved URL.
@@ -102,16 +100,11 @@ const deriveNativeMockKeys = (
       // External request: a `node:` builtin spelling is the hook's canonical
       // key already; a bare spelling ('os', or an uninstalled package rstest
       // externalized by raw request) is registered verbatim — the canonical
-      // form comes from derivations 2/3 below.
+      // form comes from derivation 2 below.
       add(resolved);
     }
   }
-  if (info?.o !== undefined) {
-    add(deriveKey(request, info.o));
-  }
-  if (info?.o !== testPath) {
-    add(deriveKey(request, testPath));
-  }
+  add(deriveKey(request, info.o));
   return keys;
 };
 

--- a/packages/core/src/runtime/worker/resolveDynamicImport.ts
+++ b/packages/core/src/runtime/worker/resolveDynamicImport.ts
@@ -3,8 +3,8 @@ import {
   builtinModules,
   createRequire as createNativeRequire,
 } from 'node:module';
-import { isAbsolute } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   asModule,
   createInteropProxy,
@@ -112,21 +112,57 @@ export const resolveImportSpecifier = ({
  * Returns `undefined` (caller falls through to a real native import) for a static
  * import, an `importActual`, or an unmocked request. Both loaders share this
  * single policy rather than re-implementing the gate at each call site.
+ *
+ * Lookup is RESOLVED-FIRST: the bundle map keys relative mocks only by their
+ * build-resolved absolute target (a raw `./foo` means different modules from
+ * different directories), so on a raw miss the bundle calls back into
+ * `resolveToPath`, which resolves a relative specifier against the importing
+ * module's directory (`resolveBase`, the rspack-injected origin) — the
+ * relative, absolute, and `file://` spellings then meet the map's absolute
+ * keys. Alias / tsconfig-paths spellings are NOT expanded (that would need the
+ * build's resolve config at runtime); they match only when the mock was
+ * declared with the same spelling — and Node cannot natively load such a
+ * specifier anyway, so an unmocked one fails loudly rather than silently
+ * loading something else. The callback only runs when at least one mock is
+ * registered.
  */
 export const maybeResolveMockedDynamicImport = (
   specifier: string,
   returnModule: boolean | undefined,
-  importAttributes?: ImportCallOptions,
+  importAttributes: ImportCallOptions | undefined,
+  resolveBase: string,
 ): unknown => {
   if (returnModule || importAttributes?.with?.rstest) {
     return undefined;
   }
   const resolver = (
     globalThis as {
-      __rstest_resolve_mocked_dynamic_request__?: (request: string) => unknown;
+      __rstest_resolve_mocked_dynamic_request__?: (
+        request: string,
+        resolveToPath?: (request: string) => string | undefined,
+      ) => unknown;
     }
   ).__rstest_resolve_mocked_dynamic_request__;
-  return typeof resolver === 'function' ? resolver(specifier) : undefined;
+  if (typeof resolver !== 'function') {
+    return undefined;
+  }
+  const resolveToPath = (request: string): string | undefined => {
+    // Builtins are fully covered by raw keys (both spellings registered).
+    if (isBuiltinSpecifier(request)) {
+      return undefined;
+    }
+    // A `file://` spelling of an absolute target only needs normalizing to
+    // the plain-path form the map keys carry.
+    if (request.startsWith('file:')) {
+      return fileURLToPath(request);
+    }
+    if (request.startsWith('./') || request.startsWith('../')) {
+      return resolve(dirname(resolveBase), request);
+    }
+    // Bare/alias spellings: raw-key matches only (see the doc block above).
+    return undefined;
+  };
+  return resolver(specifier, resolveToPath);
 };
 
 /**

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -517,7 +517,6 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -1114,7 +1113,6 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -1697,7 +1695,6 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -2282,7 +2279,6 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -3196,7 +3192,6 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {
@@ -3780,7 +3775,6 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
     RstestPlugin {
       "_args": [
         {
-          "emitMockResolvedInfo": true,
           "hoistMockModule": true,
           "importMetaPathName": true,
           "injectDynamicImportOrigin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  '@rspack/core': npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+
 packageExtensionsChecksum: sha256-/oXUNlAVRCvDfhpsbH+E7MlrA1cfGnTrmqgmHjY2sMM=
 
 importers:
@@ -12,7 +15,7 @@ importers:
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.16
-        version: 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+        version: 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@rslint/core':
         specifier: ^0.6.3
         version: 0.6.3(jiti@2.7.0)
@@ -99,7 +102,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.23.1
         version: 0.23.1(@microsoft/api-extractor@7.58.9(@types/node@22.18.6))(typescript@6.0.3)
@@ -223,7 +226,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -312,7 +315,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -372,7 +375,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -406,7 +409,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -434,7 +437,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -468,7 +471,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -518,7 +521,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -588,7 +591,7 @@ importers:
         version: 2.0.0(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
         version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.1.1)
@@ -622,7 +625,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -674,7 +677,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -714,7 +717,7 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -751,19 +754,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rspack/cli':
         specifier: ~2.1.1
-        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))
+        version: 2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))
       '@rspack/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@swc/helpers@0.5.23)
+        specifier: npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+        version: '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@rspack/dev-server':
         specifier: ~2.1.0
-        version: 2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rspack/plugin-react-refresh':
         specifier: ~2.0.2
-        version: 2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+        version: 2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -806,16 +809,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: ~2.1.1
-        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))
+        version: 2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))
       '@rspack/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@swc/helpers@0.5.23)
+        specifier: npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+        version: '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@rspack/dev-server':
         specifier: ~2.1.0
-        version: 2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rspack/plugin-react-refresh':
         specifier: ~2.0.2
-        version: 2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+        version: 2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -879,7 +882,7 @@ importers:
         version: 2.0.0(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
         version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.1.1)
@@ -936,16 +939,17 @@ importers:
         version: 6.0.3
 
   packages/adapter-rspack:
+    dependencies:
+      '@rspack/core':
+        specifier: npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940
+        version: '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
     devDependencies:
       '@rslib/core':
         specifier: 0.23.1
         version: 0.23.1(@microsoft/api-extractor@7.58.9(@types/node@22.18.6))(typescript@6.0.3)
       '@rspack/cli':
         specifier: ~2.1.1
-        version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))
-      '@rspack/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@swc/helpers@0.5.23)
+        version: 2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1058,10 +1062,10 @@ importers:
         version: 2.1.1
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.4
-        version: 2.0.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.0.4(@rsbuild/core@2.1.1)(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ^4.3.1
         version: 4.3.1
@@ -1104,7 +1108,7 @@ importers:
         version: 7.58.9(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+        version: 2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
         version: 1.4.6(@rsbuild/core@2.1.1)
@@ -1232,7 +1236,7 @@ importers:
         version: 3.0.1
       istanbul-lib-source-maps:
         specifier: ^5.0.6
-        version: 5.0.6
+        version: 5.0.6(supports-color@8.1.1)
       istanbul-reports:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1360,10 +1364,10 @@ importers:
         version: 0.0.15
       '@vscode/test-electron':
         specifier: ^2.5.2
-        version: 2.5.2
+        version: 2.5.2(supports-color@8.1.1)
       '@vscode/vsce':
         specifier: 3.9.2
-        version: 3.9.2
+        version: 3.9.2(supports-color@8.1.1)
       birpc:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1404,13 +1408,13 @@ importers:
         version: 2.0.0(@rsbuild/core@2.1.1)
       '@rspress/core':
         specifier: 2.0.15
-        version: 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.15
-        version: 2.0.15(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 2.0.15(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rstack-dev/doc-ui':
         specifier: 1.14.5
-        version: 1.14.5(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.14.5(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1437,7 +1441,7 @@ importers:
         version: 1.1.3(@rsbuild/core@2.1.1)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
-        version: 1.0.4(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.0.4(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
       rspress-plugin-sitemap:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2122,6 +2126,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -3046,11 +3056,6 @@ packages:
 
   '@rsdoctor/rspack-plugin@1.5.16':
     resolution: {integrity: sha512-CoFLPpJF+XU96sVZ8EWbbQh4ZjihmZAv3hlyQzrn+HO8VBa0BRI/k+oyRAPwg7fI0/Uc1OHDtgL7D8IST3vbTw==}
-    peerDependencies:
-      '@rspack/core': '*'
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
 
   '@rsdoctor/sdk@1.5.16':
     resolution: {integrity: sha512-t2ghEUCUKFwP12QeeLX3VvI5b+Z+SI9rwUiE8VHa+gOFi8oHkceEi0rlBf1k9BexMpQf3zP3RNTZtzo09mxpCw==}
@@ -3058,11 +3063,8 @@ packages:
   '@rsdoctor/types@1.5.16':
     resolution: {integrity: sha512-J9yqQu1VNFgLJpkgzAucjA1AkVnrg6kRyMhAzj05uYyPM6FQgFmi3NlQFDxRPLAfTuwSXC72xhSi7LYd6MuVvA==}
     peerDependencies:
-      '@rspack/core': '*'
       webpack: 5.x
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -3135,73 +3137,85 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.1.1':
-    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
+  '@rspack-canary/binding-darwin-arm64@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-eU5seMbeQsNGo5hQ4ZJvufWSeWvpAAIOv+jYLBjowA5eQptgaIB4zoqZ5AWWDRKMPoKRuFu3j24UeKdvfBggOA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.1':
-    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
+  '@rspack-canary/binding-darwin-x64@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-EFrSPxeYCbHBf7yRVZ5H5Een+VSjrRFa2lbGLLpzCdo9d//jZHJAXrFlipByDPky3fzXNAoeg2CNklEH6q8Eyw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
-    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-ls6J9O43d44rNCRT8v1Gt3ONfewAc2giG1p+HkTfNYBt+GhpKceh84kVKy+KZF1wmvjd+ieyReifq/QK52t9Uw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
-    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
+  '@rspack-canary/binding-linux-arm64-musl@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-ZlQ9WSAqq2DmVmaEubDWaSrBSlbeUaNjBAZI5Icl/rfnO9SXpKZR5EzL7xSXl+H+3zqThDCu1C5NchJ1fjzUYg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-v4hdbXWuFLUwveXrF8RkUeNhGmRgrKR9atvmIaJlOnKReZZjaNSIMthzIq+VcKMhifTX7ZRJuGnOW/tSWDYoaw==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
-    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-aTDQH5hydOtNGYjv1ZcpHkGSkhl6dwgyihzd0DI1XTKXqwlI01It16/ZdqDfMJPQwpTiSbC2Ciy/J+dAVeLHsA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.1.1':
-    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
+  '@rspack-canary/binding-linux-x64-gnu@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-Een2lCrQF1y6H4XFasF8JrUZQ8Y0B5WiWnIlLgoloP2yTBfzEU1sp8IVuY18nB86xFxXYE+8eFx+x4w7DVj5XA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.1.1':
-    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
+  '@rspack-canary/binding-linux-x64-musl@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-NqX7zRjMDA85GWsuLdywneRKHYNoykkLC/BSVirx0YYhnkzDVfEEL2mrytfG5UzMe+8Qbs6zwGSGx/sUr3zLjw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.1.1':
-    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
+  '@rspack-canary/binding-wasm32-wasi@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-EKU/AcfP0ZRT8zLbTo3ENj72GnZLoL6560kSY9/TdgIFdEQhISGBP0yyyVimoG9T+JTpAaXV7WdHhPPxXDXzlA==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
-    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-FKSwtQXn8Xoxb5V1YApVAX3REUSr3oxfLmuCBZCu/yUe0EGJMDDCusaKzd0c8VgwlF2tlqU7skJsz3GMsS66xA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
-    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-G58E6vCUixbFLHwvpUu+45e62hTSK+O7r1GOSoGdTzKcoqGiHfCjr6cQ6wUv+yAWttYIDZKVZEn6RqxfOh6ytA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.1':
-    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
+  '@rspack-canary/binding-win32-x64-msvc@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-wQzp3Trh3OSSOBNgDOKPt6auFWGg/HvcZnrt6FgqbtyjrSsqTx4UjhwOfmfEyiRXugikzYcBC7vwGS+t0Bbtew==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.1.1':
-    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
+  '@rspack-canary/binding@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-7STI8EDhKDsVfAyFzQ48T8JUvKkkdLgfiP1Mjsf7kPgiK/+65tJljJSaWVR7pNjmLPyC6oSF+VVDe+BtVXuVJQ==}
+
+  '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940':
+    resolution: {integrity: sha512-3gnI4OTtyfmrcCdWcPnbIbZQhIblWQlJ+Mzk4j/8JLuuF4HX3G+oYWfz/DtdAAfK7M9+pvi71LY4dr/t74bS/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
 
   '@rspack/cli@2.1.1':
     resolution: {integrity: sha512-zsJFurwCDesy0dud7cejObagbbXsvKcQ6j485nmnytBsXV17Uf6XfedQMxnOXBZeGIel+I7Jl/Jp3Sn08TsZuw==}
@@ -3211,18 +3225,6 @@ packages:
       '@rspack/dev-server': ^2.0.0-0
     peerDependenciesMeta:
       '@rspack/dev-server':
-        optional: true
-
-  '@rspack/core@2.1.1':
-    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
         optional: true
 
   '@rspack/dev-middleware@2.0.3':
@@ -3250,11 +3252,7 @@ packages:
   '@rspack/plugin-react-refresh@2.0.0':
     resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
     peerDependencies:
-      '@rspack/core': ^2.0.0-0
       react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
 
   '@rspack/plugin-react-refresh@2.0.2':
     resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
@@ -5895,12 +5893,9 @@ packages:
     resolution: {integrity: sha512-F0+ErFFDj3Pt+nVrCN6VlEGEzocv9s7x/aR9v2riI+WM83UAfTYBDBjGPJnT55lBLR6JSI4fmWblt+aA2JN6/w==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -7182,12 +7177,9 @@ packages:
   rspack-vue-loader@17.5.1:
     resolution: {integrity: sha512-1pXdeqYM95P0T8DO2ZcOCBnfMp62W5IG2c0RICn1rFYjHcja41IYSQLzcdc1uePEq0n4JZwvfR2lVs8wRZuwzA==}
     peerDependencies:
-      '@rspack/core': ^1.0.0 || ^2.0.0-0
       '@vue/compiler-sfc': '*'
       vue: '*'
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       '@vue/compiler-sfc':
         optional: true
       vue:
@@ -9142,6 +9134,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@node-rs/crc32-android-arm-eabi@1.10.6':
     optional: true
 
@@ -9808,7 +9807,7 @@ snapshots:
 
   '@rsbuild/core@2.1.1':
     dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9849,16 +9848,17 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.1
 
-  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.1)
+      less-loader: 12.3.3(@swc/helpers@0.5.23)(less@4.6.7)(webpack@5.108.1)
       reduce-configs: 2.0.1
     optionalDependencies:
       '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
   '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.1)':
@@ -9889,18 +9889,19 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.1
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@swc/helpers@0.5.23)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.1
@@ -9936,9 +9937,9 @@ snapshots:
       - sugarss
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.1.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.1)(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
@@ -9962,25 +9963,26 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))':
+  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3))
+      rspack-vue-loader: 17.5.1(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3))
     optionalDependencies:
       '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - '@vue/compiler-sfc'
       - vue
 
   '@rsdoctor/client@1.5.16': {}
 
-  '@rsdoctor/core@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/core@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.1)
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/sdk': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@rspack/resolver': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.47.1
@@ -9991,73 +9993,80 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
       - '@rsbuild/core'
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/graph@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       es-toolkit: 1.47.1
       path-browserify: 1.0.1
       source-map: 0.7.6
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/rspack-plugin@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
-      '@rsdoctor/core': 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-    optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rsdoctor/core': 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/sdk': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
       - '@rsbuild/core'
+      - '@swc/helpers'
       - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/sdk@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       '@rsdoctor/client': 1.5.16
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
+      '@rsdoctor/utils': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1
       tapable: 2.3.3
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/types@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       webpack: 5.108.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rsdoctor/utils@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/utils@1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@swc/helpers@0.5.23)(webpack@5.108.1)
       '@types/estree': 1.0.5
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -10072,7 +10081,8 @@ snapshots:
       rslog: 2.1.3
       strip-ansi: 6.0.1
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
   '@rslib/core@0.23.1(@microsoft/api-extractor@7.58.9(@types/node@22.18.6))(typescript@6.0.3)':
@@ -10125,95 +10135,97 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.6.3':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.1':
+  '@rspack-canary/binding-darwin-arm64@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.1':
+  '@rspack-canary/binding-darwin-x64@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
+  '@rspack-canary/binding-linux-arm64-musl@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.1':
+  '@rspack-canary/binding-linux-x64-gnu@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.1':
+  '@rspack-canary/binding-linux-x64-musl@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.1':
+  '@rspack-canary/binding-wasm32-wasi@2.1.3-canary-7caa6eff-20260703032940':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.1':
+  '@rspack-canary/binding-win32-x64-msvc@2.1.3-canary-7caa6eff-20260703032940':
     optional: true
 
-  '@rspack/binding@2.1.1':
+  '@rspack-canary/binding@2.1.3-canary-7caa6eff-20260703032940':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.1
-      '@rspack/binding-darwin-x64': 2.1.1
-      '@rspack/binding-linux-arm64-gnu': 2.1.1
-      '@rspack/binding-linux-arm64-musl': 2.1.1
-      '@rspack/binding-linux-riscv64-gnu': 2.1.1
-      '@rspack/binding-linux-riscv64-musl': 2.1.1
-      '@rspack/binding-linux-x64-gnu': 2.1.1
-      '@rspack/binding-linux-x64-musl': 2.1.1
-      '@rspack/binding-wasm32-wasi': 2.1.1
-      '@rspack/binding-win32-arm64-msvc': 2.1.1
-      '@rspack/binding-win32-ia32-msvc': 2.1.1
-      '@rspack/binding-win32-x64-msvc': 2.1.1
+      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-riscv64-gnu': '@rspack-canary/binding-linux-riscv64-gnu@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-riscv64-musl': '@rspack-canary/binding-linux-riscv64-musl@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.1.3-canary-7caa6eff-20260703032940'
+      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.1.3-canary-7caa6eff-20260703032940'
 
-  '@rspack/cli@2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23)))':
+  '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-    optionalDependencies:
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))
-
-  '@rspack/core@2.1.1(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.1.1
+      '@rspack/binding': '@rspack-canary/binding@2.1.3-canary-7caa6eff-20260703032940'
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/dev-middleware@2.0.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
-    optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-
-  '@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rspack/cli@2.1.1(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)))':
     dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-      '@rspack/dev-middleware': 2.0.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
+    optionalDependencies:
+      '@rspack/dev-server': 2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
+
+  '@rspack/dev-middleware@2.0.3(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))':
+    optionalDependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
+
+  '@rspack/dev-server@2.1.0(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
+      '@rspack/dev-middleware': 2.0.3(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@swc/helpers@0.5.23)(react-refresh@0.18.0)':
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       react-refresh: 0.18.0
-    optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -10266,12 +10278,12 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@rsbuild/core': 2.1.1
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.1)(@swc/helpers@0.5.23)
       '@rspress/shared': 2.0.15
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -10308,7 +10320,7 @@ snapshots:
       unist-util-visit-children: 3.0.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@rspack/core'
+      - '@swc/helpers'
       - '@types/mdast'
       - '@types/react'
       - core-js
@@ -10316,11 +10328,11 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-algolia@2.0.15(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@rspress/plugin-algolia@2.0.15(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -10338,9 +10350,9 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
     optionalDependencies:
-      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rushstack/node-core-library@5.23.1(@types/node@22.18.6)':
     dependencies:
@@ -11006,8 +11018,8 @@ snapshots:
 
   '@typespec/ts-http-runtime@0.3.0':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -11061,10 +11073,10 @@ snapshots:
     transitivePeerDependencies:
       - monocart-coverage-reports
 
-  '@vscode/test-electron@2.5.2':
+  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.8.5
@@ -11110,7 +11122,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.5
       '@vscode/vsce-sign-win32-x64': 2.0.5
 
-  '@vscode/vsce@3.9.2':
+  '@vscode/vsce@3.9.2(supports-color@8.1.1)':
     dependencies:
       '@azure/identity': 4.12.0
       '@secretlint/node': 10.2.2
@@ -11133,7 +11145,7 @@ snapshots:
       minimatch: 10.2.5
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2
+      secretlint: 10.2.2(supports-color@8.1.1)
       semver: 7.8.5
       tmp: 0.2.3
       typed-rest-client: 1.8.11
@@ -12801,7 +12813,7 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -12817,7 +12829,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -12992,7 +13004,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       debug: 4.4.3(supports-color@8.1.1)
@@ -13254,12 +13266,15 @@ snapshots:
       lefthook-windows-arm64: 2.1.9
       lefthook-windows-x64: 2.1.9
 
-  less-loader@12.3.3(@rspack/core@2.1.1(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.1):
+  less-loader@12.3.3(@swc/helpers@0.5.23)(less@4.6.7)(webpack@5.108.1):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       webpack: 5.108.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   less@4.6.7:
     dependencies:
@@ -14199,7 +14214,7 @@ snapshots:
 
   ovsx@1.0.2:
     dependencies:
-      '@vscode/vsce': 3.9.2
+      '@vscode/vsce': 3.9.2(supports-color@8.1.1)
       commander: 6.2.1
       follow-redirects: 1.16.0
       is-ci: 2.0.0
@@ -14856,17 +14871,20 @@ snapshots:
 
   rslog@2.1.3: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(vue@3.5.39(typescript@6.0.3)):
+  rspack-vue-loader@17.5.1(@swc/helpers@0.5.23)(vue@3.5.39(typescript@6.0.3)):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940(@swc/helpers@0.5.23)'
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       vue: 3.5.39(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
     dependencies:
-      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@swc/helpers@0.5.23)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   rspress-plugin-sitemap@1.2.1: {}
 
@@ -15033,7 +15051,7 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  secretlint@10.2.2:
+  secretlint@10.2.2(supports-color@8.1.1):
     dependencies:
       '@secretlint/config-creator': 10.2.2
       '@secretlint/formatter': 10.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,10 @@ allowBuilds:
 
 autoInstallPeers: false
 
+# TEMP (do not commit): validate rspack canary with build-resolved mock info (PR web-infra-dev/rspack#14665)
+overrides:
+  '@rspack/core': 'npm:@rspack-canary/core@2.1.3-canary-7caa6eff-20260703032940'
+
 # for vsce
 hoistPattern: ['@secretlint/*']
 
@@ -24,6 +28,7 @@ hoistPattern: ['@secretlint/*']
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@rspack/*'
+  - '@rspack-canary/*'
   - '@rsbuild/*'
   - '@rslib/*'
   - '@rspress/*'

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -188,6 +188,8 @@ const launch = await import(launchScriptPath);
 const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocked
 ```
 
+Before mock matching, a non-literal relative specifier is resolved against the **importing module's directory**. Relative paths, absolute paths, and `file://` URLs therefore all reach a mock declared for the same module — two `import('./foo')` calls from different directories are matched independently, and a relative `rs.mock('./dep')` declared in a shared helper resolves against the helper's own directory.
+
 :::warning Requirements and limitations
 
 Case 1 (the specifier resolves to the mocked module itself) works on every supported Node.js version. Cases 2 and 3 — where the **inner** import of a natively-loaded module must be mocked — additionally require:
@@ -200,7 +202,8 @@ Case 1 (the specifier resolves to the mocked module itself) works on every suppo
 - **`require()` on the native path**: a mocked module reached through `require()` inside a natively-loaded CommonJS module is not mocked — native mocks apply to ESM `import`, so the `require()` receives the real module.
 - **`isolate: false`**: a natively-loaded module is cached by Node's ESM loader across files, so a mock applied to it can persist into a later test file run by the same worker.
 - **`isolate: false` across projects**: the non-literal `import(variable)` mock resolver is published on a shared global, so when one worker runs multiple projects the resolver reflects whichever project's runtime executed last — a variable `import()` of a mocked module in an earlier project may then consult a later project's mocks. Static and literal imports are unaffected.
-- **Relative specifiers**: a relative mock is resolved against the **test file**. A relative `rs.mock('./dep')` declared in a setup file or shared helper, or a non-literal relative `import('./dep')` from a module in a different directory, may not reach the natively-loaded path. Mock such modules with an absolute or package specifier, or declare the mock in the test file.
+- **Rspack version**: module mocking requires the test build to run on `@rspack/core >= 2.1.3` — every generated mock call carries a build-resolved identity the runtime depends on. On an older rspack, `rs.mock()` fails at runtime with an upgrade hint instead of silently missing.
+- **Alias specifiers**: a non-literal `import(variable)` whose value uses a `resolve.alias` / tsconfig-paths spelling matches a mock only when the mock was declared with the **same spelling** — the alias is not expanded at runtime. An unmocked one fails loudly (Node's loader cannot resolve it natively either). Literal imports and static imports are unaffected — the build expands them.
 
 :::
 

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -188,6 +188,8 @@ const launch = await import(launchScriptPath);
 const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocked
 ```
 
+在进行 mock 匹配之前，非字面量的相对 specifier 会以**发起 import 的模块所在目录**为基准进行解析。因此相对路径、绝对路径、`file://` URL 都能命中为同一模块声明的 mock——来自不同目录的两个 `import('./foo')` 会被独立匹配，写在共享 helper 中的相对 `rs.mock('./dep')` 也会以 helper 自身目录为基准解析。
+
 :::warning 要求与限制
 
 情况 1（specifier 解析到被 mock 的模块本身）在所有受支持的 Node.js 版本上都生效。情况 2 和 3——需要 mock 一个由 Node 原生加载的模块的**内部** import——还需要满足：
@@ -200,7 +202,8 @@ const dep = await import('some-dep'); // dep's internal `os.hostname()` is mocke
 - **原生路径上的 `require()`**：在原生加载的 CommonJS 模块中通过 `require()` 访问的 mocked 模块不会被 mock——native mock 仅作用于 ESM `import`，因此该 `require()` 会拿到真实模块。
 - **`isolate: false`**：原生加载的模块会被 Node 的 ESM loader 跨文件缓存，因此对它应用的 mock 可能会保留到同一 worker 运行的后续测试文件中。
 - **跨项目的 `isolate: false`**：非字面量 `import(variable)` 的 mock 解析发布在共享全局上，因此当一个 worker 运行多个项目时，该解析器反映的是最后执行的那个项目的 runtime——较早项目中对 mocked 模块的变量 `import()` 可能会查到较晚项目的 mock。静态与字面量 import 不受影响。
-- **相对 specifier**：相对路径的 mock 以**测试文件**为基准解析。写在 setup 文件或共享 helper 中的相对 `rs.mock('./dep')`，或来自其他目录模块的非字面量相对 `import('./dep')`，可能无法命中原生加载路径。请改用绝对路径或包名 specifier，或将 mock 声明在测试文件中。
+- **Rspack 版本**：模块 mock 要求测试构建运行在 `@rspack/core >= 2.1.3` 上——每个生成的 mock 调用都携带 runtime 依赖的构建期解析标识。在更低版本的 rspack 上，`rs.mock()` 会在运行时报错并提示升级，而不是静默失效。
+- **Alias specifier**：值为 `resolve.alias` / tsconfig-paths 拼写的非字面量 `import(variable)`，只有当 mock 以**相同拼写**声明时才会命中——alias 不会在运行时被展开。未被 mock 时会显式报错（Node 的 loader 同样无法原生解析这类 specifier）。字面量 import 与静态 import 不受影响——它们由构建展开。
 
 :::
 


### PR DESCRIPTION
## Summary

Stacked on #1485. This PR is the rstest side of the breaking plan: rspack ships the build-resolved mock identity first (web-infra-dev/rspack#14665), then rstest requires it — no compatibility with older rspack.

- **BREAKING: module mocking now requires `@rspack/core >= 2.1.3`.** Every generated `rstest_mock`/`rstest_unmock` call must carry the build-resolved identity `{o, r}`; on an older rspack, `rs.mock()` fails loudly at runtime with an upgrade hint instead of silently missing. The `emitMockResolvedInfo` pass-through is removed (the option no longer exists in rspack).
- **Resolved-first matching for non-literal `import(variable)`**: relative mock requests are no longer keyed by their raw spelling (ambiguous across directories) — only by their build-resolved absolute target. On a raw-spelling miss the worker resolves a relative runtime specifier against the importing module's directory (the rspack-injected origin) and retries by absolute path, so relative, absolute, and `file://` spellings all match; two `import('./foo')` calls from different directories are matched independently, and a relative `rs.mock('./dep')` declared in a shared helper resolves against the helper's own directory (`info.o`). The testPath-based fallback derivation is gone.
- Alias / tsconfig-paths spellings are matched verbatim only, never expanded at runtime; an unmocked one fails loudly (documented as a limitation).

The last commit pins the rspack canary (`2.1.3-canary-7caa6eff`) so CI runs against the emitting rspack — **drop it once a stable @rspack/core release ships and @rsbuild/core picks it up**. Keep this PR draft until then.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/14665
- #1485
- #1454

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).