### PR TITLE
fix(core): prevent evaluation of mocked externalized dependencies

### DIFF
--- a/e2e/externals/fixtures/mock-eval/boom-esm/index.js
+++ b/e2e/externals/fixtures/mock-eval/boom-esm/index.js
@@ -1,0 +1,3 @@
+// Import-time side effect that must never run when this package is mocked.
+throw new Error('boom-esm was evaluated');
+export const real = true;

--- a/e2e/externals/fixtures/mock-eval/boom-esm/package.json
+++ b/e2e/externals/fixtures/mock-eval/boom-esm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rstest/tests-boom-esm",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js"
+}

--- a/e2e/externals/fixtures/mock-eval/boom-on-eval/index.js
+++ b/e2e/externals/fixtures/mock-eval/boom-on-eval/index.js
@@ -1,0 +1,3 @@
+// Import-time side effect that must never run when this package is mocked.
+throw new Error('boom-on-eval was evaluated');
+module.exports = { real: true };

--- a/e2e/externals/fixtures/mock-eval/boom-on-eval/package.json
+++ b/e2e/externals/fixtures/mock-eval/boom-on-eval/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rstest/tests-boom-on-eval",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/e2e/externals/fixtures/mock-eval/cjs-shaped/index.js
+++ b/e2e/externals/fixtures/mock-eval/cjs-shaped/index.js
@@ -1,0 +1,7 @@
+// axios-like CJS shape: a callable default with named exports attached.
+const instance = () => 'real';
+class Axios {}
+instance.Axios = Axios;
+module.exports = instance;
+module.exports.Axios = Axios;
+module.exports.default = instance;

--- a/e2e/externals/fixtures/mock-eval/cjs-shaped/package.json
+++ b/e2e/externals/fixtures/mock-eval/cjs-shaped/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rstest/tests-cjs-shaped",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/e2e/externals/fixtures/mock-eval/consumer-pkg/index.js
+++ b/e2e/externals/fixtures/mock-eval/consumer-pkg/index.js
@@ -1,0 +1,2 @@
+import { readFlag } from 'env-singleton';
+export const useFlag = () => readFlag();

--- a/e2e/externals/fixtures/mock-eval/consumer-pkg/package.json
+++ b/e2e/externals/fixtures/mock-eval/consumer-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rstest/tests-consumer-pkg",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js"
+}

--- a/e2e/externals/fixtures/mock-eval/env-singleton/index.js
+++ b/e2e/externals/fixtures/mock-eval/env-singleton/index.js
@@ -1,0 +1,1 @@
+export const readFlag = () => 'REAL';

--- a/e2e/externals/fixtures/mock-eval/env-singleton/package.json
+++ b/e2e/externals/fixtures/mock-eval/env-singleton/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rstest/tests-env-singleton",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js"
+}

--- a/e2e/externals/fixtures/mock-eval/sfx-mod/index.js
+++ b/e2e/externals/fixtures/mock-eval/sfx-mod/index.js
@@ -1,0 +1,2 @@
+globalThis.__RSTEST_SFX_REAL_RAN = true;
+export const flag = 'REAL';

--- a/e2e/externals/fixtures/mock-eval/sfx-mod/package.json
+++ b/e2e/externals/fixtures/mock-eval/sfx-mod/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@rstest/tests-sfx-mod",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js"
+}

--- a/e2e/externals/fixtures/test-mock-eval/callableMockRequire.test.ts
+++ b/e2e/externals/fixtures/test-mock-eval/callableMockRequire.test.ts
@@ -1,0 +1,14 @@
+import { expect, it, rs } from '@rstest/core';
+import * as actual from 'cjs-shaped' with { rstest: 'importActual' };
+// The helper requires 'sfx-mod' while the importActual external above is
+// still pending, so the mock is served through the lazy path.
+import fn from './requiresMock.cjs';
+
+rs.mockRequire('sfx-mod', () => () => 'ok');
+
+void actual;
+
+it('should keep a lazily-served mockRequire mock callable', () => {
+  expect(fn()).toBe('ok');
+  expect((globalThis as any).__RSTEST_SFX_REAL_RAN).toBeUndefined();
+});

