### PR TITLE
perf(core): lazy load package installer

### DIFF
--- a/packages/core/src/utils/packageInstaller.ts
+++ b/packages/core/src/utils/packageInstaller.ts
@@ -60,7 +60,12 @@ export const installPackage = async (
 
   const installer =
     options.installPackage ??
-    (await import('@antfu/install-pkg')).installPackage;
+    (
+      await import(
+        /* rspackChunkName: 'install-pkg' */
+        '@antfu/install-pkg'
+      )
+    ).installPackage;
   await installer(packageName, {
     cwd: root,
     dev: true,

--- a/packages/core/src/utils/packageInstaller.ts
+++ b/packages/core/src/utils/packageInstaller.ts
@@ -1,6 +1,5 @@
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
-import { installPackage as installPackageWithPackageManager } from '@antfu/install-pkg';
 import { isTTY } from './helper';
 import { color, logger } from './logger';
 
@@ -59,7 +58,9 @@ export const installPackage = async (
 
   logger.log(color.cyan(`Installing ${packageName}...`));
 
-  const installer = options.installPackage ?? installPackageWithPackageManager;
+  const installer =
+    options.installPackage ??
+    (await import('@antfu/install-pkg')).installPackage;
   await installer(packageName, {
     cwd: root,
     dev: true,


### PR DESCRIPTION
## Summary

Normal test startup currently loads the package installer even when no dependency installation is requested.

This PR loads `@antfu/install-pkg` only after the user confirms installation, moving its 10.5 kB implementation into an async chunk.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).