### PR TITLE
fix(coverage-v8): reduce conversion memory usage

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -14,7 +14,10 @@ import reports from 'istanbul-reports';
 import picomatch from 'picomatch';
 import v8ToIstanbul from 'v8-to-istanbul';
 import { createFastCoverageMap, mapWithConcurrency } from './utils';
-import { convertV8CoverageWithAst } from './v8AstConverter';
+import {
+  applyV8CoverageWithAst,
+  convertV8CoverageWithAst,
+} from './v8AstConverter';
 
 type SourceMapLike = {
   version: number;
@@ -563,6 +566,61 @@ export class CoverageProvider implements RstestCoverageProvider {
     });
   }
 
+  private async applyWithAst(
+    coverageMap: CoverageMap,
+    filePath: string,
+    entry: inspector.Profiler.ScriptCoverage,
+    options?: CollectOptions,
+    transformedSource?: TransformedSource,
+    root = this.root,
+  ): Promise<void> {
+    if (this.convertWithAst !== CoverageProvider.prototype.convertWithAst) {
+      const istanbulData = await this.convertWithAst(
+        filePath,
+        entry,
+        options,
+        transformedSource,
+        root,
+      );
+      this.filterCoverageData(istanbulData, root);
+      coverageMap.merge(istanbulData);
+      return;
+    }
+
+    const { code, sourceMap, sourceMapStr, sourceMapUrl } =
+      transformedSource ?? (await this.getTransformedSource(filePath, options));
+
+    if (this.shouldSkipSourceMapEntry(sourceMap)) {
+      return;
+    }
+
+    const outputModule = options?.outputModule ?? true;
+    const codeHash = this.hashString(code);
+    const converterCacheKey = this.getConverterCacheKey(
+      filePath,
+      code,
+      codeHash,
+      sourceMapStr,
+      outputModule,
+      root,
+    );
+
+    await applyV8CoverageWithAst({
+      coverageMap,
+      ast: () => this.parseAst(code, outputModule),
+      cacheKey: converterCacheKey,
+      code,
+      sourceFilter: (sourcePath) =>
+        this.shouldKeepOriginalSource(sourcePath, root),
+      sourceMap,
+      sourceMapUrl,
+      coverage: {
+        url: entry.url,
+        functions: entry.functions,
+      },
+    });
+  }
+
   private getConverterCacheKey(
     filePath: string,
     code: string,
@@ -786,14 +844,7 @@ export class CoverageProvider implements RstestCoverageProvider {
       COVERAGE_CONVERSION_CONCURRENCY,
       async (entry) => {
         try {
-          const istanbulData = await this.convertWithAst(
-            entry.filePath,
-            entry,
-            options,
-          );
-
-          this.filterCoverageData(istanbulData);
-          coverageMap.merge(istanbulData);
+          await this.applyWithAst(coverageMap, entry.filePath, entry, options);
         } catch (e) {
           console.error(`Failed to process coverage for ${entry.url}:`, e);
           process.exitCode = 1;
@@ -840,16 +891,14 @@ export class CoverageProvider implements RstestCoverageProvider {
 
           for (const entry of entries) {
             try {
-              const istanbulData = await this.convertWithAst(
+              await this.applyWithAst(
+                coverageMap,
                 entry.filePath,
                 entry,
                 options,
                 transformedSource,
                 root,
               );
-
-              this.filterCoverageData(istanbulData, root);
-              coverageMap.merge(istanbulData);
             } catch (e) {
               console.error(`Failed to process coverage for ${entry.url}:`, e);
               process.exitCode = 1;

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -13,7 +13,7 @@ import { createContext } from 'istanbul-lib-report';
 import reports from 'istanbul-reports';
 import picomatch from 'picomatch';
 import v8ToIstanbul from 'v8-to-istanbul';
-import { createFastCoverageMap } from './utils';
+import { createFastCoverageMap, mapWithConcurrency } from './utils';
 import { convertV8CoverageWithAst } from './v8AstConverter';
 
 type SourceMapLike = {
@@ -30,13 +30,12 @@ type CoverageReporterConstructor = new (
   options: Record<string, unknown>,
 ) => ReportBase;
 
-const MAX_PARSED_AST_CACHE_SIZE = 50;
+const COVERAGE_CONVERSION_CONCURRENCY = 4;
 const SOURCE_MAP_INNER_PATTERN =
   /\s*[#@]\s*sourceMappingURL\s*=\s*([^\s'"]*)\s*/;
 const SOURCE_MAP_URL_PATTERN = new RegExp(
   `(?:/\\*(?:\\s*\\r?\\n(?://)?)?${SOURCE_MAP_INNER_PATTERN.source}\\s*\\*/|//${SOURCE_MAP_INNER_PATTERN.source})\\s*`,
 );
-const parsedAstCache = new Map<string, ReturnType<typeof Parser.parse>>();
 
 type CoverageEntry = inspector.Profiler.ScriptCoverage & {
   filePath: string;
@@ -517,29 +516,11 @@ export class CoverageProvider implements RstestCoverageProvider {
     };
   }
 
-  private parseAst(code: string, outputModule: boolean, cacheKey: string) {
-    const cachedAst = parsedAstCache.get(cacheKey);
-    if (cachedAst) {
-      return cachedAst;
-    }
-
-    const ast = Parser.parse(code, {
+  private parseAst(code: string, outputModule: boolean) {
+    return Parser.parse(code, {
       ecmaVersion: 'latest',
-      locations: true,
-      ranges: true,
       sourceType: outputModule ? 'module' : 'script',
     });
-
-    parsedAstCache.set(cacheKey, ast);
-
-    if (parsedAstCache.size > MAX_PARSED_AST_CACHE_SIZE) {
-      const firstKey = parsedAstCache.keys().next().value;
-      if (firstKey) {
-        parsedAstCache.delete(firstKey);
-      }
-    }
-
-    return ast;
   }
 
   private async convertWithAst(
@@ -558,12 +539,6 @@ export class CoverageProvider implements RstestCoverageProvider {
 
     const outputModule = options?.outputModule ?? true;
     const codeHash = this.hashString(code);
-    const astCacheKey = this.getAstCacheKey(
-      filePath,
-      code,
-      codeHash,
-      outputModule,
-    );
     const converterCacheKey = this.getConverterCacheKey(
       filePath,
       code,
@@ -572,10 +547,9 @@ export class CoverageProvider implements RstestCoverageProvider {
       outputModule,
       root,
     );
-    const ast = this.parseAst(code, outputModule, astCacheKey);
 
     return convertV8CoverageWithAst({
-      ast,
+      ast: () => this.parseAst(code, outputModule),
       cacheKey: converterCacheKey,
       code,
       sourceFilter: (sourcePath) =>
@@ -807,8 +781,10 @@ export class CoverageProvider implements RstestCoverageProvider {
     );
     const coverageMap = this.createCoverageMap();
 
-    await Promise.all(
-      filteredEntries.map(async (entry) => {
+    await mapWithConcurrency(
+      filteredEntries,
+      COVERAGE_CONVERSION_CONCURRENCY,
+      async (entry) => {
         try {
           const istanbulData = await this.convertWithAst(
             entry.filePath,
@@ -822,7 +798,7 @@ export class CoverageProvider implements RstestCoverageProvider {
           console.error(`Failed to process coverage for ${entry.url}:`, e);
           process.exitCode = 1;
         }
-      }),
+      },
     );
 
     return coverageMap;
@@ -852,36 +828,33 @@ export class CoverageProvider implements RstestCoverageProvider {
       }
     }
 
-    await Promise.all(
-      Array.from(groups.values()).map(async ({ entries, options, root }) => {
+    await mapWithConcurrency(
+      Array.from(groups.values()),
+      COVERAGE_CONVERSION_CONCURRENCY,
+      async ({ entries, options, root }) => {
         try {
           const transformedSource = await this.getTransformedSource(
             entries[0]!.filePath,
             options,
           );
 
-          await Promise.all(
-            entries.map(async (entry) => {
-              try {
-                const istanbulData = await this.convertWithAst(
-                  entry.filePath,
-                  entry,
-                  options,
-                  transformedSource,
-                  root,
-                );
+          for (const entry of entries) {
+            try {
+              const istanbulData = await this.convertWithAst(
+                entry.filePath,
+                entry,
+                options,
+                transformedSource,
+                root,
+              );
 
-                this.filterCoverageData(istanbulData, root);
-                coverageMap.merge(istanbulData);
-              } catch (e) {
-                console.error(
-                  `Failed to process coverage for ${entry.url}:`,
-                  e,
-                );
-                process.exitCode = 1;
-              }
-            }),
-          );
+              this.filterCoverageData(istanbulData, root);
+              coverageMap.merge(istanbulData);
+            } catch (e) {
+              console.error(`Failed to process coverage for ${entry.url}:`, e);
+              process.exitCode = 1;
+            }
+          }
         } catch (e) {
           console.error(
             `Failed to process coverage for ${entries[0]!.url}:`,
@@ -889,7 +862,7 @@ export class CoverageProvider implements RstestCoverageProvider {
           );
           process.exitCode = 1;
         }
-      }),
+      },
     );
 
     return coverageMap;

--- a/packages/coverage-v8/src/utils.ts
+++ b/packages/coverage-v8/src/utils.ts
@@ -238,3 +238,24 @@ export function createFastCoverageMap(): CoverageMap {
 
   return coverageMap;
 }
+
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await mapper(items[currentIndex]!, currentIndex);
+    }
+  };
+
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return results;
+}

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -42,7 +42,7 @@ import {
   type SourceMapInput,
 } from '@jridgewell/trace-mapping';
 import type { Profiler } from 'node:inspector';
-import type { FileCoverageData } from 'istanbul-lib-coverage';
+import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage';
 import jsTokens from 'js-tokens';
 import { walk } from 'estree-walker';
 
@@ -103,6 +103,7 @@ type PreparedCoverage = {
   statements: StatementDescriptor[];
   branches: BranchDescriptor[];
 };
+type FileCoverageLike = FileCoverageData | { data: FileCoverageData };
 
 type ConvertOptions = {
   ast: unknown | (() => unknown);
@@ -132,10 +133,38 @@ const preparedCache = new Map<string, Promise<PreparedCoverage>>();
 export async function convertV8CoverageWithAst(
   options: ConvertOptions,
 ): Promise<Record<string, FileCoverageData>> {
+  const prepared = await getPreparedCoverage(options);
+
+  if (!prepared) {
+    return {};
+  }
+
+  return applyCoverage(prepared, normalize(options.coverage));
+}
+
+export async function applyV8CoverageWithAst(
+  options: ConvertOptions & { coverageMap: CoverageMap },
+): Promise<void> {
+  const prepared = await getPreparedCoverage(options);
+
+  if (!prepared) {
+    return;
+  }
+
+  applyCoverageToMap(
+    options.coverageMap,
+    prepared,
+    normalize(options.coverage),
+  );
+}
+
+async function getPreparedCoverage(
+  options: ConvertOptions,
+): Promise<PreparedCoverage | null> {
   const ignoreHints = getIgnoreHints(options.code);
 
   if (ignoreHints.length === 1 && ignoreHints[0]?.type === 'file') {
-    return {};
+    return null;
   }
 
   let prepared = preparedCache.get(options.cacheKey);
@@ -151,7 +180,7 @@ export async function convertV8CoverageWithAst(
     }
   }
 
-  return applyCoverage(await prepared, normalize(options.coverage));
+  return prepared;
 }
 
 async function prepareCoverage(
@@ -850,29 +879,76 @@ function applyCoverage(
   const data: Record<string, FileCoverageData> = {};
 
   for (const [filename, template] of Object.entries(prepared.files)) {
-    const fileCoverage: FileCoverageData = {
-      path: template.path,
-      statementMap: template.statementMap,
-      fnMap: template.fnMap,
-      branchMap: template.branchMap,
-      s: {},
-      f: {},
-      b: {},
-    };
-
-    for (let index = 0; index < template.statementCount; index++) {
-      fileCoverage.s[index] = 0;
-    }
-    for (let index = 0; index < template.functionCount; index++) {
-      fileCoverage.f[index] = 0;
-    }
-    for (const [index, length] of Object.entries(template.branchLengths)) {
-      fileCoverage.b[index] = Array(length).fill(0);
-    }
-
-    data[filename] = fileCoverage;
+    data[filename] = createFileCoverage(template);
   }
 
+  applyCoverageHits(data, prepared, ranges);
+
+  return data;
+}
+
+function applyCoverageToMap(
+  coverageMap: CoverageMap,
+  prepared: PreparedCoverage,
+  ranges: NormalizedRange[],
+): void {
+  const data: Record<string, FileCoverageData> = {};
+
+  for (const [filename, template] of Object.entries(prepared.files)) {
+    data[filename] = getOrCreateFileCoverage(coverageMap, filename, template);
+  }
+
+  applyCoverageHits(data, prepared, ranges);
+}
+
+function createFileCoverage(template: FileTemplate): FileCoverageData {
+  const fileCoverage: FileCoverageData = {
+    path: template.path,
+    statementMap: template.statementMap,
+    fnMap: template.fnMap,
+    branchMap: template.branchMap,
+    s: {},
+    f: {},
+    b: {},
+  };
+
+  for (let index = 0; index < template.statementCount; index++) {
+    fileCoverage.s[index] = 0;
+  }
+  for (let index = 0; index < template.functionCount; index++) {
+    fileCoverage.f[index] = 0;
+  }
+  for (const [index, length] of Object.entries(template.branchLengths)) {
+    fileCoverage.b[index] = Array(length).fill(0);
+  }
+
+  return fileCoverage;
+}
+
+function getOrCreateFileCoverage(
+  coverageMap: CoverageMap,
+  filename: string,
+  template: FileTemplate,
+): FileCoverageData {
+  const existingCoverage = coverageMap.data[filename] as
+    FileCoverageLike | undefined;
+
+  if (existingCoverage) {
+    return 'data' in existingCoverage
+      ? existingCoverage.data
+      : existingCoverage;
+  }
+
+  coverageMap.addFileCoverage(createFileCoverage(template));
+  const fileCoverage = coverageMap.data[filename] as FileCoverageLike;
+  return 'data' in fileCoverage ? fileCoverage.data : fileCoverage;
+}
+
+function applyCoverageHits(
+  data: Record<string, FileCoverageData>,
+  prepared: PreparedCoverage,
+  ranges: NormalizedRange[],
+): void {
   for (const descriptor of prepared.functions) {
     data[descriptor.filename]!.f[descriptor.index]! += getCount(
       descriptor,
@@ -889,20 +965,16 @@ function applyCoverage(
 
   for (const descriptor of prepared.branches) {
     const hits = data[descriptor.filename]!.b[descriptor.index]!;
-    const covered: number[] = [];
+    let previousHit = 0;
 
-    for (const range of descriptor.ranges) {
+    for (let index = 0; index < descriptor.ranges.length; index++) {
+      const range = descriptor.ranges[index]!;
       const count = getCount(range, ranges);
-      const hit = range.implicit ? count - (covered.at(-1) || 0) : count;
-      covered.push(hit);
-    }
-
-    for (let index = 0; index < hits.length; index++) {
-      hits[index] = hits[index]! + (covered[index] || 0);
+      const hit = range.implicit ? count - previousHit : count;
+      hits[index] = hits[index]! + hit;
+      previousHit = hit;
     }
   }
-
-  return data;
 }
 
 function normalize(scriptCoverage: Pick<Profiler.ScriptCoverage, 'functions'>) {

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -40,7 +40,6 @@ import {
   type EncodedSourceMap,
   type Needle,
   type SourceMapInput,
-  type SourceMapSegment,
 } from '@jridgewell/trace-mapping';
 import type { Profiler } from 'node:inspector';
 import type { FileCoverageData } from 'istanbul-lib-coverage';
@@ -106,7 +105,7 @@ type PreparedCoverage = {
 };
 
 type ConvertOptions = {
-  ast: unknown;
+  ast: unknown | (() => unknown);
   cacheKey: string;
   code: string;
   coverage: Pick<Profiler.ScriptCoverage, 'functions' | 'url'>;
@@ -115,7 +114,6 @@ type ConvertOptions = {
   sourceFilter?: (filePath: string) => boolean;
 };
 
-const WORD_PATTERN = /(\w+|\s|[^\w\s])/g;
 const SOURCE_MAP_URL_PATTERN = /[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/gm;
 const DATA_SOURCE_MAP_PATTERN = /^data:application\/json(?:;[^,]*)?,/i;
 const BASE_64_SOURCE_MAP_PATTERN =
@@ -165,16 +163,17 @@ async function prepareCoverage(
   const sourceMapResult = options.sourceMap
     ? { sourceMap: options.sourceMap, sourceMapUrl: options.sourceMapUrl }
     : await getSourceMap(filename, options.code);
-  const mapInput =
-    sourceMapResult?.sourceMap || createEmptySourceMap(filename, options.code);
-  const sourceMap = new TraceMap(
-    mapInput as SourceMapInput,
-    normalizeSourceMapUrl(sourceMapResult?.sourceMapUrl),
-  );
-  const locator = new Locator(sourceMap, options.code);
+  const sourceMap = sourceMapResult?.sourceMap
+    ? new TraceMap(
+        sourceMapResult.sourceMap as SourceMapInput,
+        normalizeSourceMapUrl(sourceMapResult.sourceMapUrl),
+      )
+    : null;
+  const locator = sourceMap
+    ? new SourceMapLocator(sourceMap, options.code)
+    : new IdentityLocator(filename, options.code);
   const builder = new CoverageBuilder(
     filename,
-    sourceMap,
     locator,
     directory,
     options.sourceFilter,
@@ -210,7 +209,9 @@ async function prepareCoverage(
   const isSkipped = (node: AstNode | null | undefined) =>
     Boolean(node && skippedNodes.has(node));
 
-  walk(options.ast as Parameters<typeof walk>[0], {
+  const ast = typeof options.ast === 'function' ? options.ast() : options.ast;
+
+  walk(ast as Parameters<typeof walk>[0], {
     enter(node) {
       const current = node as AstNode;
       if (nextIgnore !== false) {
@@ -469,14 +470,13 @@ class CoverageBuilder {
 
   constructor(
     filename: string,
-    sourceMap: TraceMap,
-    private locator: Locator,
+    private locator: CoverageLocator,
     private directory: string,
     sourceFilter?: (filePath: string) => boolean,
   ) {
     const generatedDirectory = dirname(filename);
 
-    for (const source of sourceMap.resolvedSources) {
+    for (const source of locator.getSourceFilenames()) {
       let filePath = filename;
 
       if (source) {
@@ -675,15 +675,16 @@ class CoverageBuilder {
   }
 }
 
-class Locator {
-  private cache = new Map<number, Needle>();
-  private ignoredLines = new Map<string, Set<number>>();
-  private lineStarts: number[] = [0];
+interface CoverageLocator {
+  getLoc(node: Pick<AstNode, 'start' | 'end'>): MappedLocation | null;
+  getSourceFilenames(): string[];
+}
 
-  constructor(
-    private sourceMap: TraceMap,
-    code: string,
-  ) {
+class BaseLocator {
+  private cache = new Map<number, Needle>();
+  protected lineStarts: number[] = [0];
+
+  constructor(code: string) {
     for (let index = 0; index < code.length; index++) {
       if (code.charCodeAt(index) === 10) {
         this.lineStarts.push(index + 1);
@@ -718,6 +719,55 @@ class Locator {
     };
     this.cache.set(offset, needle);
     return { ...needle };
+  }
+}
+
+class IdentityLocator extends BaseLocator implements CoverageLocator {
+  private ignoredLines: Set<number> | undefined;
+
+  constructor(
+    private filename: string,
+    private code: string,
+  ) {
+    super(code);
+  }
+
+  getSourceFilenames(): string[] {
+    return [this.filename];
+  }
+
+  getLoc(node: Pick<AstNode, 'start' | 'end'>): MappedLocation | null {
+    const start = this.offsetToNeedle(node.start);
+    const end = this.offsetToNeedle(node.end);
+    end.column -= 1;
+
+    if (!this.ignoredLines) {
+      this.ignoredLines = getIgnoredLines(this.code);
+    }
+
+    if (this.ignoredLines.has(start.line)) {
+      return null;
+    }
+
+    return {
+      start: { ...start, filename: this.filename },
+      end: { ...end, filename: this.filename },
+    };
+  }
+}
+
+class SourceMapLocator extends BaseLocator implements CoverageLocator {
+  private ignoredLines = new Map<string, Set<number>>();
+
+  constructor(
+    private sourceMap: TraceMap,
+    code: string,
+  ) {
+    super(code);
+  }
+
+  getSourceFilenames(): string[] {
+    return this.sourceMap.resolvedSources;
   }
 
   getLoc(node: Pick<AstNode, 'start' | 'end'>): MappedLocation | null {
@@ -1070,35 +1120,6 @@ function getPosition(
     line: position.line,
     column: position.column,
     filename: position.source,
-  };
-}
-
-function createEmptySourceMap(
-  filename: string,
-  code: string,
-): DecodedSourceMap {
-  const mappings: SourceMapSegment[][] = [];
-
-  for (const [line, content] of code.split('\n').entries()) {
-    const parts = content.match(WORD_PATTERN) || [];
-    const segments: SourceMapSegment[] = [];
-    let column = 0;
-
-    for (const part of parts) {
-      segments.push([column, 0, line, column]);
-      column += part.length;
-    }
-
-    mappings.push(segments);
-  }
-
-  return {
-    version: 3,
-    mappings,
-    file: filename,
-    sources: [filename],
-    sourcesContent: [code],
-    names: [],
   };
 }
 

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -1157,9 +1157,7 @@ export default class CustomCoverageReporter {
               {
                 functionName: '',
                 isBlockCoverage: true,
-                ranges: [
-                  { startOffset: 0, endOffset: code.length, count: 1 },
-                ],
+                ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
               },
             ],
           },

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -113,8 +113,6 @@ function getProviderInternals(provider: CoverageProvider): ProviderInternals {
 function parseModule(code: string) {
   return Parser.parse(code, {
     ecmaVersion: 'latest',
-    locations: true,
-    ranges: true,
     sourceType: 'module',
   });
 }
@@ -457,11 +455,11 @@ describe('coverage-v8 provider', () => {
     expect(coverage[file]?.branchMap[0]?.locations).toEqual([
       {
         start: { line: 1, column: 0 },
-        end: { line: 1, column: Number.POSITIVE_INFINITY },
+        end: { line: 1, column: 19 },
       },
       {
         start: { line: 1, column: 0 },
-        end: { line: 1, column: Number.POSITIVE_INFINITY },
+        end: { line: 1, column: 19 },
       },
     ]);
   });
@@ -1120,6 +1118,62 @@ export default class CustomCoverageReporter {
       expect(
         coverageMap?.fileCoverageFor(file).toSummary().statements.pct,
       ).toBe(100);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('limits concurrent raw coverage conversion', async () => {
+    const root = join(tmpdir(), 'rstest-coverage-v8-raw-concurrency');
+    const provider = new CoverageProvider(createOptions(), root);
+    const providerInternals = getProviderInternals(provider);
+    let activeConversions = 0;
+    let peakConversions = 0;
+
+    Object.defineProperty(providerInternals, 'convertWithAst', {
+      configurable: true,
+      value: async (filePath: string) => {
+        activeConversions++;
+        peakConversions = Math.max(peakConversions, activeConversions);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        activeConversions--;
+        return {
+          [filePath]: createFileCoverage(filePath),
+        };
+      },
+    });
+
+    const payloads = Array.from({ length: 12 }, (_, index) => {
+      const file = join(root, 'src', `covered-${index}.js`);
+      const code = `function covered${index}() { return ${index}; }`;
+
+      return {
+        entries: [
+          {
+            url: pathToFileURL(file).href,
+            filePath: file,
+            scriptId: String(index),
+            functions: [
+              {
+                functionName: '',
+                isBlockCoverage: true,
+                ranges: [
+                  { startOffset: 0, endOffset: code.length, count: 1 },
+                ],
+              },
+            ],
+          },
+        ],
+        options: { assetFiles: { [file]: code }, outputModule: true },
+      };
+    });
+
+    try {
+      const coverageMap = await provider.resolveRawCoverage(payloads);
+
+      expect(coverageMap?.files()).toHaveLength(12);
+      expect(peakConversions).toBeLessThanOrEqual(4);
+      expect(peakConversions).toBeGreaterThan(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

This PR reduces memory pressure in the V8 coverage conversion path, especially for large generated files without sourcemaps. Previously, no-sourcemap files were converted through a generated identity sourcemap and `TraceMap`, which can create millions of mapping segments for large files. This change uses an offset-based identity locator for no-sourcemap files, only constructs `TraceMap` when a real sourcemap exists, avoids extra Acorn `locations`/`ranges` metadata, drops the extra parsed AST cache, bounds concurrent coverage conversion, and applies V8 hits directly into the final `CoverageMap` instead of creating and merging a full Istanbul coverage object for each entry.

Benchmark results comparing `origin/main` vs this branch:

| Project | Command | Wall time | Peak tree RSS | Peak process RSS |
|---|---|---:|---:|---:|
| rsbuild | `pnpm test --coverage --coverage.provider=v8` | 4.67s -> 3.89s median / 4.08s avg | 1620MB -> 1546MB median / 1511MB avg | 679MB -> 537MB median / 533MB avg |
| issue demo | `NODE_OPTIONS=--max-old-space-size=1200 pnpm test --coverage` | 129.08s -> 100.38s | 2351MB -> 2074MB | 1792MB -> 1405MB |

Additional rsbuild runs on this branch:

| Run | Wall time | Peak tree RSS | Peak process RSS |
|---:|---:|---:|---:|
| 1 | 3.893s | 1602MB | 545MB |
| 2 | 4.631s | 1397MB | 524MB |
| 3 | 3.392s | 1664MB | 544MB |
| 4 | 3.365s | 1546MB | 537MB |
| 5 | 5.095s | 1347MB | 517MB |

Note: the extreme demo still OOMs with `node --max-old-space-size=700 <rstest-bin> run --coverage`, so further reductions likely need a follow-up that targets Istanbul coverage data/report aggregation.

## Related Links

- https://github.com/web-infra-dev/rstest/issues/1524

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation:

- `corepack pnpm rstest packages/coverage-v8/tests/provider.test.ts`
- `corepack pnpm --filter @rstest/coverage-v8 build`
- `corepack pnpm --filter @rstest/core build`
- `corepack pnpm --filter @rstest/coverage-istanbul build`
- `corepack pnpm run check-unused`
- pre-push `format-spell`
- pre-push package build/typecheck
- rsbuild coverage benchmark above
- issue demo coverage benchmark above