### PR TITLE
docs: update 0.11 blog baseline label

### DIFF
--- a/website/docs/en/blog/announcing-0-11.mdx
+++ b/website/docs/en/blog/announcing-0-11.mdx
@@ -86,10 +86,10 @@ Previously, the provider ran every raw V8 entry through the generic `ast-v8-to-i
 
 Measured on the [Rsbuild](https://github.com/web-infra-dev/rsbuild) repository's own test suite (`pnpm test --coverage --coverage.provider=v8`):
 
-| Version                         | Wall span | Phase sum |
-| ------------------------------- | --------: | --------: |
-| baseline (`ast-v8-to-istanbul`) |     6.05s |    60.11s |
-| Rstest 0.11                     |     1.81s |    10.28s |
+| Version           | Wall span | Phase sum |
+| ----------------- | --------: | --------: |
+| baseline (0.10.6) |     6.05s |    60.11s |
+| Rstest 0.11       |     1.81s |    10.28s |
 
 Compared with the baseline, the reworked path is about **3.34x faster**, and the summed per-file phase time drops **5.85x**. Resolving raw coverage in the main process further cuts Rstest's own processing time (about **2x** on the same project) and lowers CPU usage. The coverage output is unchanged.
 

--- a/website/docs/en/blog/announcing-0-11.mdx
+++ b/website/docs/en/blog/announcing-0-11.mdx
@@ -86,12 +86,12 @@ Previously, the provider ran every raw V8 entry through the generic `ast-v8-to-i
 
 Measured on the [Rsbuild](https://github.com/web-infra-dev/rsbuild) repository's own test suite (`pnpm test --coverage --coverage.provider=v8`):
 
-| Version           | Wall span | Phase sum |
-| ----------------- | --------: | --------: |
-| baseline (0.10.6) |     6.05s |    60.11s |
-| Rstest 0.11       |     1.81s |    10.28s |
+| Version         | Total time |
+| --------------- | ---------: |
+| baseline (0.10) |      6.05s |
+| Rstest 0.11     |      1.81s |
 
-Compared with the baseline, the reworked path is about **3.34x faster**, and the summed per-file phase time drops **5.85x**. Resolving raw coverage in the main process further cuts Rstest's own processing time (about **2x** on the same project) and lowers CPU usage. The coverage output is unchanged.
+Compared with the baseline, the reworked path is about **3.34x faster**. Resolving raw coverage in the main process further cuts Rstest's own processing time (about **2x** on the same project) and lowers CPU usage. The coverage output is unchanged.
 
 There is no configuration change — projects using `coverage.provider: 'v8'` get the speedup automatically.
 

--- a/website/docs/zh/blog/announcing-0-11.mdx
+++ b/website/docs/zh/blog/announcing-0-11.mdx
@@ -86,10 +86,10 @@ npx rstest run --shard=1/3
 
 在 [Rsbuild](https://github.com/web-infra-dev/rsbuild) 仓库自身的测试套件上（`pnpm test --coverage --coverage.provider=v8`），我们测得：
 
-| 版本                             | Wall span | Phase sum |
-| -------------------------------- | --------: | --------: |
-| baseline（`ast-v8-to-istanbul`） |     6.05s |    60.11s |
-| Rstest 0.11                      |     1.81s |    10.28s |
+| 版本               | Wall span | Phase sum |
+| ------------------ | --------: | --------: |
+| baseline（0.10.6） |     6.05s |    60.11s |
+| Rstest 0.11        |     1.81s |    10.28s |
 
 相比 baseline，重构后的路径快约 **3.34 倍**，各文件 phase 耗时之和降低 **5.85 倍**；在主进程解析 raw coverage 进一步将 Rstest 自身的处理耗时降低约 **2 倍**（同一项目），并减少了 CPU 占用。coverage 输出结果保持不变。
 

--- a/website/docs/zh/blog/announcing-0-11.mdx
+++ b/website/docs/zh/blog/announcing-0-11.mdx
@@ -86,12 +86,12 @@ npx rstest run --shard=1/3
 
 在 [Rsbuild](https://github.com/web-infra-dev/rsbuild) 仓库自身的测试套件上（`pnpm test --coverage --coverage.provider=v8`），我们测得：
 
-| 版本               | Wall span | Phase sum |
-| ------------------ | --------: | --------: |
-| baseline（0.10.6） |     6.05s |    60.11s |
-| Rstest 0.11        |     1.81s |    10.28s |
+| 版本             | 总耗时 |
+| ---------------- | -----: |
+| baseline（0.10） |  6.05s |
+| Rstest 0.11      |  1.81s |
 
-相比 baseline，重构后的路径快约 **3.34 倍**，各文件 phase 耗时之和降低 **5.85 倍**；在主进程解析 raw coverage 进一步将 Rstest 自身的处理耗时降低约 **2 倍**（同一项目），并减少了 CPU 占用。coverage 输出结果保持不变。
+相比 baseline，重构后的路径快约 **3.34 倍**；在主进程解析 raw coverage 进一步将 Rstest 自身的处理耗时降低约 **2 倍**（同一项目），并减少了 CPU 占用。coverage 输出结果保持不变。
 
 这一优化无需任何配置改动，使用 `coverage.provider: 'v8'` 的项目会自动获得。
 


### PR DESCRIPTION
## Summary

This PR updates the V8 coverage benchmark table label in the Rstest 0.11 release blog from the converter name to the compared release version (`0.10`) and keeps the English and Chinese posts in sync.

## Related Links

N/A

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).