--- a/e2e/externals/fixtures/test-mock-eval/defaultImport.test.ts
+++ b/e2e/externals/fixtures/test-mock-eval/defaultImport.test.ts
@@ -1,0 +1,14 @@
+import { expect, it, rs } from '@rstest/core';
+import * as actual from 'cjs-shaped' with { rstest: 'importActual' };
+import mockedDefault, { added } from 'cjs-shaped';
+
+// A default import compiles to `__webpack_require__.n(exports)`, which reads
+// `__esModule` among the importer's harmony requires — BEFORE the async-deps
+// await. That read must not force the factory early (the captured `actual`
+// namespace is still unsettled there).
+rs.mock('cjs-shaped', () => ({ ...actual, added: 'MOCKED' }));
+
+it('should keep a default-imported lazy mock unmaterialized until use', () => {
+  expect((mockedDefault as any).Axios).toBeDefined();
+  expect(added).toBe('MOCKED');
+});

--- a/e2e/externals/fixtures/test-mock-eval/env.d.ts
+++ b/e2e/externals/fixtures/test-mock-eval/env.d.ts
@@ -1,0 +1,6 @@
+declare module 'boom-on-eval';
+declare module 'boom-esm';
+declare module 'sfx-mod';
+declare module 'env-singleton';
+declare module 'consumer-pkg';
+declare module 'cjs-shaped';

--- a/e2e/externals/fixtures/test-mock-eval/factoryInterop.test.ts
+++ b/e2e/externals/fixtures/test-mock-eval/factoryInterop.test.ts
@@ -1,0 +1,16 @@
+import { expect, it, rs } from '@rstest/core';
+import * as actual from 'cjs-shaped' with { rstest: 'importActual' };
+import * as mocked from 'cjs-shaped';
+
+// The factory captures the `importActual` namespace of an externalized CJS
+// package. Externals load asynchronously (import-type externals), so this
+// exercises the lazily-materialized factory: the spread must observe the
+// settled namespace, not a pending promise.
+rs.mock('cjs-shaped', () => ({ ...actual, added: 'MOCKED' }));
+
+it('should spread a settled importActual namespace inside the factory', () => {
+  expect((mocked as any).added).toBe('MOCKED');
+  expect((mocked as any).Axios).toBeDefined();
+  expect(Object.keys(mocked)).toContain('Axios');
+  expect((actual as any).Axios).toBeDefined();
+});

--- a/e2e/externals/fixtures/test-mock-eval/internal/internalImport.test.ts
+++ b/e2e/externals/fixtures/test-mock-eval/internal/internalImport.test.ts
@@ -1,0 +1,10 @@
+import { expect, it, rs } from '@rstest/core';
+import { useFlag } from 'consumer-pkg';
+
+// `consumer-pkg` is an UNMOCKED externalized package whose internal
+// `import { readFlag } from 'env-singleton'` must resolve to the mock.
+rs.mock('env-singleton', () => ({ readFlag: () => 'MOCKED' }));
+
+it('should apply the mock inside an externalized package that imports it', () => {
+  expect(useFlag()).toBe('MOCKED');
+});

--- a/e2e/externals/fixtures/test-mock-eval/mockEval.test.ts
+++ b/e2e/externals/fixtures/test-mock-eval/mockEval.test.ts
@@ -1,0 +1,21 @@
+import { expect, it, rs } from '@rstest/core';
+import boom from 'boom-on-eval';
+import { real } from 'boom-esm';
+import { flag } from 'sfx-mod';
+
+rs.mock('boom-on-eval', () => ({ default: { mocked: true } }));
+rs.mock('boom-esm', () => ({ real: 'MOCKED' }));
+rs.mock('sfx-mod', () => ({ flag: 'MOCKED' }));
+
+it('should not evaluate a mocked externalized CJS module that throws at import time', () => {
+  expect(boom.mocked).toBe(true);
+});
+
+it('should not evaluate a mocked externalized ESM module that throws at import time', () => {
+  expect(real).toBe('MOCKED');
+});
+
+it('should never run the real externalized module import-time side effects', () => {
+  expect(flag).toBe('MOCKED');
+  expect((globalThis as any).__RSTEST_SFX_REAL_RAN).toBeUndefined();
+});

--- a/e2e/externals/fixtures/test-mock-eval/package.json
+++ b/e2e/externals/fixtures/test-mock-eval/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@rstest/tests-mock-eval",
+  "version": "1.0.0",
+  "private": true
+}

--- a/e2e/externals/fixtures/test-mock-eval/requiresMock.cjs
+++ b/e2e/externals/fixtures/test-mock-eval/requiresMock.cjs
@@ -1,0 +1,4 @@
+// Bundled CJS helper: its body runs among the importer's harmony requires —
+// BEFORE the async-deps await — so this require hits the mocked module while
+// async externals are still pending (the lazy Proxy path).
+module.exports = require('sfx-mod');

