### PR TITLE
fix(adapters): update peer dependency ranges to include TypeScript 7

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -41,7 +41,7 @@
     "@rstest/tsconfig": "workspace:*"
   },
   "peerDependencies": {
-    "@rsbuild/core": "*",
+    "@rsbuild/core": "^1.0.0 || ^2.0.0",
     "@rstest/core": "workspace:^"
   },
   "publishConfig": {

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@rslib/core": ">=0.18.6",
     "@rstest/core": "workspace:^",
-    "typescript": "^5 || ^6"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -42,8 +42,8 @@
     "@rstest/tsconfig": "workspace:*"
   },
   "peerDependencies": {
-    "@rspack/cli": ">=2.0.0-0",
-    "@rspack/core": ">=2.0.0-0",
+    "@rspack/cli": "^2.0.0",
+    "@rspack/core": "^2.0.0",
     "@rstest/core": "workspace:^"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

This PR updates adapter peer dependency ranges to match the supported major versions: `@rsbuild/core` now allows Rsbuild 1 and 2, `@rspack/cli` and `@rspack/core` now target stable Rspack 2, and the Rslib adapter's optional TypeScript peer range now includes TypeScript 7.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).