### PR TITLE
feat(browser): support globalSetup for browser projects

### DIFF
--- a/e2e/browser-mode/fixtures/browser-global-setup-error/globalSetup.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-error/globalSetup.ts
@@ -1,0 +1,3 @@
+export default async function globalSetup() {
+  throw new Error('Global setup failed intentionally');
+}

--- a/e2e/browser-mode/fixtures/browser-global-setup-error/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-error/rstest.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS, BROWSER_TEST_TIMEOUT } from '../ports';
+
+// Phase 5 step 5 gate: a failing `globalSetup` in a browser-only run must
+// fail the run before any browser test executes, matching node semantics.
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS['browser-global-setup-error'],
+  },
+  include: ['tests/**/*.test.ts'],
+  testTimeout: BROWSER_TEST_TIMEOUT,
+  globalSetup: ['./globalSetup.ts'],
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup-error/tests/notRun.test.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-error/tests/notRun.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+it('must not run when globalSetup fails', () => {
+  console.log('This should not be printed');
+  expect(true).toBe(true);
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/globalSetup.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/globalSetup.ts
@@ -1,0 +1,9 @@
+export default async function globalSetup() {
+  console.log('[mixed-browser-global-setup] executed');
+
+  process.env.RSTEST_E2E_GS_BROWSER = 'from-browser-setup';
+
+  return async function globalTeardown() {
+    console.log('[mixed-browser-global-teardown] executed');
+  };
+}

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/rstest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS, BROWSER_TEST_TIMEOUT } from '../../ports';
+
+export default defineConfig({
+  name: 'project-browser',
+  include: ['tests/**/*.test.ts'],
+  testTimeout: BROWSER_TEST_TIMEOUT,
+  globalSetup: ['./globalSetup.ts'],
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS['browser-global-setup-mixed'],
+  },
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/tests/browserOnly.test.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/tests/browserOnly.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+it('reads the browser project globalSetup env change', () => {
+  expect(import.meta.env.RSTEST_E2E_GS_BROWSER).toBe('from-browser-setup');
+  expect(process.env.RSTEST_E2E_GS_BROWSER).toBe('from-browser-setup');
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/globalSetup.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/globalSetup.ts
@@ -1,0 +1,9 @@
+export default async function globalSetup() {
+  console.log('[mixed-node-global-setup] executed');
+
+  process.env.RSTEST_E2E_GS_NODE = 'from-node-setup';
+
+  return async function globalTeardown() {
+    console.log('[mixed-node-global-teardown] executed');
+  };
+}

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/rstest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  name: 'project-node',
+  include: ['tests/**/*.test.ts'],
+  globalSetup: ['./globalSetup.ts'],
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/tests/node.test.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/tests/node.test.ts
@@ -1,0 +1,5 @@
+import { expect, it } from '@rstest/core';
+
+it('reads the node project globalSetup env change', () => {
+  expect(process.env.RSTEST_E2E_GS_NODE).toBe('from-node-setup');
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/rstest.config.mts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rstest/core';
+
+// Phase 5 step 5 gate: in a mixed run each project's own `globalSetup` runs,
+// the node test reads its var via `process.env`, and the browser test reads
+// its var via `import.meta.env`. The browser test file lives at a filterable
+// path so a CLI file filter can select only the browser side (regression gate
+// for the mixed-path global teardown drain when no node tests run).
+export default defineConfig({
+  projects: [
+    './project-node/rstest.config.mts',
+    './project-browser/rstest.config.mts',
+  ],
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup/globalSetup.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/globalSetup.ts
@@ -1,0 +1,11 @@
+export default async function globalSetup() {
+  console.log('[browser-global-setup] executed');
+
+  process.env.RSTEST_E2E_GS = 'from-global-setup';
+  // The fixture config sets this key via `test.env`; config must win.
+  process.env.RSTEST_E2E_GS_OVERRIDE = 'from-setup';
+
+  return async function globalTeardown() {
+    console.log('[browser-global-teardown] executed');
+  };
+}

--- a/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS, BROWSER_TEST_TIMEOUT } from '../ports';
+
+// Phase 5 step 5 gate: a browser-only run must execute `globalSetup` on the
+// host and propagate its `process.env` changes into the browser runtime env
+// store, with explicit `test.env` config still taking precedence.
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS['browser-global-setup'],
+  },
+  include: ['tests/**/*.test.ts'],
+  testTimeout: BROWSER_TEST_TIMEOUT,
+  globalSetup: ['./globalSetup.ts'],
+  env: {
+    RSTEST_E2E_GS_OVERRIDE: 'from-config',
+  },
+});

--- a/e2e/browser-mode/fixtures/browser-global-setup/tests/globalSetup.test.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/tests/globalSetup.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@rstest/core';
+
+describe('browser globalSetup env propagation', () => {
+  it('reads env changes made by globalSetup on the host', () => {
+    console.log('[browser-global-setup-test] running');
+
+    expect(import.meta.env.RSTEST_E2E_GS).toBe('from-global-setup');
+    expect(process.env.RSTEST_E2E_GS).toBe('from-global-setup');
+  });
+
+  it('keeps explicit test.env config precedence over globalSetup changes', () => {
+    expect(import.meta.env.RSTEST_E2E_GS_OVERRIDE).toBe('from-config');
+    expect(process.env.RSTEST_E2E_GS_OVERRIDE).toBe('from-config');
+  });
+
+  it('keeps the built-in static env values', () => {
+    expect(import.meta.env.NODE_ENV).toBe('test');
+    expect(process.env.RSTEST).toBe('true');
+  });
+});

--- a/e2e/browser-mode/fixtures/ports.ts
+++ b/e2e/browser-mode/fixtures/ports.ts
@@ -40,6 +40,9 @@ export const BROWSER_PORTS = {
   'no-tests-reporters': 5244,
   'browser-empty-project': 5248,
   'browser-collect-timeout': 5250,
+  'browser-global-setup': 5252,
+  'browser-global-setup-error': 5254,
+  'browser-global-setup-mixed': 5256,
 } as const;
 
 const browserPortValues = Object.values(BROWSER_PORTS);

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@rstest/core';
+import { runBrowserCli } from './utils';
+
+// Phase 5 step 5 gate (red-first): browser projects must run `globalSetup` on
+// the host — today the browser path never compiles nor executes it — and the
+// post-setup `process.env` change-set must be propagated into the browser
+// runtime env store (readable via `process.env` / `import.meta.env`), with
+// explicit `test.env` config still winning over globalSetup mutations.
+describe('browser mode - globalSetup', () => {
+  it('runs globalSetup, propagates env into browser tests, and tears down in order', async () => {
+    const { cli, expectExecSuccess } = await runBrowserCli(
+      'browser-global-setup',
+    );
+
+    await expectExecSuccess();
+
+    const setupIndex = cli.stdout.indexOf('[browser-global-setup] executed');
+    const testIndex = cli.stdout.indexOf('[browser-global-setup-test] running');
+    const teardownIndex = cli.stdout.indexOf(
+      '[browser-global-teardown] executed',
+    );
+
+    // Setup runs before any browser test output, teardown after all of it.
+    expect(setupIndex).toBeGreaterThanOrEqual(0);
+    expect(testIndex).toBeGreaterThan(setupIndex);
+    expect(teardownIndex).toBeGreaterThan(testIndex);
+  });
+
+  it('fails the run before tests when globalSetup throws', async () => {
+    const { cli, expectExecFailed, expectStderrLog } = await runBrowserCli(
+      'browser-global-setup-error',
+    );
+
+    await expectExecFailed();
+
+    expectStderrLog(/Global setup failed intentionally/);
+    expect(cli.log).not.toContain('This should not be printed');
+  });
+
+  it('runs each project globalSetup in a mixed node + browser run', async () => {
+    const { cli, expectExecSuccess } = await runBrowserCli(
+      'browser-global-setup-mixed',
+    );
+
+    await expectExecSuccess();
+
+    expect(cli.stdout).toContain('[mixed-node-global-setup] executed');
+    expect(cli.stdout).toContain('[mixed-browser-global-setup] executed');
+    expect(cli.stdout).toContain('[mixed-node-global-teardown] executed');
+    expect(cli.stdout).toContain('[mixed-browser-global-teardown] executed');
+    expect(cli.stdout).toMatch(/Tests.*2 passed/);
+  });
+
+  it('drains global teardown on the mixed path when a file filter selects only the browser project', async () => {
+    // With no node tests to run, the node executor is never constructed, so the
+    // teardown drain must live in core — otherwise the setup's IPC child leaks
+    // and the process hangs (the awaited exec would time out here).
+    const { cli, expectExecSuccess } = await runBrowserCli(
+      'browser-global-setup-mixed',
+      { args: ['project-browser/tests/browserOnly.test.ts'] },
+    );
+
+    await expectExecSuccess();
+
+    expect(cli.stdout).toContain('[mixed-browser-global-setup] executed');
+    expect(cli.stdout).toContain('[mixed-browser-global-teardown] executed');
+    // The node project matches no running tests, so its globalSetup must not run.
+    expect(cli.stdout).not.toContain('[mixed-node-global-setup] executed');
+  });
+});

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -28,7 +28,8 @@ describe('browser mode - globalSetup', () => {
 
   it('skips globalSetup when the shard slice has no files for the project', async () => {
     // The fixture has a single test file: shard 2/2 is deterministically
-    // empty, so the stage must not run setup (or queue teardown) for it.
+    // empty, so the stage must not run setup (or queue teardown) for it —
+    // and the browser cycle must honor the same shard and run no tests.
     const { cli } = await runBrowserCli('browser-global-setup', {
       args: ['--shard=2/2'],
     });
@@ -37,6 +38,7 @@ describe('browser mode - globalSetup', () => {
 
     expect(cli.stdout).not.toContain('[browser-global-setup] executed');
     expect(cli.stdout).not.toContain('[browser-global-teardown] executed');
+    expect(cli.stdout).not.toContain('[browser-global-setup-test] running');
   });
 
   it('fails the run before tests when globalSetup throws', async () => {

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -26,6 +26,19 @@ describe('browser mode - globalSetup', () => {
     expect(teardownIndex).toBeGreaterThan(testIndex);
   });
 
+  it('skips globalSetup when the shard slice has no files for the project', async () => {
+    // The fixture has a single test file: shard 2/2 is deterministically
+    // empty, so the stage must not run setup (or queue teardown) for it.
+    const { cli } = await runBrowserCli('browser-global-setup', {
+      args: ['--shard=2/2'],
+    });
+
+    await cli.exec;
+
+    expect(cli.stdout).not.toContain('[browser-global-setup] executed');
+    expect(cli.stdout).not.toContain('[browser-global-teardown] executed');
+  });
+
   it('fails the run before tests when globalSetup throws', async () => {
     const { cli, expectExecFailed, expectStderrLog } = await runBrowserCli(
       'browser-global-setup-error',

--- a/packages/browser/src/browserExecutor.ts
+++ b/packages/browser/src/browserExecutor.ts
@@ -95,6 +95,7 @@ export async function createBrowserExecutor(
         allowEmptyRun,
         appliedModifyRstestConfigEnvironments,
         onTraceEvents: opts.onTraceEvents,
+        env: opts.env,
       });
       inFlightCycle = cycle;
       try {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -2105,6 +2105,7 @@ export const runBrowserController = async (
     allowEmptyRun = false,
     filesOnly = false,
     onTraceEvents,
+    env,
   } = options ?? {};
   const buildStart = Date.now();
   // Non-watch vs watch is the live switch for self-finalize: in non-watch runs
@@ -2533,7 +2534,10 @@ export const runBrowserController = async (
       environmentName: project.environmentName,
       projectRoot: normalize(project.rootPath),
       runtimeConfig: serializableConfig(
-        projectRuntimeConfig(project, { envMode: 'static' }),
+        // `env` is the post-globalSetup change-set from the core pre-cycle
+        // stage; the projection layers it between the static base and the
+        // user `test.env` config.
+        projectRuntimeConfig(project, { envMode: 'static', env }),
       ),
       viewport: project.normalizedConfig.browser.viewport,
     }),

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -2537,7 +2537,7 @@ export const runBrowserController = async (
         // `env` is the post-globalSetup change-set from the core pre-cycle
         // stage; the projection layers it between the static base and the
         // user `test.env` config.
-        projectRuntimeConfig(project, { envMode: 'static', env }),
+        projectRuntimeConfig(project, { envMode: 'static', envOverlay: env }),
       ),
       viewport: project.normalizedConfig.browser.viewport,
     }),

--- a/packages/core/src/core/browserGlobalSetup.ts
+++ b/packages/core/src/core/browserGlobalSetup.ts
@@ -1,0 +1,197 @@
+import { createRsbuild, logger as RsbuildLogger } from '@rsbuild/core';
+import type { EntryInfo, ProjectContext, RstestContext } from '../types';
+import { isDebug } from '../utils';
+import { getSetupFiles } from '../utils/getSetupFiles';
+import { claimGlobalSetupOnce, runProjectGlobalSetup } from './globalSetup';
+import { getRsbuildEnvironmentConfig } from './modifyRstestConfig';
+import { pluginBasic } from './plugins/basic';
+import { pluginEntryWatch } from './plugins/entry';
+import { pluginExternal } from './plugins/external';
+import { pluginIgnoreResolveError } from './plugins/ignoreResolveError';
+import { pluginMockRuntime } from './plugins/mockRuntime';
+import { getProjectEntries } from './projectPlan';
+import { createRsbuildServer } from './rsbuild';
+
+export type BrowserGlobalSetupStageResult = {
+  /**
+   * Merged env change-set the browser projects' globalSetup applied to the
+   * host `process.env` (later projects win). `undefined` when no setup ran,
+   * so the browser wire stays byte-identical to a run without globalSetup.
+   */
+  env?: Record<string, string | undefined>;
+  /** Setup failures; when non-empty the browser cycle must be skipped. */
+  errors: Error[];
+};
+
+const emptyEntries = async () => ({});
+
+/**
+ * Core-owned pre-cycle globalSetup stage for browser projects.
+ *
+ * Browser projects never flow through the node Rsbuild instance, so their
+ * `globalSetup` files get a dedicated one-shot node-target compile here —
+ * created only when a browser project both declares `globalSetup` and has at
+ * least one test entry (the cold-start gate stays intact for everyone else).
+ * Setups run host-side in the same forked worker node projects use; teardown
+ * callbacks queue into the shared `runGlobalTeardown` drain.
+ *
+ * Known restriction: browser `modifyRstestConfig` hooks apply later (inside
+ * the browser run cycle), so hook-added `globalSetup` entries or hook-added
+ * test files in an otherwise-empty project are invisible to this stage.
+ *
+ * Known limitation: browser projects share one run cycle, so any project's
+ * setup failure skips the whole browser cycle (node isolates failures per
+ * project). Exit code and error reporting still surface the failure.
+ */
+export async function runBrowserGlobalSetupStage(
+  context: RstestContext,
+  browserProjects: ProjectContext[],
+): Promise<BrowserGlobalSetupStageResult> {
+  const candidates: { project: ProjectContext; entryCount: number }[] = [];
+  for (const project of browserProjects) {
+    if (!project.normalizedConfig.globalSetup.length || project._globalSetups) {
+      continue;
+    }
+    // Same "no running tests -> no globalSetup" gate as the node path,
+    // honoring include/exclude and CLI file filters.
+    const entries = await getProjectEntries({ context, project });
+    const entryCount = Object.keys(entries).length;
+    if (entryCount > 0) {
+      candidates.push({ project, entryCount });
+    }
+  }
+
+  if (candidates.length === 0) {
+    return { errors: [] };
+  }
+
+  const globalSetupFiles: Record<string, Record<string, string>> = {};
+  for (const { project } of candidates) {
+    globalSetupFiles[project.environmentName] = getSetupFiles(
+      project.normalizedConfig.globalSetup,
+      project.rootPath,
+    );
+  }
+
+  const { dev = {} } = context.normalizedConfig;
+  const debugMode = isDebug();
+  RsbuildLogger.level = debugMode ? 'verbose' : 'error';
+
+  // Same plugin set the node-target related-test graph build uses; entries are
+  // fed exclusively from `globalSetupFiles` (source/setup maps stay empty), so
+  // the compile covers the globalSetup files exactly. Pool- and
+  // instrumentation-only plugins (cache control, inspect, coverage) are
+  // omitted — globalSetup files are coverage-excluded on the node path too.
+  const rsbuildInstance = await createRsbuild({
+    callerName: 'rstest',
+    config: {
+      root: context.rootPath,
+      server: {
+        printUrls: false,
+        strictPort: false,
+        middlewareMode: true,
+        compress: false,
+        cors: false,
+        publicDir: false,
+      },
+      dev: {
+        hmr: false,
+        writeToDisk: dev.writeToDisk || debugMode,
+      },
+      environments: Object.fromEntries(
+        candidates.map(({ project }) => [
+          project.environmentName,
+          getRsbuildEnvironmentConfig(project),
+        ]),
+      ),
+      plugins: [
+        pluginBasic(context),
+        pluginIgnoreResolveError,
+        pluginMockRuntime,
+        pluginEntryWatch({
+          globTestSourceEntries: emptyEntries,
+          setupFiles: {},
+          globalSetupFiles,
+          context,
+          isWatch: false,
+        }),
+        pluginExternal(context),
+      ],
+    },
+  });
+
+  const { getRsbuildStats, closeServer } = await createRsbuildServer({
+    isWatchMode: false,
+    rsbuildInstance,
+    globTestSourceEntries: emptyEntries,
+    setupFiles: {},
+    globalSetupFiles,
+    rootPath: context.rootPath,
+  });
+
+  // Materialize compiled assets before closing the server so no compiler
+  // lingers while user setup code runs.
+  const prepared: {
+    project: ProjectContext;
+    entryCount: number;
+    globalSetupEntries: EntryInfo[];
+    assetFiles: Record<string, string>;
+    sourceMaps: Record<string, string>;
+  }[] = [];
+  try {
+    for (const { project, entryCount } of candidates) {
+      const { globalSetupEntries, getAssetFiles, getSourceMaps } =
+        await getRsbuildStats({
+          environmentName: project.environmentName,
+        });
+      const files = globalSetupEntries.flatMap((e) => e.files!);
+      const [assetFiles, sourceMaps] = await Promise.all([
+        getAssetFiles(files),
+        getSourceMaps(files),
+      ]);
+      prepared.push({
+        project,
+        entryCount,
+        globalSetupEntries,
+        assetFiles,
+        sourceMaps,
+      });
+    }
+  } finally {
+    await closeServer();
+  }
+
+  const envOverlay: Record<string, string | undefined> = {};
+  const errors: Error[] = [];
+  let ranAnySetup = false;
+
+  for (const item of prepared) {
+    if (
+      !claimGlobalSetupOnce(
+        item.project,
+        item.entryCount,
+        item.globalSetupEntries.length,
+      )
+    ) {
+      continue;
+    }
+    const {
+      success,
+      errors: setupErrors,
+      envChanges,
+    } = await runProjectGlobalSetup({
+      project: item.project,
+      globalSetupEntries: item.globalSetupEntries,
+      getAssetFiles: async () => item.assetFiles,
+      getSourceMaps: async () => item.sourceMaps,
+    });
+    if (success) {
+      ranAnySetup = true;
+      Object.assign(envOverlay, envChanges);
+    } else {
+      errors.push(...(setupErrors ?? []));
+    }
+  }
+
+  return { env: ranAnySetup ? envOverlay : undefined, errors };
+}

--- a/packages/core/src/core/browserGlobalSetup.ts
+++ b/packages/core/src/core/browserGlobalSetup.ts
@@ -5,7 +5,7 @@ import type {
   ProjectEntries,
   RstestContext,
 } from '../types';
-import { isDebug } from '../utils';
+import { isDebug, resolveShardedEntries } from '../utils';
 import { claimGlobalSetupOnce, runGlobalSetup } from './globalSetup';
 import { getRsbuildEnvironmentConfig } from './modifyRstestConfig';
 import { pluginBasic } from './plugins/basic';
@@ -53,12 +53,23 @@ export async function runBrowserGlobalSetupStage(
   browserProjects: ProjectContext[],
   options?: {
     /**
-     * Plan-resolved entries (mixed path) so the "no running tests -> no
-     * globalSetup" gate reuses the plan's glob instead of re-walking the fs.
+     * Plan-resolved (already shard-narrowed) entries from the mixed path so
+     * the "no running tests -> no globalSetup" gate reuses the plan's glob
+     * instead of re-walking the fs.
      */
     entriesCache?: Map<string, ProjectEntries>;
   },
 ): Promise<BrowserGlobalSetupStageResult> {
+  // Gate source, shard-aware in every run shape: the mixed path passes the
+  // plan's shard-narrowed cache; browser-only runs resolve the same sharded
+  // map the browser controller will use, so a project whose shard slice is
+  // empty never runs its globalSetup. When a map exists it is authoritative
+  // (absent project -> zero entries); only unsharded browser-only runs fall
+  // back to the per-project glob.
+  const gateEntries =
+    options?.entriesCache ??
+    (await resolveShardedEntries(context, { silent: true }));
+
   const candidates = (
     await Promise.all(
       browserProjects.map(async (project) => {
@@ -69,10 +80,10 @@ export async function runBrowserGlobalSetupStage(
           return undefined;
         }
         // Same "no running tests -> no globalSetup" gate as the node path,
-        // honoring include/exclude and CLI file filters.
-        const entries =
-          options?.entriesCache?.get(project.environmentName)?.entries ??
-          (await getProjectEntries({ context, project }));
+        // honoring include/exclude, CLI file filters, and sharding.
+        const entries = gateEntries
+          ? (gateEntries.get(project.environmentName)?.entries ?? {})
+          : await getProjectEntries({ context, project });
         const entryCount = Object.keys(entries).length;
         return entryCount > 0 ? { project, entryCount } : undefined;
       }),

--- a/packages/core/src/core/browserGlobalSetup.ts
+++ b/packages/core/src/core/browserGlobalSetup.ts
@@ -1,8 +1,12 @@
 import { createRsbuild, logger as RsbuildLogger } from '@rsbuild/core';
-import type { EntryInfo, ProjectContext, RstestContext } from '../types';
+import type {
+  EntryInfo,
+  ProjectContext,
+  ProjectEntries,
+  RstestContext,
+} from '../types';
 import { isDebug } from '../utils';
-import { getSetupFiles } from '../utils/getSetupFiles';
-import { claimGlobalSetupOnce, runProjectGlobalSetup } from './globalSetup';
+import { claimGlobalSetupOnce, runGlobalSetup } from './globalSetup';
 import { getRsbuildEnvironmentConfig } from './modifyRstestConfig';
 import { pluginBasic } from './plugins/basic';
 import { pluginEntryWatch } from './plugins/entry';
@@ -10,7 +14,8 @@ import { pluginExternal } from './plugins/external';
 import { pluginIgnoreResolveError } from './plugins/ignoreResolveError';
 import { pluginMockRuntime } from './plugins/mockRuntime';
 import { getProjectEntries } from './projectPlan';
-import { createRsbuildServer } from './rsbuild';
+import { createRsbuildServer, hostServerConfig } from './rsbuild';
+import { createSetupFileState } from './setupFileState';
 
 export type BrowserGlobalSetupStageResult = {
   /**
@@ -46,54 +51,58 @@ const emptyEntries = async () => ({});
 export async function runBrowserGlobalSetupStage(
   context: RstestContext,
   browserProjects: ProjectContext[],
+  options?: {
+    /**
+     * Plan-resolved entries (mixed path) so the "no running tests -> no
+     * globalSetup" gate reuses the plan's glob instead of re-walking the fs.
+     */
+    entriesCache?: Map<string, ProjectEntries>;
+  },
 ): Promise<BrowserGlobalSetupStageResult> {
-  const candidates: { project: ProjectContext; entryCount: number }[] = [];
-  for (const project of browserProjects) {
-    if (!project.normalizedConfig.globalSetup.length || project._globalSetups) {
-      continue;
-    }
-    // Same "no running tests -> no globalSetup" gate as the node path,
-    // honoring include/exclude and CLI file filters.
-    const entries = await getProjectEntries({ context, project });
-    const entryCount = Object.keys(entries).length;
-    if (entryCount > 0) {
-      candidates.push({ project, entryCount });
-    }
-  }
+  const candidates = (
+    await Promise.all(
+      browserProjects.map(async (project) => {
+        if (
+          !project.normalizedConfig.globalSetup.length ||
+          project._globalSetups
+        ) {
+          return undefined;
+        }
+        // Same "no running tests -> no globalSetup" gate as the node path,
+        // honoring include/exclude and CLI file filters.
+        const entries =
+          options?.entriesCache?.get(project.environmentName)?.entries ??
+          (await getProjectEntries({ context, project }));
+        const entryCount = Object.keys(entries).length;
+        return entryCount > 0 ? { project, entryCount } : undefined;
+      }),
+    )
+  ).filter((candidate) => candidate !== undefined);
 
   if (candidates.length === 0) {
     return { errors: [] };
   }
 
-  const globalSetupFiles: Record<string, Record<string, string>> = {};
-  for (const { project } of candidates) {
-    globalSetupFiles[project.environmentName] = getSetupFiles(
-      project.normalizedConfig.globalSetup,
-      project.rootPath,
-    );
-  }
+  const setupFileState = createSetupFileState();
+  setupFileState.refresh({
+    setupProjects: [],
+    globalSetupProjects: candidates.map(({ project }) => project),
+  });
 
   const { dev = {} } = context.normalizedConfig;
   const debugMode = isDebug();
   RsbuildLogger.level = debugMode ? 'verbose' : 'error';
 
   // Same plugin set the node-target related-test graph build uses; entries are
-  // fed exclusively from `globalSetupFiles` (source/setup maps stay empty), so
-  // the compile covers the globalSetup files exactly. Pool- and
+  // fed exclusively from the globalSetup file map (source/setup maps stay
+  // empty), so the compile covers the globalSetup files exactly. Pool- and
   // instrumentation-only plugins (cache control, inspect, coverage) are
   // omitted — globalSetup files are coverage-excluded on the node path too.
   const rsbuildInstance = await createRsbuild({
     callerName: 'rstest',
     config: {
       root: context.rootPath,
-      server: {
-        printUrls: false,
-        strictPort: false,
-        middlewareMode: true,
-        compress: false,
-        cors: false,
-        publicDir: false,
-      },
+      server: { ...hostServerConfig },
       dev: {
         hmr: false,
         writeToDisk: dev.writeToDisk || debugMode,
@@ -110,8 +119,8 @@ export async function runBrowserGlobalSetupStage(
         pluginMockRuntime,
         pluginEntryWatch({
           globTestSourceEntries: emptyEntries,
-          setupFiles: {},
-          globalSetupFiles,
+          setupFiles: setupFileState.setupFiles,
+          globalSetupFiles: setupFileState.globalSetupFiles,
           context,
           isWatch: false,
         }),
@@ -124,39 +133,41 @@ export async function runBrowserGlobalSetupStage(
     isWatchMode: false,
     rsbuildInstance,
     globTestSourceEntries: emptyEntries,
-    setupFiles: {},
-    globalSetupFiles,
+    setupFiles: setupFileState.setupFiles,
+    globalSetupFiles: setupFileState.globalSetupFiles,
     rootPath: context.rootPath,
   });
 
   // Materialize compiled assets before closing the server so no compiler
   // lingers while user setup code runs.
-  const prepared: {
+  let prepared: {
     project: ProjectContext;
     entryCount: number;
     globalSetupEntries: EntryInfo[];
     assetFiles: Record<string, string>;
     sourceMaps: Record<string, string>;
-  }[] = [];
+  }[];
   try {
-    for (const { project, entryCount } of candidates) {
-      const { globalSetupEntries, getAssetFiles, getSourceMaps } =
-        await getRsbuildStats({
-          environmentName: project.environmentName,
-        });
-      const files = globalSetupEntries.flatMap((e) => e.files!);
-      const [assetFiles, sourceMaps] = await Promise.all([
-        getAssetFiles(files),
-        getSourceMaps(files),
-      ]);
-      prepared.push({
-        project,
-        entryCount,
-        globalSetupEntries,
-        assetFiles,
-        sourceMaps,
-      });
-    }
+    prepared = await Promise.all(
+      candidates.map(async ({ project, entryCount }) => {
+        const { globalSetupEntries, getAssetFiles, getSourceMaps } =
+          await getRsbuildStats({
+            environmentName: project.environmentName,
+          });
+        const files = globalSetupEntries.flatMap((e) => e.files!);
+        const [assetFiles, sourceMaps] = await Promise.all([
+          getAssetFiles(files),
+          getSourceMaps(files),
+        ]);
+        return {
+          project,
+          entryCount,
+          globalSetupEntries,
+          assetFiles,
+          sourceMaps,
+        };
+      }),
+    );
   } finally {
     await closeServer();
   }
@@ -179,11 +190,12 @@ export async function runBrowserGlobalSetupStage(
       success,
       errors: setupErrors,
       envChanges,
-    } = await runProjectGlobalSetup({
-      project: item.project,
+    } = await runGlobalSetup({
       globalSetupEntries: item.globalSetupEntries,
-      getAssetFiles: async () => item.assetFiles,
-      getSourceMaps: async () => item.sourceMaps,
+      assetFiles: item.assetFiles,
+      sourceMaps: item.sourceMaps,
+      interopDefault: true,
+      outputModule: item.project.outputModule,
     });
     if (success) {
       ranAnySetup = true;

--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -12,8 +12,8 @@ import { ensureTestEnvironmentDependencies } from '../envDependencies';
 import { isNodeProject } from '../isBrowserProject';
 import {
   claimGlobalSetupOnce,
+  runGlobalSetup,
   runGlobalTeardown,
-  runProjectGlobalSetup,
 } from '../globalSetup';
 import { applyOnlyFailuresSelection } from '../onlyFailures';
 import {
@@ -345,13 +345,31 @@ export function createNodeExecutor(
               globalSetupEntries.length,
             )
           ) {
-            const { success, errors } = await runProjectGlobalSetup({
-              project: p,
-              globalSetupEntries,
-              getAssetFiles,
-              getSourceMaps,
-              span,
-            });
+            const files = globalSetupEntries.flatMap((e) => e.files!);
+            const globalSetupTraceArgs = {
+              project: p.name,
+              testPath: '<globalSetup>',
+            };
+            const [assetFiles, sourceMaps] = await span(
+              'host:global-setup-assets',
+              'host',
+              () => Promise.all([getAssetFiles(files), getSourceMaps(files)]),
+              globalSetupTraceArgs,
+            );
+
+            const { success, errors } = await span(
+              'host:global-setup',
+              'host',
+              () =>
+                runGlobalSetup({
+                  globalSetupEntries,
+                  assetFiles,
+                  sourceMaps,
+                  interopDefault: true,
+                  outputModule: p.outputModule,
+                }),
+              globalSetupTraceArgs,
+            );
             if (!success) {
               return {
                 results: [],

--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -12,8 +12,8 @@ import { ensureTestEnvironmentDependencies } from '../envDependencies';
 import { isNodeProject } from '../isBrowserProject';
 import {
   claimGlobalSetupOnce,
-  runGlobalSetup,
   runGlobalTeardown,
+  runProjectGlobalSetup,
 } from '../globalSetup';
 import { applyOnlyFailuresSelection } from '../onlyFailures';
 import {
@@ -345,31 +345,13 @@ export function createNodeExecutor(
               globalSetupEntries.length,
             )
           ) {
-            const files = globalSetupEntries.flatMap((e) => e.files!);
-            const globalSetupTraceArgs = {
-              project: p.name,
-              testPath: '<globalSetup>',
-            };
-            const [assetFiles, sourceMaps] = await span(
-              'host:global-setup-assets',
-              'host',
-              () => Promise.all([getAssetFiles(files), getSourceMaps(files)]),
-              globalSetupTraceArgs,
-            );
-
-            const { success, errors } = await span(
-              'host:global-setup',
-              'host',
-              () =>
-                runGlobalSetup({
-                  globalSetupEntries,
-                  assetFiles,
-                  sourceMaps,
-                  interopDefault: true,
-                  outputModule: p.outputModule,
-                }),
-              globalSetupTraceArgs,
-            );
+            const { success, errors } = await runProjectGlobalSetup({
+              project: p,
+              globalSetupEntries,
+              getAssetFiles,
+              getSourceMaps,
+              span,
+            });
             if (!success) {
               return {
                 results: [],

--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -8,8 +8,6 @@ import {
   getForceColorEnv,
   getWorkerSerialization,
   killAndWait,
-  noopTraceSpan,
-  type TraceSpan,
 } from '../utils';
 
 /**
@@ -244,53 +242,8 @@ export async function runGlobalSetup({
   return {
     success: result.success,
     errors: result.errors,
-    envChanges: result.success ? result.envChanges : undefined,
+    envChanges: result.envChanges,
   };
-}
-
-/**
- * Compile-output → setup-run step shared by the node executor's in-cycle
- * globalSetup and the core pre-cycle browser stage: fetch the setup entries'
- * assets and source maps, then execute them in the forked worker.
- */
-export async function runProjectGlobalSetup({
-  project,
-  globalSetupEntries,
-  getAssetFiles,
-  getSourceMaps,
-  span = noopTraceSpan,
-}: {
-  project: Pick<ProjectContext, 'name' | 'outputModule'>;
-  globalSetupEntries: EntryInfo[];
-  getAssetFiles: (names: string[]) => Promise<Record<string, string>>;
-  getSourceMaps: (names: string[]) => Promise<Record<string, string>>;
-  span?: TraceSpan;
-}): ReturnType<typeof runGlobalSetup> {
-  const files = globalSetupEntries.flatMap((e) => e.files!);
-  const traceArgs = {
-    project: project.name,
-    testPath: '<globalSetup>',
-  };
-  const [assetFiles, sourceMaps] = await span(
-    'host:global-setup-assets',
-    'host',
-    () => Promise.all([getAssetFiles(files), getSourceMaps(files)]),
-    traceArgs,
-  );
-
-  return span(
-    'host:global-setup',
-    'host',
-    () =>
-      runGlobalSetup({
-        globalSetupEntries,
-        assetFiles,
-        sourceMaps,
-        interopDefault: true,
-        outputModule: project.outputModule,
-      }),
-    traceArgs,
-  );
 }
 
 async function runWorkerTeardown(worker: GlobalSetupWorker): Promise<void> {

--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -8,6 +8,8 @@ import {
   getForceColorEnv,
   getWorkerSerialization,
   killAndWait,
+  noopTraceSpan,
+  type TraceSpan,
 } from '../utils';
 
 /**
@@ -200,6 +202,12 @@ export async function runGlobalSetup({
 }): Promise<{
   success: boolean;
   errors?: any[];
+  /**
+   * Env change-set (including deletions as `undefined`) the setup applied to
+   * the host `process.env`. Surfaced so the core pre-cycle stage can forward
+   * browser projects' changes onto the browser wire.
+   */
+  envChanges?: Record<string, string | undefined>;
 }> {
   const worker = new GlobalSetupWorker();
 
@@ -236,7 +244,53 @@ export async function runGlobalSetup({
   return {
     success: result.success,
     errors: result.errors,
+    envChanges: result.success ? result.envChanges : undefined,
   };
+}
+
+/**
+ * Compile-output → setup-run step shared by the node executor's in-cycle
+ * globalSetup and the core pre-cycle browser stage: fetch the setup entries'
+ * assets and source maps, then execute them in the forked worker.
+ */
+export async function runProjectGlobalSetup({
+  project,
+  globalSetupEntries,
+  getAssetFiles,
+  getSourceMaps,
+  span = noopTraceSpan,
+}: {
+  project: Pick<ProjectContext, 'name' | 'outputModule'>;
+  globalSetupEntries: EntryInfo[];
+  getAssetFiles: (names: string[]) => Promise<Record<string, string>>;
+  getSourceMaps: (names: string[]) => Promise<Record<string, string>>;
+  span?: TraceSpan;
+}): ReturnType<typeof runGlobalSetup> {
+  const files = globalSetupEntries.flatMap((e) => e.files!);
+  const traceArgs = {
+    project: project.name,
+    testPath: '<globalSetup>',
+  };
+  const [assetFiles, sourceMaps] = await span(
+    'host:global-setup-assets',
+    'host',
+    () => Promise.all([getAssetFiles(files), getSourceMaps(files)]),
+    traceArgs,
+  );
+
+  return span(
+    'host:global-setup',
+    'host',
+    () =>
+      runGlobalSetup({
+        globalSetupEntries,
+        assetFiles,
+        sourceMaps,
+        interopDefault: true,
+        outputModule: project.outputModule,
+      }),
+    traceArgs,
+  );
 }
 
 async function runWorkerTeardown(worker: GlobalSetupWorker): Promise<void> {

--- a/packages/core/src/core/projectPlan.ts
+++ b/packages/core/src/core/projectPlan.ts
@@ -7,7 +7,7 @@ import {
 import { refreshEnvironmentPartitionEntries } from './environmentPartitions';
 import { isBrowserProject, isNodeProject } from './isBrowserProject';
 
-const getProjectEntries = async ({
+export const getProjectEntries = async ({
   context,
   project,
 }: {

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -1,6 +1,7 @@
 import {
   createRsbuild,
   type ManifestData,
+  type RsbuildConfig,
   type RsbuildInstance,
   logger as RsbuildLogger,
   type RsbuildPlugin,
@@ -143,6 +144,20 @@ export const addCoveragePlugin = async (
   }
 };
 
+/**
+ * In-memory host compile server: no printed urls, no fixed port, no static
+ * hosting. Shared with the browser globalSetup stage's one-shot compile so
+ * the two host rsbuild instances cannot drift.
+ */
+export const hostServerConfig: NonNullable<RsbuildConfig['server']> = {
+  printUrls: false,
+  strictPort: false,
+  middlewareMode: true,
+  compress: false,
+  cors: false,
+  publicDir: false,
+};
+
 export const prepareRsbuild = async ({
   context,
   globTestSourceEntries,
@@ -186,14 +201,7 @@ export const prepareRsbuild = async ({
     callerName: 'rstest',
     config: {
       root: context.rootPath,
-      server: {
-        printUrls: false,
-        strictPort: false,
-        middlewareMode: true,
-        compress: false,
-        cors: false,
-        publicDir: false,
-      },
+      server: { ...hostServerConfig },
       dev: {
         hmr: false,
         writeToDisk,

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -3,7 +3,11 @@ import { isAbsolute, normalize, relative, resolve } from 'pathe';
 import { cleanCoverageReports, createCoverageProvider } from '../coverage';
 import { buildBrowserCoverageMap } from '../coverage/browserCoverageMap';
 import { ensureRunDependencies } from './dependencies';
-import type { ProjectContext, TestExecutor } from '../types';
+import type {
+  ExecutorCycleOutcome,
+  ProjectContext,
+  TestExecutor,
+} from '../types';
 import type { CoverageProvider } from '../types/coverage';
 import {
   clearScreen,
@@ -27,6 +31,10 @@ import {
   loadBrowserModule,
 } from './browserLoader';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
+import {
+  type BrowserGlobalSetupStageResult,
+  runBrowserGlobalSetupStage,
+} from './browserGlobalSetup';
 import { createNodeExecutor } from './executors/nodeExecutor';
 import { runGlobalTeardown } from './globalSetup';
 import { isBrowserProject, isNodeProject } from './isBrowserProject';
@@ -52,6 +60,19 @@ async function runBrowserModeTests(
   validateBrowserConfig(context);
   return runBrowserTests(context, { ...options, projects: browserProjects });
 }
+
+/**
+ * Errors-only outcome fed into the shared finalize when the pre-cycle browser
+ * globalSetup stage fails — same error objects and exit-code path as a node
+ * in-cycle globalSetup failure.
+ */
+const globalSetupFailureOutcome = (errors: Error[]): ExecutorCycleOutcome => ({
+  results: [],
+  testResults: [],
+  errors,
+  testPaths: [],
+  duration: { buildTime: 0, testTime: 0 },
+});
 
 const getSignalExitCode = (signal: NodeJS.Signals): number => {
   const signalNumber = osConstants.signals[signal];
@@ -253,13 +274,50 @@ export async function runTests(context: Rstest): Promise<void> {
       await browserExecutor.init();
 
       await notifyReportersOnTestRunStart(context);
-      try {
-        const outcome = await browserExecutor.runCycle({
-          buildId: 1,
-          mode: 'all',
-          updateSnapshot: snapshotManager.options.updateSnapshot,
-          onTraceEvents: traceRun.onEvents,
+      // Best-effort teardown nets for hard crashes and signal deaths between
+      // setup and teardown (parity with the mixed path's handlers); the
+      // deterministic drain in the `finally` below is the primary guarantee.
+      const teardownOnExit = () => {
+        runGlobalTeardown().catch((error) => {
+          logger.log(color.red(`Error in global teardown: ${error}`));
         });
+      };
+      const teardownOnSignal = (signal: NodeJS.Signals) => {
+        logger.log(color.yellow(`\nReceived ${signal}, cleaning up...`));
+        runGlobalTeardown()
+          .catch((error) => {
+            logger.log(color.red(`Error in global teardown: ${error}`));
+          })
+          .finally(() => {
+            process.exit(getSignalExitCode(signal));
+          });
+      };
+      const teardownSignals = ['SIGINT', 'SIGTERM', 'SIGTSTP'] as const;
+      let teardownNetRegistered = false;
+      try {
+        const stage = await runBrowserGlobalSetupStage(
+          context,
+          browserProjects,
+        );
+        if (
+          !context.embedded &&
+          (stage.env !== undefined || stage.errors.length > 0)
+        ) {
+          process.on('exit', teardownOnExit);
+          for (const signal of teardownSignals) {
+            process.on(signal, teardownOnSignal);
+          }
+          teardownNetRegistered = true;
+        }
+        const outcome = stage.errors.length
+          ? globalSetupFailureOutcome(stage.errors)
+          : await browserExecutor.runCycle({
+              buildId: 1,
+              mode: 'all',
+              updateSnapshot: snapshotManager.options.updateSnapshot,
+              env: stage.env,
+              onTraceEvents: traceRun.onEvents,
+            });
         await finalizeRunCycle(context, {
           outcomes: [outcome],
           mode: 'all',
@@ -270,9 +328,21 @@ export async function runTests(context: Rstest): Promise<void> {
           currentDeletedEntries: [],
         });
       } finally {
-        await runLifecycleStep('executor cleanup', () =>
-          browserExecutor.close(),
-        );
+        try {
+          await runLifecycleStep('global teardown', () => runGlobalTeardown());
+        } finally {
+          // The executor close must survive a throwing teardown — a skipped
+          // close leaks the launched browser and dev servers.
+          if (teardownNetRegistered) {
+            process.off('exit', teardownOnExit);
+            for (const signal of teardownSignals) {
+              process.off(signal, teardownOnSignal);
+            }
+          }
+          await runLifecycleStep('executor cleanup', () =>
+            browserExecutor.close(),
+          );
+        }
       }
     }
 
@@ -539,7 +609,14 @@ export async function runTests(context: Rstest): Promise<void> {
       }
       isCleaningUp = true;
       try {
-        await closeExecutors();
+        try {
+          await closeExecutors();
+        } finally {
+          // Signal-path drain: `executors` excludes the node executor when
+          // only browser tests run, so its close cannot be the drain point
+          // for the browser stage's setups.
+          await runLifecycleStep('global teardown', () => runGlobalTeardown());
+        }
         await runLifecycleStep('trace run finalize', () =>
           activeTraceRun.finalize(),
         );
@@ -585,6 +662,7 @@ export async function runTests(context: Rstest): Promise<void> {
     }
 
     try {
+      let browserStage: BrowserGlobalSetupStageResult = { errors: [] };
       if (hasBrowserTestsToRun) {
         const browserProjectsToRun = getBrowserProjectsToRun();
         browserShardedEntries = getBrowserShardedEntries(browserProjectsToRun);
@@ -601,6 +679,13 @@ export async function runTests(context: Rstest): Promise<void> {
         );
         executors.push(browserExecutor);
         await browserExecutor.init();
+        // Core-owned pre-cycle globalSetup stage over the resolved browser
+        // subset. It mutates the shared host `process.env`, so browser setups'
+        // env changes are also visible to node workers dispatched below.
+        browserStage = await runBrowserGlobalSetupStage(
+          context,
+          browserProjectsToRun,
+        );
       }
 
       await notifyReportersOnTestRunStart(context);
@@ -610,13 +695,16 @@ export async function runTests(context: Rstest): Promise<void> {
       // teardown early. The re-await unwraps the already-settled promises,
       // rejecting with the first failure in executor order.
       const cyclePromises = executors.map((executor) =>
-        executor.runCycle({
-          buildId: 1,
-          mode: 'all',
-          updateSnapshot: snapshotManager.options.updateSnapshot,
-          shardedEntries: browserShardedEntries,
-          onTraceEvents: forwardBrowserTraceEvents,
-        }),
+        executor.name === 'browser' && browserStage.errors.length
+          ? Promise.resolve(globalSetupFailureOutcome(browserStage.errors))
+          : executor.runCycle({
+              buildId: 1,
+              mode: 'all',
+              updateSnapshot: snapshotManager.options.updateSnapshot,
+              env: browserStage.env,
+              shardedEntries: browserShardedEntries,
+              onTraceEvents: forwardBrowserTraceEvents,
+            }),
       );
       await Promise.allSettled(cyclePromises);
       const outcomes = await Promise.all(cyclePromises);
@@ -634,12 +722,20 @@ export async function runTests(context: Rstest): Promise<void> {
       });
       isTeardown = true;
     } finally {
-      await closeExecutors();
-      if (!context.embedded) {
-        process.off('exit', unExpectedExit);
-        process.off('SIGINT', handleSignal);
-        process.off('SIGTERM', handleSignal);
-        process.off('SIGTSTP', handleSignal);
+      try {
+        await closeExecutors();
+      } finally {
+        if (!context.embedded) {
+          process.off('exit', unExpectedExit);
+          process.off('SIGINT', handleSignal);
+          process.off('SIGTERM', handleSignal);
+          process.off('SIGTSTP', handleSignal);
+        }
+        // `executors` excludes the node executor when only browser tests run,
+        // so `NodeExecutor.close()` alone cannot be the teardown drain point
+        // for the browser stage's setups; a second drain after it is a no-op,
+        // and it must run even when an executor close throws.
+        await runLifecycleStep('global teardown', () => runGlobalTeardown());
       }
     }
 

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -15,6 +15,7 @@ import {
   createTraceController,
   getForceRerunTriggerMessage,
   logger,
+  resolveShardedEntries,
   type TraceEvent,
 } from '../utils';
 import {
@@ -298,9 +299,17 @@ export async function runTests(context: Rstest): Promise<void> {
           });
       };
       try {
+        // Resolve the shard once (undefined when unsharded) and share it
+        // between the setup gate and the browser cycle so they cannot
+        // disagree on which files run — the host's own shard fallback only
+        // fires on the config-hook refresh path, not on initial resolution.
+        const browserShardedEntries = await resolveShardedEntries(context, {
+          silent: true,
+        });
         const stage = await runBrowserGlobalSetupStage(
           context,
           browserProjects,
+          { entriesCache: browserShardedEntries },
         );
         if (!context.embedded && stage.env !== undefined) {
           process.on('exit', teardownOnExit);
@@ -315,6 +324,7 @@ export async function runTests(context: Rstest): Promise<void> {
               mode: 'all',
               updateSnapshot: snapshotManager.options.updateSnapshot,
               env: stage.env,
+              shardedEntries: browserShardedEntries,
               onTraceEvents: traceRun.onEvents,
             });
         await finalizeRunCycle(context, {

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -79,6 +79,9 @@ const getSignalExitCode = (signal: NodeJS.Signals): number => {
   return typeof signalNumber === 'number' ? 128 + signalNumber : 1;
 };
 
+/** Signals every run path treats as fatal and cleans up on. */
+const FATAL_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGTSTP'] as const;
+
 /**
  * Create the coverage provider when coverage is enabled and print the
  * `Coverage enabled with <provider>` banner once. Returns null when disabled.
@@ -277,6 +280,8 @@ export async function runTests(context: Rstest): Promise<void> {
       // Best-effort teardown nets for hard crashes and signal deaths between
       // setup and teardown (parity with the mixed path's handlers); the
       // deterministic drain in the `finally` below is the primary guarantee.
+      // Registered only when a setup actually ran — failed setups never queue
+      // teardown callbacks, so there is nothing to drain for them.
       const teardownOnExit = () => {
         runGlobalTeardown().catch((error) => {
           logger.log(color.red(`Error in global teardown: ${error}`));
@@ -292,22 +297,16 @@ export async function runTests(context: Rstest): Promise<void> {
             process.exit(getSignalExitCode(signal));
           });
       };
-      const teardownSignals = ['SIGINT', 'SIGTERM', 'SIGTSTP'] as const;
-      let teardownNetRegistered = false;
       try {
         const stage = await runBrowserGlobalSetupStage(
           context,
           browserProjects,
         );
-        if (
-          !context.embedded &&
-          (stage.env !== undefined || stage.errors.length > 0)
-        ) {
+        if (!context.embedded && stage.env !== undefined) {
           process.on('exit', teardownOnExit);
-          for (const signal of teardownSignals) {
+          for (const signal of FATAL_SIGNALS) {
             process.on(signal, teardownOnSignal);
           }
-          teardownNetRegistered = true;
         }
         const outcome = stage.errors.length
           ? globalSetupFailureOutcome(stage.errors)
@@ -332,12 +331,11 @@ export async function runTests(context: Rstest): Promise<void> {
           await runLifecycleStep('global teardown', () => runGlobalTeardown());
         } finally {
           // The executor close must survive a throwing teardown — a skipped
-          // close leaks the launched browser and dev servers.
-          if (teardownNetRegistered) {
-            process.off('exit', teardownOnExit);
-            for (const signal of teardownSignals) {
-              process.off(signal, teardownOnSignal);
-            }
+          // close leaks the launched browser and dev servers. `process.off`
+          // on a never-registered listener is a no-op.
+          process.off('exit', teardownOnExit);
+          for (const signal of FATAL_SIGNALS) {
+            process.off(signal, teardownOnSignal);
           }
           await runLifecycleStep('executor cleanup', () =>
             browserExecutor.close(),
@@ -594,11 +592,19 @@ export async function runTests(context: Rstest): Promise<void> {
         return;
       }
       didCloseExecutors = true;
-      await Promise.all(
-        executors.map((executor) =>
-          runLifecycleStep('executor cleanup', () => executor.close()),
-        ),
-      );
+      try {
+        await Promise.all(
+          executors.map((executor) =>
+            runLifecycleStep('executor cleanup', () => executor.close()),
+          ),
+        );
+      } finally {
+        // `executors` excludes the node executor when only browser tests run,
+        // so `NodeExecutor.close()` alone cannot drain the browser stage's
+        // setups. A second drain is a no-op, and it must run even when an
+        // executor close throws.
+        await runLifecycleStep('global teardown', () => runGlobalTeardown());
+      }
     };
 
     let isTeardown = false;
@@ -609,14 +615,7 @@ export async function runTests(context: Rstest): Promise<void> {
       }
       isCleaningUp = true;
       try {
-        try {
-          await closeExecutors();
-        } finally {
-          // Signal-path drain: `executors` excludes the node executor when
-          // only browser tests run, so its close cannot be the drain point
-          // for the browser stage's setups.
-          await runLifecycleStep('global teardown', () => runGlobalTeardown());
-        }
+        await closeExecutors();
         await runLifecycleStep('trace run finalize', () =>
           activeTraceRun.finalize(),
         );
@@ -656,17 +655,18 @@ export async function runTests(context: Rstest): Promise<void> {
 
     if (!context.embedded) {
       process.on('exit', unExpectedExit);
-      process.on('SIGINT', handleSignal);
-      process.on('SIGTERM', handleSignal);
-      process.on('SIGTSTP', handleSignal);
+      for (const signal of FATAL_SIGNALS) {
+        process.on(signal, handleSignal);
+      }
     }
 
     try {
       let browserStage: BrowserGlobalSetupStageResult = { errors: [] };
+      let browserExecutor: TestExecutor | undefined;
       if (hasBrowserTestsToRun) {
         const browserProjectsToRun = getBrowserProjectsToRun();
         browserShardedEntries = getBrowserShardedEntries(browserProjectsToRun);
-        const browserExecutor = await loadBrowserExecutor(
+        browserExecutor = await loadBrowserExecutor(
           context,
           browserProjectsToRun,
           coverageProvider,
@@ -685,6 +685,7 @@ export async function runTests(context: Rstest): Promise<void> {
         browserStage = await runBrowserGlobalSetupStage(
           context,
           browserProjectsToRun,
+          { entriesCache: nodeExecutor.getPlan().entriesCache },
         );
       }
 
@@ -695,7 +696,7 @@ export async function runTests(context: Rstest): Promise<void> {
       // teardown early. The re-await unwraps the already-settled promises,
       // rejecting with the first failure in executor order.
       const cyclePromises = executors.map((executor) =>
-        executor.name === 'browser' && browserStage.errors.length
+        executor === browserExecutor && browserStage.errors.length
           ? Promise.resolve(globalSetupFailureOutcome(browserStage.errors))
           : executor.runCycle({
               buildId: 1,
@@ -727,15 +728,10 @@ export async function runTests(context: Rstest): Promise<void> {
       } finally {
         if (!context.embedded) {
           process.off('exit', unExpectedExit);
-          process.off('SIGINT', handleSignal);
-          process.off('SIGTERM', handleSignal);
-          process.off('SIGTSTP', handleSignal);
+          for (const signal of FATAL_SIGNALS) {
+            process.off(signal, handleSignal);
+          }
         }
-        // `executors` excludes the node executor when only browser tests run,
-        // so `NodeExecutor.close()` alone cannot be the teardown drain point
-        // for the browser stage's setups; a second drain after it is a no-op,
-        // and it must run even when an executor close throws.
-        await runLifecycleStep('global teardown', () => runGlobalTeardown());
       }
     }
 

--- a/packages/core/src/core/runtimeConfigProjection.ts
+++ b/packages/core/src/core/runtimeConfigProjection.ts
@@ -10,8 +10,8 @@ interface InheritEnvOptions {
   /** Node: spread the full env (defaults to `process.env`). */
   envMode: 'inherit';
   /**
-   * Env base to inherit from; defaults to `process.env`. A post-globalSetup
-   * snapshot is passed here once the pre-cycle stage exists.
+   * Full env base to inherit from; defaults to `process.env`, read at
+   * projection time so globalSetup mutations are already applied.
    */
   env?: EnvSource;
 }
@@ -19,6 +19,11 @@ interface InheritEnvOptions {
 interface StaticEnvOptions {
   /** Browser: emit only `NODE_ENV` + `RSTEST` plus user config env (#1351). */
   envMode: 'static';
+  /**
+   * Overlay change-set (post-globalSetup env diff), NOT a full env base:
+   * applied between the static base and the user config env. Arbitrary host
+   * env must never be passed here — it would leak onto the browser wire.
+   */
   env?: EnvSource;
 }
 
@@ -92,23 +97,27 @@ export function projectRuntimeConfig(
     silent,
   };
 
-  const envSource = options.env ?? process.env;
-
   if (options.envMode === 'static') {
     // Browser wire. Propagate NODE_ENV and the RSTEST flag from the host so
     // `process.env.NODE_ENV` / `process.env.RSTEST` (rewritten to the
     // `RSTEST_ENV_SYMBOL_KEY` symbol store) resolve in browser tests the same
-    // way they do in Node mode. User-supplied `env` wins so explicit overrides
-    // still take effect. See https://github.com/web-infra-dev/rstest/issues/1351
+    // way they do in Node mode. The globalSetup change-set overlays the base;
+    // user-supplied `env` wins so explicit overrides still take effect.
+    // Deletions (`undefined` values) are no-ops on the wire: JSON
+    // serialization drops them, and host-only vars never existed in the
+    // browser store. See https://github.com/web-infra-dev/rstest/issues/1351
     return {
       ...shared,
       env: {
-        NODE_ENV: envSource.NODE_ENV,
+        NODE_ENV: process.env.NODE_ENV,
         RSTEST: 'true',
+        ...options.env,
         ...env,
       },
     } satisfies BrowserRuntimeConfig;
   }
+
+  const envSource = options.env ?? process.env;
 
   return {
     ...shared,

--- a/packages/core/src/core/runtimeConfigProjection.ts
+++ b/packages/core/src/core/runtimeConfigProjection.ts
@@ -23,8 +23,10 @@ interface StaticEnvOptions {
    * Overlay change-set (post-globalSetup env diff), NOT a full env base:
    * applied between the static base and the user config env. Arbitrary host
    * env must never be passed here — it would leak onto the browser wire.
+   * Named apart from the inherit branch's `env` so a full `process.env`
+   * cannot be passed by symmetry and still typecheck.
    */
-  env?: EnvSource;
+  envOverlay?: EnvSource;
 }
 
 /**
@@ -111,7 +113,7 @@ export function projectRuntimeConfig(
       env: {
         NODE_ENV: process.env.NODE_ENV,
         RSTEST: 'true',
-        ...options.env,
+        ...options.envOverlay,
         ...env,
       },
     } satisfies BrowserRuntimeConfig;

--- a/packages/core/src/types/browser.ts
+++ b/packages/core/src/types/browser.ts
@@ -62,6 +62,12 @@ export interface BrowserTestRunOptions {
    * caller has `--trace` enabled.
    */
   onTraceEvents?: (events: TraceEvent[]) => void;
+  /**
+   * Post-globalSetup env change-set from the core pre-cycle stage. The host
+   * merges it into the browser runtime env store between the static base
+   * (`NODE_ENV`/`RSTEST`) and the user `test.env` config.
+   */
+  env?: Record<string, string | undefined>;
 }
 
 /**

--- a/packages/core/src/types/executor.ts
+++ b/packages/core/src/types/executor.ts
@@ -25,10 +25,12 @@ export interface ExecutorRunCycleOptions {
    */
   updateSnapshot: SnapshotUpdateState;
   /**
-   * Post-globalSetup env snapshot, produced by the core-owned pre-cycle stage.
-   * Not populated yet: the node pool re-reads `process.env` at dispatch today;
-   * Phase 5 fills this so the browser host can inject it into its per-run env
-   * store (globalSetup env propagation).
+   * Post-globalSetup env change-set produced by the core-owned pre-cycle
+   * globalSetup stage (browser projects' setups only). The node executor
+   * ignores it — the stage already mutated the host `process.env`, which the
+   * pool re-reads at dispatch; the browser executor merges it into the per-run
+   * env store between the static base (`NODE_ENV`/`RSTEST`) and the user
+   * `test.env` config.
    */
   env?: Record<string, string | undefined>;
   /** Pre-resolved sharded entries per project (key: `environmentName`). */

--- a/packages/core/tests/core/globalSetup.test.ts
+++ b/packages/core/tests/core/globalSetup.test.ts
@@ -1,10 +1,67 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { describe, expect, it } from '@rstest/core';
+import { afterAll, describe, expect, it, rs } from '@rstest/core';
 import {
   claimGlobalSetupOnce,
   GlobalSetupWorker,
+  runGlobalSetup,
 } from '../../src/core/globalSetup';
+
+// Self-contained fake of the globalSetup IPC child: replies to every `setup`
+// message with a successful result carrying a fixed env change-set, so
+// `runGlobalSetup` (which forks internally) is testable without a real child.
+rs.mock('node:child_process', () => {
+  const fork = () => {
+    const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+    return {
+      stdout: undefined,
+      stderr: undefined,
+      // Non-null exit code so `killAndWait` treats the child as already gone.
+      exitCode: 0,
+      signalCode: null,
+      on(event: string, cb: (...args: unknown[]) => void) {
+        listeners.set(event, [...(listeners.get(event) ?? []), cb]);
+        return this;
+      },
+      once(event: string, cb: (...args: unknown[]) => void) {
+        return this.on(event, cb);
+      },
+      off() {
+        return this;
+      },
+      kill: () => true,
+      send(
+        message: { id: number; type: 'setup' | 'teardown' },
+        callback?: (error: Error | null) => void,
+      ) {
+        callback?.(null);
+        queueMicrotask(() => {
+          for (const cb of listeners.get('message') ?? []) {
+            cb({
+              __rstest_global_setup__: true,
+              id: message.id,
+              result:
+                message.type === 'setup'
+                  ? {
+                      success: true,
+                      hasTeardown: false,
+                      envChanges: { RSTEST_GS_UNIT: 'from-worker' },
+                    }
+                  : { success: true },
+            });
+          }
+        });
+        return true;
+      },
+    };
+  };
+  return { fork };
+});
+
+afterAll(() => {
+  rs.doUnmock('node:child_process');
+  delete process.env.RSTEST_GS_UNIT;
+});
 
 describe('claimGlobalSetupOnce', () => {
   it('claims the gate once when there are running tests and setup entries', () => {
@@ -68,5 +125,22 @@ describe('GlobalSetupWorker', () => {
     child.emit('error', new Error('worker error'));
 
     await expect(promise).rejects.toThrow('worker error');
+  });
+});
+
+describe('runGlobalSetup', () => {
+  it('surfaces the worker env change-set and applies it to process.env', async () => {
+    const result = await runGlobalSetup({
+      globalSetupEntries: [],
+      assetFiles: {},
+      sourceMaps: {},
+      interopDefault: true,
+      outputModule: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.envChanges).toEqual({ RSTEST_GS_UNIT: 'from-worker' });
+    // The change-set is also applied to the host env (node pool reads it).
+    expect(process.env.RSTEST_GS_UNIT).toBe('from-worker');
   });
 });

--- a/packages/core/tests/core/globalSetup.test.ts
+++ b/packages/core/tests/core/globalSetup.test.ts
@@ -18,18 +18,10 @@ rs.mock('node:child_process', () => {
       stderr: undefined,
       // Non-null exit code so `killAndWait` treats the child as already gone.
       exitCode: 0,
-      signalCode: null,
       on(event: string, cb: (...args: unknown[]) => void) {
         listeners.set(event, [...(listeners.get(event) ?? []), cb]);
         return this;
       },
-      once(event: string, cb: (...args: unknown[]) => void) {
-        return this.on(event, cb);
-      },
-      off() {
-        return this;
-      },
-      kill: () => true,
       send(
         message: { id: number; type: 'setup' | 'teardown' },
         callback?: (error: Error | null) => void,

--- a/packages/core/tests/core/runtimeConfigProjection.test.ts
+++ b/packages/core/tests/core/runtimeConfigProjection.test.ts
@@ -64,7 +64,7 @@ describe('projectRuntimeConfig', () => {
       makeProject({ env: { FROM_CONFIG: 'config' } }),
       {
         envMode: 'static',
-        env: { FROM_SETUP: 'setup', FROM_CONFIG: 'setup-loses' },
+        envOverlay: { FROM_SETUP: 'setup', FROM_CONFIG: 'setup-loses' },
       },
     );
     expect(config.env).toEqual({
@@ -78,13 +78,13 @@ describe('projectRuntimeConfig', () => {
   it('static keeps the NODE_ENV base unless the overlay sets it', () => {
     const withoutNodeEnv = projectRuntimeConfig(makeProject(), {
       envMode: 'static',
-      env: { FROM_SETUP: 'setup' },
+      envOverlay: { FROM_SETUP: 'setup' },
     });
     expect(withoutNodeEnv.env?.NODE_ENV).toBe(process.env.NODE_ENV);
 
     const withNodeEnv = projectRuntimeConfig(makeProject(), {
       envMode: 'static',
-      env: { NODE_ENV: 'production' },
+      envOverlay: { NODE_ENV: 'production' },
     });
     expect(withNodeEnv.env?.NODE_ENV).toBe('production');
   });

--- a/packages/core/tests/core/runtimeConfigProjection.test.ts
+++ b/packages/core/tests/core/runtimeConfigProjection.test.ts
@@ -47,18 +47,46 @@ describe('projectRuntimeConfig', () => {
     expect('detectAsyncLeaks' in config).toBe(false);
   });
 
-  it('static env propagates only NODE_ENV + RSTEST plus config env', () => {
+  it('static env emits only NODE_ENV + RSTEST plus config env by default', () => {
     const config = projectRuntimeConfig(makeProject({ env: { FOO: 'bar' } }), {
       envMode: 'static',
-      env: { NODE_ENV: 'test', SECRET: 'hidden' },
     });
+    // `toEqual` proves no arbitrary host env leaks onto the browser wire.
     expect(config.env).toEqual({
-      NODE_ENV: 'test',
+      NODE_ENV: process.env.NODE_ENV,
       RSTEST: 'true',
       FOO: 'bar',
     });
-    // Arbitrary host env must NOT leak onto the browser wire.
-    expect('SECRET' in (config.env ?? {})).toBe(false);
+  });
+
+  it('static overlays the globalSetup change-set between base and config env', () => {
+    const config = projectRuntimeConfig(
+      makeProject({ env: { FROM_CONFIG: 'config' } }),
+      {
+        envMode: 'static',
+        env: { FROM_SETUP: 'setup', FROM_CONFIG: 'setup-loses' },
+      },
+    );
+    expect(config.env).toEqual({
+      NODE_ENV: process.env.NODE_ENV,
+      RSTEST: 'true',
+      FROM_SETUP: 'setup',
+      FROM_CONFIG: 'config',
+    });
+  });
+
+  it('static keeps the NODE_ENV base unless the overlay sets it', () => {
+    const withoutNodeEnv = projectRuntimeConfig(makeProject(), {
+      envMode: 'static',
+      env: { FROM_SETUP: 'setup' },
+    });
+    expect(withoutNodeEnv.env?.NODE_ENV).toBe(process.env.NODE_ENV);
+
+    const withNodeEnv = projectRuntimeConfig(makeProject(), {
+      envMode: 'static',
+      env: { NODE_ENV: 'production' },
+    });
+    expect(withNodeEnv.env?.NODE_ENV).toBe('production');
   });
 
   it('inherit (node) keeps node-only fields and strips coverage.reporters', () => {

--- a/website/docs/en/config/test/global-setup.mdx
+++ b/website/docs/en/config/test/global-setup.mdx
@@ -69,7 +69,7 @@ export default async function globalSetup() {
 ```
 
 :::note
-Global setup runs in a separate context: module-scope variables defined in the setup file are not accessible from tests. However, for node test workers, `process.env` mutations made in `globalSetup` are snapshotted after setup completes and propagated to each worker — setting environment variables here is a supported way to share values with node tests. This propagation does not apply to browser-mode tests; only the static `test.env` config is forwarded to browser workers.
+Global setup runs in a separate context: module-scope variables defined in the setup file are not accessible from tests. However, for node test workers, `process.env` mutations made in `globalSetup` are snapshotted after setup completes and propagated to each worker — setting environment variables here is a supported way to share values with node tests. For browser-mode tests, the environment variable changes made in the **browser project's own** `globalSetup` are propagated too: they are injected into the browser runtime env store (readable via `process.env` / `import.meta.env`), on top of the built-in `NODE_ENV` / `RSTEST` values, with explicit `test.env` config still taking precedence. Other host environment variables are not forwarded to browser tests, and in mixed projects the env changes from Node-side `globalSetup` are not merged into browser tests. `globalSetup` entries added or modified by browser provider hooks (`modifyRstestConfig`) are not picked up. Browser-mode watch runs do not execute `globalSetup` yet.
 :::
 
 ## Multiple global setup files

--- a/website/docs/zh/config/test/global-setup.mdx
+++ b/website/docs/zh/config/test/global-setup.mdx
@@ -69,7 +69,7 @@ export default async function globalSetup() {
 ```
 
 :::note
-globalSetup 文件在独立的上下文中运行：setup 文件里模块作用域的变量在测试中无法访问。对于 node 测试 worker，`globalSetup` 执行结束后 Rstest 会对 `process.env` 做一次快照并分发给每个 worker —— 所以通过在此处修改环境变量把值传给 node 测试是被支持的用法。此行为不适用于 browser 模式测试：只有静态的 `test.env` 配置会被转发到 browser worker。
+globalSetup 文件在独立的上下文中运行：setup 文件里模块作用域的变量在测试中无法访问。对于 node 测试 worker，`globalSetup` 执行结束后 Rstest 会对 `process.env` 做一次快照并分发给每个 worker —— 所以通过在此处修改环境变量把值传给 node 测试是被支持的用法。对于 browser 模式测试，**browser 项目自身**的 `globalSetup` 中所做的环境变量变更也会被传递：它们会被注入到 browser 运行时的 env 存储中（可通过 `process.env` / `import.meta.env` 读取），叠加在内置的 `NODE_ENV` / `RSTEST` 之上，且显式的 `test.env` 配置仍然优先。其他宿主环境变量不会被转发到 browser 测试；在混合项目中，Node 侧 `globalSetup` 的环境变量变更不会合并进 browser 测试。由 browser provider hook（`modifyRstestConfig`）新增或修改的 `globalSetup` 条目不会被识别。browser 模式的 watch 运行目前不会执行 `globalSetup`。
 :::
 
 ## 多个全局设置文件


### PR DESCRIPTION
## Summary

`globalSetup` never compiled nor executed for browser projects — execution only existed on the node Rsbuild path, and browser-only runs skip that instance entirely (RFC browser-mode isomorphism, Phase 5 step 5).

- Adds a core-owned pre-cycle globalSetup stage: browser projects' `globalSetup` files get a dedicated one-shot node-target compile (created only when a browser project declares `globalSetup` and has test entries, so cold start for everyone else is unchanged), and setups run in the same forked worker the node path uses.
- Env changes applied by browser `globalSetup` are captured as a change-set (not a full host env snapshot, preserving the static-env decision from #1351) and delivered at runtime into the per-project browser runtime config, readable in tests via `import.meta.env` / `process.env`; user `test.env` still wins.
- Teardown callbacks drain through the single-exit `closeExecutors` path, with exit/signal nets on the browser-only path for crash parity with node runs.
- Behavior note for mixed runs: the stage mutates the host `process.env` before node workers dispatch, so browser setups' env changes are also visible to node tests — consistent with existing cross-project node semantics.
- Known limitation (documented in code): browser projects share one run cycle, so one project's setup failure skips the whole browser cycle; exit code and error reporting still surface the failure.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1572

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

https://claude.ai/code/session_01D7M3s33C4PXLsnXADQqkAv