### PR TITLE
fix(core): explain missing Istanbul coverage helpers

### DIFF
--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -36,7 +36,7 @@ const loadDiffModules = async () => {
 };
 
 const ISTANBUL_COVERAGE_HELPER_REFERENCE_ERROR_REGEXP =
-  /(?:\bcov_[A-Za-z0-9_$]+\b.*\bis not defined\b|\bis not defined\b.*\bcov_[A-Za-z0-9_$]+\b)/;
+  /(?:cov_[A-Za-z0-9_$]+.*\bis not defined\b|\bis not defined\b.*cov_[A-Za-z0-9_$]+)/;
 
 const ISTANBUL_COVERAGE_HELPER_HINT = [
   '',

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -35,6 +35,46 @@ const loadDiffModules = async () => {
   };
 };
 
+const ISTANBUL_COVERAGE_HELPER_REFERENCE_ERROR_REGEXP =
+  /(?:\bcov_[A-Za-z0-9_$]+\b.*\bis not defined\b|\bis not defined\b.*\bcov_[A-Za-z0-9_$]+\b)/;
+
+const ISTANBUL_COVERAGE_HELPER_HINT = [
+  '',
+  'This looks like an Istanbul coverage counter from instrumented code executed outside its original scope or realm.',
+  'It can happen when a function is serialized with fn.toString() or executed via page.evaluate, Worker, node:vm, eval, or new Function.',
+].join('\n');
+
+const ISTANBUL_COVERAGE_HELPER_WORKAROUND_HINT =
+  "Exclude that source file with coverage.exclude, add an Istanbul ignore hint for small isolated snippets, switch to coverage.provider: 'v8' for non-browser tests, or avoid serializing Istanbul-instrumented functions.";
+
+const ISTANBUL_COVERAGE_HELPER_BROWSER_WORKAROUND_HINT =
+  'Exclude that source file with coverage.exclude, add an Istanbul ignore hint for small isolated snippets, or avoid serializing Istanbul-instrumented functions.';
+
+const isBrowserModeRuntime = (): boolean => {
+  const windowObject = (globalThis as { window?: unknown }).window;
+
+  return (
+    typeof windowObject === 'object' &&
+    windowObject !== null &&
+    '__RSTEST_BROWSER_OPTIONS__' in windowObject
+  );
+};
+
+const appendIstanbulCoverageHelperHint = (message: string): string => {
+  if (
+    message.includes('Istanbul coverage counter') ||
+    !ISTANBUL_COVERAGE_HELPER_REFERENCE_ERROR_REGEXP.test(message)
+  ) {
+    return message;
+  }
+
+  const workaroundHint = isBrowserModeRuntime()
+    ? ISTANBUL_COVERAGE_HELPER_BROWSER_WORKAROUND_HINT
+    : ISTANBUL_COVERAGE_HELPER_WORKAROUND_HINT;
+
+  return `${message}${ISTANBUL_COVERAGE_HELPER_HINT}\n${workaroundHint}`;
+};
+
 const REAL_TIMERS: {
   setTimeout?: typeof globalThis.setTimeout;
   clearTimeout?: typeof globalThis.clearTimeout;
@@ -82,6 +122,10 @@ export const formatTestError = async (
 
       if (error instanceof TestRegisterError && test?.type === 'case') {
         errObj.message = `Can't nest describe or test inside a test. ${error.message} because it is nested within test '${test.name}'`;
+      }
+
+      if (typeof errObj.message === 'string') {
+        errObj.message = appendIstanbulCoverageHelperHint(errObj.message);
       }
 
       if (

--- a/packages/core/tests/runner/util.test.ts
+++ b/packages/core/tests/runner/util.test.ts
@@ -1,4 +1,4 @@
-import { formatName } from '../../src/runtime/util';
+import { formatName, formatTestError } from '../../src/runtime/util';
 
 it('test formatName', () => {
   expect(formatName('test index %#', [1, 2, 3], 1)).toBe('test index 1');
@@ -14,4 +14,51 @@ it('test formatName', () => {
   expect(formatName('test $c', { a: { b: 1 } }, 0)).toBe('test undefined');
 
   expect(formatName('%j', { a: { b: 1 } }, 0)).toBe('{"a":{"b":1}}');
+});
+
+describe('formatTestError', () => {
+  it('adds a hint for missing Istanbul coverage helpers', async () => {
+    const [error] = await formatTestError(
+      new ReferenceError('cov_15453043885016330810 is not defined'),
+    );
+
+    expect(error.message).toContain('cov_15453043885016330810 is not defined');
+    expect(error.message).toContain('Istanbul coverage counter');
+    expect(error.message).toContain('coverage.exclude');
+    expect(error.message).toContain('Istanbul ignore hint');
+    expect(error.message).toContain("coverage.provider: 'v8'");
+    expect(error.message).toContain(
+      'avoid serializing Istanbul-instrumented functions',
+    );
+  });
+
+  it('does not suggest the V8 coverage provider in browser mode', async () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = {
+      __RSTEST_BROWSER_OPTIONS__: {},
+    };
+
+    try {
+      const [error] = await formatTestError(
+        new ReferenceError('cov_15453043885016330810 is not defined'),
+      );
+
+      expect(error.message).toContain('coverage.exclude');
+      expect(error.message).toContain('Istanbul ignore hint');
+      expect(error.message).not.toContain("coverage.provider: 'v8'");
+      expect(error.message).toContain(
+        'avoid serializing Istanbul-instrumented functions',
+      );
+    } finally {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it('does not add the Istanbul hint for normal reference errors', async () => {
+    const [error] = await formatTestError(
+      new ReferenceError('foo is not defined'),
+    );
+
+    expect(error.message).toBe('foo is not defined');
+  });
 });

--- a/packages/core/tests/runner/util.test.ts
+++ b/packages/core/tests/runner/util.test.ts
@@ -33,6 +33,7 @@ describe('formatTestError', () => {
   });
 
   it('does not suggest the V8 coverage provider in browser mode', async () => {
+    const hadWindow = 'window' in globalThis;
     const originalWindow = (globalThis as { window?: unknown }).window;
     (globalThis as { window?: unknown }).window = {
       __RSTEST_BROWSER_OPTIONS__: {},
@@ -50,7 +51,11 @@ describe('formatTestError', () => {
         'avoid serializing Istanbul-instrumented functions',
       );
     } finally {
-      (globalThis as { window?: unknown }).window = originalWindow;
+      if (hadWindow) {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      } else {
+        delete (globalThis as { window?: unknown }).window;
+      }
     }
   });
 

--- a/website/docs/en/config/test/coverage.mdx
+++ b/website/docs/en/config/test/coverage.mdx
@@ -105,6 +105,57 @@ import { PackageManagerTabs } from '@theme';
 
 `@rstest/coverage-istanbul` is powered by [swc-plugin-coverage-instrument](https://github.com/kwonoj/swc-plugin-coverage-instrument). Rstest applies instrumentation through SWC during transform, so this provider has good transform-time performance. It can use more runtime memory because the executed code keeps the injected counters needed to collect coverage.
 
+##### Serialized functions and other realms
+
+Istanbul injects `cov_*` coverage counter calls into instrumented files. Those counters are scoped to the transformed module that Rstest executes. If code from an instrumented file is serialized and executed somewhere else, the new scope or realm may not have the matching `cov_*` helper, and the test can fail with `ReferenceError: cov_... is not defined`.
+
+This can happen when a function is serialized with `fn.toString()` or executed through APIs such as `page.evaluate`, `Worker`, `node:vm`, `eval`, or `new Function`. To avoid the failure, exclude that source file with `coverage.exclude`, switch to `coverage.provider: 'v8'` for non-browser tests, or avoid serializing Istanbul-instrumented functions. The `v8` provider is not available in Browser Mode, so browser tests should use `coverage.exclude` or avoid serializing instrumented functions.
+
+Prefer `coverage.exclude` when a whole file is mainly used to generate, serialize, or inject code into another scope or realm. Istanbul ignore comments are better for small isolated snippets that must stay in an otherwise covered file.
+
+Exclude whole files in config:
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    provider: 'istanbul',
+    exclude: ['**/src/injected-script.ts', '**/src/**/*.{worker,evaluate}.ts'],
+  },
+});
+```
+
+You can also pass the same patterns from the CLI for a one-off run:
+
+```bash
+npx rstest run --coverage --coverage.exclude "**/src/injected-script.ts" --coverage.exclude "**/src/**/*.{worker,evaluate}.ts"
+```
+
+If the whole file should be skipped by Istanbul instrumentation, put `/* istanbul ignore file */` at the top of the file:
+
+```ts title='src/injected-script.ts'
+/* istanbul ignore file */
+
+export function createInjectedScript() {
+  return `globalThis.__APP_READY__ = true;`;
+}
+```
+
+If only one serialized function needs to be skipped, place `/* istanbul ignore next */` immediately before it:
+
+```ts
+/* istanbul ignore next */
+function browserEvaluateFn() {
+  return window.location.href;
+}
+
+await page.evaluate(browserEvaluateFn);
+```
+
+Branch-level hints such as `/* istanbul ignore if */` and `/* istanbul ignore else */` can be used for narrow environment guards. If an ignored snippet still receives an injected `cov_*` call, use `coverage.exclude` for the source file instead.
+
 #### V8 provider
 
 <ApiMeta addedVersion="0.10.2" />

--- a/website/docs/zh/config/test/coverage.mdx
+++ b/website/docs/zh/config/test/coverage.mdx
@@ -105,6 +105,57 @@ import { PackageManagerTabs } from '@theme';
 
 `@rstest/coverage-istanbul` 由 [swc-plugin-coverage-instrument](https://github.com/kwonoj/swc-plugin-coverage-instrument) 提供支持。Rstest 会在 transform 阶段通过 SWC 完成插桩，因此该 provider 具有较好的 transform 性能。但插桩后的代码会在执行时保留用于收集覆盖率的计数器，因此运行时内存占用可能更高。
 
+##### 序列化函数和其他 realm
+
+Istanbul 会向插桩后的文件注入 `cov_*` 覆盖率计数器调用。这些计数器的作用域属于 Rstest 执行的 transformed module。如果来自插桩文件的代码被序列化后在其他位置执行，新的 scope 或 realm 可能没有对应的 `cov_*` helper，测试就可能以 `ReferenceError: cov_... is not defined` 失败。
+
+当函数通过 `fn.toString()` 序列化，或者通过 `page.evaluate`、`Worker`、`node:vm`、`eval`、`new Function` 等 API 执行时，可能触发这个问题。要避免该错误，可以通过 `coverage.exclude` 排除对应源文件；在非 Browser Mode 测试中切换到 `coverage.provider: 'v8'`；或者避免序列化经过 Istanbul 插桩的函数。`v8` provider 在 Browser Mode 中不可用，因此浏览器测试应使用 `coverage.exclude`，或避免序列化经过插桩的函数。
+
+如果整个文件主要用于生成、序列化，或向其他 scope 或 realm 注入代码，优先使用 `coverage.exclude`。Istanbul ignore 注释更适合在一个仍需要收集覆盖率的文件中，跳过很小的独立片段。
+
+在配置中排除整个文件：
+
+```ts title='rstest.config.ts'
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  coverage: {
+    enabled: true,
+    provider: 'istanbul',
+    exclude: ['**/src/injected-script.ts', '**/src/**/*.{worker,evaluate}.ts'],
+  },
+});
+```
+
+也可以在临时执行时通过 CLI 传入相同的规则：
+
+```bash
+npx rstest run --coverage --coverage.exclude "**/src/injected-script.ts" --coverage.exclude "**/src/**/*.{worker,evaluate}.ts"
+```
+
+如果整个文件都不应被 Istanbul 插桩，可以在文件顶部添加 `/* istanbul ignore file */`：
+
+```ts title='src/injected-script.ts'
+/* istanbul ignore file */
+
+export function createInjectedScript() {
+  return `globalThis.__APP_READY__ = true;`;
+}
+```
+
+如果只有一个会被序列化的函数需要跳过，可以把 `/* istanbul ignore next */` 放在它前面：
+
+```ts
+/* istanbul ignore next */
+function browserEvaluateFn() {
+  return window.location.href;
+}
+
+await page.evaluate(browserEvaluateFn);
+```
+
+对于很小的环境判断分支，也可以使用 `/* istanbul ignore if */` 和 `/* istanbul ignore else */`。如果被忽略的片段里仍然出现了注入的 `cov_*` 调用，请改用 `coverage.exclude` 排除对应源文件。
+
 #### V8 provider
 
 <ApiMeta addedVersion="0.10.2" />


### PR DESCRIPTION
## Summary

This PR improves the diagnostic for opaque `cov_* is not defined` failures caused by Istanbul-instrumented code running outside its original scope or realm. It appends targeted guidance to formatted test errors, avoids suggesting the V8 coverage provider in Browser Mode, and documents how to use `coverage.exclude` or Istanbul ignore hints for serialized/evaluated code.

## Related Links

https://github.com/web-infra-dev/rstest/issues/1543

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).