### PR TITLE
feat(core): mark @rstest/core sideEffects-free for tree-shaking

### DIFF
--- a/e2e/build/sideEffects.test.ts
+++ b/e2e/build/sideEffects.test.ts
@@ -1,0 +1,57 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+
+const require = createRequire(import.meta.url);
+const coreDist = join(
+  dirname(require.resolve('@rstest/core/package.json')),
+  'dist',
+);
+
+/**
+ * Concatenate the source of every emitted chunk transitively reachable from an
+ * entry chunk by following its `import ... from "./x.js"` / `import "./x.js"`
+ * edges. Used to assert what survives tree-shaking in the shipped bundle.
+ */
+const reachableSource = (entry: string): string => {
+  const seen = new Set<string>();
+  const stack = [entry];
+  let combined = '';
+  for (let file = stack.pop(); file; file = stack.pop()) {
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const abs = join(coreDist, file);
+    if (!fs.existsSync(abs)) continue;
+    const src = fs.readFileSync(abs, 'utf8');
+    combined += src;
+    for (const [, rel] of src.matchAll(
+      /(?:from|import)\s*["'](\.\/[^"']+\.js)["']/g,
+    )) {
+      if (rel) stack.push(rel.slice(2));
+    }
+  }
+  return combined;
+};
+
+/**
+ * `@rstest/core` ships `"sideEffects": false` so consumers can tree-shake it.
+ * The worker's profiling graceful-exit handler (`src/runtime/worker/setup.ts`)
+ * is the one piece that must survive that tree-shaking: it is only kept because
+ * the worker entries call `installGracefulExit()` as a used binding. If someone
+ * reverts to a bare `import './setup'`, the module becomes side-effect-only and
+ * is dropped from the bundle — these assertions catch that regression, which a
+ * unit test importing the function directly cannot.
+ */
+describe('@rstest/core sideEffects tree-shaking', () => {
+  // Both worker entries call `installGracefulExit()`, so the handler must be
+  // reachable from each. `--cpu-prof` is unique to setup.ts's profiling guard;
+  // SIGTERM is the handler it installs. Both vanish if setup.ts is dropped.
+  for (const entry of ['worker.js', 'globalSetupWorker.js']) {
+    it(`keeps the profiling graceful-exit handler reachable from ${entry}`, () => {
+      const src = reachableSource(entry);
+      expect(src).toContain('cpu-prof');
+      expect(src).toContain('SIGTERM');
+    });
+  }
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "directory": "packages/core"
   },
   "license": "MIT",
+  "sideEffects": false,
   "type": "module",
   "exports": {
     ".": {

--- a/packages/core/src/runtime/worker/globalSetupWorker.ts
+++ b/packages/core/src/runtime/worker/globalSetupWorker.ts
@@ -1,8 +1,10 @@
-import './setup';
 import { install } from 'source-map-support';
 import type { FormattedError } from '../../types';
 import { color } from '../../utils/logger';
 import { formatTestError } from '../util';
+import { installGracefulExit } from './setup';
+
+installGracefulExit();
 
 let teardownCallbacks: (() => Promise<void> | void)[] = [];
 // Track environment variable changes

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -1,4 +1,3 @@
-import './setup';
 import { isMainThread } from 'node:worker_threads';
 import {
   isWorkerRequestEnvelope,
@@ -10,6 +9,9 @@ import {
 import { ENV } from '../../utils/env';
 import { channel } from './channels';
 import { runInPool } from './runInPool';
+import { installGracefulExit } from './setup';
+
+installGracefulExit();
 
 const send = (response: WorkerResponse): void => {
   channel.send(wrapWorkerResponse(response));

--- a/packages/core/src/runtime/worker/setup.ts
+++ b/packages/core/src/runtime/worker/setup.ts
@@ -1,16 +1,26 @@
-const gracefulExit: boolean = process.execArgv.some(
-  (execArg) =>
-    execArg.startsWith('--perf') ||
-    execArg.startsWith('--prof') ||
-    execArg.startsWith('--cpu-prof') ||
-    execArg.startsWith('--heap-prof') ||
-    execArg.startsWith('--diagnostic-dir'),
-);
+/**
+ * Install a graceful SIGTERM handler for profiling runs.
+ *
+ * Must be called as an explicit, used binding from the worker entries rather
+ * than relied on as a bare `import './setup'` side effect: `@rstest/core`
+ * declares `"sideEffects": false`, so a side-effect-only module would be
+ * tree-shaken out of the worker bundle, silently dropping this handler.
+ */
+export function installGracefulExit(): void {
+  const gracefulExit: boolean = process.execArgv.some(
+    (execArg) =>
+      execArg.startsWith('--perf') ||
+      execArg.startsWith('--prof') ||
+      execArg.startsWith('--cpu-prof') ||
+      execArg.startsWith('--heap-prof') ||
+      execArg.startsWith('--diagnostic-dir'),
+  );
 
-if (gracefulExit) {
-  // gracefully handle SIGTERM to generate CPU profile
-  // https://github.com/nodejs/node/issues/55094
-  process.on('SIGTERM', () => {
-    process.exit();
-  });
+  if (gracefulExit) {
+    // gracefully handle SIGTERM to generate CPU profile
+    // https://github.com/nodejs/node/issues/55094
+    process.on('SIGTERM', () => {
+      process.exit();
+    });
+  }
 }

--- a/packages/core/tests/runtime/worker/setup.test.ts
+++ b/packages/core/tests/runtime/worker/setup.test.ts
@@ -1,0 +1,51 @@
+import { installGracefulExit } from '../../../src/runtime/worker/setup';
+
+/**
+ * `installGracefulExit` replaced a bare `import './setup'` side effect so the
+ * profiling SIGTERM handler survives `@rstest/core`'s `"sideEffects": false`
+ * tree-shaking. These tests pin the handler-registration contract; the
+ * used-binding call site in the worker entries is what keeps it in the bundle.
+ */
+describe('installGracefulExit', () => {
+  const originalExecArgv = process.execArgv;
+
+  afterEach(() => {
+    process.execArgv = originalExecArgv;
+  });
+
+  const collectSignalListeners = (run: () => void): string[] => {
+    const signals: string[] = [];
+    const onSpy = rs
+      .spyOn(process, 'on')
+      .mockImplementation((event: string | symbol) => {
+        signals.push(String(event));
+        return process;
+      });
+    try {
+      run();
+    } finally {
+      onSpy.mockRestore();
+    }
+    return signals;
+  };
+
+  it('registers the handler for every supported profiling flag', () => {
+    for (const flag of [
+      '--perf-basic-prof',
+      '--prof',
+      '--cpu-prof',
+      '--heap-prof',
+      '--diagnostic-dir=/tmp',
+    ]) {
+      process.execArgv = [flag];
+      expect(collectSignalListeners(installGracefulExit)).toContain('SIGTERM');
+    }
+  });
+
+  it('does not register a handler for a normal run', () => {
+    process.execArgv = ['--enable-source-maps'];
+    expect(collectSignalListeners(installGracefulExit)).not.toContain(
+      'SIGTERM',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Declares `"sideEffects": false` on `@rstest/core` so downstream bundlers can tree-shake the package. The motivating win: when a test file is accidentally bundled into an app, the unused `loadConfig`/`merge*` config helpers — and the `@rsbuild/core` → `@rspack/core` graph they value-import via `src/config.ts` — can now be dropped instead of dragged in.

The blanket flag has one trap: the worker's bare `import './setup'` is a side-effect-only module, so `sideEffects: false` tree-shakes it out of the built worker bundle, silently dropping the profiling SIGTERM graceful-exit handler used on `--cpu-prof`/`--prof`/`--heap-prof`/`--diagnostic-dir` runs (see nodejs/node#55094). This PR converts `setup.ts` into an exported `installGracefulExit()` and calls it as a used binding from both worker entries (`worker/index.ts`, `globalSetupWorker.ts`) so the handler survives tree-shaking. `setup.ts` was the only side-effect-only module in `src/`; the browser-runtime graph is unaffected (only dead color-helper modules drop). A unit test pins the handler-registration contract.

## Related Links

- Closes #1497

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).