### PR TITLE
release: 0.11.1

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/playwright",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Playwright fixture integration for Rstest",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
Bump all Rstest packages to `0.11.1`.

## Changes since 0.11.0

- fix(core): report running test case as failed on worker crash (#1536)
- feat(core): add task metadata support (#1507)
- fix(adapters): update peer dependency ranges to include TypeScript 7 (#1533)
- fix(coverage-v8): reduce conversion memory usage (#1532)
- fix(coverage-v8): omit invalid raw sourcemaps (#1527)
- fix(core): keep Mocked<T> construct signatures for this-typed members (#1519)
- fix(core): keep Mocked<T> assignable to T for construct+call members (#1516)
- feat(core): mark @rstest/core sideEffects-free for tree-shaking (#1513)
- fix(core): accept rs.fn()/rs.spyOn() mocks in call-order matchers (#1517)
- feat(playwright): add Playwright integration package (#1396)
- feat(core): support modifying Rstest config via Rsbuild plugins (#1475)

Release process per CONTRIBUTING.md: after CI passes, trigger the release action to publish to npm, then merge.