### PR TITLE
fix(vscode): handle trailing slash in project root

### DIFF
--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -164,11 +164,7 @@ export class Project implements vscode.Disposable {
       .getNormalizedConfig()
       .then((config) => {
         if (this.cancellationSource.token.isCancellationRequested) return;
-        // A configured root may end with a path separator (e.g. when derived
-        // from a file URL). Strip it so the glob `cwd` and later path joins
-        // don't yield doubled separators that break test-item URI matching.
-        const root = config.root.replace(/[\\/]+$/, '') || config.root;
-        this.root = vscode.Uri.file(root);
+        this.root = vscode.Uri.file(config.root);
         this.include = config.include;
         this.exclude = config.exclude;
         this.startWatchingWorkspace(this.root);

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -164,7 +164,11 @@ export class Project implements vscode.Disposable {
       .getNormalizedConfig()
       .then((config) => {
         if (this.cancellationSource.token.isCancellationRequested) return;
-        this.root = vscode.Uri.file(config.root);
+        // A configured root may end with a path separator (e.g. when derived
+        // from a file URL). Strip it so the glob `cwd` and later path joins
+        // don't yield doubled separators that break test-item URI matching.
+        const root = config.root.replace(/[\\/]+$/, '') || config.root;
+        this.root = vscode.Uri.file(root);
         this.include = config.include;
         this.exclude = config.exclude;
         this.startWatchingWorkspace(this.root);

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -365,9 +365,7 @@ export class Project implements vscode.Disposable {
       parents: string[],
       collection: vscode.TestItemCollection,
     ) => {
-      const uri = vscode.Uri.file(
-        [this.root.fsPath, ...parents, key].join(path.sep),
-      );
+      const uri = vscode.Uri.file(path.join(this.root.fsPath, ...parents, key));
       const children = Object.entries(value);
 
       if (children.length === 1) {

--- a/packages/vscode/tests/fixtures/workspace-1/config/trailing-slash.config.ts
+++ b/packages/vscode/tests/fixtures/workspace-1/config/trailing-slash.config.ts
@@ -1,0 +1,6 @@
+import path from 'node:path';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  root: `${path.resolve(__dirname, '..')}${path.sep}`,
+});

--- a/packages/vscode/tests/suite/helpers.ts
+++ b/packages/vscode/tests/suite/helpers.ts
@@ -77,7 +77,11 @@ export function getTestItemByLabels(
   const item = labels.reduce(
     (item, label) =>
       item &&
-      getTestItems(item.children).find((child) => child.label === label),
+      getTestItems(item.children).find(
+        // normalize to linux path style, matching `toLabelTree`, so labels
+        // built with `path.sep` still match on Windows
+        (child) => child.label.replaceAll(path.sep, '/') === label,
+      ),
     {
       children: collection,
     } as vscode.TestItem | undefined,

--- a/packages/vscode/tests/suite/workspace.test.ts
+++ b/packages/vscode/tests/suite/workspace.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import vscode from 'vscode';
-import { toLabelTree, waitFor } from './helpers';
+import { getTestItemByLabels, toLabelTree, waitFor } from './helpers';
 
 suite('Workspace discover suite', () => {
   test('Extension should discover workspaces and projects', async () => {
@@ -267,5 +267,38 @@ suite('Workspace discover suite', () => {
         },
       ]);
     });
+  });
+
+  test('discovers test cases when project root has a trailing separator', async () => {
+    const extension = vscode.extensions.getExtension('rstack.rstest');
+    if (extension && !extension.isActive) {
+      await extension.activate();
+    }
+
+    const testController: vscode.TestController =
+      extension?.exports.testController;
+    const config = vscode.workspace.getConfiguration('rstest');
+    const configFileGlobPattern = config.get<string[]>('configFileGlobPattern');
+    assert.ok(configFileGlobPattern);
+    await config.update('configFileGlobPattern', [
+      ...configFileGlobPattern,
+      '**/trailing-slash.config.ts',
+    ]);
+
+    try {
+      await waitFor(() => {
+        const testFile = getTestItemByLabels(testController.items, [
+          'config/trailing-slash.config.ts',
+          'test',
+          'foo.test.ts',
+        ]);
+        assert.ok(
+          testFile.children.size > 0,
+          'Test file should be associated with its test cases',
+        );
+      });
+    } finally {
+      await config.update('configFileGlobPattern', undefined);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fix VS Code test matching when the configured root ends with a path separator.

This can happen when resolving a root directory from a file URL, for example:

```ts
fileURLToPath(new URL('..', import.meta.url));
```

Previously, joining paths manually could produce a double separator, so reported test results did not match the discovered test items.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
