### PR TITLE
docs: update Rstack domain links

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1792,7 +1792,7 @@ const createBrowserRuntime = async ({
 
                       // Extract and merge sourcemaps from pre-built @rstest/core files
                       // This preserves the sourcemap chain for inline snapshot support
-                      // See: https://rspack.dev/config/module-rules#rulesextractsourcemap
+                      // See: https://rspack.rs/config/module-rules#rulesextractsourcemap
                       const browserRuntimeDir = dirname(browserRuntimePath);
                       rspackConfig.module = rspackConfig.module || {};
                       rspackConfig.module.rules =

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -1,6 +1,6 @@
 # Rstest documentation site
 
-This is the documentation website for Rstest, built with [Rspress](https://rspress.dev).
+This is the documentation website for Rstest, built with [Rspress](https://rspress.rs).
 
 ## Structure
 

--- a/website/docs/en/guide/integration/rsbuild.mdx
+++ b/website/docs/en/guide/integration/rsbuild.mdx
@@ -6,7 +6,7 @@ import { ApiMeta } from '@components/ApiMeta';
 
 # Rsbuild
 
-This guide covers how to integrate Rstest with [Rsbuild](https://rsbuild.dev) for seamless testing in your Rsbuild projects.
+This guide covers how to integrate Rstest with [Rsbuild](https://rsbuild.rs) for seamless testing in your Rsbuild projects.
 
 ## Quick start
 
@@ -304,5 +304,5 @@ export default defineConfig({
 
 ## Related documentation
 
-- [Rsbuild configuration overview](https://rsbuild.dev/config)
+- [Rsbuild configuration overview](https://rsbuild.rs/config)
 - [Rstest configuration overview](/config/)

--- a/website/docs/en/guide/integration/rspack.mdx
+++ b/website/docs/en/guide/integration/rspack.mdx
@@ -1,6 +1,6 @@
 # Rspack
 
-This guide covers how to integrate Rstest with [Rspack](https://rspack.dev) for seamless testing in your Rspack projects.
+This guide covers how to integrate Rstest with [Rspack](https://rspack.rs) for seamless testing in your Rspack projects.
 
 ## Quick start
 
@@ -213,5 +213,5 @@ export default defineConfig({
 
 ## Related documentation
 
-- [Rspack configuration overview](https://rspack.dev/config)
+- [Rspack configuration overview](https://rspack.rs/config)
 - [Rstest configuration overview](/config/)

--- a/website/docs/zh/guide/integration/rsbuild.mdx
+++ b/website/docs/zh/guide/integration/rsbuild.mdx
@@ -6,7 +6,7 @@ import { ApiMeta } from '@components/ApiMeta';
 
 # Rsbuild
 
-本指南介绍了如何将 Rstest 与 [Rsbuild](https://rsbuild.dev) 集成，以便在你的 Rsbuild 项目中进行无缝测试。
+本指南介绍了如何将 Rstest 与 [Rsbuild](https://rsbuild.rs) 集成，以便在你的 Rsbuild 项目中进行无缝测试。
 
 ## 快速开始
 
@@ -304,5 +304,5 @@ export default defineConfig({
 
 ## 相关文档
 
-- [Rsbuild 配置概览](https://rsbuild.dev/config)
+- [Rsbuild 配置概览](https://rsbuild.rs/config)
 - [Rstest 配置概览](/config/)

--- a/website/docs/zh/guide/integration/rspack.mdx
+++ b/website/docs/zh/guide/integration/rspack.mdx
@@ -1,6 +1,6 @@
 # Rspack
 
-本指南介绍了如何将 Rstest 与 [Rspack](https://rspack.dev) 集成，以便在你的 Rspack 项目中进行无缝测试。
+本指南介绍了如何将 Rstest 与 [Rspack](https://rspack.rs) 集成，以便在你的 Rspack 项目中进行无缝测试。
 
 ## 快速开始
 
@@ -213,5 +213,5 @@ export default defineConfig({
 
 ## 相关文档
 
-- [Rspack 配置概览](https://rspack.dev/config)
+- [Rspack 配置概览](https://rspack.rs/config)
 - [Rstest 配置概览](/config/)


### PR DESCRIPTION
## Summary

This PR updates Rsbuild, Rspack, and Rspress references from their legacy `.dev` domains to the current `.rs` domains across the bilingual integration guides, documentation instructions, and a browser source comment.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).