### PR TITLE
fix(vscode): nest multi-project test tree by directory

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -6,6 +6,7 @@ import { Project, WorkspaceManager } from './project';
 import { RstestFileCoverage } from './testRunReporter';
 import {
   gatherTestItems,
+  ProjectFolder,
   TestCase,
   TestFile,
   TestFolder,
@@ -207,6 +208,9 @@ class Rstest {
           await data.api.runTest({
             ...commonOptions,
           });
+        } else if (data instanceof ProjectFolder) {
+          // grouping folder spans multiple projects; recurse into children
+          await discoverTests(gatherTestItems(test.children, false));
         } else if (data instanceof TestFolder) {
           await data.api.runTest({
             ...commonOptions,

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -6,7 +6,11 @@ import vscode from 'vscode';
 import { watchConfigValue } from './config';
 import { logger } from './logger';
 import { RstestApi } from './master';
-import { TestFile, TestFolder, testData } from './testTree';
+import { ProjectFolder, TestFile, TestFolder, testData } from './testTree';
+
+// The default config file name at the workspace root. A lone project using it
+// is shown without a project node (its test files sit directly under the root).
+const DEFAULT_ROOT_CONFIG_RE = /^rstest\.config\.[mc]?[tj]s$/;
 
 export class WorkspaceManager implements vscode.Disposable {
   public projects = new Map<string, Project>();
@@ -129,8 +133,109 @@ export class WorkspaceManager implements vscode.Disposable {
   private refreshAllProject() {
     const collection = this.testItem?.children ?? this.testController.items;
     collection.replace([]);
-    for (const project of this.projects.values()) {
-      project.refresh(this.projects.size === 1, collection);
+
+    // Standard single-project setup (one project using the default config name
+    // at the workspace root): show its test files directly, with no project node.
+    if (this.projects.size === 1) {
+      const [[configFilePath, project]] = this.projects;
+      const relative = path.relative(
+        this.workspaceFolder.uri.fsPath,
+        vscode.Uri.parse(configFilePath).fsPath,
+      );
+      if (DEFAULT_ROOT_CONFIG_RE.test(relative)) {
+        project.refresh(collection, null);
+        return;
+      }
+    }
+
+    this.buildProjectTree(collection);
+  }
+
+  // Group projects into a folder tree by their config file directory, so the
+  // project level nests like the file level instead of showing a flat list of
+  // `dir/rstest.config.ts` entries. A project is shown as its own directory
+  // (e.g. `packages/core`); the config file name is only used to disambiguate
+  // a root-level config or multiple configs sharing one directory.
+  private buildProjectTree(rootCollection: vscode.TestItemCollection) {
+    type TreeNode = { children: Map<string, TreeNode>; project?: Project };
+    const root: TreeNode = { children: new Map() };
+
+    for (const [configFilePath, project] of this.projects) {
+      const relative = path.relative(
+        this.workspaceFolder.uri.fsPath,
+        vscode.Uri.parse(configFilePath).fsPath,
+      );
+      let node = root;
+      for (const segment of relative.split(path.sep)) {
+        let next = node.children.get(segment);
+        if (!next) {
+          next = { children: new Map() };
+          node.children.set(segment, next);
+        }
+        node = next;
+      }
+      node.project = project;
+    }
+
+    const handleTreeItem = (
+      key: string,
+      node: TreeNode,
+      mergedParents: string[],
+      parents: string[],
+      collection: vscode.TestItemCollection,
+    ) => {
+      const children = [...node.children];
+
+      // Collapse single-child chains: a directory with exactly one child merges
+      // into it, whether the child is another directory or the project's config
+      // file, so `packages/core/rstest.config.ts` shows as one `packages/core`
+      // project node.
+      if (children.length === 1) {
+        const [childKey, childNode] = children[0];
+        handleTreeItem(
+          childKey,
+          childNode,
+          [...mergedParents, key],
+          [...parents, key],
+          collection,
+        );
+        return;
+      }
+
+      if (node.project) {
+        // The config file node: label it by its directory (mergedParents), and
+        // fall back to the file name only when it has no directory of its own
+        // (a root-level config, or configs sharing a directory).
+        const label = mergedParents.join(path.sep) || key;
+        node.project.refresh(collection, label);
+        return;
+      }
+
+      const label = [...mergedParents, key].join(path.sep);
+      const uri = vscode.Uri.file(
+        path.join(this.workspaceFolder.uri.fsPath, ...parents, key),
+      );
+      const item = this.testController.createTestItem(
+        uri.toString(),
+        label,
+        uri,
+      );
+      collection.add(item);
+      testData.set(item, new ProjectFolder());
+
+      for (const [childKey, childNode] of children) {
+        handleTreeItem(
+          childKey,
+          childNode,
+          [],
+          [...parents, key],
+          item.children,
+        );
+      }
+    };
+
+    for (const [key, node] of root.children) {
+      handleTreeItem(key, node, [], [], rootCollection);
     }
   }
 }
@@ -175,33 +280,29 @@ export class Project implements vscode.Disposable {
       });
   }
 
+  // `label` is the project node's label, or `null` to hoist its test files
+  // directly under `parentCollection` with no project node (the standard
+  // single-project case). The layout decision is owned by `WorkspaceManager`.
   public refresh(
-    isOnlyOne: boolean,
     parentCollection: vscode.TestItemCollection,
+    label: string | null,
   ) {
     this.parentCollection = parentCollection;
-    const configFileName = path.relative(
-      this.workspaceFolder.uri.fsPath,
-      this.configFileUri.fsPath,
-    );
-    // if this is the only one project, and placed at root of workspace,
-    // and matches normal config file name, skip create test item
-    const skipCreateTestItem =
-      isOnlyOne && configFileName.match(/^rstest\.config\.[mc]?[tj]s$/);
-    if (skipCreateTestItem) {
-      if (this.testItem) {
-        this.testItem = undefined;
-      }
+    if (label === null) {
+      this.testItem = undefined;
     } else {
       if (!this.testItem) {
         this.testItem = this.testController.createTestItem(
           this.configFileUri.toString(),
-          path.relative(this.workspaceFolder.uri.path, this.configFileUri.path),
+          label,
           // Do not set `uri`, so that VSCode’s “Run Tests” works correctly.
           // https://github.com/microsoft/vscode/blob/3b42759b8b501e68106c72b5683dcc114ed789e1/src/vs/workbench/contrib/testing/common/testService.ts#L278-L280
         );
         testData.set(this.testItem, this);
       }
+      // label may change across refreshes as the surrounding project tree
+      // gains or loses siblings
+      this.testItem.label = label;
       this.parentCollection.add(this.testItem);
     }
     this.buildTree();

--- a/packages/vscode/src/testTree.ts
+++ b/packages/vscode/src/testTree.ts
@@ -10,7 +10,7 @@ const textDecoder = new TextDecoder('utf-8');
 
 export const testData = new WeakMap<
   vscode.TestItem,
-  WorkspaceManager | Project | TestFolder | TestFile | TestCase
+  WorkspaceManager | Project | TestFolder | ProjectFolder | TestFile | TestCase
 >();
 
 const getContentFromFilesystem = async (uri: vscode.Uri) => {
@@ -45,6 +45,11 @@ export class TestFolder {
     public uri: vscode.Uri,
   ) {}
 }
+
+// Marker for a folder node that groups multiple projects by directory. Unlike
+// `TestFolder`, it does not belong to a single project/api, so running it
+// recurses into its children instead of invoking one api.
+export class ProjectFolder {}
 
 export class TestFile {
   public didResolve = false;

--- a/packages/vscode/tests/suite/workspace.test.ts
+++ b/packages/vscode/tests/suite/workspace.test.ts
@@ -69,7 +69,7 @@ suite('Workspace discover suite', () => {
           label: 'workspace-2',
           children: [
             {
-              label: 'folder/project-2/rstest.config.ts',
+              label: 'folder/project-2',
               children: [
                 {
                   label: 'test',
@@ -78,7 +78,7 @@ suite('Workspace discover suite', () => {
               ],
             },
             {
-              label: 'project-1/rstest.config.ts',
+              label: 'project-1',
               children: [
                 {
                   label: 'test',
@@ -141,7 +141,7 @@ suite('Workspace discover suite', () => {
           label: 'workspace-2',
           children: [
             {
-              label: 'project-1/foo.config.ts',
+              label: 'project-1',
               children: [
                 {
                   label: 'test',
@@ -168,7 +168,7 @@ suite('Workspace discover suite', () => {
           label: 'workspace-2',
           children: [
             {
-              label: 'folder/project-2/foo.config.ts',
+              label: 'folder/project-2',
               children: [
                 {
                   label: 'test',
@@ -177,7 +177,7 @@ suite('Workspace discover suite', () => {
               ],
             },
             {
-              label: 'project-1/foo.config.ts',
+              label: 'project-1',
               children: [
                 {
                   label: 'test',
@@ -226,7 +226,7 @@ suite('Workspace discover suite', () => {
           label: 'workspace-2',
           children: [
             {
-              label: 'folder/project-2/rstest.config.ts',
+              label: 'folder/project-2',
               children: [
                 {
                   label: 'test',
@@ -235,7 +235,7 @@ suite('Workspace discover suite', () => {
               ],
             },
             {
-              label: 'project-1/rstest.config.ts',
+              label: 'project-1',
               children: [
                 {
                   label: 'test',
@@ -288,7 +288,7 @@ suite('Workspace discover suite', () => {
     try {
       await waitFor(() => {
         const testFile = getTestItemByLabels(testController.items, [
-          'config/trailing-slash.config.ts',
+          'config',
           'test',
           'foo.test.ts',
         ]);


### PR DESCRIPTION
## Summary

In the VS Code Testing view, when a workspace contains multiple rstest config files (a monorepo), each project was listed flat and labeled with its full relative config path (e.g. `packages/core/rstest.config.ts`). The extension produced a flat structure, so VS Code's "Show as Tree" could not group projects by folder.

This nests the project level into a directory tree, mirroring the existing per-project file tree. A project is now shown as its own directory (e.g. `packages/core`), with shared directory prefixes rendered as folder nodes; the config file name only appears to disambiguate a root-level config or multiple configs sharing one directory. A grouping folder spans projects, so running it recurses into its child projects. The standard single-project setup (default config at the workspace root) is unchanged — its test files still render directly with no project node.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
