### PR TITLE
fix(core): reset module mocks between test files when isolate is false

### DIFF
--- a/e2e/no-isolate/fixtures/mock-stale-cache/a-warmup.test.ts
+++ b/e2e/no-isolate/fixtures/mock-stale-cache/a-warmup.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@rstest/core';
+import { getValue } from './consumer';
+
+// No mock in this file. If b-mock runs first, its mock of dep must NOT leak
+// into this file — neither directly nor through the cached consumer.
+test('a-warmup: sees real dep', () => {
+  expect(getValue()).toBe('REAL');
+});

--- a/e2e/no-isolate/fixtures/mock-stale-cache/b-mock.test.ts
+++ b/e2e/no-isolate/fixtures/mock-stale-cache/b-mock.test.ts
@@ -1,0 +1,20 @@
+import { expect, rstest, test } from '@rstest/core';
+import { getValue } from './consumer';
+import { singleton } from './singleton';
+
+// If a-warmup runs first, consumer is already cached with the REAL dep
+// closure; the mock must still take effect through consumer.
+rstest.mock('./dep', () => ({ value: () => 'MOCKED' }));
+
+test('b-mock: mock of dep takes effect through consumer', () => {
+  expect(getValue()).toBe('MOCKED');
+});
+
+// The fresh module world for this mocking file must be established BEFORE the
+// setup file loads — otherwise setup would hold one singleton instance and
+// this test another.
+test('b-mock: setup and test share the same module instance', () => {
+  expect(singleton).toBe(
+    (globalThis as Record<string, unknown>).__setupSingleton,
+  );
+});

--- a/e2e/no-isolate/fixtures/mock-stale-cache/consumer.ts
+++ b/e2e/no-isolate/fixtures/mock-stale-cache/consumer.ts
@@ -1,0 +1,4 @@
+// Intermediate module: captures `dep` in its closure at evaluation time.
+import { value } from './dep';
+
+export const getValue = (): string => value();

--- a/e2e/no-isolate/fixtures/mock-stale-cache/dep.ts
+++ b/e2e/no-isolate/fixtures/mock-stale-cache/dep.ts
@@ -1,0 +1,1 @@
+export const value = (): string => 'REAL';

--- a/e2e/no-isolate/fixtures/mock-stale-cache/rstest.config.ts
+++ b/e2e/no-isolate/fixtures/mock-stale-cache/rstest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  isolate: false,
+  setupFiles: ['./setup.ts'],
+  // One worker so both files share a module registry deterministically.
+  pool: { maxWorkers: 1 },
+});

--- a/e2e/no-isolate/fixtures/mock-stale-cache/setup.ts
+++ b/e2e/no-isolate/fixtures/mock-stale-cache/setup.ts
@@ -1,0 +1,5 @@
+import { singleton } from './singleton';
+
+// Records the instance the setup file sees; mocking files must observe the
+// same one from their test code.
+(globalThis as Record<string, unknown>).__setupSingleton = singleton;

--- a/e2e/no-isolate/fixtures/mock-stale-cache/singleton.ts
+++ b/e2e/no-isolate/fixtures/mock-stale-cache/singleton.ts
@@ -1,0 +1,4 @@
+// Module-level instance shared between the setup file and test files. A mock
+// file's pre-flush must run BEFORE setup loads, so setup and test code still
+// see the SAME instance (see the identity assertion in b-mock.test.ts).
+export const singleton: { tag: string } = { tag: 'shared' };

