### PR TITLE
feat(vscode): add editor and Test Explorer UX commands

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -34,6 +34,28 @@
         "title": "Update Snapshot",
         "category": "Testing",
         "icon": "$(merge)"
+      },
+      {
+        "command": "rstest.openOutput",
+        "title": "Show Output",
+        "category": "Rstest"
+      },
+      {
+        "command": "rstest.revealInTestExplorer",
+        "title": "Reveal in Test Explorer",
+        "category": "Rstest"
+      },
+      {
+        "command": "rstest.copyErrorOutput",
+        "title": "Copy Error Output",
+        "category": "Rstest",
+        "icon": "$(copy)"
+      },
+      {
+        "command": "rstest.copyTestItemErrors",
+        "title": "Copy Test Errors",
+        "category": "Rstest",
+        "icon": "$(copy)"
       }
     ],
     "configuration": {
@@ -150,12 +172,34 @@
         {
           "command": "rstest.updateSnapshot",
           "when": "false"
+        },
+        {
+          "command": "rstest.revealInTestExplorer",
+          "when": "false"
+        },
+        {
+          "command": "rstest.copyErrorOutput",
+          "when": "false"
+        },
+        {
+          "command": "rstest.copyTestItemErrors",
+          "when": "false"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "rstest.revealInTestExplorer",
+          "when": "resourcePath in rstest.testFiles"
         }
       ],
       "testing/message/content": [
         {
           "command": "rstest.updateSnapshot",
           "when": "testMessage == canUpdateSnapshot"
+        },
+        {
+          "command": "rstest.copyErrorOutput",
+          "when": "resourcePath in rstest.testFiles"
         }
       ],
       "testing/message/context": [
@@ -163,6 +207,23 @@
           "command": "rstest.updateSnapshot",
           "group": "inline@1",
           "when": "testMessage == canUpdateSnapshot"
+        },
+        {
+          "command": "rstest.copyErrorOutput",
+          "group": "inline@2",
+          "when": "resourcePath in rstest.testFiles"
+        }
+      ],
+      "testing/item/context": [
+        {
+          "command": "rstest.copyTestItemErrors",
+          "when": "controllerId == 'rstest'"
+        }
+      ],
+      "testing/item/gutter": [
+        {
+          "command": "rstest.copyTestItemErrors",
+          "when": "controllerId == 'rstest'"
         }
       ]
     }

