### PR TITLE
fix(core): keep Mocked<T> construct signatures for this-typed members

### DIFF
--- a/e2e/mock/tests/mockObject.test.ts
+++ b/e2e/mock/tests/mockObject.test.ts
@@ -257,7 +257,9 @@ describe('rs.mocked', () => {
   });
 
   // Type-level regression: `Mocked<T>` must stay assignable back to `T`,
-  // including members that are both constructable and callable (issue #1515).
+  // including members that are both constructable and callable (issue #1515),
+  // whether or not the call signature carries a `this` parameter — the latter
+  // is the shape a `function` + `class` declaration merge produces.
   test('Mocked<T> stays assignable to T for construct+call members', () => {
     class Handle {
       _tag!: number;
@@ -265,19 +267,37 @@ describe('rs.mocked', () => {
     interface Api {
       op: (new () => Handle) & (() => Promise<number>);
     }
+    interface ThisApi {
+      op: (new () => Handle) & ((this: ThisApi) => Promise<number>);
+    }
     const asReal = (mocked: Mocked<Api>): Api => mocked;
+    const asRealThis = (mocked: Mocked<ThisApi>): ThisApi => mocked;
     // The construct signature must also survive: `new mocked.op()` should
-    // infer `Handle`, not `Mock`'s synthetic `ReturnType<T>` (`Promise`).
+    // infer `Handle`, not `Mock`'s synthetic `ReturnType<T>` (`Promise`),
+    // and the this-typed member must stay callable without a receiver.
     const constructsHandle = (mocked: Mocked<Api>): Handle => new mocked.op();
+    const constructsHandleThis = (mocked: Mocked<ThisApi>): Handle =>
+      new mocked.op();
+    const callsWithoutReceiver = (mocked: Mocked<ThisApi>): Promise<number> =>
+      mocked.op();
     // Same must hold on the deep path (`rs.mockObject` / `rs.mocked(x, true)`).
     type DeepMocked = ReturnType<typeof rs.mockObject<Api>>;
+    type DeepMockedThis = ReturnType<typeof rs.mockObject<ThisApi>>;
     const asRealDeep = (mocked: DeepMocked): Api => mocked;
+    const asRealThisDeep = (mocked: DeepMockedThis): ThisApi => mocked;
     const constructsHandleDeep = (mocked: DeepMocked): Handle =>
       new mocked.op();
+    const constructsHandleThisDeep = (mocked: DeepMockedThis): Handle =>
+      new mocked.op();
     expect(asReal).toBeTypeOf('function');
+    expect(asRealThis).toBeTypeOf('function');
     expect(constructsHandle).toBeTypeOf('function');
+    expect(constructsHandleThis).toBeTypeOf('function');
+    expect(callsWithoutReceiver).toBeTypeOf('function');
     expect(asRealDeep).toBeTypeOf('function');
+    expect(asRealThisDeep).toBeTypeOf('function');
     expect(constructsHandleDeep).toBeTypeOf('function');
+    expect(constructsHandleThisDeep).toBeTypeOf('function');
   });
 
   // Type-level regression: mocking a function typed with an explicit `this`

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -254,12 +254,22 @@ type Properties<T> = {
   [K in keyof T]: T[K] extends MockProcedure ? never : K;
 }[keyof T];
 
-// A mock-wrapped callable. `OmitThisParameter<T>` comes first so a construct+call
-// member keeps `T`'s real construct signature at `new mocked.fn()` sites
-// (`Mock<T>`'s synthetic `new` returns `ReturnType<T>` and would otherwise shadow
-// it). Stripping `this` keeps `mocked(args)` callable without a receiver for
-// methods typed with an explicit `this`, which a bare `T` would break.
-type MockedCallable<T extends MockProcedure> = OmitThisParameter<T> & Mock<T>;
+// A mock-wrapped callable. Stripping `this` keeps `mocked(args)` callable
+// without a receiver for methods typed with an explicit `this`, which a bare
+// `T` would break — but when a `this` parameter is present,
+// `OmitThisParameter<T>` rebuilds a bare call signature and drops `T`'s
+// construct signature, so `ConstructSignature<T>` re-extracts it (the tuple
+// wrapping avoids distributing over union members). `T`'s real signatures come
+// before `Mock<T>` so a construct+call member keeps its real construct
+// signature at `new mocked.fn()` sites (`Mock<T>`'s synthetic `new` returns
+// `ReturnType<T>` and would otherwise shadow it).
+type ConstructSignature<T> = [T] extends [new (...args: infer A) => infer R]
+  ? new (...args: A) => R
+  : unknown;
+
+type MockedCallable<T extends MockProcedure> = OmitThisParameter<T> &
+  ConstructSignature<T> &
+  Mock<T>;
 
 // The extra `{ [K in keyof T]: T[K] }` restores named/static properties that
 // `OmitThisParameter` drops when it rebuilds a this-less call signature.


### PR DESCRIPTION
## Summary

#1516 kept `Mocked<T>` assignable to `T` for construct+call members, but only when the call signature has no `this` parameter — there `OmitThisParameter<T>` returns `T` unchanged. When the call signature carries an explicit `this` (the shape a `function` + `class` declaration merge produces), `OmitThisParameter<T>` rebuilds a bare call signature and drops `T`'s construct signature, so `Mocked<T>` was again not assignable to `T`.

Fix: re-extract the construct signature (`ConstructSignature<T>`) and intersect it back ahead of `Mock<T>`'s synthetic `new`, so `new mocked.op()` keeps inferring the real instance type. The conditional is tuple-wrapped to avoid distributing over union-typed members. The #1515 compile-time regression test is extended with the this-typed variant (shallow and deep paths, construct inference, receiver-free call).

## Related Links

- Follow-up report: https://github.com/web-infra-dev/rstest/issues/1515#issuecomment-4913125502
- #1516

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).