### PR TITLE
chore: enforce unified package versions under packages/

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Check Dependency Version
         run: pnpm run check-dependency-version
 
+      - name: Check Version Consistency
+        run: pnpm run check-version-consistency
+
       - name: Check Unused Code
         run: pnpm run check-unused
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "check-dependency-version": "pnpx check-dependency-version-consistency --ignore-package @rstest/test-mock-re-exports . && echo",
     "check-spell": "pnpx cspell && heading-case",
     "check-unused": "knip",
+    "check-version-consistency": "node scripts/checkVersionConsistency.mjs",
     "e2e": "cd e2e && pnpm test && pnpm test:commonjs && pnpm test:no-isolate",
     "format": "prettier --write . && heading-case --write",
     "lint": "prettier --check . && pnpm run check-spell && pnpm run lint:type",

--- a/scripts/checkVersionConsistency.mjs
+++ b/scripts/checkVersionConsistency.mjs
@@ -1,0 +1,57 @@
+// Enforce that every package released together shares one version. The release
+// train is defined by bump.config.mts (`bumpp` bumps every packages/* except
+// the negated globs), so this check mirrors that set: all packages/* must share
+// the same `version`, with the same exclusions.
+//
+// Plain .mjs (not .mts) so it runs on the full supported Node range, including
+// Node 20 which cannot execute TypeScript directly.
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packagesDir = join(rootDir, 'packages');
+
+// Packages intentionally excluded from the unified release version. Keep in sync
+// with the `!packages/*` negations in bump.config.mts. browser-ui is a private,
+// prebuilt UI container that is not part of the versioned release train.
+const EXCLUDED = new Set(['browser-ui']);
+
+const packages = [];
+for (const name of readdirSync(packagesDir)) {
+  if (EXCLUDED.has(name)) {
+    continue;
+  }
+
+  let pkg;
+  try {
+    pkg = JSON.parse(
+      readFileSync(join(packagesDir, name, 'package.json'), 'utf8'),
+    );
+  } catch {
+    // Not a package directory (missing/invalid package.json).
+    continue;
+  }
+
+  if (pkg.version) {
+    packages.push({ name: pkg.name ?? name, version: pkg.version });
+  }
+}
+
+const versions = new Set(packages.map((pkg) => pkg.version));
+
+if (versions.size > 1) {
+  const detail = packages
+    .map((pkg) => `  ${pkg.name}: ${pkg.version}`)
+    .join('\n');
+  console.error(
+    `✗ Package versions under packages/ are not unified:\n${detail}\n\n` +
+      'All packages in the release train must share one version. ' +
+      'See bump.config.mts.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ All ${packages.length} packages under packages/ share version ${[...versions][0]}`,
+);

--- a/scripts/checkVersionConsistency.mjs
+++ b/scripts/checkVersionConsistency.mjs
@@ -33,9 +33,20 @@ for (const name of readdirSync(packagesDir)) {
     continue;
   }
 
-  if (pkg.version) {
-    packages.push({ name: pkg.name ?? name, version: pkg.version });
-  }
+  packages.push({ name: pkg.name ?? name, version: pkg.version });
+}
+
+// A release-train package with no version is a worse drift than a mismatch, and
+// silently skipping it would let CI pass. Fail loudly instead.
+const missing = packages.filter((pkg) => !pkg.version);
+if (missing.length > 0) {
+  console.error(
+    '✗ Packages under packages/ are missing a version field:\n' +
+      missing.map((pkg) => `  ${pkg.name}`).join('\n') +
+      '\n\nEvery package in the release train must declare a version. ' +
+      'See bump.config.mts.',
+  );
+  process.exit(1);
 }
 
 const versions = new Set(packages.map((pkg) => pkg.version));


### PR DESCRIPTION
## Summary

The packages under `packages/` are released together and must share a single version. `bump.config.mts` already keeps them in lockstep at bump time, but a manual edit to any `package.json` could silently desync them, and neither `check-dependency-version-consistency` nor syncpack covers a package's own `version` field.

This adds a small CI guard (`scripts/checkVersionConsistency.mjs`) asserting all packages in the release train share one version. The excluded set mirrors the `!packages/*` negations in `bump.config.mts` (`browser-ui` is a private prebuilt UI, not part of the versioned release). Written as plain `.mjs` so it runs on the full supported Node range, and wired into the ubuntu `lint` job so it runs exactly once.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).