--- a/e2e/no-isolate/mockReset.test.ts
+++ b/e2e/no-isolate/mockReset.test.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from '@rstest/core';
+import { runRstestCli } from '../scripts/';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('module mocks under isolate: false', () => {
+  // Runs the `mock-stale-cache` fixture (one worker, isolate: false). Its
+  // files never assume an execution order, so both regressions stay covered
+  // whichever way the runner schedules them: a mock must take effect through
+  // a consumer cached by an earlier file (module-mock pre-flush, see
+  // runInPool.ts), and must not leak into later files (between-files cleaner,
+  // see mockRuntimeCode.js). Details live in the fixture files' own comments.
+  // See https://github.com/web-infra-dev/rstest/issues/1556.
+  it('applies and undoes module mocks across the file boundary', async ({
+    onTestFinished,
+  }) => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures', 'mock-stale-cache'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
+});

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -47,7 +47,11 @@ const hasOwn = (target, property) => Object.hasOwn(target, property);
 const isPromise = (value) => value instanceof Promise;
 
 // Restore a module id to its captured original factory and drop its cache
-// entry — undoing a mock.
+// entry — undoing a mock. Deliberately keeps the registry entry in
+// `rstest_original_module_factories`: the between-files reset infers "the
+// previous file installed mocks" from a non-empty registry, so entries must
+// survive a mid-file `rs.unmock` (modules evaluated while the mock was live
+// may still hold mocked closures and need the boundary flush).
 const restoreOriginalFactory = (id) => {
   const factory = __webpack_require__.rstest_original_module_factories[id];
   if (factory) {
@@ -334,4 +338,35 @@ __webpack_require__.rstest_reset_modules = () => {
 __webpack_require__.rstest_hoisted = (fn) => {
   return fn();
 };
+//#endregion
+
+//#region reset mocks between files
+// Registered into the per-file cleaner registry (see moduleCacheControl.ts);
+// the worker invokes cleaners before each file only when `isolate: false`.
+// If the previous file installed module mocks, undo them: restore every
+// patched factory, reset the registries, and flush the shared module cache so
+// modules that captured mocked exports re-evaluate. The mocking file itself
+// got a fresh module world before it loaded (module-mock pre-flush in
+// runInPool.ts). See https://github.com/web-infra-dev/rstest/issues/1556.
+const rstestResetMocksBetweenFiles = () => {
+  const mockedIds = Object.keys(
+    __webpack_require__.rstest_original_module_factories,
+  );
+  if (mockedIds.length === 0) {
+    return;
+  }
+  for (const id of mockedIds) {
+    restoreOriginalFactory(id);
+  }
+  __webpack_require__.rstest_original_modules = {};
+  __webpack_require__.rstest_original_module_factories = {};
+  __webpack_require__.rstest_mocked_ids_by_request = Object.create(null);
+  for (const id of Object.keys(__webpack_module_cache__)) {
+    delete __webpack_module_cache__[id];
+  }
+};
+
+(global.__rstest_cache_cleaners__ ??= new Set()).add(
+  rstestResetMocksBetweenFiles,
+);
 //#endregion

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -35,6 +35,10 @@ import {
   type SetupFileState,
 } from './setupFileState';
 
+// Dependency type the rspack RstestPlugin (instantiated in plugins/basic.ts)
+// assigns to compiled `rs.mock`-family calls; not exported by @rspack/core.
+const RSTEST_MOCK_DEPENDENCY_TYPE = 'rstest mock module id';
+
 type TestEntryToChunkHashes = {
   name: string;
   /** key is chunk asset file path, value is chunk hash */
@@ -589,8 +593,39 @@ export const createRsbuildServer = async ({
     // stats types, but the top-level `assets[].size` is always present.
     const assetSizes = new Map(assets!.map((a) => [a.name, a.size]));
 
+    // Chunk ids containing modules that install module mocks (`rs.mock` and
+    // friends): the RstestPlugin compiles every mock call into a dependency
+    // with its own dependency type, so the dependency graph identifies mocking
+    // entries precisely. Under `isolate: false` the worker gives those entries
+    // a fresh module world (see `loadFiles` in runInPool.ts); with isolation
+    // each file gets a fresh worker anyway, so the scan is skipped.
+    const mockChunkIds = new Set<string | number>();
+    if (!inspectedConfig?.isolate) {
+      const { chunkGraph } = stats.compilation;
+      for (const module of stats.compilation.modules) {
+        if (
+          module.dependencies.some(
+            (dep) => dep.type === RSTEST_MOCK_DEPENDENCY_TYPE,
+          )
+        ) {
+          for (const chunk of chunkGraph.getModuleChunks(module)) {
+            if (chunk.id != null) {
+              mockChunkIds.add(chunk.id);
+            }
+          }
+        }
+      }
+    }
+    // `undefined` (not `false`) when the scan was skipped: the flag is only
+    // meaningful with a shared module registry.
+    const hasModuleMock = (chunkIds: (string | number)[]) =>
+      inspectedConfig?.isolate
+        ? undefined
+        : chunkIds.some((id) => mockChunkIds.has(id));
+
     for (const entry of Object.keys(entrypoints!)) {
       const e = entrypoints![entry]!;
+      const chunks = e.chunks || [];
 
       const distPath = path.join(
         outputPath!,
@@ -606,7 +641,8 @@ export const createRsbuildServer = async ({
           runtimeDistPath,
           testPath: setupFiles[environmentName][entry],
           files: entryFiles[entry],
-          chunks: e.chunks || [],
+          chunks,
+          hasModuleMock: hasModuleMock(chunks),
         });
       } else if (sourceEntries[entry]) {
         if (
@@ -620,7 +656,8 @@ export const createRsbuildServer = async ({
           runtimeDistPath,
           testPath: sourceEntries[entry],
           files: entryFiles[entry],
-          chunks: e.chunks || [],
+          chunks,
+          hasModuleMock: hasModuleMock(chunks),
           size:
             e.assetsSize ??
             (e.assets ?? []).reduce(
@@ -634,7 +671,7 @@ export const createRsbuildServer = async ({
           runtimeDistPath,
           testPath: globalSetupFiles[environmentName][entry],
           files: entryFiles[entry],
-          chunks: e.chunks || [],
+          chunks,
         });
       }
     }

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -322,6 +322,7 @@ const loadFiles = async ({
   distPath,
   runtimeDistPath,
   testPath,
+  hasModuleMock,
   interopDefault,
   isolate,
   outputModule,
@@ -333,6 +334,7 @@ const loadFiles = async ({
   distPath: string;
   runtimeDistPath?: string;
   testPath: string;
+  hasModuleMock?: boolean;
   interopDefault: boolean;
   isolate: boolean;
   outputModule: boolean;
@@ -342,23 +344,36 @@ const loadFiles = async ({
     ? await import('./loadEsModule')
     : await import('./loadModule');
 
-  // Clean each kept runtime chunk's webpack module cache before re-running setup
-  // + entry. A reused worker can hold several projects' runtime chunks at once
-  // (isolate: false), so invoke EVERY registered cleaner — each is self-scoped to
-  // its own chunk's cache, so over-calling is a harmless no-op. See
-  // `moduleCacheControl.ts` for why this is a per-chunk registry, not a single
-  // `global.__rstest_clean_core_cache__` slot.
   if (!isolate) {
-    await loadModule({
-      codeContent: `if (global && global.__rstest_cache_cleaners__) {
+    if (hasModuleMock || setupEntries.some((entry) => entry.hasModuleMock)) {
+      // A file that installs module mocks (`hasModuleMock` is derived from
+      // the compiler's dependency graph, see `getRsbuildStats` in rsbuild.ts)
+      // gets a fully fresh module world, setup files included — so a mock
+      // always applies and setup + test code keep sharing the same module
+      // instances. The between-files cleaner in mockRuntimeCode.js undoes the
+      // mocks afterwards. The full flush also empties the cleaner registry,
+      // leaving nothing for the branch below to invoke.
+      // See https://github.com/web-infra-dev/rstest/issues/1556.
+      const { flushAllLoaderCaches } = await import('./interop');
+      await flushAllLoaderCaches();
+    } else {
+      // Clean each kept runtime chunk's webpack module cache before re-running
+      // setup + entry. A reused worker can hold several projects' runtime
+      // chunks at once, so invoke EVERY registered cleaner — each is
+      // self-scoped to its own chunk's cache, so over-calling is a harmless
+      // no-op. See `moduleCacheControl.ts` for why this is a per-chunk
+      // registry, not a single `global.__rstest_clean_core_cache__` slot.
+      await loadModule({
+        codeContent: `if (global && global.__rstest_cache_cleaners__) {
   global.__rstest_cache_cleaners__.forEach((fn) => fn());
   }`,
-      distPath: '',
-      testPath,
-      rstestContext,
-      assetFiles,
-      interopDefault,
-    });
+        distPath: '',
+        testPath,
+        rstestContext,
+        assetFiles,
+        interopDefault,
+      });
+    }
   }
 
   // run setup files
@@ -400,7 +415,7 @@ export const runInPool = async (
 > => {
   isTeardown = false;
   const {
-    entryInfo: { distPath, runtimeDistPath, testPath },
+    entryInfo: { distPath, runtimeDistPath, testPath, hasModuleMock },
     setupEntries,
     assets,
     type,
@@ -491,6 +506,7 @@ export const runInPool = async (
         distPath,
         runtimeDistPath,
         testPath,
+        hasModuleMock,
         assetFiles,
         setupEntries,
         interopDefault,
@@ -601,6 +617,7 @@ export const runInPool = async (
         distPath,
         runtimeDistPath,
         testPath,
+        hasModuleMock,
         assetFiles,
         setupEntries,
         interopDefault,

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -17,6 +17,13 @@ export type EntryInfo = {
   testPath: TestPath;
   files?: string[];
   /**
+   * Whether any module in this entry's chunks installs module mocks
+   * (`rs.mock` and friends), derived from the compiler's dependency graph.
+   * Under `isolate: false` the worker gives such entries a fresh module world
+   * (see `loadFiles` in runInPool.ts). Only populated when isolation is off.
+   */
+  hasModuleMock?: boolean;
+  /**
    * Bundle size (in bytes) of this entry's emitted assets, including its
    * dependency graph. Used as the cold-start cost proxy when ordering test
    * files that have no cached duration yet. Only populated for test entries.

--- a/website/docs/en/config/test/isolate.mdx
+++ b/website/docs/en/config/test/isolate.mdx
@@ -18,6 +18,10 @@ If your code has no side effects, turning off this option will help improve perf
 When `isolate` is `false`, a module imported by multiple test files is evaluated **once per worker**, not once per file. Any code at that shared module's top level — including hooks registered there (e.g. a helper that calls `beforeEach` at module scope) — therefore runs only for the first file that loads it, not for every file. For setup that must run per file, use [`setupFiles`](/config/test/setup-files), which Rstest re-runs for each test file even without isolation.
 :::
 
+:::warning Files that mock modules behave as if isolated
+Even with `isolate: false`, a module mock only applies to the file that declares it. To keep this guarantee, a file that uses module mocks (`rstest.mock`, `rstest.mockRequire`, `rstest.doMock`, …) re-evaluates the modules it imports instead of reusing state left by earlier files, and the shared module cache is reset again after it finishes — so the files that run after it also start from fresh modules. In other words, module-state sharing restarts at every file that mocks: it is only kept between test files with no mocking file scheduled in between. This includes setup files — a module mock installed in a setup file makes every test file start from fresh modules.
+:::
+
 import { Tab, Tabs } from '@theme';
 
 <Tabs defaultValue='rstest.config.ts'>

--- a/website/docs/zh/config/test/isolate.mdx
+++ b/website/docs/zh/config/test/isolate.mdx
@@ -18,6 +18,10 @@ description: 默认情况下，Rstest 会运行每个测试在一个独立的环
 当 `isolate` 为 `false` 时，被多个测试文件引入的模块在每个 worker 中**只会被求值一次**，而非每个文件求值一次。因此该共享模块顶层的所有代码——包括在其模块作用域注册的 hooks（例如某个 helper 在模块作用域调用 `beforeEach`）——只会对第一个加载它的文件生效，而不会对每个文件生效。如果某段 setup 逻辑需要按文件执行，请使用 [`setupFiles`](/config/test/setup-files)，即使关闭隔离，Rstest 也会为每个测试文件重新执行它。
 :::
 
+:::warning 使用模块 mock 的文件表现如同隔离模式
+即使 `isolate` 为 `false`，模块 mock 也只作用于声明它的那个文件。为了保证这一点，使用了模块 mock（`rstest.mock`、`rstest.mockRequire`、`rstest.doMock` 等）的文件会重新求值它引入的模块（而不是复用先前文件留下的状态），文件结束后共享的模块缓存也会再次重置——因此其后运行的文件同样从全新的模块开始。换句话说，模块状态共享会在每个使用 mock 的文件处重新开始：只有中间没有 mock 文件的测试文件之间才会保持共享。这也包括 setup 文件——如果 setup 文件中安装了模块 mock，所有测试文件都会从全新的模块开始。
+:::
+
 import { Tab, Tabs } from '@theme';
 
 <Tabs defaultValue='rstest.config.ts'>


### PR DESCRIPTION
## Summary

Under `isolate: false`, all test files in a worker share one module cache, but `rstest.mock` patches module factories worker-globally. Depending on file execution order this silently broke both directions: a mock failed to apply when an earlier file had already cached a module that consumes the mock target (stale consumer closure), and a mock installed by an earlier file leaked into later files (factories were never restored). See the reproduction in #1556.

The fix keeps the user's mental model identical to `isolate: true` — mocks just work per file, no new API to learn:

- **Compile-time detection:** the rspack RstestPlugin compiles every `rs.mock`-family call into a dependency with a dedicated dependency type, so `getRsbuildStats` derives per-entry `hasModuleMock` flags from the dependency graph (only when isolation is off; the default path skips the scan entirely).
- **Fresh world for mocking files:** before a flagged entry (or an entry whose setup file is flagged) loads, the worker flushes the loader caches, so the file's mocks always apply — including through consumers cached by earlier files — and setup + test code share the same module instances.
- **Automatic undo:** a between-files cleaner registered by the mock runtime restores patched factories, resets the mock registries, and flushes the cache after a mocking file, so mocks never leak into later files.

Behavior change: module-state sharing restarts at every file that uses module mocks (`rstest.mock`, `rstest.mockRequire`, `rstest.doMock`, …) and is kept between files with no mocking file in between (#1373's sharing for non-mocking runs unchanged). Docs updated (en/zh); covered by an order-independent e2e fixture asserting both directions plus the setup/test module-instance identity.

## Related Links

- https://github.com/web-infra-dev/rstest/issues/1556

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
