### PR TITLE
fix(vscode): keep gutter ranges when a run reports no test location

### DIFF
--- a/packages/vscode/src/testTree.ts
+++ b/packages/vscode/src/testTree.ts
@@ -141,15 +141,36 @@ export class TestFile {
   }
 
   public updateFromList(tests: TestInfo[]) {
+    // A run's reported tests may arrive without a source location (the runtime
+    // only emits locations when `includeTaskLocation` resolves one, which
+    // depends on the project's core version and build). Snapshot the ranges we
+    // already have so a location-less test keeps its range instead of
+    // collapsing to line 1, which would move every gutter icon to the imports.
+    const previousRanges = new Map<string, vscode.Range>();
+    const rangeKey = (names: string[]) => names.join('\x00');
+    const snapshot = (item: vscode.TestItem, names: string[]) => {
+      if (item.range) previousRanges.set(rangeKey(names), item.range);
+      item.children.forEach((child) =>
+        snapshot(child, [...names, child.label]),
+      );
+    };
+    this.children.forEach((item) => snapshot(item, [item.label]));
+
     const handleChild = (
       test: TestInfo,
       parent: vscode.TestItem[],
       parentNames: string[],
     ) => {
-      // vscode location is zero based
-      const line = (test.location?.line ?? 1) - 1;
-      const column = (test.location?.column ?? 1) - 1;
-      const range = new vscode.Range(line, column, line, column);
+      const names = [...parentNames, test.name];
+      let range: vscode.Range | undefined;
+      if (test.location) {
+        // vscode location is zero based
+        const line = test.location.line - 1;
+        const column = test.location.column - 1;
+        range = new vscode.Range(line, column, line, column);
+      } else {
+        range = previousRanges.get(rangeKey(names));
+      }
       const testItem = this.onTest(
         range,
         test.name,
@@ -160,7 +181,7 @@ export class TestFile {
       if (test.type === 'suite') {
         const children: vscode.TestItem[] = [];
         test.tests.forEach((child) => {
-          handleChild(child, children, [...parentNames, test.name]);
+          handleChild(child, children, names);
         });
         testItem.children.replace(children);
       }
@@ -178,7 +199,7 @@ export class TestFile {
   }
 
   private onTest(
-    range: vscode.Range,
+    range: vscode.Range | undefined,
     name: string,
     testType: 'test' | 'it' | 'suite' | 'describe',
     parent: vscode.TestItem[],
@@ -196,7 +217,7 @@ export class TestFile {
       new TestCase(this.api, this.uri, parentNames, isSuite ? 'suite' : 'case'),
     );
 
-    testItem.range = range;
+    if (range) testItem.range = range;
 
     // warn about duplicated name
     if (siblingsCount) testItem.error = `Duplicated ${testType} name`;

--- a/packages/vscode/src/testTree.ts
+++ b/packages/vscode/src/testTree.ts
@@ -32,6 +32,13 @@ export function getTestItemId(name: string, siblingIndex: number): string {
   return siblingIndex ? [name, siblingIndex].join('@@@@@@') : name;
 }
 
+// Occurrence index of `name` among the siblings already collected in `parent`
+// (0 for the first). Shared by tree creation and the range snapshot so both
+// derive the same duplicate-aware id via getTestItemId.
+function siblingIndexOf(parent: vscode.TestItem[], name: string): number {
+  return parent.filter((child) => child.label === name).length;
+}
+
 export function gatherTestItems(
   collection: vscode.TestItemCollection,
   recursive = true,
@@ -146,22 +153,27 @@ export class TestFile {
     // depends on the project's core version and build). Snapshot the ranges we
     // already have so a location-less test keeps its range instead of
     // collapsing to line 1, which would move every gutter icon to the imports.
+    // Keys are the path of duplicate-aware item ids so that duplicate sibling
+    // names each keep their own range.
     const previousRanges = new Map<string, vscode.Range>();
-    const rangeKey = (names: string[]) => names.join('\x00');
-    const snapshot = (item: vscode.TestItem, names: string[]) => {
-      if (item.range) previousRanges.set(rangeKey(names), item.range);
-      item.children.forEach((child) =>
-        snapshot(child, [...names, child.label]),
-      );
+    const rangeKey = (idPath: string[]) => idPath.join('\x00');
+    const snapshot = (item: vscode.TestItem, idPath: string[]) => {
+      if (item.range) previousRanges.set(rangeKey(idPath), item.range);
+      item.children.forEach((child) => snapshot(child, [...idPath, child.id]));
     };
-    this.children.forEach((item) => snapshot(item, [item.label]));
+    this.children.forEach((item) => snapshot(item, [item.id]));
 
     const handleChild = (
       test: TestInfo,
       parent: vscode.TestItem[],
       parentNames: string[],
+      parentIds: string[],
     ) => {
       const names = [...parentNames, test.name];
+      const ids = [
+        ...parentIds,
+        getTestItemId(test.name, siblingIndexOf(parent, test.name)),
+      ];
       let range: vscode.Range | undefined;
       if (test.location) {
         // vscode location is zero based
@@ -169,7 +181,7 @@ export class TestFile {
         const column = test.location.column - 1;
         range = new vscode.Range(line, column, line, column);
       } else {
-        range = previousRanges.get(rangeKey(names));
+        range = previousRanges.get(rangeKey(ids));
       }
       const testItem = this.onTest(
         range,
@@ -181,7 +193,7 @@ export class TestFile {
       if (test.type === 'suite') {
         const children: vscode.TestItem[] = [];
         test.tests.forEach((child) => {
-          handleChild(child, children, names);
+          handleChild(child, children, names, ids);
         });
         testItem.children.replace(children);
       }
@@ -192,7 +204,7 @@ export class TestFile {
         ? tests[0].tests
         : tests;
     realTests.forEach((test) => {
-      handleChild(test, children, []);
+      handleChild(test, children, [], []);
     });
     this.children = children;
     this.testItem?.children.replace(this.children);
@@ -205,7 +217,7 @@ export class TestFile {
     parent: vscode.TestItem[],
     parentNames: string[],
   ) {
-    const siblingsCount = parent.filter((child) => child.label === name).length;
+    const siblingsCount = siblingIndexOf(parent, name);
 
     const id = getTestItemId(name, siblingsCount);
 

--- a/packages/vscode/tests/unit/testTree.test.ts
+++ b/packages/vscode/tests/unit/testTree.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, rs } from '@rstest/core';
+
+rs.mock('vscode', () => {
+  class Range {
+    constructor(
+      public startLine: number,
+      public startChar: number,
+      public endLine: number,
+      public endChar: number,
+    ) {}
+  }
+  const channel = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    appendLine: () => {},
+    dispose: () => {},
+  };
+  const vscode = {
+    Range,
+    Uri: {
+      file: (fsPath: string) => ({
+        fsPath,
+        toString: () => `file://${fsPath}`,
+      }),
+    },
+    window: { createOutputChannel: () => channel },
+    workspace: { fs: {} },
+  };
+  return { ...vscode, default: vscode };
+});
+
+const makeCollection = () => {
+  const map = new Map<string, any>();
+  return {
+    replace: (items: any[]) => {
+      map.clear();
+      for (const item of items) map.set(item.id, item);
+    },
+    forEach: (cb: (item: any) => void) => map.forEach((v) => cb(v)),
+    get: (id: string) => map.get(id),
+    get size() {
+      return map.size;
+    },
+  };
+};
+
+const createController = () =>
+  ({
+    createTestItem: (id: string, label: string, uri: unknown) => ({
+      id,
+      label,
+      uri,
+      range: undefined as any,
+      error: undefined as any,
+      children: makeCollection(),
+    }),
+  }) as any;
+
+const location = (line: number) => ({ line, column: 3 });
+
+// suite "outer" @ line 7, cases "a" @ 12 and "b" @ 16 (1-based, like core)
+const withLocations = [
+  {
+    type: 'suite',
+    name: 'outer',
+    location: location(7),
+    tests: [
+      { type: 'case', name: 'a', location: location(12), tests: [] },
+      { type: 'case', name: 'b', location: location(16), tests: [] },
+    ],
+  },
+] as any;
+
+const withoutLocations = [
+  {
+    type: 'suite',
+    name: 'outer',
+    location: undefined,
+    tests: [
+      { type: 'case', name: 'a', location: undefined, tests: [] },
+      { type: 'case', name: 'b', location: undefined, tests: [] },
+    ],
+  },
+] as any;
+
+describe('TestFile.updateFromList', () => {
+  it('keeps existing ranges when a rebuilt test reports no location', async () => {
+    const { TestFile } = await import('../../src/testTree');
+    const controller = createController();
+    const uri = { fsPath: '/x/outer.test.ts', toString: () => 'file:///x' };
+    const file = new TestFile({} as any, uri as any, controller);
+    const root = controller.createTestItem('root', 'outer.test.ts', uri);
+    file.setTestItem(root);
+
+    // Discovery-like pass with real source locations.
+    file.updateFromList(withLocations);
+    const suite1 = root.children.get('outer');
+    expect(suite1.range.startLine).toBe(6);
+    expect(suite1.children.get('a').range.startLine).toBe(11);
+    expect(suite1.children.get('b').range.startLine).toBe(15);
+
+    // A run reports the same tests without locations; ranges must survive
+    // instead of collapsing to line 1.
+    file.updateFromList(withoutLocations);
+    const suite2 = root.children.get('outer');
+    expect(suite2.range.startLine).toBe(6);
+    expect(suite2.children.get('a').range.startLine).toBe(11);
+    expect(suite2.children.get('b').range.startLine).toBe(15);
+  });
+
+  it('uses the reported location when one is present', async () => {
+    const { TestFile } = await import('../../src/testTree');
+    const controller = createController();
+    const uri = { fsPath: '/x/outer.test.ts', toString: () => 'file:///x' };
+    const file = new TestFile({} as any, uri as any, controller);
+    file.setTestItem(controller.createTestItem('root', 'outer.test.ts', uri));
+
+    file.updateFromList(withLocations);
+    file.updateFromList([
+      {
+        type: 'suite',
+        name: 'outer',
+        location: location(9),
+        tests: [{ type: 'case', name: 'a', location: location(20), tests: [] }],
+      },
+    ] as any);
+
+    const root = (file as any).testItem;
+    const suite = root.children.get('outer');
+    expect(suite.range.startLine).toBe(8);
+    expect(suite.children.get('a').range.startLine).toBe(19);
+  });
+});

--- a/packages/vscode/tests/unit/testTree.test.ts
+++ b/packages/vscode/tests/unit/testTree.test.ts
@@ -132,4 +132,39 @@ describe('TestFile.updateFromList', () => {
     expect(suite.range.startLine).toBe(8);
     expect(suite.children.get('a').range.startLine).toBe(19);
   });
+
+  it('preserves separate ranges for duplicate sibling names', async () => {
+    const { TestFile, getTestItemId } = await import('../../src/testTree');
+    const controller = createController();
+    const uri = { fsPath: '/x/dup.test.ts', toString: () => 'file:///x' };
+    const file = new TestFile({} as any, uri as any, controller);
+    const root = controller.createTestItem('root', 'dup.test.ts', uri);
+    file.setTestItem(root);
+
+    const dup = [
+      { type: 'case', name: 'renders', location: location(4), tests: [] },
+      { type: 'case', name: 'renders', location: location(9), tests: [] },
+    ] as any;
+    file.updateFromList(dup);
+    // duplicate siblings get distinct ids by occurrence index
+    expect(root.children.get(getTestItemId('renders', 0)).range.startLine).toBe(
+      3,
+    );
+    expect(root.children.get(getTestItemId('renders', 1)).range.startLine).toBe(
+      8,
+    );
+
+    // location-less rebuild must keep each occurrence's own range, not collapse
+    // both onto the last one's.
+    file.updateFromList([
+      { type: 'case', name: 'renders', location: undefined, tests: [] },
+      { type: 'case', name: 'renders', location: undefined, tests: [] },
+    ] as any);
+    expect(root.children.get(getTestItemId('renders', 0)).range.startLine).toBe(
+      3,
+    );
+    expect(root.children.get(getTestItemId('renders', 1)).range.startLine).toBe(
+      8,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Test gutter icons could jump onto the file's import block after running tests. On every run the extension rebuilds a file's test tree from the run's reported tests (via `onTestFileReady` → `updateFromList`) so dynamically generated `.each` cases are picked up — this is intentional and covered by `runtimeList.test.ts`. But the rebuild took each reported test's source location at face value, and the runtime only emits a location when the project's `@rstest/core` resolves `includeTaskLocation` (which varies by the user's installed core version and whether their build carries source maps). When a location was missing, the rebuilt range collapsed to `(0, 0)`, moving every gutter icon to line 1.

- `updateFromList` now snapshots the ranges already on the tree (keyed by the test's name path) before rebuilding, and reuses the existing range for any reported test that arrives without a location — so statically parsed ranges survive a run.
- `onTest` leaves `range` unset when no location is known instead of pointing at the wrong line, so a genuinely new location-less test gets no misleading gutter icon rather than one on the imports.

The fix lives entirely in the extension: it tolerates real-world variation in the user's core/build rather than depending on the runtime always reporting a location.

## Checklist

- [x] Tests updated. Added `tests/unit/testTree.test.ts` covering range preservation on a location-less rebuild and location precedence when one is reported. The existing `tests/suite/runtimeList.test.ts` still exercises the run→rebuild upgrade path (it asserts labels, unaffected by ranges).
- [x] Documentation updated (or not required). No public API or config change.
