### PR TITLE
fix(vscode): harden worker lifecycle and add node executable config

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -44,6 +44,20 @@
           "scope": "resource",
           "type": "string"
         },
+        "rstest.nodeExecutable": {
+          "markdownDescription": "Overrides the `node` binary used to spawn the Rstest test worker process. Provide an absolute path to a Node.js executable (for example, a version-manager or custom build). When empty, the `node` binary on `PATH` is used. Supports `${workspaceFolder}` placeholder.",
+          "scope": "resource",
+          "type": "string"
+        },
+        "rstest.nodeExecArgs": {
+          "description": "Extra arguments passed to the Node executable when spawning the test worker (e.g. --experimental-vm-modules). Must be an array of strings.",
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
         "rstest.configFileGlobPattern": {
           "description": "Glob patterns used to discover config files. Must be an array of strings.",
           "type": "array",

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -18,6 +18,8 @@ const configSchema = object({
   // The path to a package.json file of a Rstest executable.
   // Used as a last resort if the extension cannot auto-detect @rstest/core.
   rstestPackagePath: fallback(optional(string()), undefined),
+  nodeExecutable: fallback(optional(string()), undefined),
+  nodeExecArgs: fallback(array(string()), []),
   configFileGlobPattern: fallback(array(string()), [
     '**/rstest.config.{mjs,ts,js,cjs,mts,cts}',
   ]),

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -24,6 +24,7 @@ export function deactivate() {
 }
 
 class Rstest {
+  private context: vscode.ExtensionContext;
   private ctrl: vscode.TestController;
   private workspaces = new Map<string, WorkspaceManager>();
   private workspaceWatcher?: vscode.Disposable;
@@ -37,9 +38,11 @@ class Rstest {
   }
 
   constructor(context: vscode.ExtensionContext) {
+    this.context = context;
     this.ctrl = vscode.tests.createTestController('rstest', 'Rstest');
     context.subscriptions.push(this.ctrl);
     context.subscriptions.push(this.diagnostics);
+    context.subscriptions.push(logger);
 
     this.startScanWorkspaces();
     this.setupTestController();
@@ -57,14 +60,22 @@ class Rstest {
       true,
     );
 
-    vscode.commands.registerCommand(
-      'rstest.updateSnapshot',
-      (params: { test: vscode.TestItem; message: vscode.TestMessage }) =>
-        this.startTestRun(
-          new vscode.TestRunRequest([params.test], undefined, this.runProfile),
-          new vscode.CancellationTokenSource().token,
-          true,
-        ),
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        'rstest.updateSnapshot',
+        (params: { test: vscode.TestItem; message: vscode.TestMessage }) => {
+          const cancellation = new vscode.CancellationTokenSource();
+          return this.startTestRun(
+            new vscode.TestRunRequest(
+              [params.test],
+              undefined,
+              this.runProfile,
+            ),
+            cancellation.token,
+            true,
+          ).finally(() => cancellation.dispose());
+        },
+      ),
     );
 
     this.ctrl.createRunProfile(
@@ -117,6 +128,7 @@ class Rstest {
           this.refreshAllWorkspaces();
         },
       );
+      this.context.subscriptions.push(this.workspaceWatcher);
     }
   }
 

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -17,7 +17,7 @@ import type { Worker } from './worker';
 export const runningWorkers = new Set<BirpcReturn<Worker, TestRunReporter>>();
 
 export class RstestApi {
-  private childProcess: ChildProcess | null = null;
+  private childProcesses = new Set<ChildProcess>();
   private coreVersionTooLowWarned = false;
 
   constructor(
@@ -26,6 +26,10 @@ export class RstestApi {
     private configFilePath: string,
     private project: Project,
   ) {}
+
+  private expandWorkspaceFolder(value: string): string {
+    return value.replaceAll('${workspaceFolder}', this.workspace.uri.fsPath);
+  }
 
   private resolveRstestPath(): string {
     // TODO: support Yarn PnP
@@ -37,10 +41,8 @@ export class RstestApi {
       );
 
       if (configuredPackagePath) {
-        // Support ${workspaceFolder} placeholder
-        configuredPackagePath = configuredPackagePath.replace(
-          '${workspaceFolder}',
-          this.workspace.uri.fsPath,
+        configuredPackagePath = this.expandWorkspaceFolder(
+          configuredPackagePath,
         );
         // Validate that the path points to package.json
         if (!configuredPackagePath.endsWith('package.json')) {
@@ -241,25 +243,94 @@ export class RstestApi {
       execArgv.push('--inspect-wait');
     }
     const workerPath = path.resolve(__dirname, 'worker.js');
+    const configuredExecutable = getConfigValue(
+      'nodeExecutable',
+      this.workspace,
+    );
+    const nodeExecutable = configuredExecutable
+      ? this.expandWorkspaceFolder(configuredExecutable)
+      : 'node';
+    const nodeExecArgs = getConfigValue('nodeExecArgs', this.workspace).map(
+      (arg) => this.expandWorkspaceFolder(arg),
+    );
     logger.debug('Spawning worker process', {
       workerPath,
+      nodeExecutable,
+      nodeExecArgs,
     });
-    const rstestProcess = spawn('node', [...execArgv, workerPath], {
-      cwd: this.cwd,
-      stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
-      serialization: 'advanced',
-      env: {
-        // same as packages/core/src/cli/prepare.ts
-        // if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test'
-        NODE_ENV: 'test',
-        ...process.env,
-        // process.env.RSTEST = 'true';
-        RSTEST: 'true',
-        FORCE_COLOR: '1',
+    const rstestProcess = spawn(
+      nodeExecutable,
+      [...nodeExecArgs, ...execArgv, workerPath],
+      {
+        cwd: this.cwd,
+        stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+        serialization: 'advanced',
+        env: {
+          // same as packages/core/src/cli/prepare.ts
+          // if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test'
+          NODE_ENV: 'test',
+          ...process.env,
+          // process.env.RSTEST = 'true';
+          RSTEST: 'true',
+          FORCE_COLOR: '1',
+        },
+      },
+    );
+    this.childProcesses.add(rstestProcess);
+
+    rstestProcess.stdout?.on('data', (d) => {
+      const content = d.toString();
+      logger.debug('[worker stdout]', content.trimEnd());
+    });
+
+    rstestProcess.stderr?.on('data', (d) => {
+      const content = d.toString();
+      logger.error('[worker stderr]', content.trimEnd());
+    });
+
+    const worker = createBirpc<Worker, TestRunReporter>(testRunReporter, {
+      // Target the local process rather than the shared field, which is
+      // reassigned on every spawn; skip once the IPC channel is gone.
+      post: (data) => {
+        if (rstestProcess.connected) rstestProcess.send(data);
+      },
+      on: (fn) => rstestProcess.on('message', fn),
+      bind: 'functions',
+      timeout: 600_000,
+      off: () => {
+        rstestProcess.kill();
+        this.childProcesses.delete(rstestProcess);
+        runningWorkers.delete(worker);
       },
     });
-    this.childProcess = rstestProcess;
 
+    runningWorkers.add(worker);
+
+    logger.debug('Sent init payload to worker', {
+      root: this.cwd,
+      rstestPath,
+      configFilePath: this.configFilePath,
+    });
+
+    rstestProcess.on('error', (error) => {
+      logger.error('Worker process error', error);
+      vscode.window.showErrorMessage(
+        `Rstest worker process failed: ${error.message}`,
+      );
+      // Reject any in-flight birpc calls instead of letting them hang; $close
+      // runs the `off` handler, which removes the process from the Set.
+      if (!worker.$closed) worker.$close();
+    });
+
+    rstestProcess.on('exit', (code, signal) => {
+      logger.debug('Worker process exited', { code, signal });
+      // Unblock pending calls when the worker exits before we closed it.
+      if (!worker.$closed) worker.$close();
+    });
+
+    // Attach the debugger only after the error/exit handlers are wired, so a
+    // spawn failure (e.g. a misconfigured `nodeExecutable`) during this await is
+    // handled instead of throwing uncaught in the extension host.
     if (startDebugging) {
       const startedDebugging = await vscode.debug.startDebugging(
         this.workspace,
@@ -279,45 +350,13 @@ export class RstestApi {
       }
     }
 
-    rstestProcess.stdout?.on('data', (d) => {
-      const content = d.toString();
-      logger.debug('[worker stdout]', content.trimEnd());
-    });
-
-    rstestProcess.stderr?.on('data', (d) => {
-      const content = d.toString();
-      logger.error('[worker stderr]', content.trimEnd());
-    });
-
-    const worker = createBirpc<Worker, TestRunReporter>(testRunReporter, {
-      // use this.childProcess to catch post is called after process killed
-      post: (data) => this.childProcess?.send(data),
-      on: (fn) => rstestProcess.on('message', fn),
-      bind: 'functions',
-      timeout: 600_000,
-      off: () => {
-        rstestProcess.kill();
-        runningWorkers.delete(worker);
-      },
-    });
-
-    runningWorkers.add(worker);
-
-    logger.debug('Sent init payload to worker', {
-      root: this.cwd,
-      rstestPath,
-      configFilePath: this.configFilePath,
-    });
-
-    rstestProcess.on('exit', (code, signal) => {
-      logger.debug('Worker process exited', { code, signal });
-    });
-
     return worker;
   }
 
   public dispose() {
-    this.childProcess?.kill();
-    this.childProcess = null;
+    for (const child of this.childProcesses) {
+      child.kill();
+    }
+    this.childProcesses.clear();
   }
 }

--- a/packages/vscode/src/testRunReporter.ts
+++ b/packages/vscode/src/testRunReporter.ts
@@ -13,7 +13,7 @@ import type { DiagnosticEntry, RstestDiagnostics } from './diagnostics';
 import { logger } from './logger';
 import type { Project } from './project';
 import type { LogLevel } from './shared/logger';
-import { TestFile, testData } from './testTree';
+import { getTestItemId, TestFile, testData } from './testTree';
 
 export class TestRunReporter implements Reporter {
   constructor(
@@ -36,19 +36,52 @@ export class TestRunReporter implements Reporter {
     this.run?.appendOutput(message.replaceAll('\n', '\r\n'));
   }
 
+  // Core reports results by name path only, so duplicate sibling names are
+  // indistinguishable from the path alone. We reproduce the tree's id scheme
+  // (see getTestItemId) by counting same-named siblings under each parent, and
+  // pair a test's start/result events via its stable testId so a given test
+  // always resolves to the same occurrence. Both caches are per-run and reset
+  // in onTestRunStart (the reporter instance is reused across watch runs).
+  private resolvedItems = new Map<string, vscode.TestItem | undefined>();
+  private siblingCounters = new Map<vscode.TestItem, Map<string, number>>();
+
   private generatePath(value: TestCaseInfo | TestSuiteInfo | TestResult) {
     return value.name === ROOT_SUITE_NAME
       ? []
       : [...(value.parentNames || []), value.name];
   }
+  private pickSibling(parent: vscode.TestItem, name: string) {
+    let counts = this.siblingCounters.get(parent);
+    if (!counts) {
+      counts = new Map();
+      this.siblingCounters.set(parent, counts);
+    }
+    const index = counts.get(name) ?? 0;
+    counts.set(name, index + 1);
+    return parent.children.get(getTestItemId(name, index));
+  }
   private findTestItem(value: TestCaseInfo | TestSuiteInfo | TestResult) {
+    if (this.resolvedItems.has(value.testId)) {
+      return this.resolvedItems.get(value.testId);
+    }
     const fileItem = this.project?.testFiles.get(
       vscode.Uri.file(value.testPath).toString(),
     )?.testItem;
-    return this.generatePath(value).reduce<vscode.TestItem | undefined>(
-      (item, name) => item?.children.get(name),
-      fileItem,
-    );
+    const path = this.generatePath(value);
+    // Ancestors are assumed unique and resolved by their plain name; only the
+    // reported item's own segment needs sibling disambiguation.
+    const parent = path
+      .slice(0, -1)
+      .reduce<vscode.TestItem | undefined>(
+        (item, name) => item?.children.get(name),
+        fileItem,
+      );
+    const item =
+      path.length === 0
+        ? fileItem
+        : parent && this.pickSibling(parent, path[path.length - 1]);
+    this.resolvedItems.set(value.testId, item);
+    return item;
   }
   /** check whether current running suite/case contains reported suite/case */
   private contains(value: TestCaseInfo | TestSuiteInfo | TestResult) {
@@ -200,6 +233,8 @@ export class TestRunReporter implements Reporter {
   private isFirstRun = true;
 
   async onTestRunStart() {
+    this.resolvedItems.clear();
+    this.siblingCounters.clear();
     this.diagnostics?.clearForProject(this.projectKey);
     if (!this.isFirstRun) {
       this.run = this.createTestRun?.();

--- a/packages/vscode/src/testTree.ts
+++ b/packages/vscode/src/testTree.ts
@@ -23,6 +23,15 @@ const getContentFromFilesystem = async (uri: vscode.Uri) => {
   }
 };
 
+// Duplicate sibling test/suite names get a unique TestItem id by appending
+// their 0-based occurrence index. Creation (TestFile.onTest) and result lookup
+// (TestRunReporter.findTestItem) must derive ids identically, so both go
+// through this helper. `siblingIndex` is the number of prior same-named
+// siblings (0 for the first, which keeps its plain name as id).
+export function getTestItemId(name: string, siblingIndex: number): string {
+  return siblingIndex ? [name, siblingIndex].join('@@@@@@') : name;
+}
+
 export function gatherTestItems(
   collection: vscode.TestItemCollection,
   recursive = true,
@@ -172,9 +181,7 @@ export class TestFile {
   ) {
     const siblingsCount = parent.filter((child) => child.label === name).length;
 
-    // generate unique id to duplicated item
-    let id = name;
-    if (siblingsCount) id = [name, siblingsCount].join('@@@@@@');
+    const id = getTestItemId(name, siblingsCount);
 
     const isSuite = testType === 'describe' || testType === 'suite';
 


### PR DESCRIPTION
## Summary

The extension assumed a single live worker per project. When workers actually coexist (a continuous run alongside a file-watch `listTests`, or a debug attach that awaits), this caused misrouted messages and leaked processes. This PR hardens the worker lifecycle and closes the most common "extension does nothing" failure mode, plus two smaller correctness/hygiene fixes. **No `@rstest/core` changes** — items that would require touching core (discovery/run isomorphism) are intentionally deferred until the core JS API stabilizes.

- **birpc misrouting** — `post` targeted the shared `this.childProcess` field, which is reassigned on every spawn, so a second worker stole the first's outbound IPC. `post` now targets the captured local process (matching `on`/`off`).
- **Orphaned workers** — `dispose()` killed only the last-spawned child. Each spawned process is now tracked in a per-instance `Set`, and `dispose()` kills every live worker.
- **Uncaught spawn failure / hung calls** — the worker had no `error` handler (ENOENT/EACCES threw uncaught in the extension host) and an unexpected exit never settled the awaiting birpc call (10-minute hang). Added an `error` handler and `$close()` on error/unexpected-exit; both are wired **before** the debug-attach await so a misconfigured executable is handled too.
- **Configurable Node binary** — new `rstest.nodeExecutable` / `rstest.nodeExecArgs` settings replace the hardcoded `node`, fixing the frequent case where a version-manager shim is missing from a GUI-launched editor's `PATH`. Both support `${workspaceFolder}`.
- **Duplicate test names** — results now map to the correct `TestItem` by sharing the occurrence-index id scheme between tree creation and result lookup, so a duplicate sibling no longer stays enqueued or flips the other's status. This covers duplicate sibling leaves and duplicate sibling suites reported as the item itself; duplicate *ancestor* suites that contain children are a separate case (see Known limitation).
- **Disposable hygiene** — the update-snapshot command, the workspace-folders watcher, and the output channel are routed through `context.subscriptions`, and the snapshot run's `CancellationTokenSource` is disposed.

## Known limitation

Duplicate sibling `describe` blocks that each contain child tests (e.g. two `describe('dup', () => it('case', …))` in one file) still cannot resolve those children: the reported result path carries only `parentNames` (names, with no per-suite occurrence index), so ancestor segments are matched by plain name and always resolve to the first same-named suite. This is unchanged from before this PR — the previous lookup resolved *every* segment (including the leaf) by plain name, so ancestors were never disambiguated and this PR is a strict improvement with no regression. Applying occurrence-aware resolution at each segment does not compose, because an ancestor suite is shared across many events (its own start/result plus every descendant), so a per-`(parent, name)` counter advances on the suite's own events and would then misroute its children. A robust fix needs core to emit a stable occurrence/id path in the reported result, and is deferred with the other core-coupled work until the core JS API stabilizes.

## Checklist

- [x] Tests updated (or not required). Behavioral fixes are on worker spawn/crash and multi-worker paths that the extension-host e2e harness cannot reliably exercise; verified via type-check, unit tests, and build. CI runs the full e2e suite.
- [x] Documentation updated (or not required). The two new settings are self-documented via `contributes.configuration` in `package.json`.