--- a/packages/vscode/src/errorStore.ts
+++ b/packages/vscode/src/errorStore.ts
@@ -1,0 +1,32 @@
+import type vscode from 'vscode';
+
+// Retains the last run's failure messages per test item so the
+// `rstest.copyTestItemErrors` command can surface them. Kept separate from
+// RstestDiagnostics because that store is gated on `rstest.applyDiagnostic` and
+// drops messages without a resolvable source location, whereas copying errors
+// should work regardless of the diagnostics setting and keep every message.
+export class TestErrorStore {
+  private readonly messagesByTest = new WeakMap<
+    vscode.TestItem,
+    vscode.TestMessage[]
+  >();
+
+  public set(testItem: vscode.TestItem, messages: vscode.TestMessage[]) {
+    this.messagesByTest.set(testItem, messages);
+  }
+
+  public clear(testItem: vscode.TestItem) {
+    this.messagesByTest.delete(testItem);
+  }
+
+  public get(testItem: vscode.TestItem): vscode.TestMessage[] {
+    return this.messagesByTest.get(testItem) ?? [];
+  }
+}
+
+// Flatten a TestMessage's text (string or MarkdownString) to plain text.
+export function testMessageText(message: vscode.TestMessage): string {
+  return typeof message.message === 'string'
+    ? message.message
+    : message.message.value;
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { RstestDiagnostics } from './diagnostics';
+import { TestErrorStore, testMessageText } from './errorStore';
 import { logger } from './logger';
 import { runningWorkers } from './master';
 import { Project, WorkspaceManager } from './project';
@@ -32,6 +33,7 @@ class Rstest {
   private runProfile!: vscode.TestRunProfile;
   private coverageProfile!: vscode.TestRunProfile;
   private diagnostics = new RstestDiagnostics();
+  private errorStore = new TestErrorStore();
 
   // Add getter to access the test controller for testing
   get testController() {
@@ -79,6 +81,8 @@ class Rstest {
       ),
     );
 
+    this.registerCommands();
+
     this.ctrl.createRunProfile(
       'Debug Tests',
       vscode.TestRunProfileKind.Debug,
@@ -103,6 +107,87 @@ class Rstest {
       }
       return [];
     };
+  }
+
+  private registerCommands() {
+    const register = (
+      command: string,
+      callback: (...args: any[]) => unknown,
+    ) => {
+      this.context.subscriptions.push(
+        vscode.commands.registerCommand(command, callback),
+      );
+    };
+
+    register('rstest.openOutput', () => logger.show());
+
+    register('rstest.revealInTestExplorer', async (uri?: vscode.Uri) => {
+      const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+      const item = target && this.findTestFileItem(target);
+      if (!item) {
+        vscode.window.showInformationMessage(
+          'This file is not a known Rstest test file.',
+        );
+        return;
+      }
+      await vscode.commands.executeCommand('vscode.revealTestInExplorer', item);
+    });
+
+    register(
+      'rstest.copyErrorOutput',
+      async (args?: { test: vscode.TestItem; message: vscode.TestMessage }) => {
+        if (!args?.message) return;
+        await vscode.env.clipboard.writeText(testMessageText(args.message));
+      },
+    );
+
+    register(
+      'rstest.copyTestItemErrors',
+      async (testItem?: vscode.TestItem) => {
+        if (!testItem) return;
+        const errors = this.collectErrors(testItem);
+        if (!errors.length) {
+          vscode.window.showInformationMessage('No test errors to copy.');
+          return;
+        }
+        await vscode.env.clipboard.writeText(errors.join('\n\n'));
+      },
+    );
+  }
+
+  // Errors for a test item plus any descendants (a file/suite item aggregates
+  // its leaves' failures).
+  private collectErrors(item: vscode.TestItem): string[] {
+    const errors: string[] = [];
+    for (const test of [item, ...gatherTestItems(item.children)]) {
+      for (const message of this.errorStore.get(test)) {
+        errors.push(testMessageText(message));
+      }
+    }
+    return errors;
+  }
+
+  private findTestFileItem(uri: vscode.Uri): vscode.TestItem | undefined {
+    const key = uri.toString();
+    for (const workspace of this.workspaces.values()) {
+      for (const project of workspace.projects.values()) {
+        const item = project.testFiles.get(key)?.testItem;
+        if (item) return item;
+      }
+    }
+    return undefined;
+  }
+
+  private updateTestFilesContext() {
+    const paths: string[] = [];
+    for (const workspace of this.workspaces.values()) {
+      for (const project of workspace.projects.values()) {
+        for (const file of project.testFiles.values()) {
+          paths.push(file.uri.fsPath);
+        }
+      }
+    }
+    vscode.commands.executeCommand('setContext', 'rstest.testFiles', paths);
   }
 
   private startScanWorkspaces() {
@@ -139,7 +224,9 @@ class Rstest {
 
     this.workspaces.set(
       workspaceFolder.uri.toString(),
-      new WorkspaceManager(workspaceFolder, this.ctrl),
+      new WorkspaceManager(workspaceFolder, this.ctrl, () =>
+        this.updateTestFilesContext(),
+      ),
     );
   }
 
@@ -156,6 +243,7 @@ class Rstest {
     for (const workspace of this.workspaces.values()) {
       workspace.refresh(vscode.workspace.workspaceFolders?.length === 1);
     }
+    this.updateTestFilesContext();
   }
 
   private startTestRun = async (
@@ -188,6 +276,7 @@ class Rstest {
       kind: request.profile?.kind,
       continuous: request.continuous,
       diagnostics: this.diagnostics,
+      errorStore: this.errorStore,
       createTestRun: () =>
         createTestRun(
           new vscode.TestRunRequest(

--- a/packages/vscode/src/logger.ts
+++ b/packages/vscode/src/logger.ts
@@ -13,6 +13,10 @@ class MasterLogger extends BaseLogger implements vscode.Disposable {
     this.#channel[level](message);
   }
 
+  public show() {
+    this.#channel.show();
+  }
+
   public dispose() {
     this.#channel.dispose();
   }

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -6,6 +6,7 @@ import regexpEscape from 'core-js-pure/actual/regexp/escape';
 import vscode from 'vscode';
 import { getConfigValue } from './config';
 import type { RstestDiagnostics } from './diagnostics';
+import type { TestErrorStore } from './errorStore';
 import { logger } from './logger';
 import type { Project } from './project';
 import { TestRunReporter } from './testRunReporter';
@@ -164,6 +165,7 @@ export class RstestApi {
     kind,
     continuous,
     diagnostics,
+    errorStore,
     createTestRun,
   }: {
     run: vscode.TestRun;
@@ -175,6 +177,7 @@ export class RstestApi {
     kind?: vscode.TestRunProfileKind;
     continuous?: boolean;
     diagnostics?: RstestDiagnostics;
+    errorStore?: TestErrorStore;
     createTestRun?: () => vscode.TestRun;
   }) {
     let onFinish!: () => void;
@@ -201,6 +204,7 @@ export class RstestApi {
       createTestRun,
       this.configFilePath,
       applyDiagnostic ? diagnostics : undefined,
+      errorStore,
     );
 
     const worker = await this.createChildProcess(

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -20,6 +20,7 @@ export class WorkspaceManager implements vscode.Disposable {
   constructor(
     private workspaceFolder: vscode.WorkspaceFolder,
     private testController: vscode.TestController,
+    private onDidChangeTestFiles?: () => void,
   ) {
     this.workspacePath = workspaceFolder.uri.toString();
     this.configValueWatcher = this.startWatchingWorkspace();
@@ -120,6 +121,7 @@ export class WorkspaceManager implements vscode.Disposable {
       configFileUri,
       this.testController,
       this.testItem?.children ?? this.testController.items,
+      this.onDidChangeTestFiles,
     );
     this.projects.set(configFilePath, project);
   }
@@ -254,6 +256,7 @@ export class Project implements vscode.Disposable {
     private configFileUri: vscode.Uri,
     private testController: vscode.TestController,
     public parentCollection: vscode.TestItemCollection,
+    private onDidChangeTestFiles?: () => void,
   ) {
     // use dirname of config file as default root
     this.root = configFileUri.with({ path: path.dirname(configFileUri.path) });
@@ -515,5 +518,8 @@ export class Project implements vscode.Disposable {
     for (const [childKey, childValue] of Object.entries(tree)) {
       handleTreeItem(childKey, childValue, [], [], this.collection);
     }
+    // testFiles has settled for this project; let the extension refresh any
+    // derived state (e.g. the `rstest.testFiles` context key).
+    this.onDidChangeTestFiles?.();
   }
 }

--- a/packages/vscode/src/testRunReporter.ts
+++ b/packages/vscode/src/testRunReporter.ts
@@ -114,7 +114,7 @@ export class TestRunReporter implements Reporter {
       }
     }
   }
-  onTestFileResult(test: TestFileResult) {
+  async onTestFileResult(test: TestFileResult) {
     // only update test file result when explicit run itself or parent
     if (this.path.length) return;
 
@@ -127,13 +127,32 @@ export class TestRunReporter implements Reporter {
       case 'todo':
       case 'skip':
         this.run?.skipped(fileItem);
+        this.errorStore?.clear(fileItem);
         break;
       case 'pass':
         this.run?.passed(fileItem, test.duration);
+        this.errorStore?.clear(fileItem);
         break;
-      case 'fail':
-        this.run?.failed(fileItem, [], test.duration);
+      case 'fail': {
+        // When a file fails before any test case runs (a syntax/collection
+        // error or a worker crash during collection), the errors live only on
+        // the file result and no onTestCaseResult fires to surface or store
+        // them. Surface them on the file item so they appear in the failure
+        // widget and copyTestItemErrors can find them. When cases did run,
+        // their per-case results already carry the errors (core also
+        // re-aggregates suite hook errors onto file.errors, but those are
+        // already surfaced/stored via onTestSuiteResult on the file item), so
+        // we skip here to avoid double-reporting. This relies on core keeping
+        // file.errors as the sole carrier only when no case ran.
+        const fileErrors = test.results?.length
+          ? []
+          : await this.createErrors(test.errors, test.testPath);
+        this.run?.failed(fileItem, fileErrors, test.duration);
+        if (fileErrors.length) {
+          this.errorStore?.set(fileItem, fileErrors);
+        }
         break;
+      }
     }
   }
 
@@ -183,11 +202,7 @@ export class TestRunReporter implements Reporter {
         break;
       }
       case 'fail': {
-        const errors = await Promise.all(
-          (result.errors || []).map(async (error) =>
-            this.createError(error, result.testPath),
-          ),
-        );
+        const errors = await this.createErrors(result.errors, result.testPath);
         this.run?.failed(testItem, errors, result.duration);
         this.diagnostics?.setForTest(
           this.projectKey,
@@ -309,6 +324,12 @@ export class TestRunReporter implements Reporter {
               );
         }),
       ),
+    );
+  }
+
+  private createErrors(errors: TestResult['errors'], testPath: string) {
+    return Promise.all(
+      (errors || []).map((error) => this.createError(error, testPath)),
     );
   }
 

--- a/packages/vscode/src/testRunReporter.ts
+++ b/packages/vscode/src/testRunReporter.ts
@@ -10,6 +10,7 @@ import vscode from 'vscode';
 import { ROOT_SUITE_NAME } from '../../core/src/utils/constants';
 import { parseErrorStacktrace } from '../../core/src/utils/error';
 import type { DiagnosticEntry, RstestDiagnostics } from './diagnostics';
+import type { TestErrorStore } from './errorStore';
 import { logger } from './logger';
 import type { Project } from './project';
 import type { LogLevel } from './shared/logger';
@@ -25,6 +26,7 @@ export class TestRunReporter implements Reporter {
     private createTestRun?: () => vscode.TestRun,
     private projectKey = '',
     private diagnostics?: RstestDiagnostics,
+    private errorStore?: TestErrorStore,
   ) {}
 
   public async log(level: LogLevel, message: string) {
@@ -170,12 +172,14 @@ export class TestRunReporter implements Reporter {
       case 'pass': {
         this.run?.passed(testItem, result.duration);
         this.diagnostics?.clearForTest(this.projectKey, testItem);
+        this.errorStore?.clear(testItem);
         break;
       }
       case 'skip':
       case 'todo': {
         this.run?.skipped(testItem);
         this.diagnostics?.clearForTest(this.projectKey, testItem);
+        this.errorStore?.clear(testItem);
         break;
       }
       case 'fail': {
@@ -190,6 +194,7 @@ export class TestRunReporter implements Reporter {
           testItem,
           this.createDiagnostics(testItem, errors),
         );
+        this.errorStore?.set(testItem, errors);
         break;
       }
     }

--- a/packages/vscode/tests/suite/uxCommands.test.ts
+++ b/packages/vscode/tests/suite/uxCommands.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert';
+import vscode from 'vscode';
+import { getTestItemByLabels, waitFor } from './helpers';
+
+suite('Editor / Test Explorer UX commands', () => {
+  test('openOutput, copyErrorOutput, revealInTestExplorer, copyTestItemErrors', async () => {
+    const extension = vscode.extensions.getExtension('rstack.rstest');
+    assert.ok(extension, 'Extension should be present');
+    if (!extension.isActive) {
+      await extension.activate();
+    }
+    const rstestInstance: any = extension.exports;
+    const controller: vscode.TestController = rstestInstance.testController;
+    assert.ok(controller, 'Test controller should be exported');
+
+    // openOutput just reveals the channel — it must not throw.
+    await vscode.commands.executeCommand('rstest.openOutput');
+
+    const fileItem = await waitFor(() =>
+      getTestItemByLabels(controller.items, ['test', 'progress.test.ts']),
+    );
+
+    // copyErrorOutput copies the given message's text to the clipboard.
+    await vscode.env.clipboard.writeText('');
+    await vscode.commands.executeCommand('rstest.copyErrorOutput', {
+      test: fileItem,
+      message: new vscode.TestMessage('copied error text'),
+    });
+    assert.strictEqual(
+      await vscode.env.clipboard.readText(),
+      'copied error text',
+    );
+
+    // revealInTestExplorer delegates to the built-in reveal command; this
+    // fails loudly if the command id or argument shape is wrong.
+    assert.ok(fileItem.uri, 'test file item should have a uri');
+    await vscode.commands.executeCommand(
+      'rstest.revealInTestExplorer',
+      fileItem.uri,
+    );
+
+    // Run the failing fixture so the error store is populated, then copy the
+    // file item's aggregated errors.
+    await rstestInstance.startTestRun(
+      new vscode.TestRunRequest(
+        [fileItem],
+        undefined,
+        rstestInstance.runProfile,
+      ),
+      new vscode.CancellationTokenSource().token,
+      false,
+    );
+
+    await vscode.commands.executeCommand('rstest.copyTestItemErrors', fileItem);
+    assert.match(
+      await vscode.env.clipboard.readText(),
+      /expected 1 to equal 2/,
+    );
+  });
+});

--- a/packages/vscode/tests/unit/errorStore.test.ts
+++ b/packages/vscode/tests/unit/errorStore.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@rstest/core';
+import { TestErrorStore, testMessageText } from '../../src/errorStore';
+
+const item = (id: string) => ({ id }) as any;
+const msg = (message: unknown) => ({ message }) as any;
+
+describe('TestErrorStore', () => {
+  it('stores and returns messages per test item', () => {
+    const store = new TestErrorStore();
+    const a = item('a');
+    const b = item('b');
+    store.set(a, [msg('boom')]);
+    expect(store.get(a).map((m) => m.message)).toEqual(['boom']);
+    // unknown item has no errors
+    expect(store.get(b)).toEqual([]);
+  });
+
+  it('clears entries, and an empty set removes them', () => {
+    const store = new TestErrorStore();
+    const a = item('a');
+    store.set(a, [msg('boom')]);
+    store.clear(a);
+    expect(store.get(a)).toEqual([]);
+
+    store.set(a, [msg('again')]);
+    store.set(a, []); // overwriting with no messages
+    expect(store.get(a)).toEqual([]);
+  });
+});
+
+describe('testMessageText', () => {
+  it('returns string messages verbatim', () => {
+    expect(testMessageText(msg('plain error'))).toBe('plain error');
+  });
+
+  it('reads the value of a MarkdownString message', () => {
+    expect(testMessageText(msg({ value: '**bold** error' }))).toBe(
+      '**bold** error',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Rounds out the editor / Test Explorer experience with four commands, none of which touch `@rstest/core`:

- **`rstest.openOutput`** (command palette: "Rstest: Show Output") — reveals the extension's output channel.
- **`rstest.revealInTestExplorer`** (editor tab context menu on a test file) — reveals that file's item in the Test Explorer.
- **`rstest.copyErrorOutput`** (inline test-result / failure-message menu) — copies a single failure message to the clipboard.
- **`rstest.copyTestItemErrors`** (Test Explorer item + gutter menu) — copies a test/file/suite item's failures, aggregating its descendants'.

## Implementation notes

- Failure messages are retained in a new always-on `TestErrorStore` (a `WeakMap<TestItem, TestMessage[]>`), threaded through `runTest` alongside the existing diagnostics seam and populated on fail / cleared on pass. It is deliberately separate from `RstestDiagnostics`, which is gated on `rstest.applyDiagnostic` and drops messages without a resolvable source location — copying errors should work regardless of that setting and keep every message.
- The editor and failure-message menus are gated by a `rstest.testFiles` context key. It is refreshed from project discovery (`buildTree`), so it stays correct after async discovery completes and when test files are added or removed while the extension runs.

## Checklist

- [x] Tests updated. Added `tests/unit/errorStore.test.ts` for the store and the message-flattening helper. The command handlers themselves are thin wrappers over VS Code APIs (clipboard, reveal, output channel) exercised via the extension host.
- [x] Documentation updated (or not required). Commands and menus are self-documented via `contributes` in `package.json`.
