### PR TITLE
docs: clarify Rstest as a JavaScript testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://codspeed.io/web-infra-dev/rstest?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed" /></a>
 </p>
 
-Rstest is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
+Rstest is a JavaScript testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
 
 Rstest offers full Jest-compatible APIs while providing native, out-of-the-box support for TypeScript, ESM, and more, ensuring a modern and efficient testing experience.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@
 
 # Rstest
 
-Rstest is a testing framework powered by Rspack.
+Rstest is a JavaScript testing framework powered by Rspack.
 
 ## Documentation
 

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -1,10 +1,10 @@
 ---
-description: Rstest is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem,  enabling seamless integration into existing Rspack-based projects.
+description: Rstest is a JavaScript testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem,  enabling seamless integration into existing Rspack-based projects.
 ---
 
 # Introduction
 
-Rstest is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
+Rstest is a JavaScript testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
 
 Rstest offers full Jest-compatible APIs while providing native, out-of-the-box support for TypeScript, ESM, CJS, and more, ensuring a modern and efficient testing experience.
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -1,10 +1,10 @@
 ---
-description: Rstest 是一个基于 Rspack 的测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
+description: Rstest 是一个基于 Rspack 的 JavaScript 测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
 ---
 
 # 介绍
 
-Rstest 是一个基于 Rspack 的测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
+Rstest 是一个基于 Rspack 的 JavaScript 测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
 
 Rstest 提供兼容 Jest 的 API，同时提供对 TypeScript、ESM、CJS 等的原生、开箱即用支持，确保现代高效的测试体验。
 

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -8,7 +8,8 @@ import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 import pluginSitemap from 'rspress-plugin-sitemap';
 
 const siteUrl = 'https://rstest.rs';
-const description = 'The Rspack-based testing framework';
+const description =
+  'Rstest is a JavaScript testing framework powered by Rspack';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
@@ -16,8 +17,7 @@ export default defineConfig({
   icon: 'https://assets.rspack.rs/rstest/rstest-logo.svg',
   logo: 'https://assets.rspack.rs/rstest/rstest-logo.svg',
   logoText: 'Rstest',
-  description:
-    'Rstest is a testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.',
+  description,
   markdown: {
     link: {
       checkAnchors: true,
@@ -65,7 +65,7 @@ export default defineConfig({
       {
         lang: 'zh',
         label: '简体中文',
-        description: '由 Rspack 驱动的测试框架',
+        description: 'Rstest 是由 Rspack 驱动的 JavaScript 测试框架',
       },
     ],
   },


### PR DESCRIPTION
## Summary

Following #1551, this PR continues to distinguish Rstest from the Rust ecosystem's project of the same name. It consistently describes Rstest as a JavaScript testing framework across site metadata, introduction pages, and package READMEs so agents and documentation consumers identify the correct project.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1551

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).