### PR TITLE
docs(prompts): distinguish Rstest from Rust crate

### DIFF
--- a/website/docs/en/guide/start/ai.mdx
+++ b/website/docs/en/guide/start/ai.mdx
@@ -27,7 +27,7 @@ Use this prompt to add Rstest to a project that doesn't have a test runner confi
 <Prompt
   title="Set up Rstest"
   description="Copy this prompt and send it to your coding agent."
-  prompt={`Set up Rstest in this project by following the instructions here:
+  prompt={`Set up Rstest, the JavaScript testing framework, in this project by following the instructions here:
 https://rstest.rs/guide/start/agent-install.md`}
 />
 
@@ -38,7 +38,7 @@ Use this prompt to migrate an existing Jest or Vitest project to Rstest. For con
 <Prompt
   title="Migrate to Rstest"
   description="Copy this prompt and send it to your coding agent."
-  prompt={`Migrate this project to Rstest by following the instructions here:
+  prompt={`Migrate this project to Rstest, the JavaScript testing framework, by following the instructions here:
 https://rstest.rs/guide/start/agent-migrate.md`}
 />
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -51,7 +51,7 @@ If you are using a coding agent, you can copy the following prompt to set up Rst
 <Prompt
   title="Set up Rstest"
   description="Copy this prompt and send it to your coding agent."
-  prompt={`Set up Rstest in this project by following the instructions here:
+  prompt={`Set up Rstest, the JavaScript testing framework, in this project by following the instructions here:
 https://rstest.rs/guide/start/agent-install.md`}
 />
 
@@ -60,7 +60,7 @@ If you are migrating from an existing Jest or Vitest project, use this prompt:
 <Prompt
   title="Migrate to Rstest"
   description="Copy this prompt and send it to your coding agent."
-  prompt={`Migrate this project to Rstest by following the instructions here:
+  prompt={`Migrate this project to Rstest, the JavaScript testing framework, by following the instructions here:
 https://rstest.rs/guide/start/agent-migrate.md`}
 />
 

--- a/website/docs/en/shared/agent-install.md
+++ b/website/docs/en/shared/agent-install.md
@@ -2,6 +2,8 @@
 
 Set up Rstest in a project that doesn't have a test runner configured yet. Pick the target, detect what it needs, install, verify.
 
+Rstest here means `@rstest/core`, the JavaScript testing framework powered by Rsbuild, not the Rust crate of the same name.
+
 ## Prerequisite check
 
 If the target already has Jest or Vitest configured (any of the signals below), **STOP this prompt and fetch https://rstest.rs/guide/start/agent-migrate.md instead** — migration has its own flow:

--- a/website/docs/zh/guide/start/ai.mdx
+++ b/website/docs/zh/guide/start/ai.mdx
@@ -27,7 +27,7 @@ import { PackageManagerTabs } from '@theme';
 <Prompt
   title="设置 Rstest"
   description="复制这个 prompt 并发送给你的 Coding Agent。"
-  prompt={`Set up Rstest in this project by following the instructions here:
+  prompt={`Set up Rstest, the JavaScript testing framework, in this project by following the instructions here:
 https://rstest.rs/guide/start/agent-install.md`}
 />
 
@@ -38,7 +38,7 @@ https://rstest.rs/guide/start/agent-install.md`}
 <Prompt
   title="迁移到 Rstest"
   description="复制这个 prompt 并发送给你的 Coding Agent。"
-  prompt={`Migrate this project to Rstest by following the instructions here:
+  prompt={`Migrate this project to Rstest, the JavaScript testing framework, by following the instructions here:
 https://rstest.rs/guide/start/agent-migrate.md`}
 />
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -51,7 +51,7 @@ import { PackageManagerTabs } from '@theme';
 <Prompt
   title="设置 Rstest"
   description="复制这个 prompt 并发送给你的 Coding Agent。"
-  prompt={`Set up Rstest in this project by following the instructions here:
+  prompt={`Set up Rstest, the JavaScript testing framework, in this project by following the instructions here:
 https://rstest.rs/guide/start/agent-install.md`}
 />
 
@@ -60,7 +60,7 @@ https://rstest.rs/guide/start/agent-install.md`}
 <Prompt
   title="迁移到 Rstest"
   description="复制这个 prompt 并发送给你的 Coding Agent。"
-  prompt={`Migrate this project to Rstest by following the instructions here:
+  prompt={`Migrate this project to Rstest, the JavaScript testing framework, by following the instructions here:
 https://rstest.rs/guide/start/agent-migrate.md`}
 />
 


### PR DESCRIPTION
## Summary

Rstest can be confused with the Rust ecosystem's crate of the same name, which may lead coding agents to choose the wrong testing framework. This PR identifies Rstest as the JavaScript testing framework in the setup and migration prompts, and adds the same clarification to the agent setup instructions.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).