### PR TITLE
fix: re-export AsymmetricMatchersContaining and Matchers types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,10 +98,12 @@ export type { Rspack } from '@rsbuild/core';
 export type {
   Assertion,
   DescribeAPI as Describe,
+  AsymmetricMatchersContaining,
   ExpectStatic,
   ExtendConfig,
   ExtendConfigFn,
   Fixtures,
+  Matchers,
   ProjectConfig,
   RealTimers,
   Reporter,

--- a/packages/core/src/types/expect.ts
+++ b/packages/core/src/types/expect.ts
@@ -121,6 +121,8 @@ export interface Assertion<T = any> extends VitestAssertion<T> {
   rejects: PromisifyAssertion<T>;
 }
 
+export type { AsymmetricMatchersContaining, Matchers } from '@vitest/expect';
+
 export interface ExpectStatic extends VitestExpectStatic {
   <T>(actual: T, message?: string): Assertion<T>;
   unreachable: (message?: string) => never;


### PR DESCRIPTION
## Summary

Re-exporting AsymmetricMatchersContaining and Matchers allows them to be augmented directly:

```ts
declare module "@rstest/core" {
  interface Matchers<T> {
    toBeEven: () => void;
  }
  interface AsymmetricMatchersContaining {
    even: () => any
  }
}

expect(2).toBeEven()
expect({ count: 2 }).toEqual({ count: expect.even() })
expect({ count: 3 }).toEqual({ count: expect.not.even() })
```

This fixes `expect.not.even()` not being exposed (if `Assertion` is augmented instead) and is also useful for libraries that only want to expose matchers as either symmetric or asymmetric, but not both (e.g. [mix-n-matchers](https://eskimojo14.github.io/mix-n-matchers/))

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
