### PR TITLE
fix(core): report running test case as failed on worker crash

### DIFF
--- a/e2e/worker/index.test.ts
+++ b/e2e/worker/index.test.ts
@@ -44,6 +44,24 @@ describe('test worker behavior', () => {
     expect(cli.log).toContain(marker);
   });
 
+  it('should report the running test case as failed when worker exits unexpectedly', async () => {
+    const { expectExecFailed, cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'worker.panic.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: fixtureDir,
+        },
+      },
+    });
+
+    await expectExecFailed();
+    // The case that was running at crash time is attributed as a failed test
+    // case rather than silently dropped from the counts (#1535).
+    expect(cli.log).toContain('should crash the worker process');
+    expect(cli.stdout).toMatch(/Tests\s+1 failed/);
+  });
+
   it('should handle unhandledRejection error correctly', async () => {
     const { expectExecFailed, expectStderrLog } = await runRstestCli({
       command: 'rstest',

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -226,13 +226,18 @@ const buildTask = async ({
  * Convert a worker crash or pool error into a fail-status `TestFileResult`.
  * Enriches the error with context about which test cases were running at the
  * time of the crash (if any).
+ *
+ * Returns the file result plus the synthetic `crashedResults` (the cases that
+ * were running at crash time). The caller replays those through the live
+ * `onTestCaseResult` reporter hook so incremental reporters stay consistent
+ * with the final totals — they are already included in `fileResult.results`.
  */
 const workerErrorToResult = (
   err: unknown,
   testPath: string,
   projectName: string,
   context: RstestContext,
-): TestFileResult => {
+): { fileResult: TestFileResult; crashedResults: TestResult[] } => {
   const error = toError(err);
 
   (error as any).fullStack = true;
@@ -245,6 +250,7 @@ const workerErrorToResult = (
   const completedResults = runningModule?.results || [];
 
   let results = completedResults;
+  let crashedResults: TestResult[] = [];
   // The crash error stays at the file level unless we can attribute it to a
   // running case below, in which case it moves onto that case.
   let errors = [error];
@@ -263,7 +269,7 @@ const workerErrorToResult = (
 
     error.message += `\n\n${color.white(hint)}`;
 
-    const crashedResults: TestResult[] = runningTests.map((test) => ({
+    crashedResults = runningTests.map((test) => ({
       testId: test.testId,
       status: 'fail',
       name: test.name,
@@ -280,13 +286,16 @@ const workerErrorToResult = (
   }
 
   return {
-    testId: getFileTaskId(testPath),
-    project: projectName,
-    testPath,
-    status: 'fail',
-    name: '',
-    results,
-    errors,
+    fileResult: {
+      testId: getFileTaskId(testPath),
+      project: projectName,
+      testPath,
+      status: 'fail',
+      name: '',
+      results,
+      errors,
+    },
+    crashedResults,
   };
 };
 
@@ -551,13 +560,26 @@ export const createPool = async ({
             'host',
             () => pool.runTest(task),
             { ...traceArgs, worker: task.worker },
-          ).catch((err: unknown) => {
-            return workerErrorToResult(
+          ).catch(async (err: unknown) => {
+            const { fileResult, crashedResults } = workerErrorToResult(
               err,
               entryInfo.testPath,
               projectName,
               context,
             );
+            // Each crashed case already fired `onTestCaseStart`; complete the
+            // pair with a live `onTestCaseResult` so incremental reporters (dot,
+            // custom accounting) render it, matching the final totals. Counting
+            // stays sourced from `fileResult.results`, so the state manager is
+            // intentionally not touched here to avoid double-counting.
+            for (const caseResult of crashedResults) {
+              await Promise.all(
+                reporters.map((reporter) =>
+                  reporter.onTestCaseResult?.(caseResult),
+                ),
+              );
+            }
+            return fileResult;
           });
 
           if (result.coverage) {

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -242,7 +242,16 @@ const workerErrorToResult = (
 
   const runningModule = context.stateManager.runningModules.get(testPath);
   const runningTests = runningModule?.runningTests;
+  const completedResults = runningModule?.results || [];
 
+  let results = completedResults;
+  // The crash error stays at the file level unless we can attribute it to a
+  // running case below, in which case it moves onto that case.
+  let errors = [error];
+
+  // When the worker dies mid-test, attribute the crash to the test case(s) that
+  // were running so they surface as failed test cases in the `Tests` totals,
+  // instead of the case silently vanishing from the counts (#1535).
   if (runningTests?.length) {
     const getCaseName = (test: TestCaseInfo) =>
       `"${test.name}"${test.parentNames?.length ? ` (Under suite: ${test.parentNames?.join(' > ')})` : ''}`;
@@ -253,6 +262,21 @@ const workerErrorToResult = (
         : `The below test cases may be relevant, as they were running when the error occurred:\n  - ${runningTests.map((t) => getCaseName(t)).join('\n  - ')}`;
 
     error.message += `\n\n${color.white(hint)}`;
+
+    const crashedResults: TestResult[] = runningTests.map((test) => ({
+      testId: test.testId,
+      status: 'fail',
+      name: test.name,
+      testPath: test.testPath,
+      parentNames: test.parentNames,
+      project: test.project,
+      errors: [error],
+    }));
+
+    results = [...completedResults, ...crashedResults];
+    // The error is attributed to the crashed case(s) above; keep it off the
+    // file-level result so the failing-tests summary doesn't print it twice.
+    errors = [];
   }
 
   return {
@@ -261,8 +285,8 @@ const workerErrorToResult = (
     testPath,
     status: 'fail',
     name: '',
-    results: runningModule?.results || [],
-    errors: [error],
+    results,
+    errors,
   };
 };
 


### PR DESCRIPTION
## Summary

When a worker process exits unexpectedly while a test is running (a native addon crash, an OOM kill, or any abrupt process death), rstest marked only the **file** as failed — the test case that was executing vanished from the `Tests` counts and the crashed file was reported with `(0)` tests, even though rstest already knew which case was running.

This makes an unexpected worker exit surface as a normal failing test case: the running case(s) are synthesized as failed `TestResult`s and included in the file's results, so they appear in the `Tests` totals (`Tests 1 failed | 1 passed`) attributed to that specific case. The crash error is attributed to those case(s) and kept off the file-level result so the failing-tests summary does not print it twice. When no case was running (crash during setup/import), the error stays at the file level as before.

## Related Links

- Closes #1535

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).