### PR TITLE
test(playwright): skip headed e2e without display

### DIFF
--- a/e2e/playwright/index.test.ts
+++ b/e2e/playwright/index.test.ts
@@ -6,6 +6,16 @@ import { runRstestCli } from '../scripts';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const canRunHeadedPlaywrightTests =
+  process.platform === 'darwin' ||
+  process.platform === 'win32' ||
+  (process.platform === 'linux' &&
+    Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY));
+
+const shouldRunHeadedPlaywrightTests =
+  canRunHeadedPlaywrightTests &&
+  Boolean(process.env.CI || process.env.RSTEST_E2E_RUN_HEADED);
+
 describe('@rstest/playwright', () => {
   it('runs with Playwright fixtures and assertions', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
@@ -24,7 +34,7 @@ describe('@rstest/playwright', () => {
     expect(cli.stdout).toContain('Test Files 2 passed');
   });
 
-  it(
+  it.skipIf(!shouldRunHeadedPlaywrightTests)(
     'can opt into headed debug mode from a test',
     { timeout: 60_000 },
     async () => {

--- a/packages/playwright/tests/fixture.test.ts
+++ b/packages/playwright/tests/fixture.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { execFile, type ExecFileOptions } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
@@ -24,6 +24,16 @@ const debugOptions = {
 } satisfies PlaywrightOptions;
 
 const execFileAsync = promisify(execFile);
+
+const runRstestSubprocess = (args: string[], options: ExecFileOptions = {}) =>
+  execFileAsync(process.execPath, args, {
+    ...options,
+    env: {
+      ...process.env,
+      ...options.env,
+      GITHUB_STEP_SUMMARY: undefined,
+    },
+  });
 
 const createPlaywrightTempRoot = () =>
   mkdtemp(join(__dirname, '../.tmp-rstest-playwright-'));
@@ -135,8 +145,7 @@ test('does not force a local expect for core expect users', async () => {
     );
 
     await rejects(
-      execFileAsync(
-        process.execPath,
+      runRstestSubprocess(
         [
           join(__dirname, '../../core/bin/rstest.js'),
           '--root',
@@ -520,8 +529,7 @@ test(
         `,
       );
 
-      await execFileAsync(
-        process.execPath,
+      await runRstestSubprocess(
         [
           join(__dirname, '../../core/bin/rstest.js'),
           '--root',
@@ -622,8 +630,7 @@ test('cleans up request and serve fixtures after a failed cleanup', async () => 
       `,
     );
 
-    const { stdout, stderr } = await execFileAsync(
-      process.execPath,
+    const { stdout, stderr } = await runRstestSubprocess(
       [
         join(__dirname, '../../core/bin/rstest.js'),
         '--root',


### PR DESCRIPTION
## Summary

Skip the headed Playwright debug e2e when the current environment cannot launch headed browsers. This keeps Linux CI environments without `DISPLAY` or `WAYLAND_DISPLAY` from failing on the debug-mode smoke test, while still running it on macOS, Windows, and Linux environments that provide a display.

Also suppress `GITHUB_STEP_SUMMARY` for nested rstest subprocesses in the Playwright package fixture tests, so expected nested failures do not pollute the parent GitHub Actions job summary.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1396

## Validation

- `./node_modules/.bin/prettier -w e2e/playwright/index.test.ts`
- `./node_modules/.bin/rslint e2e/playwright/index.test.ts`
- `CI=true ../node_modules/.bin/rstest run playwright/index.test.ts --reporter=verbose` from `e2e`
- `./node_modules/.bin/prettier -w packages/playwright/tests/fixture.test.ts`
- `./node_modules/.bin/rslint packages/playwright/tests/fixture.test.ts`
- `GITHUB_STEP_SUMMARY=$(mktemp) CI=true ./node_modules/.bin/rstest run packages/playwright/tests/fixture.test.ts --reporter=verbose`