### PR TITLE
fix(core): preserve test-file dispatch order under isolate: false

### DIFF
--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -492,13 +492,9 @@ export const createPool = async ({
       });
       const setupAssets = setupEntries.flatMap((entry) => entry.files || []);
 
-      const results = await Promise.all(
-        entries.map(async (entryInfo, index) => {
-          const traceArgs = {
-            project: projectName,
-            testPath: entryInfo.testPath,
-          };
-          const task = await traceSpan(
+      const tasks = await Promise.all(
+        entries.map((entryInfo, index) =>
+          traceSpan(
             'host:build-task',
             'host',
             () =>
@@ -519,8 +515,18 @@ export const createPool = async ({
                 traceSpan,
                 buildId,
               }),
-            traceArgs,
-          );
+            { project: projectName, testPath: entryInfo.testPath },
+          ),
+        ),
+      );
+
+      const results = await Promise.all(
+        tasks.map(async (task, index) => {
+          const entryInfo = entries[index]!;
+          const traceArgs = {
+            project: projectName,
+            testPath: entryInfo.testPath,
+          };
 
           const result = await traceSpan(
             'host:pool-run-test',


### PR DESCRIPTION
## Summary

Fixes an intermittent `isolate: false` failure: a `globalThis` / shared-module
value written by an earlier test file was sometimes `undefined` in a later file,
but only under full-suite load.

With `pool.maxWorkers: 1`, files run in the order they reach the pool. `runTests`
awaited each file's `buildTask` inline before submitting it, and `buildTask`'s
asset-assembly latency varies (skipped entirely when memory is tight) — so under
memory pressure a later file could be submitted first and run before an earlier
one, breaking cross-file sharing.

Fix: build all tasks first, then submit them to the pool in entry order. Asset
assembly still runs concurrently — only the submit order is pinned.

- **Before:** submit order = whichever `buildTask` resolves first ≠ entry order.
- **After:** submit in entry order → deterministic execution order.

## Related Links

- Fixtures / prior art: #1373, #1376

## Checklist

- [x] Tests updated (or not required). Covered by e2e `e2e/no-isolate/moduleSharing.test.ts`.
- [x] Documentation updated (or not required). Internal scheduling only.
