### PR TITLE
feat(vscode): add "Run in Terminal" and dedup aggregated projects

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -56,6 +56,12 @@
         "title": "Copy Test Errors",
         "category": "Rstest",
         "icon": "$(copy)"
+      },
+      {
+        "command": "rstest.runInTerminal",
+        "title": "Run in Terminal",
+        "category": "Rstest",
+        "icon": "$(terminal)"
       }
     ],
     "configuration": {
@@ -164,6 +170,18 @@
           "description": "Show diagnostics in editor and Problems panel for failed tests.",
           "type": "boolean",
           "default": true
+        },
+        "rstest.terminalShellPath": {
+          "markdownDescription": "Path to the shell used by the **Run in Terminal** command. Leave empty to use your default integrated terminal so its profile and environment are honored. Note: command arguments are quoted for POSIX shells; on Windows point this at a POSIX-style shell (e.g. Git Bash) if a test name needs quoting.",
+          "type": "string"
+        },
+        "rstest.terminalShellArgs": {
+          "markdownDescription": "Arguments passed to the shell used by the **Run in Terminal** command.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
         }
       }
     },
@@ -183,6 +201,10 @@
         },
         {
           "command": "rstest.copyTestItemErrors",
+          "when": "false"
+        },
+        {
+          "command": "rstest.runInTerminal",
           "when": "false"
         }
       ],
