### PR TITLE
[stress] native watcher — 50-round macos-14 pressure test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,14 +223,16 @@ jobs:
         run: pnpm run test:vscode
 
   # ======== native-watcher stress (draft only) ========
-  # 50-round pressure test of the rspack native watcher on macos-14, where the
-  # stale-FSEvent flake used to surface. 10 shards x 5 fresh rounds = 50 runs
-  # of the watch e2e suite. Not wired into test-gate; remove before merge.
+  # 50-round pressure test at REAL e2e volume on macos-14, where the
+  # stale-FSEvent watch flake only surfaces under full-suite load. Each round
+  # runs the complete `pnpm test` (rstest run over all ~237 e2e files, incl.
+  # browser-mode) exactly like the real e2e job. 10 shards x 5 fresh rounds =
+  # 50 full runs. Not wired into test-gate; remove before merge.
   stress-watch:
     needs: prepare
     if: needs.prepare.outputs.changed == 'true'
     runs-on: macos-14
-    timeout-minutes: 20
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -256,13 +258,18 @@ jobs:
       - name: Build Packages
         run: pnpm run build
 
-      - name: Stress watch e2e (5 fresh rounds)
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          install-webkit: 'true'
+
+      - name: Stress full e2e (5 fresh rounds)
         run: |
           cd e2e
           fail=0
           for r in 1 2 3 4 5; do
-            echo "===== shard ${{ matrix.shard }} round $r/5 ====="
-            if pnpm exec rstest run watch/; then
+            echo "===== shard ${{ matrix.shard }} round $r/5 (full pnpm test) ====="
+            if pnpm test; then
               echo "shard ${{ matrix.shard }} round $r: PASS"
             else
               echo "shard ${{ matrix.shard }} round $r: FAIL"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,6 +222,55 @@ jobs:
         if: matrix.test_script == 'test' && (needs.prepare.outputs.is_full_run == 'true' || (matrix.os == 'windows-latest' && matrix.node_version == '24'))
         run: pnpm run test:vscode
 
+  # ======== native-watcher stress (draft only) ========
+  # 50-round pressure test of the rspack native watcher on macos-14, where the
+  # stale-FSEvent flake used to surface. 10 shards x 5 fresh rounds = 50 runs
+  # of the watch e2e suite. Not wired into test-gate; remove before merge.
+  stress-watch:
+    needs: prepare
+    if: needs.prepare.outputs.changed == 'true'
+    runs-on: macos-14
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build Packages
+        run: pnpm run build
+
+      - name: Stress watch e2e (5 fresh rounds)
+        run: |
+          cd e2e
+          fail=0
+          for r in 1 2 3 4 5; do
+            echo "===== shard ${{ matrix.shard }} round $r/5 ====="
+            if pnpm exec rstest run watch/; then
+              echo "shard ${{ matrix.shard }} round $r: PASS"
+            else
+              echo "shard ${{ matrix.shard }} round $r: FAIL"
+              fail=1
+            fi
+          done
+          exit $fail
+
   # ======== codspeed ========
   # Temporarily disabled: CodSpeed runner quota exhausted.
   # Re-enable once quota resets.

--- a/e2e/watch/fixtures-dynamic/rstest.config.mts
+++ b/e2e/watch/fixtures-dynamic/rstest.config.mts
@@ -1,11 +1,3 @@
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({
-  tools: {
-    rspack: {
-      watchOptions: {
-        aggregateTimeout: 10,
-      },
-    },
-  },
-});
+export default defineConfig({});

--- a/e2e/watch/fixtures-environment-comment/rstest.config.mts
+++ b/e2e/watch/fixtures-environment-comment/rstest.config.mts
@@ -1,11 +1,3 @@
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({
-  tools: {
-    rspack: {
-      watchOptions: {
-        aggregateTimeout: 10,
-      },
-    },
-  },
-});
+export default defineConfig({});

