### PR TITLE
perf(core): skip package manager detection without failures

### DIFF
--- a/packages/core/src/reporter/md.ts
+++ b/packages/core/src/reporter/md.ts
@@ -906,10 +906,6 @@ export class MdReporter implements Reporter {
       filterRerunTestPaths,
     });
 
-    const packageManagerAgent = this.options.reproduction
-      ? await detectPackageManagerAgent(rootPath)
-      : 'npm';
-
     const {
       failedTests,
       passedTests,
@@ -967,6 +963,9 @@ export class MdReporter implements Reporter {
         lines.push('Note: all tests passed. Lists omitted for brevity.');
       }
     } else {
+      const packageManagerAgent = this.options.reproduction
+        ? await detectPackageManagerAgent(rootPath)
+        : 'npm';
       const maxFailures = Math.max(0, this.options.failures.max);
       const shouldTruncate = failures.length > maxFailures;
       const displayedFailures = shouldTruncate


### PR DESCRIPTION
## Summary

Markdown reports with reproduction enabled previously detected the package manager even when no test failures needed a reproduction command.

Scope detection to failure rendering so successful runs skip unnecessary filesystem work without changing failure output.

## Benchmark

In the Rsbuild `node --run test` workload , the isolated median wall-time saving was 5.59 ms (0.51%)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).