### PR TITLE
fix(e2e): avoid nested GitHub Actions annotations

### DIFF
--- a/e2e/scripts/index.ts
+++ b/e2e/scripts/index.ts
@@ -165,6 +165,7 @@ export async function runRstestCli({
       env: {
         ...baseEnv,
         ...(options?.nodeOptions?.env || {}),
+        GITHUB_ACTIONS: options?.nodeOptions?.env?.GITHUB_ACTIONS || undefined,
         GITHUB_STEP_SUMMARY:
           options?.nodeOptions?.env?.GITHUB_STEP_SUMMARY || undefined,
       },


### PR DESCRIPTION
## Summary

E2E helper subprocesses currently inherit the parent `GITHUB_ACTIONS=true` signal in CI, so a failing child `rstest` run can auto-enable the GitHub Actions reporter and emit workflow commands that are then embedded again in the parent failure output. This PR clears `GITHUB_ACTIONS` for `runRstestCli` subprocesses by default, while still allowing tests to opt in explicitly via `nodeOptions.env.GITHUB_ACTIONS`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).