--- a/e2e/watch/fixtures-setup/rstest.config.mts
+++ b/e2e/watch/fixtures-setup/rstest.config.mts
@@ -4,11 +4,4 @@ export default defineConfig({
   passWithNoTests: true,
   setupFiles: ['./rstest.setup.ts'],
   exclude: ['**/node_modules/**', '**/dist/**'],
-  tools: {
-    rspack: {
-      watchOptions: {
-        aggregateTimeout: 10,
-      },
-    },
-  },
 });

--- a/e2e/watch/fixtures-shortcuts/rstest.config.mts
+++ b/e2e/watch/fixtures-shortcuts/rstest.config.mts
@@ -6,11 +6,4 @@ process.stdin.setRawMode = () => process.stdin;
 export default defineConfig({
   reporters: ['default'],
   disableConsoleIntercept: true,
-  tools: {
-    rspack: {
-      watchOptions: {
-        aggregateTimeout: 10,
-      },
-    },
-  },
 });

--- a/e2e/watch/fixtures/rstest.config.mts
+++ b/e2e/watch/fixtures/rstest.config.mts
@@ -1,11 +1,3 @@
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({
-  tools: {
-    rspack: {
-      watchOptions: {
-        aggregateTimeout: 10,
-      },
-    },
-  },
-});
+export default defineConfig({});

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -921,7 +921,7 @@ export const runRest = async ({
         process.off('unhandledRejection', unexpectedlyExitHandler);
       });
 
-      watchFilesForRestart({
+      await watchFilesForRestart({
         rstest,
         options,
         filters,

--- a/packages/core/src/core/plugins/entry.ts
+++ b/packages/core/src/core/plugins/entry.ts
@@ -56,8 +56,7 @@ export const pluginEntryWatch: (params: {
         };
 
         config.watchOptions ??= {};
-        // FIXME: Temporarily default to 5 to debounce rerun in watch mode.
-        config.watchOptions.aggregateTimeout = 5;
+        config.watchOptions.aggregateTimeout = 100;
         // TODO: rspack should support `(string | RegExp)[]` type
         // https://github.com/web-infra-dev/rspack/issues/10596
         config.watchOptions.ignored = castArray(
@@ -78,6 +77,9 @@ export const pluginEntryWatch: (params: {
           ...Object.values(globalSetupFiles?.[environment.name] || {}),
           '**/*.snap',
         );
+
+        config.experiments ??= {};
+        config.experiments.nativeWatcher = true;
 
         const configFilePath = context.projects.find(
           (project) => project.environmentName === environment.name,

--- a/packages/core/src/core/restart.ts
+++ b/packages/core/src/core/restart.ts
@@ -93,6 +93,8 @@ export async function watchFilesForRestart({
     ignoreInitial: true,
     // If watching fails due to read permissions, the errors will be suppressed silently.
     ignorePermissionErrors: true,
+    usePolling: true,
+    interval: 100,
     ...watchOptions,
   });
 

--- a/packages/core/src/utils/watchFiles.ts
+++ b/packages/core/src/utils/watchFiles.ts
@@ -35,5 +35,7 @@ export async function createChokidar(
     }
   }
 
-  return chokidar.watch(Array.from(watchFiles), options);
+  const watcher = chokidar.watch(Array.from(watchFiles), options);
+  await new Promise<void>((resolve) => watcher.once('ready', () => resolve()));
+  return watcher;
 }

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -1944,6 +1944,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
   "entry": [Function],
   "experiments": {
     "asyncWebAssembly": false,
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "externals": [
@@ -2565,7 +2566,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
   },
   "target": "node",
   "watchOptions": {
-    "aggregateTimeout": 5,
+    "aggregateTimeout": 100,
     "ignored": [
       "**/.git",
       "**/node_modules",


### PR DESCRIPTION
**Draft / do-not-merge.** Stress-validation companion to #1441.

Runs the watch e2e suite **50 times on macos-14** (10 shards × 5 fresh rounds) with the rspack native watcher enabled, to statistically confirm the stale-FSEvent flake (~7.5% baseline, `expected '' to match 'other.test.ts'`) is gone on released `@rsbuild/core 2.1.4` / `@rspack/core 2.1.2`.

Contains the #1441 watcher-enablement changes plus a throwaway `stress-watch` CI job (not wired into `test-gate`). The stress job is removed before #1441 merges.