--- a/e2e/externals/fixtures/test-mock-eval/requiresMock.d.cts
+++ b/e2e/externals/fixtures/test-mock-eval/requiresMock.d.cts
@@ -1,0 +1,2 @@
+declare const mockedSfxMod: () => string;
+export default mockedSfxMod;

--- a/e2e/externals/fixtures/test-mock-eval/rstest.config.ts
+++ b/e2e/externals/fixtures/test-mock-eval/rstest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testEnvironment: 'node',
+  include: ['*.test.ts'],
+});

--- a/e2e/externals/fixtures/test-mock-eval/rstest.internal.config.ts
+++ b/e2e/externals/fixtures/test-mock-eval/rstest.internal.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testEnvironment: 'node',
+  include: ['internal/*.test.ts'],
+});

--- a/e2e/externals/fixtures/test-mock-eval/sideEffectOnly.test.ts
+++ b/e2e/externals/fixtures/test-mock-eval/sideEffectOnly.test.ts
@@ -1,0 +1,18 @@
+import { expect, it, rs } from '@rstest/core';
+import * as actual from 'cjs-shaped' with { rstest: 'importActual' };
+import 'sfx-mod';
+
+// A side-effect-only import never reads an export, so nothing materializes
+// the lazy mock on access; the worker's post-evaluation flush must run the
+// factory instead.
+rs.mock('sfx-mod', () => {
+  (globalThis as any).__MOCK_FACTORY_RAN = true;
+  return { flag: 'MOCKED' };
+});
+
+void actual;
+
+it('should run the factory of a side-effect-only imported mock', () => {
+  expect((globalThis as any).__MOCK_FACTORY_RAN).toBe(true);
+  expect((globalThis as any).__RSTEST_SFX_REAL_RAN).toBeUndefined();
+});

--- a/e2e/externals/fixtures/test-mock-eval/thenExport.test.ts
+++ b/e2e/externals/fixtures/test-mock-eval/thenExport.test.ts
@@ -1,0 +1,18 @@
+import { expect, it, rs } from '@rstest/core';
+import * as actual from 'cjs-shaped' with { rstest: 'importActual' };
+import { added, then } from 'cjs-shaped';
+
+// `then` reads are masked only until the factory materializes (the async-deps
+// machinery thenable-probes every dep); afterwards a genuine `then` export is
+// served like any other, matching the eager path.
+rs.mock('cjs-shaped', () => ({
+  ...actual,
+  added: 'MOCKED',
+  then: () => 'THEN',
+}));
+
+it('should expose a genuine then export once materialized', () => {
+  expect(added).toBe('MOCKED');
+  expect(typeof then).toBe('function');
+  expect((then as () => string)()).toBe('THEN');
+});

