### PR TITLE
fix(core): accept rs.fn()/rs.spyOn() mocks in call-order matchers

### DIFF
--- a/e2e/expect/test/index.test.ts
+++ b/e2e/expect/test/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@rstest/core';
+import { describe, expect, it, rs } from '@rstest/core';
 
 describe('Expect API', () => {
   it('test expect API', () => {
@@ -95,6 +95,24 @@ describe('Expect API', () => {
 
     expect(['blue', 'red']).not.toContain('blu');
     expect('blue red').not.toMatch('redd');
+  });
+
+  // Regression guard for #1514: a mock from `rs.fn()` / `rs.spyOn()` must be
+  // accepted by the call-order matchers without a cast under strict
+  // type-checking, including through inherited chains like `.not`. The value is
+  // the no-cast usage being type-checked (`e2e` is in the `pnpm typecheck`
+  // scope); reverting the fix makes these lines fail to compile.
+  it('toHaveBeenCalledBefore / toHaveBeenCalledAfter accept a mock without a cast', () => {
+    const a = rs.fn();
+    const b = rs.fn();
+
+    a();
+    b();
+
+    expect(a).toHaveBeenCalledBefore(b);
+    expect(b).toHaveBeenCalledAfter(a);
+    expect(b).not.toHaveBeenCalledBefore(a);
+    expect(a).not.toHaveBeenCalledAfter(b);
   });
 
   it.fails('test not failed', () => {

--- a/e2e/spy/withImplementation.test.ts
+++ b/e2e/spy/withImplementation.test.ts
@@ -40,7 +40,7 @@ describe('test withImplementation', () => {
 
     myMockFn.mockImplementationOnce(mockFn1);
 
-    myMockFn.withImplementation(
+    const withImplReturn = myMockFn.withImplementation(
       () => {
         logs.push('[call temp]');
         return 'temp';
@@ -53,6 +53,8 @@ describe('test withImplementation', () => {
       },
     );
 
+    // A sync callback returns the mock instance, so it can be chained.
+    expect(withImplReturn).toBe(myMockFn);
     expect(myMockFn.getMockImplementation()).toBe(mockFn1);
     expect(isMockCalled).toBe(false);
 
@@ -72,7 +74,8 @@ describe('test withImplementation', () => {
       return 'original';
     });
 
-    await myMockFn.withImplementation(
+    // An async callback resolves to the mock instance.
+    const withImplReturn = await myMockFn.withImplementation(
       () => {
         logs.push('[1 - call temp]');
         return 'temp';
@@ -83,6 +86,8 @@ describe('test withImplementation', () => {
         logs.push(`[1 - callback res] ${res}`);
       },
     );
+
+    expect(withImplReturn).toBe(myMockFn);
 
     logs.push('[1 - call myMockFn]');
 

--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -95,12 +95,15 @@ export const initSpy = (
         : implementation;
     };
 
-    function withImplementation(fn: T, cb: () => void): void;
-    function withImplementation(fn: T, cb: () => Promise<void>): Promise<void>;
+    function withImplementation(fn: T, cb: () => void): Mock<T>;
+    function withImplementation(
+      fn: T,
+      cb: () => Promise<void>,
+    ): Promise<Mock<T>>;
     function withImplementation(
       fn: T,
       cb: () => void | Promise<void>,
-    ): void | Promise<void> {
+    ): Mock<T> | Promise<Mock<T>> {
       const originalImplementation = implementation;
       const originalMockImplementationOnce = mockImplementationOnce;
 
@@ -118,10 +121,12 @@ export const initSpy = (
       if (result instanceof Promise) {
         return result.then(() => {
           reset();
+          return spyFn;
         });
       }
 
       reset();
+      return spyFn;
     }
 
     spyFn.withImplementation = withImplementation;

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -149,7 +149,7 @@ export interface MockInstance<T extends FunctionLike = FunctionLike> {
   withImplementation<T2>(
     fn: NormalizedProcedure<T>,
     callback: () => T2,
-  ): T2 extends Promise<unknown> ? Promise<void> : void;
+  ): T2 extends Promise<unknown> ? Promise<this> : this;
   /**
    * Return the `this` context from the method without invoking the actual implementation.
    */

--- a/website/docs/en/api/runtime-api/rstest/mock-instance.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-instance.mdx
@@ -126,9 +126,9 @@ fn(); // returns undefined
 
 ## withImplementation
 
-- **Type:** `(fn: Function, callback: () => any) => void | Promise<void>`
+- **Type:** `(fn: Function, callback: () => any) => MockInstance | Promise<MockInstance>`
 
-Temporarily replaces the mock implementation while the callback is executed, then restores the original implementation.
+Temporarily replaces the mock implementation while the callback is executed, then restores the original implementation. Returns the mock instance (or a promise resolving to it when the callback is async).
 
 ```ts
 const fn = rs.fn(() => 1);

--- a/website/docs/zh/api/runtime-api/rstest/mock-instance.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-instance.mdx
@@ -126,9 +126,9 @@ fn(); // 返回 undefined
 
 ## withImplementation
 
-- **类型：** `(fn: Function, callback: () => any) => void | Promise<void>`
+- **类型：** `(fn: Function, callback: () => any) => MockInstance | Promise<MockInstance>`
 
-临时替换 mock 的实现函数，在 callback 执行期间生效，执行完毕后恢复原实现。
+临时替换 mock 的实现函数，在 callback 执行期间生效，执行完毕后恢复原实现。返回该 mock 实例（callback 为异步时返回 resolve 为该实例的 promise）。
 
 ```ts
 const fn = rs.fn(() => 1);


### PR DESCRIPTION
## Summary

Under `strict` type-checking, a mock from `rs.fn()` / `rs.spyOn()` was rejected by the `toHaveBeenCalledBefore` / `toHaveBeenCalledAfter` matchers, forcing a cast (#1514).

These matchers are inherited from `@vitest/expect` and type their `mock` parameter as the `MockInstance` shape from that package. An Rstest mock was not assignable to it because `withImplementation` returned `void`.

This aligns `withImplementation` to return the mock instance — a superset of the previous `void`, so existing call sites are unaffected. As a result an Rstest mock becomes assignable to the inherited matcher parameter, so the call-order matchers *and* their `.not` / `.resolves` / `.rejects` chains accept it without a cast (fixing the root cause rather than overriding the two matchers individually).

## Related Links

- Closes #1514

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).