### PR TITLE
docs: recommend cleaning up stubs after each test

### DIFF
--- a/website/docs/en/api/runtime-api/rstest/utilities.mdx
+++ b/website/docs/en/api/runtime-api/rstest/utilities.mdx
@@ -69,6 +69,16 @@ rs.unstubAllEnvs();
 expect(process.env.NODE_ENV).not.toBe('test');
 ```
 
+When stubbing environment variables in multiple tests, call `rs.unstubAllEnvs()` in an [`afterEach`](/api/runtime-api/test-api/hooks#aftereach) hook to restore them after every test:
+
+```ts
+import { afterEach } from '@rstest/core';
+
+afterEach(() => {
+  rs.unstubAllEnvs();
+});
+```
+
 ## rs.stubGlobal
 
 - **Alias:** `rstest.stubGlobal`
@@ -125,6 +135,16 @@ rs.stubGlobal('myGlobal', 123);
 // ... run some code
 rs.unstubAllGlobals();
 expect(globalThis.myGlobal).toBeUndefined();
+```
+
+When stubbing global variables in multiple tests, call `rs.unstubAllGlobals()` in an [`afterEach`](/api/runtime-api/test-api/hooks#aftereach) hook to restore them after every test:
+
+```ts
+import { afterEach } from '@rstest/core';
+
+afterEach(() => {
+  rs.unstubAllGlobals();
+});
 ```
 
 ## rs.setConfig

--- a/website/docs/zh/api/runtime-api/rstest/utilities.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/utilities.mdx
@@ -69,6 +69,16 @@ rs.unstubAllEnvs();
 expect(process.env.NODE_ENV).not.toBe('test');
 ```
 
+在多个测试中模拟环境变量时，可以在 [`afterEach`](/api/runtime-api/test-api/hooks#aftereach) Hook 中调用 `rs.unstubAllEnvs()`，以便在每个测试结束后恢复环境变量：
+
+```ts
+import { afterEach } from '@rstest/core';
+
+afterEach(() => {
+  rs.unstubAllEnvs();
+});
+```
+
 ## rs.stubGlobal
 
 - **别名：** `rstest.stubGlobal`
@@ -125,6 +135,16 @@ rs.stubGlobal('myGlobal', 123);
 // ... 执行相关代码
 rs.unstubAllGlobals();
 expect(globalThis.myGlobal).toBeUndefined();
+```
+
+在多个测试中模拟全局变量时，可以在 [`afterEach`](/api/runtime-api/test-api/hooks#aftereach) Hook 中调用 `rs.unstubAllGlobals()`，以便在每个测试结束后恢复全局变量：
+
+```ts
+import { afterEach } from '@rstest/core';
+
+afterEach(() => {
+  rs.unstubAllGlobals();
+});
 ```
 
 ## rs.setConfig


### PR DESCRIPTION
## Summary

- Document how to restore stubbed environment and global variables with `afterEach`.
- Add the guidance to both English and Chinese runtime API docs and link to the `afterEach` API.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).