--- a/e2e/externals/mockedExternalizedEval.test.ts
+++ b/e2e/externals/mockedExternalizedEval.test.ts
@@ -1,0 +1,62 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeAll, describe, it } from '@rstest/core';
+import fse from 'fs-extra';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const FAKE_PACKAGES = [
+  'boom-on-eval',
+  'boom-esm',
+  'sfx-mod',
+  'env-singleton',
+  'consumer-pkg',
+  'cjs-shaped',
+];
+
+// https://github.com/web-infra-dev/rstest/issues/1456
+describe('rs.mock of an externalized dependency', () => {
+  beforeAll(() => {
+    for (const pkg of FAKE_PACKAGES) {
+      fse.copySync(
+        join(__dirname, './fixtures/mock-eval', pkg),
+        join(__dirname, './fixtures/test-mock-eval/node_modules', pkg),
+      );
+    }
+  });
+
+  it('should prevent the real externalized module from being evaluated', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures/test-mock-eval'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+
+  // Depends on #1485 (native `module.registerHooks` mock bridge): the mock
+  // must reach an UNMOCKED externalized package's internal static import of
+  // the mocked module, which is resolved by Node's loader outside the bundle.
+  // The fixture (fixtures/test-mock-eval/internal/) is in place — un-skip
+  // once #1485 lands.
+  it.skip('should apply the mock inside an externalized package that imports it', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', './rstest.internal.config.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures/test-mock-eval'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+});

--- a/e2e/mock/tests/mock.test.ts
+++ b/e2e/mock/tests/mock.test.ts
@@ -53,7 +53,5 @@ it('mocked axios', async () => {
 
   expect(originalAxios.Axios).toBeDefined();
 
-  if (process.env.RSTEST_OUTPUT_MODULE !== 'false') {
-    expect(axios.Axios).toBeDefined();
-  }
+  expect(axios.Axios).toBeDefined();
 });

--- a/packages/core/src/core/plugins/external.ts
+++ b/packages/core/src/core/plugins/external.ts
@@ -138,7 +138,6 @@ function matchesBundledDependency(
 }
 
 const autoExternalNodeModules: (
-  outputModule: boolean,
   bundledDependencies?: BundleDependencyPattern[],
 ) => (
   data: Rspack.ExternalItemFunctionData,
@@ -148,7 +147,7 @@ const autoExternalNodeModules: (
     type?: Rspack.ExternalsType,
   ) => void,
 ) => void =
-  (outputModule, bundledDependencies) =>
+  (bundledDependencies) =>
   ({ context, request, dependencyType, getResolve }, callback) => {
     if (!request) {
       return callback();
@@ -167,11 +166,15 @@ const autoExternalNodeModules: (
       callback(
         undefined,
         externalPath,
-        dependencyType === 'commonjs'
-          ? 'commonjs'
-          : outputModule
-            ? 'module-import'
-            : 'import',
+        // `import` (dynamic) also under module output, NOT `module-import`
+        // (static): a static external is evaluated by the ESM loader before
+        // the bundle body runs, so a hoisted `rs.mock` can never prevent the
+        // real module's evaluation — an import-time side effect (or throw)
+        // escapes the mock (#1456). An import-type external loads at
+        // `__webpack_require__` time, AFTER mock registration, so a mocked
+        // external's factory is already replaced and the real module is
+        // never touched.
+        dependencyType === 'commonjs' ? 'commonjs' : 'import',
       );
     };
 
@@ -244,6 +247,10 @@ function autoExternalNodeBuiltin(
     callback(
       undefined,
       request,
+      // Builtins keep the static `module-import` form: evaluating a core
+      // module early is side-effect-free, so the #1456 deferral in
+      // `doExternal` above buys nothing here, and the factory swap still
+      // intercepts every bundled importer of a mocked builtin.
       dependencyType === 'commonjs' ? 'commonjs' : 'module-import',
     );
   } else {
@@ -262,7 +269,6 @@ export const pluginExternal: (context: RstestContext) => RsbuildPlugin = (
           testEnvironment,
           output: { bundleDependencies } = {},
         },
-        outputModule,
       } = context.projects.find((p) => p.environmentName === name)!;
 
       const shouldExternalize =
@@ -277,7 +283,6 @@ export const pluginExternal: (context: RstestContext) => RsbuildPlugin = (
           externals: shouldExternalize
             ? [
                 autoExternalNodeModules(
-                  outputModule,
                   Array.isArray(bundleDependencies)
                     ? bundleDependencies
                     : undefined,

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -2,11 +2,40 @@
 
 const originalWebpackRequire = __webpack_require__;
 
+// Async-external exports that have not settled yet. An import-type external
+// (see `doExternal` in plugins/external.ts) loads through a native dynamic
+// import, so requiring it yields a Promise that the importer's async-deps
+// machinery unwraps later. A hoisted function-mock factory may capture such a
+// namespace binding (e.g. spread an `importActual` import); the factory
+// therefore must not run while any of these are pending — see the
+// lazily-materialized mock exports in `getMockImplementation`.
+const rstest_pending_async_exports = new Set();
+// Every promise ever tracked, so a settled external — whose exports stay the
+// SAME cached promise on every later require — is not re-added (and does not
+// re-open the pending window) each time another module requires it.
+const rstest_tracked_async_exports = new WeakSet();
+
+const trackAsyncExports = (exportsValue) => {
+  if (
+    isPromise(exportsValue) &&
+    !rstest_tracked_async_exports.has(exportsValue)
+  ) {
+    rstest_tracked_async_exports.add(exportsValue);
+    rstest_pending_async_exports.add(exportsValue);
+    const untrack = () => rstest_pending_async_exports.delete(exportsValue);
+    // `.then(onSettled, onSettled)`, not `.finally` — finally re-throws a
+    // rejection into a new promise chain nobody handles (unhandledRejection);
+    // the rejection itself still surfaces through the importer's await.
+    exportsValue.then(untrack, untrack);
+  }
+  return exportsValue;
+};
+
 //#region proxy __webpack_require__
 __webpack_require__ = new Proxy(
   function (...args) {
     try {
-      return originalWebpackRequire(...args);
+      return trackAsyncExports(originalWebpackRequire(...args));
     } catch (e) {
       const errMsg = e.message ?? e.toString();
       if (errMsg.includes('__webpack_modules__[moduleId] is not a function')) {
@@ -259,15 +288,93 @@ const getMockImplementation = (mockType = 'mock') => {
         __webpack_exports__,
         __webpack_require__,
       ) {
-        const res = modFactory();
+        const runFactory = () => {
+          const res = modFactory();
 
-        if (isPromise(res)) {
-          throw new Error(
-            `[Rstest] An async mock factory is not supported. ` +
-              `Use a sync factory; to keep part of the original module, ` +
-              `import it with \`with { rstest: 'importActual' }\` and spread it in.`,
-          );
+          if (isPromise(res)) {
+            throw new Error(
+              `[Rstest] An async mock factory is not supported. ` +
+                `Use a sync factory; to keep part of the original module, ` +
+                `import it with \`with { rstest: 'importActual' }\` and spread it in.`,
+            );
+          }
+          return res;
+        };
+
+        // The factory may capture async-external namespace bindings (e.g.
+        // spread an `importActual` import) that are still unsettled while the
+        // importer's harmony requires run. Those bindings are only reassigned
+        // to real namespaces when the importer's async-deps `await` resumes,
+        // and that await includes THIS mocked dep — so the factory can never
+        // run "after the await" as a dep (the importer waits on the mock, the
+        // mock would wait on the importer's rebinding). Break the cycle by
+        // serving a lazily-materialized namespace: exports settle immediately
+        // (a Proxy), the importer resumes and rebinds its vars, and the
+        // factory runs on FIRST PROPERTY ACCESS, when the captured bindings
+        // are settled namespaces. Only engaged while async externals are
+        // actually pending; otherwise the eager path below runs, as before.
+        if (rstest_pending_async_exports.size > 0) {
+          let materializedExports;
+          const materialize = () => {
+            if (materializedExports === undefined) {
+              const res = runFactory();
+              if (isMockRequire) {
+                materializedExports = res;
+              } else {
+                // Same interop policy as the eager path below, applied once
+                // at materialization by the same helper, so the two paths
+                // cannot diverge.
+                materializedExports = {};
+                defineExportsWithCjsInterop(
+                  res,
+                  materializedExports,
+                  __webpack_require__,
+                );
+              }
+            }
+            return materializedExports;
+          };
+          // Runtime probes must not force the factory: the async-deps
+          // machinery checks `.then` (thenable) and `Symbol("rspack queues")`
+          // (async module), `Object.prototype.toString` reads
+          // `Symbol.toStringTag`. An ESM namespace never has symbol exports,
+          // so every symbol read answers `undefined` without materializing —
+          // and the mock must not look async, or the importer would await it
+          // back into the very cycle this Proxy breaks.
+          const isRuntimeProbe = (property) =>
+            property === 'then' || typeof property === 'symbol';
+          __webpack_module__.exports = new Proxy(Object.create(null), {
+            get(_, property) {
+              return isRuntimeProbe(property)
+                ? undefined
+                : materialize()[property];
+            },
+            has(_, property) {
+              return isRuntimeProbe(property)
+                ? false
+                : Reflect.has(materialize(), property);
+            },
+            ownKeys(_) {
+              return Reflect.ownKeys(materialize());
+            },
+            getOwnPropertyDescriptor(_, property) {
+              const descriptor = Reflect.getOwnPropertyDescriptor(
+                materialize(),
+                property,
+              );
+              // `configurable: true` unconditionally: the Proxy target is an
+              // empty object, and reporting a non-configurable descriptor for
+              // a property the target does not own violates the Proxy
+              // invariant and throws.
+              return descriptor
+                ? { ...descriptor, configurable: true }
+                : undefined;
+            },
+          });
+          return;
         }
+
+        const res = runFactory();
 
         if (isMockRequire) {
           __webpack_module__.exports = res;

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -374,42 +374,60 @@ const getMockImplementation = (mockType = 'mock') => {
             }
             return undefined;
           };
-          const lazyExports = new Proxy(Object.create(null), {
-            get(_, property) {
-              if (materializedExports === undefined) {
-                const probed = preMaterializeAnswer(property);
-                if (probed) {
-                  return probed.value;
+          // mockRequire serves the factory result verbatim, and that result
+          // may be CALLABLE (`rs.mockRequire('pkg', () => () => 'ok')`) — a
+          // Proxy is only callable when its target is, so the mockRequire
+          // path proxies an arrow function and forwards `apply`. An ARROW
+          // function specifically: it has no own non-configurable `prototype`
+          // (a regular function's would make the `ownKeys` trap below throw
+          // a Proxy invariant violation on `Object.keys`), at the cost of
+          // `new` on a
+          // lazily-served mockRequire mock throwing — constructing through a
+          // Proxy requires a constructible target. The rs.mock path keeps a
+          // plain object target: a namespace is never callable.
+          const lazyExports = new Proxy(
+            isMockRequire ? () => {} : Object.create(null),
+            {
+              apply(_, thisArg, args) {
+                return Reflect.apply(materialize(), thisArg, args);
+              },
+              get(_, property) {
+                if (materializedExports === undefined) {
+                  const probed = preMaterializeAnswer(property);
+                  if (probed) {
+                    return probed.value;
+                  }
                 }
-              }
-              return materialize()[property];
-            },
-            has(_, property) {
-              if (materializedExports === undefined) {
-                const probed = preMaterializeAnswer(property);
-                if (probed) {
-                  return probed.value !== undefined;
+                return materialize()[property];
+              },
+              has(_, property) {
+                if (materializedExports === undefined) {
+                  const probed = preMaterializeAnswer(property);
+                  if (probed) {
+                    return probed.value !== undefined;
+                  }
                 }
-              }
-              return Reflect.has(materialize(), property);
+                return Reflect.has(materialize(), property);
+              },
+              ownKeys(_) {
+                return Reflect.ownKeys(materialize());
+              },
+              getOwnPropertyDescriptor(_, property) {
+                const descriptor = Reflect.getOwnPropertyDescriptor(
+                  materialize(),
+                  property,
+                );
+                // `configurable: true` unconditionally: the Proxy target owns
+                // no non-configurable properties (an empty object, or an arrow
+                // function whose `length`/`name` are configurable), and
+                // reporting a non-configurable descriptor for a property the
+                // target does not own violates the Proxy invariant and throws.
+                return descriptor
+                  ? { ...descriptor, configurable: true }
+                  : undefined;
+              },
             },
-            ownKeys(_) {
-              return Reflect.ownKeys(materialize());
-            },
-            getOwnPropertyDescriptor(_, property) {
-              const descriptor = Reflect.getOwnPropertyDescriptor(
-                materialize(),
-                property,
-              );
-              // `configurable: true` unconditionally: the Proxy target is an
-              // empty object, and reporting a non-configurable descriptor for
-              // a property the target does not own violates the Proxy
-              // invariant and throws.
-              return descriptor
-                ? { ...descriptor, configurable: true }
-                : undefined;
-            },
-          });
+          );
           __webpack_module__.exports = lazyExports;
           // Guarantee the factory runs even when nothing ever reads an
           // export (a side-effect-only `import 'pkg'`): the worker flushes

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -334,25 +334,48 @@ const getMockImplementation = (mockType = 'mock') => {
             }
             return materializedExports;
           };
-          // Runtime probes must not force the factory: the async-deps
-          // machinery checks `.then` (thenable) and `Symbol("rspack queues")`
-          // (async module), `Object.prototype.toString` reads
-          // `Symbol.toStringTag`. An ESM namespace never has symbol exports,
-          // so every symbol read answers `undefined` without materializing —
-          // and the mock must not look async, or the importer would await it
-          // back into the very cycle this Proxy breaks.
-          const isRuntimeProbe = (property) =>
-            property === 'then' || typeof property === 'symbol';
+          // Until the factory has run, the runtime's own module-loading reads
+          // must be answered WITHOUT forcing it: the async-deps machinery
+          // checks `.then` (thenable) and `Symbol("rspack queues")` (async
+          // module), `Object.prototype.toString` reads `Symbol.toStringTag`,
+          // and `__webpack_require__.n` reads `__esModule` — all while the
+          // captured bindings may still be unsettled (and the mock must not
+          // look async, or the importer would await it back into the very
+          // cycle this Proxy breaks). `then`/symbols answer undefined;
+          // `__esModule` answers `true`, which is a constant of the namespace
+          // `defineExportsWithCjsInterop` will build (its `.r` call), so no
+          // materialization is needed for a correct answer. Once materialized,
+          // every read — including a genuine `then` export — delegates to the
+          // real namespace, matching the eager path. Residual limitation: a
+          // mock whose FIRST-ever accessed export is named `then` reads
+          // `undefined` (indistinguishable from a thenable probe).
+          const preMaterializeAnswer = (property) => {
+            if (property === '__esModule' && !isMockRequire) {
+              return { value: true };
+            }
+            if (property === 'then' || typeof property === 'symbol') {
+              return { value: undefined };
+            }
+            return undefined;
+          };
           __webpack_module__.exports = new Proxy(Object.create(null), {
             get(_, property) {
-              return isRuntimeProbe(property)
-                ? undefined
-                : materialize()[property];
+              if (materializedExports === undefined) {
+                const probed = preMaterializeAnswer(property);
+                if (probed) {
+                  return probed.value;
+                }
+              }
+              return materialize()[property];
             },
             has(_, property) {
-              return isRuntimeProbe(property)
-                ? false
-                : Reflect.has(materialize(), property);
+              if (materializedExports === undefined) {
+                const probed = preMaterializeAnswer(property);
+                if (probed) {
+                  return probed.value !== undefined;
+                }
+              }
+              return Reflect.has(materialize(), property);
             },
             ownKeys(_) {
               return Reflect.ownKeys(materialize());

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -15,6 +15,22 @@ const rstest_pending_async_exports = new Set();
 // re-open the pending window) each time another module requires it.
 const rstest_tracked_async_exports = new WeakSet();
 
+// Lazy mocks whose factory has not run yet (the lazily-materialized Proxy in
+// `getMockImplementation`). The worker invokes every registered flusher after
+// the test module graph is evaluated — every captured binding settled — and
+// before tests execute (see `runInPool`), so a mock imported ONLY for its
+// side effects (`import 'pkg'`, no export ever read) still runs its factory,
+// as it does on the eager path. A Set registry rather than a single global
+// slot, for the same reason as `__rstest_cache_cleaners__`
+// (moduleCacheControl.ts): under `isolate: false` a reused worker holds
+// several runtime chunks at once, each with its own mock runtime instance.
+const rstest_lazy_mock_factories = [];
+(globalThis.__rstest_lazy_mock_flushers__ ??= new Set()).add(() => {
+  while (rstest_lazy_mock_factories.length > 0) {
+    rstest_lazy_mock_factories.shift()();
+  }
+});
+
 const trackAsyncExports = (exportsValue) => {
   if (
     isPromise(exportsValue) &&
@@ -358,7 +374,7 @@ const getMockImplementation = (mockType = 'mock') => {
             }
             return undefined;
           };
-          __webpack_module__.exports = new Proxy(Object.create(null), {
+          const lazyExports = new Proxy(Object.create(null), {
             get(_, property) {
               if (materializedExports === undefined) {
                 const probed = preMaterializeAnswer(property);
@@ -393,6 +409,19 @@ const getMockImplementation = (mockType = 'mock') => {
                 ? { ...descriptor, configurable: true }
                 : undefined;
             },
+          });
+          __webpack_module__.exports = lazyExports;
+          // Guarantee the factory runs even when nothing ever reads an
+          // export (a side-effect-only `import 'pkg'`): the worker flushes
+          // this queue once the module graph is evaluated. Guarded so it
+          // runs only while this mock still owns the module — after an
+          // unmock, re-mock, or resetModules the cache entry is gone (or
+          // repopulated by a different factory), and running THIS factory
+          // would resurrect a replaced mock's side effects.
+          rstest_lazy_mock_factories.push(() => {
+            if (__webpack_module_cache__[id]?.exports === lazyExports) {
+              materialize();
+            }
           });
           return;
         }

--- a/packages/core/src/runtime/worker/interop.ts
+++ b/packages/core/src/runtime/worker/interop.ts
@@ -175,15 +175,19 @@ export const clearSyntheticModuleCache = (): void => {
 };
 
 /**
- * Drop the per-chunk cache cleaners registered by the cache-control runtime
- * module (see `core/plugins/moduleCacheControl.ts`). Call only on a full flush:
- * the runtime chunks are evicted, so re-evaluating each one re-registers a fresh
- * cleaner — keeping the old ones would pin stale chunk caches across rebuilds.
+ * Drop the per-chunk registries populated by bundle runtime code — the cache
+ * cleaners (see `core/plugins/moduleCacheControl.ts`) and the lazy-mock
+ * flushers (see `mockRuntimeCode.js`). Call only on a full flush: the runtime
+ * chunks are evicted, so re-evaluating each one re-registers fresh entries —
+ * keeping the old ones would pin stale chunk scopes across rebuilds.
  */
 export const clearCacheCleaners = (): void => {
-  (
-    globalThis as { __rstest_cache_cleaners__?: Set<() => void> }
-  ).__rstest_cache_cleaners__?.clear();
+  const registries = globalThis as {
+    __rstest_cache_cleaners__?: Set<() => void>;
+    __rstest_lazy_mock_flushers__?: Set<() => void>;
+  };
+  registries.__rstest_cache_cleaners__?.clear();
+  registries.__rstest_lazy_mock_flushers__?.clear();
 };
 
 /**

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -387,6 +387,18 @@ const loadFiles = async ({
     assetFiles,
     interopDefault,
   });
+
+  // The module graph is fully evaluated here, so every async external has
+  // settled and the bindings a lazy mock factory captured are real
+  // namespaces. Run the factories nothing has materialized yet (each runtime
+  // chunk's mock runtime registers a flusher — see
+  // `__rstest_lazy_mock_flushers__` in mockRuntimeCode.js), so a factory
+  // side effect from a side-effect-only `import 'pkg'` is not silently
+  // skipped.
+  const lazyMockFlushers = (
+    globalThis as { __rstest_lazy_mock_flushers__?: Set<() => void> }
+  ).__rstest_lazy_mock_flushers__;
+  lazyMockFlushers?.forEach((flush) => flush());
 };
 
 export const runInPool = async (

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -394,7 +394,12 @@ const loadFiles = async ({
   // chunk's mock runtime registers a flusher — see
   // `__rstest_lazy_mock_flushers__` in mockRuntimeCode.js), so a factory
   // side effect from a side-effect-only `import 'pkg'` is not silently
-  // skipped.
+  // skipped. This is the earliest point the worker can hook: the factory's
+  // captured bindings are only reassigned when its module's async-deps await
+  // resumes, so running factories during the import statement itself is
+  // exactly the unsettled-capture timing the lazy path exists to avoid —
+  // even though a top-level statement between the import and the end of the
+  // module body will not observe the side effect yet.
   const lazyMockFlushers = (
     globalThis as { __rstest_lazy_mock_flushers__?: Set<() => void> }
   ).__rstest_lazy_mock_flushers__;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,11 +261,25 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
 
+  e2e/externals/fixtures/mock-eval/boom-esm: {}
+
+  e2e/externals/fixtures/mock-eval/boom-on-eval: {}
+
+  e2e/externals/fixtures/mock-eval/cjs-shaped: {}
+
+  e2e/externals/fixtures/mock-eval/consumer-pkg: {}
+
+  e2e/externals/fixtures/mock-eval/env-singleton: {}
+
+  e2e/externals/fixtures/mock-eval/sfx-mod: {}
+
   e2e/externals/fixtures/test-bundle: {}
 
   e2e/externals/fixtures/test-interop: {}
 
   e2e/externals/fixtures/test-lodash: {}
+
+  e2e/externals/fixtures/test-mock-eval: {}
 
   e2e/externals/fixtures/test-module-field: {}
 


### PR DESCRIPTION
## Summary

With the default node externalization, `rs.mock()` of an externalized dependency applied the mock value to the importer's binding, but the real module was still evaluated first — an import-time side effect (or throw) escaped the mock and crashed the run (first symptom of #1456, e.g. mocking `electron-updater` outside the Electron runtime).

- Externalize `node_modules` with the `import` external type in both output modes (previously static `module-import` under ES module output). Externals now load at `__webpack_require__` time — after hoisted mock registration — so a mocked external's factory is already replaced and the real module is never evaluated.
- Import-type externals load as async deps, which a hoisted mock factory may capture unsettled (e.g. spreading an `importActual` namespace) — and the importer's async-deps `await` includes the mocked dep itself, so the factory can never run after that await. While async externals are pending, function mocks are served as a lazily-materialized namespace Proxy: the factory runs on first property access, when the captured bindings have settled. This also fixes the same capture bug that already existed under `RSTEST_OUTPUT_MODULE=false`, so the `axios.Axios` assertion in the mock e2e is now un-gated.
- The second symptom of #1456 (a mock reaching an *unmocked* externalized package's internal import of the mocked module) additionally requires the native `module.registerHooks` bridge from #1485. Its e2e fixture is included but stubbed with `it.skip` — un-skip once #1485 lands. No rspack version requirement in this PR.

## Related Links

- https://github.com/web-infra-dev/rstest/issues/1456
- https://github.com/web-infra-dev/rstest/pull/1485

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).