@@ -216,11 +238,20 @@
       ],
       "testing/item/context": [
         {
+          "command": "rstest.runInTerminal",
+          "group": "rstest@1",
+          "when": "controllerId == 'rstest'"
+        },
+        {
           "command": "rstest.copyTestItemErrors",
           "when": "controllerId == 'rstest'"
         }
       ],
       "testing/item/gutter": [
+        {
+          "command": "rstest.runInTerminal",
+          "when": "controllerId == 'rstest'"
+        },
         {
           "command": "rstest.copyTestItemErrors",
           "when": "controllerId == 'rstest'"

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -36,6 +36,10 @@ const configSchema = object({
     'ast',
   ),
   applyDiagnostic: fallback(boolean(), true),
+  // Shell used by the "Run in Terminal" command. Empty falls back to the
+  // user's default integrated terminal (so its profile/env are honored).
+  terminalShellPath: fallback(optional(string()), undefined),
+  terminalShellArgs: fallback(array(string()), []),
 });
 
 type ExtensionConfig = InferOutput<typeof configSchema>;

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -319,8 +319,8 @@ class Rstest {
 
         const data = testData.get(test);
         if (data instanceof WorkspaceManager) {
-          if (data.projects.size === 1) {
-            const project = data.projects.values().next().value!;
+          if (data.activeProjects.size === 1) {
+            const project = data.activeProjects.values().next().value!;
             await project.api.runTest({
               ...commonOptions,
             });
@@ -359,8 +359,8 @@ class Rstest {
       if (!request.include?.length) {
         if (this.workspaces.size === 1) {
           const workspace = this.workspaces.values().next().value!;
-          if (workspace.projects.size === 1) {
-            const project = workspace.projects.values().next().value!;
+          if (workspace.activeProjects.size === 1) {
+            const project = workspace.activeProjects.values().next().value!;
             await project.api.runTest({
               ...commonOptions,
             });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import { TestErrorStore, testMessageText } from './errorStore';
 import { logger } from './logger';
 import { runningWorkers } from './master';
 import { Project, WorkspaceManager } from './project';
+import { disposeTerminal } from './terminal';
 import { RstestFileCoverage } from './testRunReporter';
 import {
   gatherTestItems,
@@ -23,6 +24,7 @@ export function deactivate() {
   for (const worker of runningWorkers) {
     worker.$close();
   }
+  disposeTerminal();
 }
 
 class Rstest {
@@ -140,6 +142,26 @@ class Rstest {
         await vscode.env.clipboard.writeText(testMessageText(args.message));
       },
     );
+
+    register('rstest.runInTerminal', (testItem?: vscode.TestItem) => {
+      if (!testItem) return;
+      const data = testData.get(testItem);
+      if (data instanceof TestCase) {
+        data.api.runInTerminal({
+          fileFilter: data.uri.fsPath,
+          testCaseNamePath: data.parentNames.concat(testItem.label),
+          isSuite: data.type === 'suite',
+        });
+      } else if (data instanceof TestFile || data instanceof TestFolder) {
+        data.api.runInTerminal({ fileFilter: data.uri.fsPath });
+      } else if (data instanceof Project) {
+        data.api.runInTerminal({});
+      } else {
+        vscode.window.showInformationMessage(
+          'Run in Terminal is not available for this item.',
+        );
+      }
+    });
 
     register(
       'rstest.copyTestItemErrors',

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -9,6 +9,7 @@ import type { RstestDiagnostics } from './diagnostics';
 import type { TestErrorStore } from './errorStore';
 import { logger } from './logger';
 import type { Project } from './project';
+import { runInTerminal as sendToTerminal, shellQuote } from './terminal';
 import { TestRunReporter } from './testRunReporter';
 import {
   formatCoreVersionWarningMessage,
@@ -52,38 +53,71 @@ export class RstestApi {
     return value.replaceAll('${workspaceFolder}', this.workspace.uri.fsPath);
   }
 
-  private resolveRstestPath(): string {
+  // Regex source that selects a single reported case by its name path. Shared by
+  // the worker run (wrapped in RegExp) and the terminal `-t` argument so both
+  // select the same case.
+  private buildTestNamePattern(
+    testCaseNamePath: string[],
+    isSuite?: boolean,
+  ): string {
+    return `^${regexpEscape(testCaseNamePath.join(' '))}${isSuite ? ' ' : '$'}`;
+  }
+
+  // The node executable + exec args used to run a worker or the CLI, honoring
+  // the `nodeExecutable` / `nodeExecArgs` settings (`${workspaceFolder}`
+  // expanded).
+  private resolveNodeCommand(): {
+    nodeExecutable: string;
+    nodeExecArgs: string[];
+  } {
+    const configuredExecutable = getConfigValue(
+      'nodeExecutable',
+      this.workspace,
+    );
+    return {
+      nodeExecutable: configuredExecutable
+        ? this.expandWorkspaceFolder(configuredExecutable)
+        : 'node',
+      nodeExecArgs: getConfigValue('nodeExecArgs', this.workspace).map((arg) =>
+        this.expandWorkspaceFolder(arg),
+      ),
+    };
+  }
+
+  // Resolve the `@rstest/core` package.json specifier honoring a configured
+  // `rstestPackagePath`: the bare package spec when it is not set, or the
+  // validated absolute path to the configured package.json. Shared by the
+  // worker resolution and the terminal CLI resolution.
+  private resolveConfiguredPackageJson(): string {
     // TODO: support Yarn PnP
-    try {
-      // Check if user configured a custom package path (last resort fix)
-      let configuredPackagePath = getConfigValue(
-        'rstestPackagePath',
-        this.workspace,
+    let configuredPackagePath = getConfigValue(
+      'rstestPackagePath',
+      this.workspace,
+    );
+    if (!configuredPackagePath) {
+      return '@rstest/core/package.json';
+    }
+    configuredPackagePath = this.expandWorkspaceFolder(configuredPackagePath);
+    if (!configuredPackagePath.endsWith('package.json')) {
+      throw new Error(
+        `"rstest.rstestPackagePath" must point to a package.json file, instead got: ${configuredPackagePath}`,
       );
+    }
+    return path.isAbsolute(configuredPackagePath)
+      ? configuredPackagePath
+      : path.resolve(this.workspace.uri.fsPath, configuredPackagePath);
+  }
 
-      if (configuredPackagePath) {
-        configuredPackagePath = this.expandWorkspaceFolder(
-          configuredPackagePath,
-        );
-        // Validate that the path points to package.json
-        if (!configuredPackagePath.endsWith('package.json')) {
-          const errorMessage = `"rstest.rstestPackagePath" must point to a package.json file, instead got: ${configuredPackagePath}`;
-          throw new Error(errorMessage);
-        }
-
-        // User provided a custom path to package.json
-        configuredPackagePath = path.isAbsolute(configuredPackagePath)
-          ? configuredPackagePath
-          : path.resolve(this.workspace.uri.fsPath, configuredPackagePath);
-
-        logger.debug(
-          'Using configured rstestPackagePath:',
-          configuredPackagePath,
-        );
+  private resolveRstestPath(): string {
+    try {
+      const packageJson = this.resolveConfiguredPackageJson();
+      const configured = packageJson !== '@rstest/core/package.json';
+      if (configured) {
+        logger.debug('Using configured rstestPackagePath:', packageJson);
       }
 
       const nodeExport = require.resolve(
-        configuredPackagePath ? dirname(configuredPackagePath) : '@rstest/core',
+        configured ? dirname(packageJson) : '@rstest/core',
         {
           paths: [this.cwd],
         },
@@ -91,12 +125,9 @@ export class RstestApi {
 
       let corePackageJsonPath: string;
       try {
-        corePackageJsonPath = require.resolve(
-          configuredPackagePath || '@rstest/core/package.json',
-          {
-            paths: [this.cwd],
-          },
-        );
+        corePackageJsonPath = require.resolve(packageJson, {
+          paths: [this.cwd],
+        });
       } catch (e) {
         vscode.window.showErrorMessage(
           'Failed to resolve @rstest/core/package.json. Please upgrade @rstest/core to the latest version.',
@@ -131,6 +162,23 @@ export class RstestApi {
       vscode.window.showErrorMessage((e as any).toString());
       throw e;
     }
+  }
+
+  // Resolve the rstest CLI executable (its package `bin`) for the terminal run
+  // mode, honoring a configured `rstestPackagePath` the same way as the worker
+  // resolution above.
+  private resolveRstestBin(): string {
+    const pkgJsonPath = require.resolve(this.resolveConfiguredPackageJson(), {
+      paths: [this.cwd],
+    });
+    const pkg = require(pkgJsonPath) as {
+      bin?: string | Record<string, string>;
+    };
+    const binRel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.rstest;
+    if (!binRel) {
+      throw new Error('Could not resolve the rstest CLI binary');
+    }
+    return path.join(path.dirname(pkgJsonPath), binRel);
   }
 
   public async getNormalizedConfig() {
@@ -222,9 +270,7 @@ export class RstestApi {
         command: continuous ? 'watch' : 'run',
         fileFilters: fileFilter ? [fileFilter] : undefined,
         testNamePattern: testCaseNamePath
-          ? new RegExp(
-              `^${regexpEscape(testCaseNamePath.join(' '))}${isSuite ? ' ' : '$'}`,
-            )
+          ? new RegExp(this.buildTestNamePattern(testCaseNamePath, isSuite))
           : undefined,
         update: updateSnapshot,
         configFilePath: this.configFilePath,
@@ -251,6 +297,59 @@ export class RstestApi {
       });
 
     await promise;
+  }
+
+  private buildCliCommand({
+    fileFilter,
+    testCaseNamePath,
+    isSuite,
+  }: {
+    fileFilter?: string;
+    testCaseNamePath?: string[];
+    isSuite?: boolean;
+  }): string {
+    const { nodeExecutable, nodeExecArgs } = this.resolveNodeCommand();
+
+    // Prefer a path relative to the run cwd for readability; fall back to the
+    // absolute path when the target is outside the cwd.
+    const relative = (target: string) => {
+      const rel = path.relative(this.cwd, target);
+      return rel && !rel.startsWith('..') ? rel : target;
+    };
+
+    const args = ['run'];
+    if (fileFilter) {
+      args.push(relative(fileFilter));
+    }
+    if (testCaseNamePath?.length) {
+      // Terminal run selects the same case as the in-editor run.
+      args.push('-t', this.buildTestNamePattern(testCaseNamePath, isSuite));
+    }
+    args.push('-c', relative(this.configFilePath));
+
+    return [nodeExecutable, ...nodeExecArgs, this.resolveRstestBin(), ...args]
+      .map(shellQuote)
+      .join(' ');
+  }
+
+  public runInTerminal(options: {
+    fileFilter?: string;
+    testCaseNamePath?: string[];
+    isSuite?: boolean;
+  }): void {
+    let command: string;
+    try {
+      command = this.buildCliCommand(options);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Rstest: ${message}`);
+      return;
+    }
+    sendToTerminal(command, {
+      cwd: this.cwd,
+      shellPath: getConfigValue('terminalShellPath', this.workspace),
+      shellArgs: getConfigValue('terminalShellArgs', this.workspace),
+    });
   }
 
   public async createChildProcess(
@@ -283,16 +382,7 @@ export class RstestApi {
       );
     }
     const workerPath = path.resolve(__dirname, 'worker.js');
-    const configuredExecutable = getConfigValue(
-      'nodeExecutable',
-      this.workspace,
-    );
-    const nodeExecutable = configuredExecutable
-      ? this.expandWorkspaceFolder(configuredExecutable)
-      : 'node';
-    const nodeExecArgs = getConfigValue('nodeExecArgs', this.workspace).map(
-      (arg) => this.expandWorkspaceFolder(arg),
-    );
+    const { nodeExecutable, nodeExecArgs } = this.resolveNodeCommand();
     const nodeEnv = getConfigValue('nodeEnv', this.workspace);
     const debugNodeEnv = startDebugging
       ? getConfigValue('debugNodeEnv', this.workspace)

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -312,20 +312,25 @@ export class RstestApi {
 
     // Prefer a path relative to the run cwd for readability; fall back to the
     // absolute path when the target is outside the cwd.
-    const relative = (target: string) => {
+    const relativeToCwd = (target: string) => {
       const rel = path.relative(this.cwd, target);
       return rel && !rel.startsWith('..') ? rel : target;
     };
 
     const args = ['run'];
     if (fileFilter) {
-      args.push(relative(fileFilter));
+      // Keep the positional file filter absolute: Core matches it against the
+      // resolved config `root`, which can differ from the run cwd (the config
+      // file's directory) when a config sets a custom `root`. A cwd-relative
+      // path would then miss the discovered test files.
+      args.push(fileFilter);
     }
     if (testCaseNamePath?.length) {
       // Terminal run selects the same case as the in-editor run.
       args.push('-t', this.buildTestNamePattern(testCaseNamePath, isSuite));
     }
-    args.push('-c', relative(this.configFilePath));
+    // `-c` is resolved relative to the process cwd, which is `this.cwd`.
+    args.push('-c', relativeToCwd(this.configFilePath));
 
     return [nodeExecutable, ...nodeExecArgs, this.resolveRstestBin(), ...args]
       .map(shellQuote)

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -6,7 +6,7 @@ import vscode from 'vscode';
 import { watchConfigValue } from './config';
 import { logger } from './logger';
 import { RstestApi } from './master';
-import { computeCoveredConfigs } from './projectCoverage';
+import { type ChildProjectRef, computeCoveredConfigs } from './projectCoverage';
 import { ProjectFolder, TestFile, TestFolder, testData } from './testTree';
 
 // The default config file name at the workspace root. A lone project using it
@@ -164,27 +164,28 @@ export class WorkspaceManager implements vscode.Disposable {
     this.buildProjectTree(collection, activeProjects);
   }
 
-  // A project whose root is aggregated by *another* project via `projects` is
-  // shown only under that parent; suppress the standalone copy so its test files
-  // are not duplicated. Coverage from the project's own `projects` is ignored,
-  // since an aggregator's inline children may share its own root.
+  // A config file aggregated by *another* project via `projects` is shown only
+  // under that parent; suppress the standalone copy so its test files are not
+  // duplicated. `this.projects` is keyed by URI string, while matching uses
+  // fs paths.
   private resolveActiveProjects(): Map<string, Project> {
     const entries = [...this.projects];
     const covered = computeCoveredConfigs(
-      entries.map(([configFilePath, project]) => ({
-        configFilePath,
+      entries.map(([uri, project]) => ({
+        key: uri,
+        configFilePath: vscode.Uri.parse(uri).fsPath,
         root: project.root.fsPath,
-        childProjectRoots: project.childProjectRoots,
+        childProjects: project.childProjects,
         include: project.include,
       })),
     );
 
     const activeProjects = new Map<string, Project>();
-    for (const [configFilePath, project] of entries) {
-      const isCovered = covered.has(configFilePath);
+    for (const [uri, project] of entries) {
+      const isCovered = covered.has(uri);
       project.setSuppressed(isCovered);
       if (!isCovered) {
-        activeProjects.set(configFilePath, project);
+        activeProjects.set(uri, project);
       }
     }
     return activeProjects;
@@ -291,12 +292,12 @@ export class Project implements vscode.Disposable {
   include: string[] = [];
   exclude: string[] = [];
   testFiles = new Map<string, TestFile>();
-  // Normalized root directories of the sub-projects this config aggregates via
-  // `projects`. Populated once the config resolves; empty for a leaf config.
-  childProjectRoots: string[] = [];
-  // A project whose root is already covered by another (aggregator) project is
-  // suppressed: it neither watches files nor renders test items, so the same
-  // tests are not shown twice.
+  // Sub-projects this config aggregates via `projects`. Populated once the
+  // config resolves; empty for a leaf config.
+  childProjects: ChildProjectRef[] = [];
+  // A project whose config file is already covered by another (aggregator)
+  // project is suppressed: it neither watches files nor renders test items, so
+  // the same tests are not shown twice.
   suppressed = false;
   #watch?: vscode.Disposable;
   constructor(
@@ -324,7 +325,7 @@ export class Project implements vscode.Disposable {
         this.root = vscode.Uri.file(config.root);
         this.include = config.include;
         this.exclude = config.exclude;
-        this.childProjectRoots = config.projectRoots ?? [];
+        this.childProjects = config.childProjects;
         this.applyWatch();
         this.onConfigResolved?.();
       })

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -15,6 +15,10 @@ const DEFAULT_ROOT_CONFIG_RE = /^rstest\.config\.[mc]?[tj]s$/;
 
 export class WorkspaceManager implements vscode.Disposable {
   public projects = new Map<string, Project>();
+  // The subset of `projects` currently shown (not suppressed as a duplicate of
+  // an aggregating parent). Kept in sync by `refreshAllProject`. Run All uses
+  // this rather than `projects` so it runs the same set the tree displays.
+  public activeProjects = new Map<string, Project>();
   private workspacePath: string;
   private testItem?: vscode.TestItem;
   private configValueWatcher: vscode.Disposable;
@@ -141,6 +145,7 @@ export class WorkspaceManager implements vscode.Disposable {
     collection.replace([]);
 
     const activeProjects = this.resolveActiveProjects();
+    this.activeProjects = activeProjects;
 
     // Standard single-project setup (one project using the default config name
     // at the workspace root): show its test files directly, with no project node.

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -175,6 +175,7 @@ export class WorkspaceManager implements vscode.Disposable {
         configFilePath,
         root: project.root.fsPath,
         childProjectRoots: project.childProjectRoots,
+        include: project.include,
       })),
     );
 

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -6,6 +6,7 @@ import vscode from 'vscode';
 import { watchConfigValue } from './config';
 import { logger } from './logger';
 import { RstestApi } from './master';
+import { computeCoveredConfigs, normalizeRoot } from './projectCoverage';
 import { ProjectFolder, TestFile, TestFolder, testData } from './testTree';
 
 // The default config file name at the workspace root. A lone project using it
@@ -122,6 +123,9 @@ export class WorkspaceManager implements vscode.Disposable {
       this.testController,
       this.testItem?.children ?? this.testController.items,
       this.onDidChangeTestFiles,
+      // Re-render once the config resolves: coverage (which project aggregates
+      // which) is only known then, and it decides which projects to show.
+      () => this.refreshAllProject(),
     );
     this.projects.set(configFilePath, project);
   }
@@ -136,10 +140,12 @@ export class WorkspaceManager implements vscode.Disposable {
     const collection = this.testItem?.children ?? this.testController.items;
     collection.replace([]);
 
+    const activeProjects = this.resolveActiveProjects();
+
     // Standard single-project setup (one project using the default config name
     // at the workspace root): show its test files directly, with no project node.
-    if (this.projects.size === 1) {
-      const [[configFilePath, project]] = this.projects;
+    if (activeProjects.size === 1) {
+      const [[configFilePath, project]] = activeProjects;
       const relative = path.relative(
         this.workspaceFolder.uri.fsPath,
         vscode.Uri.parse(configFilePath).fsPath,
@@ -150,7 +156,32 @@ export class WorkspaceManager implements vscode.Disposable {
       }
     }
 
-    this.buildProjectTree(collection);
+    this.buildProjectTree(collection, activeProjects);
+  }
+
+  // A project whose root is aggregated by *another* project via `projects` is
+  // shown only under that parent; suppress the standalone copy so its test files
+  // are not duplicated. Coverage from the project's own `projects` is ignored,
+  // since an aggregator's inline children may share its own root.
+  private resolveActiveProjects(): Map<string, Project> {
+    const entries = [...this.projects];
+    const covered = computeCoveredConfigs(
+      entries.map(([configFilePath, project]) => ({
+        configFilePath,
+        root: project.root.fsPath,
+        childProjectRoots: project.childProjectRoots,
+      })),
+    );
+
+    const activeProjects = new Map<string, Project>();
+    for (const [configFilePath, project] of entries) {
+      const isCovered = covered.has(configFilePath);
+      project.setSuppressed(isCovered);
+      if (!isCovered) {
+        activeProjects.set(configFilePath, project);
+      }
+    }
+    return activeProjects;
   }
 
   // Group projects into a folder tree by their config file directory, so the
@@ -158,11 +189,14 @@ export class WorkspaceManager implements vscode.Disposable {
   // `dir/rstest.config.ts` entries. A project is shown as its own directory
   // (e.g. `packages/core`); the config file name is only used to disambiguate
   // a root-level config or multiple configs sharing one directory.
-  private buildProjectTree(rootCollection: vscode.TestItemCollection) {
+  private buildProjectTree(
+    rootCollection: vscode.TestItemCollection,
+    projects: Map<string, Project>,
+  ) {
     type TreeNode = { children: Map<string, TreeNode>; project?: Project };
     const root: TreeNode = { children: new Map() };
 
-    for (const [configFilePath, project] of this.projects) {
+    for (const [configFilePath, project] of projects) {
       const relative = path.relative(
         this.workspaceFolder.uri.fsPath,
         vscode.Uri.parse(configFilePath).fsPath,
@@ -251,12 +285,21 @@ export class Project implements vscode.Disposable {
   include: string[] = [];
   exclude: string[] = [];
   testFiles = new Map<string, TestFile>();
+  // Normalized root directories of the sub-projects this config aggregates via
+  // `projects`. Populated once the config resolves; empty for a leaf config.
+  childProjectRoots: string[] = [];
+  // A project whose root is already covered by another (aggregator) project is
+  // suppressed: it neither watches files nor renders test items, so the same
+  // tests are not shown twice.
+  suppressed = false;
+  #watch?: vscode.Disposable;
   constructor(
     private workspaceFolder: vscode.WorkspaceFolder,
     private configFileUri: vscode.Uri,
     private testController: vscode.TestController,
     public parentCollection: vscode.TestItemCollection,
     private onDidChangeTestFiles?: () => void,
+    private onConfigResolved?: () => void,
   ) {
     // use dirname of config file as default root
     this.root = configFileUri.with({ path: path.dirname(configFileUri.path) });
@@ -275,12 +318,37 @@ export class Project implements vscode.Disposable {
         this.root = vscode.Uri.file(config.root);
         this.include = config.include;
         this.exclude = config.exclude;
-        this.startWatchingWorkspace(this.root);
+        this.childProjectRoots = (config.projectRoots ?? []).map(normalizeRoot);
+        this.applyWatch();
+        this.onConfigResolved?.();
       })
       .catch((error) => {
         if (this.cancellationSource.token.isCancellationRequested) return;
         logger.error('Failed to initialize project config', error);
+        // Let the manager settle its tree even when a config fails to load.
+        this.onConfigResolved?.();
       });
+  }
+
+  private applyWatch() {
+    if (this.suppressed) return;
+    if (!this.#watch) {
+      this.#watch = this.startWatchingWorkspace(this.root);
+    }
+  }
+
+  // Called by WorkspaceManager once it knows whether another project already
+  // covers this config file.
+  public setSuppressed(value: boolean) {
+    if (this.suppressed === value) return;
+    this.suppressed = value;
+    if (value) {
+      this.#watch?.dispose();
+      this.#watch = undefined;
+      this.testFiles.clear();
+    } else {
+      this.applyWatch();
+    }
   }
 
   // `label` is the project node's label, or `null` to hoist its test files
@@ -311,13 +379,14 @@ export class Project implements vscode.Disposable {
     this.buildTree();
   }
   dispose() {
+    this.#watch?.dispose();
     this.api.dispose();
     this.cancellationSource.cancel();
   }
   get collection() {
     return this.testItem?.children || this.parentCollection;
   }
-  private async startWatchingWorkspace(root: vscode.Uri) {
+  private startWatchingWorkspace(root: vscode.Uri): vscode.Disposable {
     const matchInclude = picomatch(this.include);
     const matchExclude = picomatch(this.exclude);
     const isInclude = (uri: vscode.Uri) => {
@@ -433,9 +502,7 @@ export class Project implements vscode.Disposable {
         }
       },
     );
-    this.cancellationSource.token.onCancellationRequested(() =>
-      watcher.dispose(),
-    );
+    return watcher;
   }
   // TODO pass cancellation token to updateFromDisk
   private updateOrCreateFile(uri: vscode.Uri, tests?: TestInfo[]) {
@@ -452,6 +519,10 @@ export class Project implements vscode.Disposable {
   }
 
   private buildTree() {
+    // A suppressed project must not render into its collection; its config file
+    // is already covered by an aggregator project.
+    if (this.suppressed) return;
+
     type NestedRecord = { [K: string]: NestedRecord };
 
     const tree: NestedRecord = {};

--- a/packages/vscode/src/project.ts
+++ b/packages/vscode/src/project.ts
@@ -6,7 +6,7 @@ import vscode from 'vscode';
 import { watchConfigValue } from './config';
 import { logger } from './logger';
 import { RstestApi } from './master';
-import { computeCoveredConfigs, normalizeRoot } from './projectCoverage';
+import { computeCoveredConfigs } from './projectCoverage';
 import { ProjectFolder, TestFile, TestFolder, testData } from './testTree';
 
 // The default config file name at the workspace root. A lone project using it
@@ -318,7 +318,7 @@ export class Project implements vscode.Disposable {
         this.root = vscode.Uri.file(config.root);
         this.include = config.include;
         this.exclude = config.exclude;
-        this.childProjectRoots = (config.projectRoots ?? []).map(normalizeRoot);
+        this.childProjectRoots = config.projectRoots ?? [];
         this.applyWatch();
         this.onConfigResolved?.();
       })

--- a/packages/vscode/src/projectCoverage.ts
+++ b/packages/vscode/src/projectCoverage.ts
@@ -3,11 +3,59 @@ import path from 'node:path';
 // Normalize a project root to a stable key for coverage comparison. Core may
 // report roots with a trailing separator (e.g. `packages/core/`) while the
 // extension derives its own from a config file path without one.
-export const normalizeRoot = (root: string): string =>
+const normalizeRoot = (root: string): string =>
   path.normalize(root).replace(/[\\/]+$/, '');
 
-// Config files whose root is aggregated by *another* config via `projects`.
-// `childProjectRoots` are expected pre-normalized (see `normalizeRoot`).
+const isSubset = (a: Set<string>, b: Set<string>): boolean => {
+  if (a.size > b.size) {
+    return false;
+  }
+  for (const value of a) {
+    if (!b.has(value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+// Whether `ancestor` is a strict parent directory of `descendant`. Both are
+// expected pre-normalized (see `normalizeRoot`).
+const isStrictAncestor = (ancestor: string, descendant: string): boolean => {
+  const rel = path.relative(ancestor, descendant);
+  // `rel === ''` covers the equal-path case (not a strict ancestor).
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+};
+
+// Whether `parent` aggregates a nested intermediate config `child`. `initCli`
+// flattens such a child to its grandchildren, so the child's own root never
+// appears in `parent`'s root list — but its grandchildren roots do. So the
+// child is covered when its own aggregated roots are a subset of the parent's.
+// When the two sets are equal (a parent that aggregates *only* this one nested
+// child), the outer config — the one whose root is an ancestor — wins, so two
+// unrelated configs with identical roots never suppress each other (hiding
+// both).
+const aggregatesNestedConfig = (
+  child: { root: string; children: Set<string> },
+  parent: { root: string; children: Set<string> },
+): boolean => {
+  if (child.children.size === 0 || !isSubset(child.children, parent.children)) {
+    return false;
+  }
+  return (
+    parent.children.size > child.children.size ||
+    isStrictAncestor(parent.root, child.root)
+  );
+};
+
+// Config files whose tests are already rendered by *another* config, so the
+// extension should not register them as their own top-level project (otherwise
+// the same files show up twice). Roots (own and child) are normalized here, so
+// callers may pass them raw. A config is covered when another config either:
+//   - aggregates this config's own root via `projects` (a leaf child). This is
+//     an explicit, unconditional signal, so no ancestry check is needed.
+//   - aggregates this config's own child roots (a nested intermediate config;
+//     see `aggregatesNestedConfig`). This is inferred from the flattened
+//     grandchildren, so it carries a tiebreak for the ambiguous equal-set case.
 // Coverage from a config's own `projects` is ignored, since an aggregator's
 // inline children may share its own root (which would otherwise hide it).
 export function computeCoveredConfigs(
@@ -17,13 +65,18 @@ export function computeCoveredConfigs(
     childProjectRoots: string[];
   }[],
 ): Set<string> {
+  const nodes = projects.map((project) => ({
+    configFilePath: project.configFilePath,
+    root: normalizeRoot(project.root),
+    children: new Set(project.childProjectRoots.map(normalizeRoot)),
+  }));
   const covered = new Set<string>();
-  for (const project of projects) {
-    const ownRoot = normalizeRoot(project.root);
-    const isCovered = projects.some(
+  for (const project of nodes) {
+    const isCovered = nodes.some(
       (other) =>
         other.configFilePath !== project.configFilePath &&
-        other.childProjectRoots.includes(ownRoot),
+        (other.children.has(project.root) ||
+          aggregatesNestedConfig(project, other)),
     );
     if (isCovered) {
       covered.add(project.configFilePath);

--- a/packages/vscode/src/projectCoverage.ts
+++ b/packages/vscode/src/projectCoverage.ts
@@ -60,19 +60,25 @@ const aggregatesNestedConfig = (
 //   - aggregates this config's own child roots (a nested intermediate config;
 //     see `aggregatesNestedConfig`). This is inferred from the flattened
 //     grandchildren, so it carries a tiebreak for the ambiguous equal-set case.
-// Coverage from a config's own `projects` is ignored, since an aggregator's
-// inline children may share its own root (which would otherwise hide it).
+// In both cases the parent must also be able to *display* the child's files:
+// in AST mode a project only globs its own `include`, so a child whose include
+// patterns the parent does not also match is kept visible (its tests would
+// otherwise vanish from the tree even though the aggregated run still executes
+// them). Coverage from a config's own `projects` is ignored, since an
+// aggregator's inline children may share its own root (which would hide it).
 export function computeCoveredConfigs(
   projects: {
     configFilePath: string;
     root: string;
     childProjectRoots: string[];
+    include: string[];
   }[],
 ): Set<string> {
   const nodes = projects.map((project) => ({
     configFilePath: project.configFilePath,
     root: normalizeRoot(project.root),
     children: new Set(project.childProjectRoots.map(normalizeRoot)),
+    include: new Set(project.include),
   }));
   const configsPerRoot = new Map<string, number>();
   for (const node of nodes) {
@@ -84,6 +90,7 @@ export function computeCoveredConfigs(
     const isCovered = nodes.some(
       (other) =>
         other.configFilePath !== project.configFilePath &&
+        isSubset(project.include, other.include) &&
         ((rootIsUnique && other.children.has(project.root)) ||
           aggregatesNestedConfig(project, other)),
     );

--- a/packages/vscode/src/projectCoverage.ts
+++ b/packages/vscode/src/projectCoverage.ts
@@ -52,7 +52,11 @@ const aggregatesNestedConfig = (
 // the same files show up twice). Roots (own and child) are normalized here, so
 // callers may pass them raw. A config is covered when another config either:
 //   - aggregates this config's own root via `projects` (a leaf child). This is
-//     an explicit, unconditional signal, so no ancestry check is needed.
+//     only applied when the root uniquely identifies a single discovered
+//     config: when several configs share a directory (e.g. `rstest.config.ts`
+//     plus `rstest.e2e.config.ts`, with different `include`/`exclude`), a
+//     parent that aggregates only one of them must not hide the others, whose
+//     tests it does not render.
 //   - aggregates this config's own child roots (a nested intermediate config;
 //     see `aggregatesNestedConfig`). This is inferred from the flattened
 //     grandchildren, so it carries a tiebreak for the ambiguous equal-set case.
@@ -70,12 +74,17 @@ export function computeCoveredConfigs(
     root: normalizeRoot(project.root),
     children: new Set(project.childProjectRoots.map(normalizeRoot)),
   }));
+  const configsPerRoot = new Map<string, number>();
+  for (const node of nodes) {
+    configsPerRoot.set(node.root, (configsPerRoot.get(node.root) ?? 0) + 1);
+  }
   const covered = new Set<string>();
   for (const project of nodes) {
+    const rootIsUnique = configsPerRoot.get(project.root) === 1;
     const isCovered = nodes.some(
       (other) =>
         other.configFilePath !== project.configFilePath &&
-        (other.children.has(project.root) ||
+        ((rootIsUnique && other.children.has(project.root)) ||
           aggregatesNestedConfig(project, other)),
     );
     if (isCovered) {

--- a/packages/vscode/src/projectCoverage.ts
+++ b/packages/vscode/src/projectCoverage.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+
+// Normalize a project root to a stable key for coverage comparison. Core may
+// report roots with a trailing separator (e.g. `packages/core/`) while the
+// extension derives its own from a config file path without one.
+export const normalizeRoot = (root: string): string =>
+  path.normalize(root).replace(/[\\/]+$/, '');
+
+// Config files whose root is aggregated by *another* config via `projects`.
+// `childProjectRoots` are expected pre-normalized (see `normalizeRoot`).
+// Coverage from a config's own `projects` is ignored, since an aggregator's
+// inline children may share its own root (which would otherwise hide it).
+export function computeCoveredConfigs(
+  projects: {
+    configFilePath: string;
+    root: string;
+    childProjectRoots: string[];
+  }[],
+): Set<string> {
+  const covered = new Set<string>();
+  for (const project of projects) {
+    const ownRoot = normalizeRoot(project.root);
+    const isCovered = projects.some(
+      (other) =>
+        other.configFilePath !== project.configFilePath &&
+        other.childProjectRoots.includes(ownRoot),
+    );
+    if (isCovered) {
+      covered.add(project.configFilePath);
+    }
+  }
+  return covered;
+}

--- a/packages/vscode/src/projectCoverage.ts
+++ b/packages/vscode/src/projectCoverage.ts
@@ -1,10 +1,21 @@
 import path from 'node:path';
 
-// Normalize a project root to a stable key for coverage comparison. Core may
-// report roots with a trailing separator (e.g. `packages/core/`) while the
-// extension derives its own from a config file path without one.
-const normalizeRoot = (root: string): string =>
-  path.normalize(root).replace(/[\\/]+$/, '');
+export type ChildProjectRef = {
+  // The child's own config file, or null for an inline project.
+  configFilePath: string | null;
+  root: string | null;
+};
+
+// Normalize a reported path (a root directory or a config file) to a stable
+// comparison key. Core may report roots with a trailing separator (e.g.
+// `packages/core/`) while the extension derives its own from a config file
+// path without one; on Windows paths are case-insensitive and VS Code
+// lowercases drive letters in `Uri.fsPath` while core reports paths as the
+// process resolved them.
+const normalizePath = (value: string): string => {
+  const normalized = path.normalize(value).replace(/[\\/]+$/, '');
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+};
 
 const isSubset = (a: Set<string>, b: Set<string>): boolean => {
   if (a.size > b.size) {
@@ -19,83 +30,95 @@ const isSubset = (a: Set<string>, b: Set<string>): boolean => {
 };
 
 // Whether `ancestor` is a strict parent directory of `descendant`. Both are
-// expected pre-normalized (see `normalizeRoot`).
+// expected pre-normalized (see `normalizePath`).
 const isStrictAncestor = (ancestor: string, descendant: string): boolean => {
   const rel = path.relative(ancestor, descendant);
   // `rel === ''` covers the equal-path case (not a strict ancestor).
   return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
 };
 
+type Node = {
+  key: string;
+  configFilePath: string;
+  root: string;
+  footprint: Set<string>;
+  include: Set<string>;
+};
+
 // Whether `parent` aggregates a nested intermediate config `child`. `initCli`
-// flattens such a child to its grandchildren, so the child's own root never
-// appears in `parent`'s root list — but its grandchildren roots do. So the
-// child is covered when its own aggregated roots are a subset of the parent's.
-// When the two sets are equal (a parent that aggregates *only* this one nested
+// flattens such a child to its leaf projects, so the child's own config file
+// never appears in `parent`'s footprint — but its leaves do. So the child is
+// covered when its own footprint is a subset of the parent's. When the two
+// footprints are equal (a parent that aggregates *only* this one nested
 // child), the outer config — the one whose root is an ancestor — wins, so two
-// unrelated configs with identical roots never suppress each other (hiding
-// both).
-const aggregatesNestedConfig = (
-  child: { root: string; children: Set<string> },
-  parent: { root: string; children: Set<string> },
-): boolean => {
-  if (child.children.size === 0 || !isSubset(child.children, parent.children)) {
+// unrelated configs with identical footprints never suppress each other
+// (hiding both).
+const aggregatesNestedConfig = (child: Node, parent: Node): boolean => {
+  if (
+    child.footprint.size === 0 ||
+    !isSubset(child.footprint, parent.footprint)
+  ) {
     return false;
   }
   return (
-    parent.children.size > child.children.size ||
+    parent.footprint.size > child.footprint.size ||
     isStrictAncestor(parent.root, child.root)
   );
 };
 
 // Config files whose tests are already rendered by *another* config, so the
 // extension should not register them as their own top-level project (otherwise
-// the same files show up twice). Roots (own and child) are normalized here, so
-// callers may pass them raw. A config is covered when another config either:
-//   - aggregates this config's own root via `projects` (a leaf child). This is
-//     only applied when the root uniquely identifies a single discovered
-//     config: when several configs share a directory (e.g. `rstest.config.ts`
-//     plus `rstest.e2e.config.ts`, with different `include`/`exclude`), a
-//     parent that aggregates only one of them must not hide the others, whose
-//     tests it does not render.
-//   - aggregates this config's own child roots (a nested intermediate config;
-//     see `aggregatesNestedConfig`). This is inferred from the flattened
-//     grandchildren, so it carries a tiebreak for the ambiguous equal-set case.
+// the same files show up twice). Each project's `footprint` is the set of leaf
+// projects it runs, keyed by config file when the leaf has one and by root for
+// inline projects. A config is covered when another config either:
+//   - has this config's own file in its footprint (it directly aggregates this
+//     config as a leaf — exact identity, so a directory holding several
+//     configs is disambiguated for free);
+//   - aggregates this config's own leaves (a nested intermediate config, whose
+//     own file `initCli` flattens away; see `aggregatesNestedConfig`).
 // In both cases the parent must also be able to *display* the child's files:
 // in AST mode a project only globs its own `include`, so a child whose include
 // patterns the parent does not also match is kept visible (its tests would
 // otherwise vanish from the tree even though the aggregated run still executes
-// them). Coverage from a config's own `projects` is ignored, since an
-// aggregator's inline children may share its own root (which would hide it).
+// them). Returns the `key`s of the covered configs; `configFilePath` is only
+// match material.
 export function computeCoveredConfigs(
   projects: {
+    key: string;
     configFilePath: string;
     root: string;
-    childProjectRoots: string[];
+    childProjects: ChildProjectRef[];
     include: string[];
   }[],
 ): Set<string> {
-  const nodes = projects.map((project) => ({
-    configFilePath: project.configFilePath,
-    root: normalizeRoot(project.root),
-    children: new Set(project.childProjectRoots.map(normalizeRoot)),
-    include: new Set(project.include),
-  }));
-  const configsPerRoot = new Map<string, number>();
-  for (const node of nodes) {
-    configsPerRoot.set(node.root, (configsPerRoot.get(node.root) ?? 0) + 1);
-  }
+  const nodes = projects.map((project): Node => {
+    const footprint = new Set<string>();
+    for (const child of project.childProjects) {
+      if (child.configFilePath) {
+        footprint.add(normalizePath(child.configFilePath));
+      } else if (child.root) {
+        footprint.add(normalizePath(child.root));
+      }
+    }
+    return {
+      key: project.key,
+      configFilePath: normalizePath(project.configFilePath),
+      root: normalizePath(project.root),
+      footprint,
+      include: new Set(project.include),
+    };
+  });
   const covered = new Set<string>();
   for (const project of nodes) {
-    const rootIsUnique = configsPerRoot.get(project.root) === 1;
     const isCovered = nodes.some(
       (other) =>
-        other.configFilePath !== project.configFilePath &&
+        other !== project &&
         isSubset(project.include, other.include) &&
-        ((rootIsUnique && other.children.has(project.root)) ||
+        (other.footprint.has(project.configFilePath) ||
           aggregatesNestedConfig(project, other)),
     );
     if (isCovered) {
-      covered.add(project.configFilePath);
+      covered.add(project.key);
     }
   }
   return covered;

--- a/packages/vscode/src/terminal.ts
+++ b/packages/vscode/src/terminal.ts
@@ -1,0 +1,48 @@
+import vscode from 'vscode';
+
+// A single reused "Rstest" integrated terminal for the shell-terminal run mode.
+// The terminal is recreated when its shell options change or the user closed
+// it. Kept as a module singleton so runs from different projects share one
+// terminal, mirroring how `logger` is a shared output channel.
+let terminal: vscode.Terminal | undefined;
+let signature = '';
+
+export interface TerminalOptions {
+  cwd: string;
+  shellPath?: string;
+  shellArgs?: string[];
+}
+
+export function runInTerminal(command: string, options: TerminalOptions): void {
+  const sig = JSON.stringify(options);
+  // Dispose when the user closed it (exitStatus set) or the shell changed.
+  if (terminal && (terminal.exitStatus || signature !== sig)) {
+    terminal.dispose();
+    terminal = undefined;
+  }
+  if (!terminal) {
+    terminal = vscode.window.createTerminal({
+      name: 'Rstest',
+      cwd: options.cwd,
+      shellPath: options.shellPath || undefined,
+      shellArgs: options.shellArgs?.length ? options.shellArgs : undefined,
+    });
+    signature = sig;
+  }
+  terminal.show(true);
+  terminal.sendText(command);
+}
+
+export function disposeTerminal(): void {
+  terminal?.dispose();
+  terminal = undefined;
+}
+
+// POSIX single-quote quoting. Bare tokens (safe characters only) are left
+// as-is for readability; everything else is single-quoted so the shell does
+// not expand `$`, `^`, `(`, spaces, etc. in a `-t` pattern or a path.
+export function shellQuote(value: string): string {
+  if (value === '') return "''";
+  if (/^[A-Za-z0-9_./:@%+=-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/packages/vscode/src/worker/index.ts
+++ b/packages/vscode/src/worker/index.ts
@@ -62,15 +62,16 @@ export class Worker {
       root: rstest.context.normalizedConfig.root,
       include: rstest.context.normalizedConfig.include,
       exclude: rstest.context.normalizedConfig.exclude.patterns,
-      // Root directories of the sub-projects this config aggregates via
-      // `projects`. Empty for a leaf config. The extension uses these to avoid
-      // registering a child config as its own top-level project when a parent
-      // already covers it (otherwise the same test files show up twice). Roots
-      // are used rather than config-file paths so nested/inline projects (which
-      // have no own config file) are still matched.
-      projectRoots: projects
-        .map((project) => project.config.root)
-        .filter((root): root is string => Boolean(root)),
+      // Sub-projects this config aggregates via `projects`. Empty for a leaf
+      // config. The extension uses these to avoid registering a child config
+      // as its own top-level project when a parent already covers it
+      // (otherwise the same test files show up twice). A file-based child is
+      // identified by its config file; inline children only have a root.
+      // `null` (not `undefined`) so the fields survive the IPC JSON round-trip.
+      childProjects: projects.map((project) => ({
+        configFilePath: project.configFilePath ?? null,
+        root: project.config.root ?? null,
+      })),
     };
   }
 

--- a/packages/vscode/src/worker/index.ts
+++ b/packages/vscode/src/worker/index.ts
@@ -53,22 +53,31 @@ export class Worker {
       fileFilters ?? [],
     );
 
-    return rstest;
+    return { rstest, projects };
   }
 
   public async getNormalizedConfig(options: WorkerInitOptions) {
-    const rstest = await this.init(options);
+    const { rstest, projects } = await this.init(options);
     return {
       root: rstest.context.normalizedConfig.root,
       include: rstest.context.normalizedConfig.include,
       exclude: rstest.context.normalizedConfig.exclude.patterns,
+      // Root directories of the sub-projects this config aggregates via
+      // `projects`. Empty for a leaf config. The extension uses these to avoid
+      // registering a child config as its own top-level project when a parent
+      // already covers it (otherwise the same test files show up twice). Roots
+      // are used rather than config-file paths so nested/inline projects (which
+      // have no own config file) are still matched.
+      projectRoots: projects
+        .map((project) => project.config.root)
+        .filter((root): root is string => Boolean(root)),
     };
   }
 
   public async runTest(data: WorkerInitOptions) {
     logger.debug('Received runTest request', JSON.stringify(data, null, 2));
     try {
-      const rstest = await this.init(data);
+      const { rstest } = await this.init(data);
       if (data.coverage?.enabled) {
         rstest.context.normalizedConfig.coverage.reporters.push(
           new CoverageReporter(),
@@ -83,7 +92,7 @@ export class Worker {
   }
 
   public async listTests(data: WorkerInitOptions) {
-    const rstest = await this.init({ ...data, command: 'list' });
+    const { rstest } = await this.init({ ...data, command: 'list' });
     const res = await rstest.listTests({});
     return res;
   }

--- a/packages/vscode/tests/suite/uxCommands.test.ts
+++ b/packages/vscode/tests/suite/uxCommands.test.ts
@@ -56,5 +56,14 @@ suite('Editor / Test Explorer UX commands', () => {
       await vscode.env.clipboard.readText(),
       /expected 1 to equal 2/,
     );
+
+    // runInTerminal builds the real rstest command and opens a shell terminal;
+    // it must resolve the CLI and not throw.
+    await vscode.commands.executeCommand('rstest.runInTerminal', fileItem);
+    const terminal = await waitFor(() =>
+      vscode.window.terminals.find((candidate) => candidate.name === 'Rstest'),
+    );
+    assert.ok(terminal, 'a Rstest terminal should be created');
+    terminal.dispose();
   });
 });

--- a/packages/vscode/tests/unit/projectCoverage.test.ts
+++ b/packages/vscode/tests/unit/projectCoverage.test.ts
@@ -1,17 +1,32 @@
 import { describe, expect, it } from '@rstest/core';
-import { computeCoveredConfigs } from '../../src/projectCoverage';
+import {
+  type ChildProjectRef,
+  computeCoveredConfigs,
+} from '../../src/projectCoverage';
 
-// Roots are absolute in practice; use POSIX-looking paths for readability.
-// `include` defaults to a shared pattern so root/subset coverage is exercised
-// without the include guard getting in the way; pass a distinct one to exercise
-// the guard itself.
+// Paths are absolute in practice; use POSIX-looking paths for readability.
+// `include` defaults to a shared pattern so identity/footprint coverage is
+// exercised without the include guard getting in the way; pass a distinct one
+// to exercise the guard itself.
 const DEFAULT_INCLUDE = ['**/*.test.ts'];
+// The caller-side key is the config file path itself for readability (in the
+// extension it is a URI string).
 const p = (
   configFilePath: string,
   root: string,
-  childProjectRoots: string[] = [],
+  childProjects: ChildProjectRef[] = [],
   include: string[] = DEFAULT_INCLUDE,
-) => ({ configFilePath, root, childProjectRoots, include });
+) => ({ key: configFilePath, configFilePath, root, childProjects, include });
+// A file-based child project (has its own config file).
+const file = (configFilePath: string): ChildProjectRef => ({
+  configFilePath,
+  root: null,
+});
+// An inline child project (no config file of its own).
+const inline = (root: string): ChildProjectRef => ({
+  configFilePath: null,
+  root,
+});
 
 describe('computeCoveredConfigs', () => {
   it('suppresses child configs aggregated by a root config', () => {
@@ -19,11 +34,11 @@ describe('computeCoveredConfigs', () => {
     // package also has its own standalone config.
     const covered = computeCoveredConfigs([
       p('/repo/rstest.config.ts', '/repo', [
-        '/repo/packages/core',
-        '/repo/packages/dts',
-        '/repo/tests',
+        file('/repo/packages/core/rstest.config.ts'),
+        file('/repo/packages/dts/rstest.config.ts'),
+        file('/repo/tests/rstest.config.ts'),
       ]),
-      p('/repo/tests/rstest.config.ts', '/repo/tests', ['/repo/tests']),
+      p('/repo/tests/rstest.config.ts', '/repo/tests', [inline('/repo/tests')]),
       p('/repo/packages/core/rstest.config.ts', '/repo/packages/core'),
       p('/repo/packages/dts/rstest.config.ts', '/repo/packages/dts'),
     ]);
@@ -36,18 +51,6 @@ describe('computeCoveredConfigs', () => {
     ]);
   });
 
-  it('does not suppress a config via its own projects (self-coverage)', () => {
-    // A lone aggregator whose inline children share its own root must not hide
-    // itself.
-    const covered = computeCoveredConfigs([
-      p('/repo/tests/rstest.config.ts', '/repo/tests', [
-        '/repo/tests',
-        '/repo/tests',
-      ]),
-    ]);
-    expect(covered.size).toBe(0);
-  });
-
   it('keeps independent per-package configs when there is no aggregator', () => {
     const covered = computeCoveredConfigs([
       p('/repo/packages/a/rstest.config.ts', '/repo/packages/a'),
@@ -56,53 +59,74 @@ describe('computeCoveredConfigs', () => {
     expect(covered.size).toBe(0);
   });
 
-  it('suppresses a nested intermediate config the root also aggregates', () => {
-    // A root aggregates `sub` (which itself has `projects`) plus another
-    // project. `initCli` flattens `sub` to its grandchildren, so `sub`'s own
-    // root never appears in the root's list — but its grandchildren roots do.
+  it('does not suppress a lone aggregator of inline children', () => {
+    // A lone aggregator whose inline children share its own root must not hide
+    // itself.
+    const covered = computeCoveredConfigs([
+      p('/repo/tests/rstest.config.ts', '/repo/tests', [
+        inline('/repo/tests'),
+        inline('/repo/tests'),
+      ]),
+    ]);
+    expect(covered.size).toBe(0);
+  });
+
+  it('suppresses exactly the aggregated config when a directory has several', () => {
+    // `apps/web` has two standalone configs (e.g. different include/exclude),
+    // and the root aggregates only one of them by file. Only that file is
+    // covered; the other config keeps its own tests visible.
     const covered = computeCoveredConfigs([
       p('/repo/rstest.config.ts', '/repo', [
-        '/repo/sub/a',
-        '/repo/sub/b',
-        '/repo/other',
+        file('/repo/apps/web/rstest.config.ts'),
+      ]),
+      p('/repo/apps/web/rstest.config.ts', '/repo/apps/web'),
+      p('/repo/apps/web/rstest.e2e.config.ts', '/repo/apps/web'),
+    ]);
+    expect([...covered]).toEqual(['/repo/apps/web/rstest.config.ts']);
+  });
+
+  it('suppresses a nested intermediate config the root also aggregates', () => {
+    // A root aggregates `sub` (which itself has `projects`) plus another
+    // project. `initCli` flattens `sub` to its leaf projects, so `sub`'s own
+    // config file never appears in the root's child list — but its leaves do.
+    const covered = computeCoveredConfigs([
+      p('/repo/rstest.config.ts', '/repo', [
+        file('/repo/sub/a/rstest.config.ts'),
+        file('/repo/sub/b/rstest.config.ts'),
+        file('/repo/other/rstest.config.ts'),
       ]),
       p('/repo/sub/rstest.config.ts', '/repo/sub', [
-        '/repo/sub/a',
-        '/repo/sub/b',
+        file('/repo/sub/a/rstest.config.ts'),
+        file('/repo/sub/b/rstest.config.ts'),
       ]),
     ]);
     expect([...covered]).toEqual(['/repo/sub/rstest.config.ts']);
   });
 
   it('suppresses a nested config even when the root aggregates only it', () => {
-    // The root aggregates a single nested child, so both flatten to the same
-    // grandchildren. The outer (ancestor-root) config wins.
+    // The root aggregates a single nested child with inline leaves, so both
+    // flatten to the same footprint. The outer (ancestor-root) config wins.
     const covered = computeCoveredConfigs([
-      p('/repo/rstest.config.ts', '/repo', ['/repo/sub/a', '/repo/sub/b']),
+      p('/repo/rstest.config.ts', '/repo', [
+        inline('/repo/sub/a'),
+        inline('/repo/sub/b'),
+      ]),
       p('/repo/sub/rstest.config.ts', '/repo/sub', [
-        '/repo/sub/a',
-        '/repo/sub/b',
+        inline('/repo/sub/a'),
+        inline('/repo/sub/b'),
       ]),
     ]);
     expect([...covered]).toEqual(['/repo/sub/rstest.config.ts']);
   });
 
-  it('never lets two unrelated configs with identical roots hide each other', () => {
+  it('never lets two unrelated configs with identical footprints hide each other', () => {
     const covered = computeCoveredConfigs([
-      p('/repo/a/rstest.config.ts', '/repo/a', ['/shared/1', '/shared/2']),
-      p('/repo/b/rstest.config.ts', '/repo/b', ['/shared/1', '/shared/2']),
-    ]);
-    expect(covered.size).toBe(0);
-  });
-
-  it('does not suppress standalone configs sharing a root the parent aggregates', () => {
-    // `apps/web` has two standalone configs (e.g. different include/exclude).
-    // The root aggregates `apps/web` via only one of them, so a root-only check
-    // would hide the other config's tests. Neither may be suppressed.
-    const covered = computeCoveredConfigs([
-      p('/repo/rstest.config.ts', '/repo', ['/repo/apps/web']),
-      p('/repo/apps/web/rstest.config.ts', '/repo/apps/web'),
-      p('/repo/apps/web/rstest.e2e.config.ts', '/repo/apps/web'),
+      p('/repo/a/rstest.config.ts', '/repo/a', [
+        file('/shared/1/rstest.config.ts'),
+      ]),
+      p('/repo/b/rstest.config.ts', '/repo/b', [
+        file('/shared/1/rstest.config.ts'),
+      ]),
     ]);
     expect(covered.size).toBe(0);
   });
@@ -112,7 +136,9 @@ describe('computeCoveredConfigs', () => {
     // which the root's own include does not glob (AST mode). Suppressing it
     // would hide those tests, so the child stays visible.
     const covered = computeCoveredConfigs([
-      p('/repo/rstest.config.ts', '/repo', ['/repo/e2e']),
+      p('/repo/rstest.config.ts', '/repo', [
+        file('/repo/e2e/rstest.config.ts'),
+      ]),
       p('/repo/e2e/rstest.config.ts', '/repo/e2e', [], ['**/*.e2e.ts']),
     ]);
     expect(covered.size).toBe(0);
@@ -123,7 +149,7 @@ describe('computeCoveredConfigs', () => {
       p(
         '/repo/rstest.config.ts',
         '/repo',
-        ['/repo/pkg'],
+        [file('/repo/pkg/rstest.config.ts')],
         ['**/*.test.ts', '**/*.spec.ts'],
       ),
       p('/repo/pkg/rstest.config.ts', '/repo/pkg', [], ['**/*.test.ts']),
@@ -131,12 +157,20 @@ describe('computeCoveredConfigs', () => {
     expect([...covered]).toEqual(['/repo/pkg/rstest.config.ts']);
   });
 
-  it('matches a root reported with a trailing separator', () => {
+  it('normalizes reported paths before matching', () => {
     const covered = computeCoveredConfigs([
-      p('/repo/rstest.config.ts', '/repo', ['/repo/packages/core']),
-      // core's own root arrives with a trailing separator.
-      p('/repo/packages/core/rstest.config.ts', '/repo/packages/core/'),
+      p('/repo/rstest.config.ts', '/repo', [
+        // Child config file reported with a redundant segment.
+        file('/repo/packages/./core/rstest.config.ts'),
+        // Flattened inline leaf reported with a trailing separator.
+        inline('/repo/sub/a/'),
+      ]),
+      p('/repo/packages/core/rstest.config.ts', '/repo/packages/core'),
+      p('/repo/sub/rstest.config.ts', '/repo/sub', [inline('/repo/sub/a')]),
     ]);
-    expect([...covered]).toEqual(['/repo/packages/core/rstest.config.ts']);
+    expect([...covered].sort()).toEqual([
+      '/repo/packages/core/rstest.config.ts',
+      '/repo/sub/rstest.config.ts',
+    ]);
   });
 });

--- a/packages/vscode/tests/unit/projectCoverage.test.ts
+++ b/packages/vscode/tests/unit/projectCoverage.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from '@rstest/core';
 import { computeCoveredConfigs } from '../../src/projectCoverage';
 
 // Roots are absolute in practice; use POSIX-looking paths for readability.
+// `include` defaults to a shared pattern so root/subset coverage is exercised
+// without the include guard getting in the way; pass a distinct one to exercise
+// the guard itself.
+const DEFAULT_INCLUDE = ['**/*.test.ts'];
 const p = (
   configFilePath: string,
   root: string,
   childProjectRoots: string[] = [],
-) => ({ configFilePath, root, childProjectRoots });
+  include: string[] = DEFAULT_INCLUDE,
+) => ({ configFilePath, root, childProjectRoots, include });
 
 describe('computeCoveredConfigs', () => {
   it('suppresses child configs aggregated by a root config', () => {
@@ -100,6 +105,30 @@ describe('computeCoveredConfigs', () => {
       p('/repo/apps/web/rstest.e2e.config.ts', '/repo/apps/web'),
     ]);
     expect(covered.size).toBe(0);
+  });
+
+  it('keeps a child config whose include the parent does not match', () => {
+    // The root aggregates `e2e`, but the child matches only `**/*.e2e.ts`,
+    // which the root's own include does not glob (AST mode). Suppressing it
+    // would hide those tests, so the child stays visible.
+    const covered = computeCoveredConfigs([
+      p('/repo/rstest.config.ts', '/repo', ['/repo/e2e']),
+      p('/repo/e2e/rstest.config.ts', '/repo/e2e', [], ['**/*.e2e.ts']),
+    ]);
+    expect(covered.size).toBe(0);
+  });
+
+  it('suppresses a child whose include is a subset of the parent include', () => {
+    const covered = computeCoveredConfigs([
+      p(
+        '/repo/rstest.config.ts',
+        '/repo',
+        ['/repo/pkg'],
+        ['**/*.test.ts', '**/*.spec.ts'],
+      ),
+      p('/repo/pkg/rstest.config.ts', '/repo/pkg', [], ['**/*.test.ts']),
+    ]);
+    expect([...covered]).toEqual(['/repo/pkg/rstest.config.ts']);
   });
 
   it('matches a root reported with a trailing separator', () => {

--- a/packages/vscode/tests/unit/projectCoverage.test.ts
+++ b/packages/vscode/tests/unit/projectCoverage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from '@rstest/core';
+import { computeCoveredConfigs } from '../../src/projectCoverage';
+
+// Roots are absolute in practice; use POSIX-looking paths for readability.
+const p = (
+  configFilePath: string,
+  root: string,
+  childProjectRoots: string[] = [],
+) => ({ configFilePath, root, childProjectRoots });
+
+describe('computeCoveredConfigs', () => {
+  it('suppresses child configs aggregated by a root config', () => {
+    // Mirrors rslib: a root config aggregates packages/* and tests, while each
+    // package also has its own standalone config.
+    const covered = computeCoveredConfigs([
+      p('/repo/rstest.config.ts', '/repo', [
+        '/repo/packages/core',
+        '/repo/packages/dts',
+        '/repo/tests',
+      ]),
+      p('/repo/tests/rstest.config.ts', '/repo/tests', ['/repo/tests']),
+      p('/repo/packages/core/rstest.config.ts', '/repo/packages/core'),
+      p('/repo/packages/dts/rstest.config.ts', '/repo/packages/dts'),
+    ]);
+
+    // Only the aggregator root survives.
+    expect([...covered].sort()).toEqual([
+      '/repo/packages/core/rstest.config.ts',
+      '/repo/packages/dts/rstest.config.ts',
+      '/repo/tests/rstest.config.ts',
+    ]);
+  });
+
+  it('does not suppress a config via its own projects (self-coverage)', () => {
+    // A lone aggregator whose inline children share its own root must not hide
+    // itself.
+    const covered = computeCoveredConfigs([
+      p('/repo/tests/rstest.config.ts', '/repo/tests', [
+        '/repo/tests',
+        '/repo/tests',
+      ]),
+    ]);
+    expect(covered.size).toBe(0);
+  });
+
+  it('keeps independent per-package configs when there is no aggregator', () => {
+    const covered = computeCoveredConfigs([
+      p('/repo/packages/a/rstest.config.ts', '/repo/packages/a'),
+      p('/repo/packages/b/rstest.config.ts', '/repo/packages/b'),
+    ]);
+    expect(covered.size).toBe(0);
+  });
+
+  it('matches a root reported with a trailing separator', () => {
+    const covered = computeCoveredConfigs([
+      p('/repo/rstest.config.ts', '/repo', ['/repo/packages/core']),
+      // core's own root arrives with a trailing separator.
+      p('/repo/packages/core/rstest.config.ts', '/repo/packages/core/'),
+    ]);
+    expect([...covered]).toEqual(['/repo/packages/core/rstest.config.ts']);
+  });
+});

--- a/packages/vscode/tests/unit/projectCoverage.test.ts
+++ b/packages/vscode/tests/unit/projectCoverage.test.ts
@@ -90,6 +90,18 @@ describe('computeCoveredConfigs', () => {
     expect(covered.size).toBe(0);
   });
 
+  it('does not suppress standalone configs sharing a root the parent aggregates', () => {
+    // `apps/web` has two standalone configs (e.g. different include/exclude).
+    // The root aggregates `apps/web` via only one of them, so a root-only check
+    // would hide the other config's tests. Neither may be suppressed.
+    const covered = computeCoveredConfigs([
+      p('/repo/rstest.config.ts', '/repo', ['/repo/apps/web']),
+      p('/repo/apps/web/rstest.config.ts', '/repo/apps/web'),
+      p('/repo/apps/web/rstest.e2e.config.ts', '/repo/apps/web'),
+    ]);
+    expect(covered.size).toBe(0);
+  });
+
   it('matches a root reported with a trailing separator', () => {
     const covered = computeCoveredConfigs([
       p('/repo/rstest.config.ts', '/repo', ['/repo/packages/core']),

--- a/packages/vscode/tests/unit/projectCoverage.test.ts
+++ b/packages/vscode/tests/unit/projectCoverage.test.ts
@@ -51,6 +51,45 @@ describe('computeCoveredConfigs', () => {
     expect(covered.size).toBe(0);
   });
 
+  it('suppresses a nested intermediate config the root also aggregates', () => {
+    // A root aggregates `sub` (which itself has `projects`) plus another
+    // project. `initCli` flattens `sub` to its grandchildren, so `sub`'s own
+    // root never appears in the root's list — but its grandchildren roots do.
+    const covered = computeCoveredConfigs([
+      p('/repo/rstest.config.ts', '/repo', [
+        '/repo/sub/a',
+        '/repo/sub/b',
+        '/repo/other',
+      ]),
+      p('/repo/sub/rstest.config.ts', '/repo/sub', [
+        '/repo/sub/a',
+        '/repo/sub/b',
+      ]),
+    ]);
+    expect([...covered]).toEqual(['/repo/sub/rstest.config.ts']);
+  });
+
+  it('suppresses a nested config even when the root aggregates only it', () => {
+    // The root aggregates a single nested child, so both flatten to the same
+    // grandchildren. The outer (ancestor-root) config wins.
+    const covered = computeCoveredConfigs([
+      p('/repo/rstest.config.ts', '/repo', ['/repo/sub/a', '/repo/sub/b']),
+      p('/repo/sub/rstest.config.ts', '/repo/sub', [
+        '/repo/sub/a',
+        '/repo/sub/b',
+      ]),
+    ]);
+    expect([...covered]).toEqual(['/repo/sub/rstest.config.ts']);
+  });
+
+  it('never lets two unrelated configs with identical roots hide each other', () => {
+    const covered = computeCoveredConfigs([
+      p('/repo/a/rstest.config.ts', '/repo/a', ['/shared/1', '/shared/2']),
+      p('/repo/b/rstest.config.ts', '/repo/b', ['/shared/1', '/shared/2']),
+    ]);
+    expect(covered.size).toBe(0);
+  });
+
   it('matches a root reported with a trailing separator', () => {
     const covered = computeCoveredConfigs([
       p('/repo/rstest.config.ts', '/repo', ['/repo/packages/core']),

--- a/packages/vscode/tests/unit/terminal.test.ts
+++ b/packages/vscode/tests/unit/terminal.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, rs } from '@rstest/core';
+
+// terminal.ts imports `vscode` (used only inside functions), so a stub is enough
+// to load the module and exercise the pure `shellQuote`.
+rs.mock('vscode', () => ({ default: {} }));
+
+import { shellQuote } from '../../src/terminal';
+
+describe('shellQuote', () => {
+  it('leaves safe tokens unquoted', () => {
+    expect(shellQuote('run')).toBe('run');
+    expect(shellQuote('--coverage')).toBe('--coverage');
+    expect(shellQuote('src/foo.test.ts')).toBe('src/foo.test.ts');
+  });
+
+  it('single-quotes values with shell-significant characters', () => {
+    // A `-t` pattern must not be expanded by the shell.
+    expect(shellQuote('^CLI options applies overrides$')).toBe(
+      "'^CLI options applies overrides$'",
+    );
+    expect(shellQuote('a b')).toBe("'a b'");
+    expect(shellQuote('$HOME')).toBe("'$HOME'");
+  });
+
+  it('escapes embedded single quotes', () => {
+    expect(shellQuote("it's ok")).toBe("'it'\\''s ok'");
+  });
+
+  it('quotes the empty string', () => {
+    expect(shellQuote('')).toBe("''");
+  });
+});


### PR DESCRIPTION
## Summary

Two VS Code extension improvements:

- **Run in Terminal**: a new command on the test item and gutter context menus that builds the real `rstest` CLI command for the selected file / suite / case and runs it in a reused integrated terminal. This makes the exact command and its raw output visible, and lets users copy or re-run it manually. The command mirrors the in-editor run's test-name pattern so it selects the same case, and honors two new settings, `rstest.terminalShellPath` / `rstest.terminalShellArgs` (empty falls back to the default integrated terminal so its profile/env are honored). Argument quoting is POSIX single-quote style; the settings note the Windows caveat.

- **Dedup aggregated projects**: the extension discovers every `rstest.config.*` as a top-level project, but a parent config can aggregate the same sub-projects via `projects`, so the same test file appeared twice (e.g. once under the aggregator and once under a package's own config), including duplicate gutter/Test Explorer entries. The worker's `getNormalizedConfig` now reports the roots a config aggregates; a project whose root is covered by **another** project is suppressed (its watcher stopped and its items not rendered). Coverage is keyed by normalized root directory rather than config-file path so nested/inline projects that have no own config file are matched too, and self-coverage is excluded so a lone aggregator whose inline children share its root is not hidden.

Shared helpers were extracted to keep the terminal command and the worker run consistent (test-name pattern, node command, `@rstest/core` package.json resolution).

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).