### PR TITLE
ci: use Node 24 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.22.1 # pin to avoid bug in 22.22.2
+          node-version: 24
+          check-latest: true
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

This PR keeps the release workflow on `npm@latest` and fixes the current engine failure by running the npm publishing job on Node 24. The failed release run installed `npm@12.0.0`, whose engine requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, while the workflow was pinned to Node 22.22.1. `check-latest: true` keeps the Node 24 line current instead of relying on an older runner cache hit.

The VS Code extension publishing job is unchanged because it does not install `npm@latest`; this keeps the fix scoped to the failing npm package publish job.

## Related Links

- https://github.com/web-infra-dev/rstest/actions/runs/29025415735/job/86143648383
- https://docs.npmjs.com/trusted-publishers/
- https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#check-latest-version

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
