### PR TITLE
feat(core): add getRstestConfig API

### DIFF
--- a/e2e/browser-mode/fixtures/config/modified/modified.test.ts
+++ b/e2e/browser-mode/fixtures/config/modified/modified.test.ts
@@ -2,6 +2,15 @@ import { expect, test } from '@rstest/core';
 
 test('modifyRstestConfig applies browser test discovery and Rsbuild config', () => {
   expect(location.href).toContain('localhost');
+  // @ts-expect-error - defined by a browser Rsbuild plugin through getRstestConfig
+  expect(__GET_RSTEST_CONFIG_BROWSER_ENABLED__).toBe(true);
+  // @ts-expect-error - defined by a browser Rsbuild plugin through getRstestConfig
+  expect(__GET_RSTEST_CONFIG_INCLUDE__).toEqual([
+    './*.test.ts',
+    './git/*.test.ts',
+  ]);
+  // @ts-expect-error - defined by a browser Rsbuild plugin through getRstestConfig
+  expect(__GET_RSTEST_CONFIG_POOL__).toBe('forks');
   // @ts-expect-error - defined by a browser Rsbuild plugin through modifyRstestConfig
   expect(__MODIFY_RSTEST_CONFIG_DEFINE__).toBe('modified-value');
 });

--- a/e2e/browser-mode/fixtures/config/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/config/rstest.config.mts
@@ -11,6 +11,9 @@ const modifyBrowserRstestConfigPlugin = (): RsbuildPlugin => ({
     }
 
     const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+    const rstestConfig = rstestApi?.getRstestConfig();
+    const pool = rstestConfig?.pool;
+    const poolType = typeof pool === 'string' ? pool : pool?.type;
     rstestApi?.modifyRstestConfig((config) => {
       if (process.env.RSTEST_E2E_MUTATE_BROWSER_HEADLESS) {
         config.browser ??= { provider: 'playwright' };
@@ -29,6 +32,11 @@ const modifyBrowserRstestConfigPlugin = (): RsbuildPlugin => ({
       config.source ??= {};
       config.source.define = {
         ...config.source.define,
+        __GET_RSTEST_CONFIG_BROWSER_ENABLED__: JSON.stringify(
+          rstestConfig?.browser?.enabled,
+        ),
+        __GET_RSTEST_CONFIG_INCLUDE__: JSON.stringify(rstestConfig?.include),
+        __GET_RSTEST_CONFIG_POOL__: JSON.stringify(poolType),
         __MODIFY_RSTEST_CONFIG_DEFINE__: JSON.stringify('modified-value'),
       };
     });

--- a/e2e/build/fixtures/modifyRstestConfig/project-a.test.ts
+++ b/e2e/build/fixtures/modifyRstestConfig/project-a.test.ts
@@ -2,9 +2,13 @@ import { expect, it } from '@rstest/core';
 import { projectValue } from '@project-value';
 
 declare const __MODIFIED_PROJECT__: string;
+declare const __GET_RSTEST_CONFIG_POOL__: string;
+declare const __GET_RSTEST_CONFIG_PROJECT__: string;
 
 it('uses project-a modified config', () => {
   expect(__MODIFIED_PROJECT__).toBe('project-a');
+  expect(__GET_RSTEST_CONFIG_POOL__).toBe('forks');
+  expect(__GET_RSTEST_CONFIG_PROJECT__).toBe('project-a');
   expect(projectValue).toBe('project-a');
   expect(
     (globalThis as typeof globalThis & { __PROJECT_SETUP_VALUE__: string })

--- a/e2e/build/fixtures/modifyRstestConfig/project-b.test.ts
+++ b/e2e/build/fixtures/modifyRstestConfig/project-b.test.ts
@@ -2,9 +2,13 @@ import { expect, it } from '@rstest/core';
 import { projectValue } from '@project-value';
 
 declare const __MODIFIED_PROJECT__: string;
+declare const __GET_RSTEST_CONFIG_POOL__: string;
+declare const __GET_RSTEST_CONFIG_PROJECT__: string;
 
 it('uses project-b modified config', () => {
   expect(__MODIFIED_PROJECT__).toBe('project-b');
+  expect(__GET_RSTEST_CONFIG_POOL__).toBe('forks');
+  expect(__GET_RSTEST_CONFIG_PROJECT__).toBe('project-b');
   expect(projectValue).toBe('project-b');
   expect(
     (globalThis as typeof globalThis & { __PROJECT_SETUP_VALUE__: string })

--- a/e2e/build/fixtures/modifyRstestConfig/return-project.test.ts
+++ b/e2e/build/fixtures/modifyRstestConfig/return-project.test.ts
@@ -2,9 +2,13 @@ import { expect, it } from '@rstest/core';
 import { projectValue } from '@project-value';
 
 declare const __MODIFIED_PROJECT__: string;
+declare const __GET_RSTEST_CONFIG_POOL__: string;
+declare const __GET_RSTEST_CONFIG_PROJECT__: string;
 
 it('uses returned modified config with root placeholders', () => {
   expect(__MODIFIED_PROJECT__).toBe('return-project');
+  expect(__GET_RSTEST_CONFIG_POOL__).toBe('forks');
+  expect(__GET_RSTEST_CONFIG_PROJECT__).toBe('return-project');
   expect(projectValue).toBe('return-project');
   expect(
     (globalThis as typeof globalThis & { __PROJECT_SETUP_VALUE__: string })

--- a/e2e/build/fixtures/modifyRstestConfig/rstest.config.mts
+++ b/e2e/build/fixtures/modifyRstestConfig/rstest.config.mts
@@ -13,6 +13,9 @@ const modifyRstestConfigPlugin = (projectName: string): RsbuildPlugin => ({
     }
 
     const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+    const rstestConfig = rstestApi?.getRstestConfig();
+    const pool = rstestConfig?.pool;
+    const poolType = typeof pool === 'string' ? pool : pool?.type;
 
     rstestApi?.modifyRstestConfig((config) => {
       const setupFiles = Array.isArray(config.setupFiles)
@@ -34,7 +37,9 @@ const modifyRstestConfigPlugin = (projectName: string): RsbuildPlugin => ({
         ...config.source,
         define: {
           ...(config.source?.define || {}),
+          __GET_RSTEST_CONFIG_PROJECT__: JSON.stringify(rstestConfig?.name),
           __MODIFIED_PROJECT__: JSON.stringify(projectName),
+          __GET_RSTEST_CONFIG_POOL__: JSON.stringify(poolType),
         },
       };
       config.resolve = {
@@ -58,6 +63,9 @@ const returnRstestConfigPlugin = (projectName: string): RsbuildPlugin => ({
     }
 
     const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+    const rstestConfig = rstestApi?.getRstestConfig();
+    const pool = rstestConfig?.pool;
+    const poolType = typeof pool === 'string' ? pool : pool?.type;
 
     rstestApi?.modifyRstestConfig((config) => ({
       include: [`<rootDir>/${projectName}.test.ts`],
@@ -70,7 +78,9 @@ const returnRstestConfigPlugin = (projectName: string): RsbuildPlugin => ({
         ...config.source,
         define: {
           ...(config.source?.define || {}),
+          __GET_RSTEST_CONFIG_PROJECT__: JSON.stringify(rstestConfig?.name),
           __MODIFIED_PROJECT__: JSON.stringify(projectName),
+          __GET_RSTEST_CONFIG_POOL__: JSON.stringify(poolType),
         },
       },
       resolve: {
@@ -87,6 +97,10 @@ const returnRstestConfigPlugin = (projectName: string): RsbuildPlugin => ({
 });
 
 export default defineConfig({
+  pool: {
+    type: 'forks',
+    maxWorkers: 2,
+  },
   projects: [
     {
       name: 'project-a',

--- a/e2e/build/fixtures/modifyRstestConfig/rstest.noInitialTests.config.mts
+++ b/e2e/build/fixtures/modifyRstestConfig/rstest.noInitialTests.config.mts
@@ -12,7 +12,12 @@ const revealNodeTestsPlugin = (): RsbuildPlugin => ({
       return;
     }
 
-    api.useExposed<RstestExposeAPI>('rstest')?.modifyRstestConfig((config) => {
+    const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+    const rstestConfig = rstestApi?.getRstestConfig();
+    const pool = rstestConfig?.pool;
+    const poolType = typeof pool === 'string' ? pool : pool?.type;
+
+    rstestApi?.modifyRstestConfig((config) => {
       config.include = ['project-a.test.ts'];
       config.setupFiles = [
         fileURLToPath(new URL('./setup/project-a.ts', import.meta.url)),
@@ -25,6 +30,8 @@ const revealNodeTestsPlugin = (): RsbuildPlugin => ({
         ...config.source,
         define: {
           ...(config.source?.define || {}),
+          __GET_RSTEST_CONFIG_POOL__: JSON.stringify(poolType),
+          __GET_RSTEST_CONFIG_PROJECT__: JSON.stringify(rstestConfig?.name),
           __MODIFIED_PROJECT__: JSON.stringify('project-a'),
         },
       };
@@ -42,7 +49,12 @@ const revealNodeTestsPlugin = (): RsbuildPlugin => ({
 });
 
 export default defineConfig({
+  name: 'project-a',
   include: ['missing-before-modify.test.ts'],
   passWithNoTests: false,
+  pool: {
+    type: 'forks',
+    maxWorkers: 2,
+  },
   plugins: [revealNodeTestsPlugin()],
 });

--- a/packages/core/src/core/modifyRstestConfig.ts
+++ b/packages/core/src/core/modifyRstestConfig.ts
@@ -551,13 +551,28 @@ export const getRsbuildEnvironmentConfig = (
 });
 
 const createRstestExposeAPI = (
-  environmentName: string,
+  context: RstestContext,
+  project: ProjectContext,
   modifyRstestConfigCallbacks: Map<string, ModifyRstestConfigCallback[]>,
 ): RstestExposeAPI => ({
+  getRstestConfig: () =>
+    clonePlainConfig({
+      ...context.normalizedConfig,
+      ...project.normalizedConfig,
+      pool: context.normalizedConfig.pool,
+      reporters: context.normalizedConfig.reporters,
+      shard: context.normalizedConfig.shard,
+      output: {
+        ...context.normalizedConfig.output,
+        ...project.normalizedConfig.output,
+        distPath: context.normalizedConfig.output.distPath,
+      },
+    }),
   modifyRstestConfig: (callback) => {
-    const callbacks = modifyRstestConfigCallbacks.get(environmentName) ?? [];
+    const callbacks =
+      modifyRstestConfigCallbacks.get(project.environmentName) ?? [];
     callbacks.push(callback);
-    modifyRstestConfigCallbacks.set(environmentName, callbacks);
+    modifyRstestConfigCallbacks.set(project.environmentName, callbacks);
   },
 });
 
@@ -602,10 +617,7 @@ export const initModifyRstestConfigHooks = (
   for (const project of exposeProjects) {
     rsbuildInstance.expose(
       'rstest',
-      createRstestExposeAPI(
-        project.environmentName,
-        modifyRstestConfigCallbacks,
-      ),
+      createRstestExposeAPI(context, project, modifyRstestConfigCallbacks),
       {
         environment: project.environmentName,
       },

--- a/packages/core/src/core/modifyRstestConfig.ts
+++ b/packages/core/src/core/modifyRstestConfig.ts
@@ -149,99 +149,6 @@ const clonePlainConfig = <T>(value: T): T => {
   return value;
 };
 
-// Opaque provider options can contain callable or class-instance values, so
-// public snapshots must detach own state without flattening their prototypes.
-const cloneConfigSnapshot = <T>(
-  value: T,
-  seen = new WeakMap<object, unknown>(),
-): T => {
-  if (
-    value === null ||
-    (typeof value !== 'object' && typeof value !== 'function')
-  ) {
-    return value;
-  }
-
-  const source = value as object;
-  const cached = seen.get(source);
-  if (cached) {
-    return cached as T;
-  }
-
-  if (value instanceof RegExp) {
-    const clone = new RegExp(value.source, value.flags);
-    clone.lastIndex = value.lastIndex;
-    seen.set(source, clone);
-    return clone as T;
-  }
-
-  if (value instanceof Date) {
-    const clone = new Date(value);
-    seen.set(source, clone);
-    return clone as T;
-  }
-
-  if (value instanceof Map) {
-    const clone = new Map();
-    seen.set(source, clone);
-    for (const [key, item] of value) {
-      clone.set(
-        cloneConfigSnapshot(key, seen),
-        cloneConfigSnapshot(item, seen),
-      );
-    }
-    return clone as T;
-  }
-
-  if (value instanceof Set) {
-    const clone = new Set();
-    seen.set(source, clone);
-    for (const item of value) {
-      clone.add(cloneConfigSnapshot(item, seen));
-    }
-    return clone as T;
-  }
-
-  let clone: object;
-  if (Array.isArray(value)) {
-    clone = [];
-  } else if (typeof value === 'function') {
-    const sourceFunction = value;
-    clone = function (this: unknown, ...args: unknown[]) {
-      if (new.target) {
-        return Reflect.construct(sourceFunction, args, sourceFunction);
-      }
-      return Reflect.apply(sourceFunction, this, args);
-    };
-    Object.setPrototypeOf(clone, Object.getPrototypeOf(sourceFunction));
-  } else {
-    clone = Object.create(Object.getPrototypeOf(value));
-  }
-
-  seen.set(source, clone);
-  for (const key of Reflect.ownKeys(source)) {
-    if (Array.isArray(value) && key === 'length') {
-      continue;
-    }
-
-    const existingDescriptor = Object.getOwnPropertyDescriptor(clone, key);
-    if (existingDescriptor && !existingDescriptor.configurable) {
-      continue;
-    }
-
-    const descriptor = Object.getOwnPropertyDescriptor(source, key);
-    if (!descriptor) {
-      continue;
-    }
-    if ('value' in descriptor) {
-      descriptor.value = cloneConfigSnapshot(descriptor.value, seen);
-    }
-    Object.defineProperty(clone, key, descriptor);
-  }
-
-  return clone as T;
-};
-
 const isConfigValueEqual = (left: unknown, right: unknown): boolean => {
   if (Object.is(left, right)) {
     return true;
@@ -649,7 +556,7 @@ const createRstestExposeAPI = (
   modifyRstestConfigCallbacks: Map<string, ModifyRstestConfigCallback[]>,
 ): RstestExposeAPI => ({
   getRstestConfig: () =>
-    cloneConfigSnapshot({
+    clonePlainConfig({
       ...project.normalizedConfig,
       projects: context.originalConfig.projects,
       pool: context.normalizedConfig.pool,
@@ -660,6 +567,15 @@ const createRstestExposeAPI = (
       onConsoleLog: context.normalizedConfig.onConsoleLog,
       silent: context.normalizedConfig.silent,
       bail: context.normalizedConfig.bail,
+      update: context.normalizedConfig.update,
+      onlyFailures: context.normalizedConfig.onlyFailures,
+      passWithNoTests: context.normalizedConfig.passWithNoTests,
+      forceRerunTriggers: Array.from(
+        new Set([
+          ...context.normalizedConfig.forceRerunTriggers,
+          ...project.normalizedConfig.forceRerunTriggers,
+        ]),
+      ),
       shard: context.normalizedConfig.shard,
       output: {
         ...project.normalizedConfig.output,

--- a/packages/core/src/core/modifyRstestConfig.ts
+++ b/packages/core/src/core/modifyRstestConfig.ts
@@ -149,6 +149,99 @@ const clonePlainConfig = <T>(value: T): T => {
   return value;
 };
 
+// Opaque provider options can contain callable or class-instance values, so
+// public snapshots must detach own state without flattening their prototypes.
+const cloneConfigSnapshot = <T>(
+  value: T,
+  seen = new WeakMap<object, unknown>(),
+): T => {
+  if (
+    value === null ||
+    (typeof value !== 'object' && typeof value !== 'function')
+  ) {
+    return value;
+  }
+
+  const source = value as object;
+  const cached = seen.get(source);
+  if (cached) {
+    return cached as T;
+  }
+
+  if (value instanceof RegExp) {
+    const clone = new RegExp(value.source, value.flags);
+    clone.lastIndex = value.lastIndex;
+    seen.set(source, clone);
+    return clone as T;
+  }
+
+  if (value instanceof Date) {
+    const clone = new Date(value);
+    seen.set(source, clone);
+    return clone as T;
+  }
+
+  if (value instanceof Map) {
+    const clone = new Map();
+    seen.set(source, clone);
+    for (const [key, item] of value) {
+      clone.set(
+        cloneConfigSnapshot(key, seen),
+        cloneConfigSnapshot(item, seen),
+      );
+    }
+    return clone as T;
+  }
+
+  if (value instanceof Set) {
+    const clone = new Set();
+    seen.set(source, clone);
+    for (const item of value) {
+      clone.add(cloneConfigSnapshot(item, seen));
+    }
+    return clone as T;
+  }
+
+  let clone: object;
+  if (Array.isArray(value)) {
+    clone = [];
+  } else if (typeof value === 'function') {
+    const sourceFunction = value;
+    clone = function (this: unknown, ...args: unknown[]) {
+      if (new.target) {
+        return Reflect.construct(sourceFunction, args, sourceFunction);
+      }
+      return Reflect.apply(sourceFunction, this, args);
+    };
+    Object.setPrototypeOf(clone, Object.getPrototypeOf(sourceFunction));
+  } else {
+    clone = Object.create(Object.getPrototypeOf(value));
+  }
+
+  seen.set(source, clone);
+  for (const key of Reflect.ownKeys(source)) {
+    if (Array.isArray(value) && key === 'length') {
+      continue;
+    }
+
+    const existingDescriptor = Object.getOwnPropertyDescriptor(clone, key);
+    if (existingDescriptor && !existingDescriptor.configurable) {
+      continue;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (!descriptor) {
+      continue;
+    }
+    if ('value' in descriptor) {
+      descriptor.value = cloneConfigSnapshot(descriptor.value, seen);
+    }
+    Object.defineProperty(clone, key, descriptor);
+  }
+
+  return clone as T;
+};
+
 const isConfigValueEqual = (left: unknown, right: unknown): boolean => {
   if (Object.is(left, right)) {
     return true;
@@ -556,14 +649,19 @@ const createRstestExposeAPI = (
   modifyRstestConfigCallbacks: Map<string, ModifyRstestConfigCallback[]>,
 ): RstestExposeAPI => ({
   getRstestConfig: () =>
-    clonePlainConfig({
-      ...context.normalizedConfig,
+    cloneConfigSnapshot({
       ...project.normalizedConfig,
+      projects: context.originalConfig.projects,
       pool: context.normalizedConfig.pool,
       reporters: context.normalizedConfig.reporters,
+      isolate: context.normalizedConfig.isolate,
+      coverage: context.normalizedConfig.coverage,
+      resolveSnapshotPath: context.normalizedConfig.resolveSnapshotPath,
+      onConsoleLog: context.normalizedConfig.onConsoleLog,
+      silent: context.normalizedConfig.silent,
+      bail: context.normalizedConfig.bail,
       shard: context.normalizedConfig.shard,
       output: {
-        ...context.normalizedConfig.output,
         ...project.normalizedConfig.output,
         distPath: context.normalizedConfig.output.distPath,
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ import type {
   NormalizedCoverageOptions,
   RstestExposeAPI,
   ProjectConfig,
+  ResolvedRstestConfig,
   RstestConfig,
 } from './types';
 
@@ -18,6 +19,7 @@ export type {
   CoverageOptions,
   CoverageProvider,
   NormalizedCoverageOptions,
+  ResolvedRstestConfig,
   RsbuildPlugin,
   RstestConfig,
   RstestExposeAPI,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -16,6 +16,18 @@ export type ModifyRstestConfigCallback = (
 
 export type RstestExposeAPI = {
   /**
+   * Get a snapshot of the resolved Rstest config for the current Rsbuild
+   * environment.
+   *
+   * This API is exposed to Rsbuild plugins through `api.useExposed('rstest')`
+   * in both Node Mode and Browser Mode projects.
+   * It combines the global Rstest config with the current project's config.
+   * Project-scoped values take precedence while global-only values are kept.
+   *
+   * Mutating the returned snapshot does not change the Rstest config.
+   */
+  getRstestConfig: () => Readonly<RstestConfig>;
+  /**
    * Modify the Rstest config for the current Rsbuild environment.
    *
    * This API is exposed to Rsbuild plugins through `api.useExposed('rstest')`

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -16,15 +16,15 @@ export type ModifyRstestConfigCallback = (
 
 export type RstestExposeAPI = {
   /**
-   * Get a snapshot of the resolved Rstest config for the current Rsbuild
-   * environment.
+   * Get the resolved Rstest config for the current Rsbuild environment.
    *
    * This API is exposed to Rsbuild plugins through `api.useExposed('rstest')`
    * in both Node Mode and Browser Mode projects.
-   * It combines the global Rstest config with the current project's config.
-   * Project-scoped values take precedence while global-only values are kept.
+   * It combines the current project's config with the effective global and
+   * run-level config.
    *
-   * Mutating the returned snapshot does not change the Rstest config.
+   * The returned config uses a read-only type. Opaque values retain their
+   * original identity and behavior.
    */
   getRstestConfig: () => Readonly<ResolvedRstestConfig>;
   /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -26,7 +26,7 @@ export type RstestExposeAPI = {
    *
    * Mutating the returned snapshot does not change the Rstest config.
    */
-  getRstestConfig: () => Readonly<RstestConfig>;
+  getRstestConfig: () => Readonly<ResolvedRstestConfig>;
   /**
    * Modify the Rstest config for the current Rsbuild environment.
    *

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -224,6 +224,14 @@ describe('prepareRsbuild', () => {
       { distPath: string | undefined; module: boolean | undefined }
     >();
     const getterPoolTypes = new Map<string, string | undefined>();
+    const getterGlobalConfig = new Map<
+      string,
+      {
+        performance: unknown;
+        shard: { count: number; index: number } | undefined;
+        silent: boolean | 'passed-only' | undefined;
+      }
+    >();
     const callbackIncludes = new Map<string, string[] | undefined>();
     const createModifyRstestConfigPlugin = (
       include: string,
@@ -246,6 +254,11 @@ describe('prepareRsbuild', () => {
           include,
           typeof pool === 'string' ? pool : pool?.type,
         );
+        getterGlobalConfig.set(include, {
+          performance: configSnapshot?.performance,
+          shard: configSnapshot?.shard,
+          silent: configSnapshot?.silent,
+        });
         configSnapshot?.include?.push('mutated-snapshot');
 
         rstestApi?.modifyRstestConfig((config) => {
@@ -265,6 +278,7 @@ describe('prepareRsbuild', () => {
         resolve: {},
         source: {},
         output: { module: false },
+        silent: false,
         tools: {},
         testEnvironment: {
           name: 'node',
@@ -282,6 +296,7 @@ describe('prepareRsbuild', () => {
         resolve: {},
         source: {},
         output: { module: true },
+        silent: false,
         tools: {},
         testEnvironment: {
           name: 'node',
@@ -293,10 +308,14 @@ describe('prepareRsbuild', () => {
     const context = {
       rootPath,
       command: 'run',
+      originalConfig: {},
       normalizedConfig: {
         root: rootPath,
         name: 'test',
         include: ['global-original'],
+        performance: { buildCache: false },
+        shard: { count: 2, index: 1 },
+        silent: 'passed-only',
         output: {
           distPath: {
             root: TEMP_RSTEST_OUTPUT_DIR,
@@ -319,6 +338,16 @@ describe('prepareRsbuild', () => {
     expect(getterIncludes.get('from-project-b')).toEqual(['original-b']);
     expect(getterPoolTypes.get('from-project-a')).toBe('threads');
     expect(getterPoolTypes.get('from-project-b')).toBe('threads');
+    expect(getterGlobalConfig.get('from-project-a')).toEqual({
+      performance: undefined,
+      shard: { count: 2, index: 1 },
+      silent: 'passed-only',
+    });
+    expect(getterGlobalConfig.get('from-project-b')).toEqual({
+      performance: undefined,
+      shard: { count: 2, index: 1 },
+      silent: 'passed-only',
+    });
     expect(getterOutput.get('from-project-a')).toEqual({
       distPath: TEMP_RSTEST_OUTPUT_DIR,
       module: false,
@@ -332,6 +361,83 @@ describe('prepareRsbuild', () => {
     expect(context.normalizedConfig.include).toEqual(['global-original']);
     expect(projectA.normalizedConfig.include).toEqual(['from-project-a']);
     expect(projectB.normalizedConfig.include).toEqual(['from-project-b']);
+  });
+
+  it('should detach non-plain values in exposed config snapshots', async () => {
+    class ProviderOption {
+      value = 'original';
+    }
+
+    const providerOption = new ProviderOption();
+    const providerCallback = Object.assign(() => 'original', {
+      state: { value: 'original' },
+    });
+    const testNamePattern = /original/g;
+    const readConfigPlugin: RsbuildPlugin = {
+      name: 'read-detached-rstest-config',
+      setup(api) {
+        const snapshot = api
+          .useExposed<RstestExposeAPI>('rstest')
+          ?.getRstestConfig();
+        const providerOptions = snapshot?.browser?.providerOptions as
+          | {
+              callback: typeof providerCallback;
+              option: ProviderOption;
+            }
+          | undefined;
+
+        if (snapshot?.testNamePattern instanceof RegExp) {
+          snapshot.testNamePattern.lastIndex = 4;
+        }
+        if (providerOptions) {
+          providerOptions.option.value = 'snapshot';
+          providerOptions.callback.state.value = 'snapshot';
+        }
+      },
+    };
+    const project = {
+      name: 'browser-project',
+      rootPath,
+      environmentName: 'browser-project',
+      normalizedConfig: {
+        include: ['original.test.ts'],
+        plugins: [readConfigPlugin],
+        resolve: {},
+        source: {},
+        output: {},
+        tools: {},
+        testNamePattern,
+        testEnvironment: { name: 'node' },
+        browser: {
+          enabled: true,
+          providerOptions: {
+            callback: providerCallback,
+            option: providerOption,
+          },
+        },
+      },
+    };
+    const context = {
+      rootPath,
+      command: 'run',
+      originalConfig: {},
+      normalizedConfig: {
+        output: { distPath: { root: TEMP_RSTEST_OUTPUT_DIR } },
+        pool: { execArgv: [], type: 'forks' },
+      },
+      projects: [project],
+    } as unknown as RstestContext;
+    const rsbuildInstance = await prepareRsbuild({
+      context,
+      globTestSourceEntries: async () => ({}),
+      setupFileState: createSetupFileState(),
+    });
+
+    await rsbuildInstance.initConfigs();
+
+    expect(testNamePattern.lastIndex).toBe(0);
+    expect(providerOption.value).toBe('original');
+    expect(providerCallback.state.value).toBe('original');
   });
 
   it('should apply modified rstest config before generating rsbuild config', async () => {

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -227,9 +227,13 @@ describe('prepareRsbuild', () => {
     const getterGlobalConfig = new Map<
       string,
       {
+        forceRerunTriggers: string[] | undefined;
+        onlyFailures: boolean | undefined;
+        passWithNoTests: boolean | undefined;
         performance: unknown;
         shard: { count: number; index: number } | undefined;
         silent: boolean | 'passed-only' | undefined;
+        update: boolean | undefined;
       }
     >();
     const callbackIncludes = new Map<string, string[] | undefined>();
@@ -255,9 +259,13 @@ describe('prepareRsbuild', () => {
           typeof pool === 'string' ? pool : pool?.type,
         );
         getterGlobalConfig.set(include, {
+          forceRerunTriggers: configSnapshot?.forceRerunTriggers,
+          onlyFailures: configSnapshot?.onlyFailures,
+          passWithNoTests: configSnapshot?.passWithNoTests,
           performance: configSnapshot?.performance,
           shard: configSnapshot?.shard,
           silent: configSnapshot?.silent,
+          update: configSnapshot?.update,
         });
         configSnapshot?.include?.push('mutated-snapshot');
 
@@ -274,12 +282,16 @@ describe('prepareRsbuild', () => {
       environmentName: 'project-a',
       normalizedConfig: {
         include: ['original-a'],
+        forceRerunTriggers: ['project-a.config.ts'],
+        onlyFailures: false,
         plugins: [createModifyRstestConfigPlugin('from-project-a')],
+        passWithNoTests: false,
         resolve: {},
         source: {},
         output: { module: false },
         silent: false,
         tools: {},
+        update: false,
         testEnvironment: {
           name: 'node',
         },
@@ -292,12 +304,16 @@ describe('prepareRsbuild', () => {
       environmentName: 'project-b',
       normalizedConfig: {
         include: ['original-b'],
+        forceRerunTriggers: ['project-b.config.ts'],
+        onlyFailures: false,
         plugins: [createModifyRstestConfigPlugin('from-project-b')],
+        passWithNoTests: false,
         resolve: {},
         source: {},
         output: { module: true },
         silent: false,
         tools: {},
+        update: false,
         testEnvironment: {
           name: 'node',
         },
@@ -312,10 +328,14 @@ describe('prepareRsbuild', () => {
       normalizedConfig: {
         root: rootPath,
         name: 'test',
+        forceRerunTriggers: ['root.config.ts'],
         include: ['global-original'],
+        onlyFailures: true,
+        passWithNoTests: true,
         performance: { buildCache: false },
         shard: { count: 2, index: 1 },
         silent: 'passed-only',
+        update: true,
         output: {
           distPath: {
             root: TEMP_RSTEST_OUTPUT_DIR,
@@ -339,14 +359,22 @@ describe('prepareRsbuild', () => {
     expect(getterPoolTypes.get('from-project-a')).toBe('threads');
     expect(getterPoolTypes.get('from-project-b')).toBe('threads');
     expect(getterGlobalConfig.get('from-project-a')).toEqual({
+      forceRerunTriggers: ['root.config.ts', 'project-a.config.ts'],
+      onlyFailures: true,
+      passWithNoTests: true,
       performance: undefined,
       shard: { count: 2, index: 1 },
       silent: 'passed-only',
+      update: true,
     });
     expect(getterGlobalConfig.get('from-project-b')).toEqual({
+      forceRerunTriggers: ['root.config.ts', 'project-b.config.ts'],
+      onlyFailures: true,
+      passWithNoTests: true,
       performance: undefined,
       shard: { count: 2, index: 1 },
       silent: 'passed-only',
+      update: true,
     });
     expect(getterOutput.get('from-project-a')).toEqual({
       distPath: TEMP_RSTEST_OUTPUT_DIR,
@@ -363,36 +391,43 @@ describe('prepareRsbuild', () => {
     expect(projectB.normalizedConfig.include).toEqual(['from-project-b']);
   });
 
-  it('should detach non-plain values in exposed config snapshots', async () => {
+  it('should preserve opaque values in exposed config', async () => {
     class ProviderOption {
-      value = 'original';
+      #value = 'original';
+
+      getValue() {
+        return this.#value;
+      }
     }
 
     const providerOption = new ProviderOption();
-    const providerCallback = Object.assign(() => 'original', {
-      state: { value: 'original' },
-    });
+    const providerCallback = () => 'original';
+    const providerPromise = Promise.resolve('original');
+    const providerUrl = new URL('https://rstest.rs/guide');
+    const providerBytes = new Uint8Array([1, 2, 3]);
     const testNamePattern = /original/g;
+    type ProviderOptions = {
+      bytes: Uint8Array;
+      callback: typeof providerCallback;
+      option: ProviderOption;
+      promise: Promise<string>;
+      url: URL;
+    };
+    let exposedProviderOptions: ProviderOptions | undefined;
+    let exposedBundlePattern: RegExp | string | undefined;
     const readConfigPlugin: RsbuildPlugin = {
-      name: 'read-detached-rstest-config',
+      name: 'read-opaque-rstest-config',
       setup(api) {
         const snapshot = api
           .useExposed<RstestExposeAPI>('rstest')
           ?.getRstestConfig();
-        const providerOptions = snapshot?.browser?.providerOptions as
-          | {
-              callback: typeof providerCallback;
-              option: ProviderOption;
-            }
-          | undefined;
-
-        if (snapshot?.testNamePattern instanceof RegExp) {
-          snapshot.testNamePattern.lastIndex = 4;
-        }
-        if (providerOptions) {
-          providerOptions.option.value = 'snapshot';
-          providerOptions.callback.state.value = 'snapshot';
-        }
+        exposedProviderOptions = snapshot?.browser
+          ?.providerOptions as ProviderOptions;
+        exposedBundlePattern = Array.isArray(
+          snapshot?.output?.bundleDependencies,
+        )
+          ? snapshot.output.bundleDependencies[0]
+          : undefined;
       },
     };
     const project = {
@@ -400,19 +435,22 @@ describe('prepareRsbuild', () => {
       rootPath,
       environmentName: 'browser-project',
       normalizedConfig: {
+        forceRerunTriggers: [],
         include: ['original.test.ts'],
         plugins: [readConfigPlugin],
         resolve: {},
         source: {},
-        output: {},
+        output: { bundleDependencies: [testNamePattern] },
         tools: {},
-        testNamePattern,
         testEnvironment: { name: 'node' },
         browser: {
-          enabled: true,
+          enabled: false,
           providerOptions: {
+            bytes: providerBytes,
             callback: providerCallback,
             option: providerOption,
+            promise: providerPromise,
+            url: providerUrl,
           },
         },
       },
@@ -422,6 +460,7 @@ describe('prepareRsbuild', () => {
       command: 'run',
       originalConfig: {},
       normalizedConfig: {
+        forceRerunTriggers: [],
         output: { distPath: { root: TEMP_RSTEST_OUTPUT_DIR } },
         pool: { execArgv: [], type: 'forks' },
       },
@@ -435,9 +474,17 @@ describe('prepareRsbuild', () => {
 
     await rsbuildInstance.initConfigs();
 
-    expect(testNamePattern.lastIndex).toBe(0);
-    expect(providerOption.value).toBe('original');
-    expect(providerCallback.state.value).toBe('original');
+    expect(exposedBundlePattern).toBe(testNamePattern);
+    expect(exposedProviderOptions?.option).toBe(providerOption);
+    expect(exposedProviderOptions?.option.getValue()).toBe('original');
+    expect(exposedProviderOptions?.callback).toBe(providerCallback);
+    expect(exposedProviderOptions?.callback()).toBe('original');
+    expect(exposedProviderOptions?.promise).toBe(providerPromise);
+    await expect(exposedProviderOptions?.promise).resolves.toBe('original');
+    expect(exposedProviderOptions?.url).toBe(providerUrl);
+    expect(exposedProviderOptions?.url.href).toBe('https://rstest.rs/guide');
+    expect(exposedProviderOptions?.bytes).toBe(providerBytes);
+    expect(exposedProviderOptions?.bytes.byteLength).toBe(3);
   });
 
   it('should apply modified rstest config before generating rsbuild config', async () => {

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -217,7 +217,14 @@ describe('prepareRsbuild', () => {
     }
   });
 
-  it('should expose project-scoped rstest API to Rsbuild plugins', async () => {
+  it('should expose merged global and project config snapshots', async () => {
+    const getterIncludes = new Map<string, string[]>();
+    const getterOutput = new Map<
+      string,
+      { distPath: string | undefined; module: boolean | undefined }
+    >();
+    const getterPoolTypes = new Map<string, string | undefined>();
+    const callbackIncludes = new Map<string, string[] | undefined>();
     const createModifyRstestConfigPlugin = (
       include: string,
     ): RsbuildPlugin => ({
@@ -225,7 +232,24 @@ describe('prepareRsbuild', () => {
       setup(api) {
         const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
+        const configSnapshot = rstestApi?.getRstestConfig();
+        getterIncludes.set(include, [...(configSnapshot?.include || [])]);
+        getterOutput.set(include, {
+          distPath:
+            typeof configSnapshot?.output?.distPath === 'string'
+              ? configSnapshot.output.distPath
+              : configSnapshot?.output?.distPath?.root,
+          module: configSnapshot?.output?.module,
+        });
+        const pool = configSnapshot?.pool;
+        getterPoolTypes.set(
+          include,
+          typeof pool === 'string' ? pool : pool?.type,
+        );
+        configSnapshot?.include?.push('mutated-snapshot');
+
         rstestApi?.modifyRstestConfig((config) => {
+          callbackIncludes.set(include, config.include);
           config.include = [include];
         });
       },
@@ -240,7 +264,7 @@ describe('prepareRsbuild', () => {
         plugins: [createModifyRstestConfigPlugin('from-project-a')],
         resolve: {},
         source: {},
-        output: {},
+        output: { module: false },
         tools: {},
         testEnvironment: {
           name: 'node',
@@ -257,7 +281,7 @@ describe('prepareRsbuild', () => {
         plugins: [createModifyRstestConfigPlugin('from-project-b')],
         resolve: {},
         source: {},
-        output: {},
+        output: { module: true },
         tools: {},
         testEnvironment: {
           name: 'node',
@@ -266,28 +290,46 @@ describe('prepareRsbuild', () => {
       },
     };
 
-    const rsbuildInstance = await prepareRsbuild({
-      context: {
-        rootPath,
-        command: 'run',
-        normalizedConfig: {
-          root: rootPath,
-          name: 'test',
-          output: {
-            distPath: {
-              root: TEMP_RSTEST_OUTPUT_DIR,
-            },
+    const context = {
+      rootPath,
+      command: 'run',
+      normalizedConfig: {
+        root: rootPath,
+        name: 'test',
+        include: ['global-original'],
+        output: {
+          distPath: {
+            root: TEMP_RSTEST_OUTPUT_DIR,
           },
-          pool: { type: 'forks' },
         },
-        projects: [projectA, projectB],
-      } as unknown as RstestContext,
+        pool: { type: 'threads' },
+      },
+      projects: [projectA, projectB],
+    } as unknown as RstestContext;
+
+    const rsbuildInstance = await prepareRsbuild({
+      context,
       globTestSourceEntries: async () => ({}),
       setupFileState: createSetupFileState(),
     });
 
     await rsbuildInstance.initConfigs();
 
+    expect(getterIncludes.get('from-project-a')).toEqual(['original-a']);
+    expect(getterIncludes.get('from-project-b')).toEqual(['original-b']);
+    expect(getterPoolTypes.get('from-project-a')).toBe('threads');
+    expect(getterPoolTypes.get('from-project-b')).toBe('threads');
+    expect(getterOutput.get('from-project-a')).toEqual({
+      distPath: TEMP_RSTEST_OUTPUT_DIR,
+      module: false,
+    });
+    expect(getterOutput.get('from-project-b')).toEqual({
+      distPath: TEMP_RSTEST_OUTPUT_DIR,
+      module: true,
+    });
+    expect(callbackIncludes.get('from-project-a')).toEqual(['original-a']);
+    expect(callbackIncludes.get('from-project-b')).toEqual(['original-b']);
+    expect(context.normalizedConfig.include).toEqual(['global-original']);
     expect(projectA.normalizedConfig.include).toEqual(['from-project-a']);
     expect(projectB.normalizedConfig.include).toEqual(['from-project-b']);
   });

--- a/website/docs/en/config/build/plugins.mdx
+++ b/website/docs/en/config/build/plugins.mdx
@@ -54,7 +54,7 @@ Rstest exposes its integration APIs through [`api.useExposed('rstest')`](https:/
 
 <ApiMeta addedVersion="0.11.2" />
 
-Use `getRstestConfig` to read a snapshot of the resolved Rstest config for the current Rsbuild environment. It combines the normalized global Rstest config with the current project's config: project-scoped values take precedence, while global-only options such as `pool`, `reporters`, and `output.distPath` are retained.
+Use `getRstestConfig` to read a snapshot of the resolved Rstest config for the current Rsbuild environment. It combines the current project's normalized config with global-only options such as `pool`, `reporters`, `shard`, and `output.distPath`.
 
 ```ts title="rstest-plugin.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
@@ -87,7 +87,7 @@ export const myPlugin = (): RsbuildPlugin => ({
 
 In multi-project mode, `getRstestConfig` returns the global config merged with the config of the project that owns the current Rsbuild environment. Mutating values on the returned snapshot does not change Rstest's internal config.
 
-**Type:** `() => Readonly<RstestConfig>`
+**Type:** `() => Readonly<ResolvedRstestConfig>`
 
 ## Modify Rstest config in Rsbuild plugins \{#modify-rstest-config}
 

--- a/website/docs/en/config/build/plugins.mdx
+++ b/website/docs/en/config/build/plugins.mdx
@@ -29,19 +29,12 @@ export default defineConfig({
 
 Check out the Rsbuild [plugin list](https://rsbuild.rs/plugins/list#official-plugins) to discover available plugins. These plugins can also be used with Rstest.
 
-## Modify Rstest config in Rsbuild plugins \{#modify-rstest-config}
+## Detect whether a plugin is running in Rstest \{#detect-rstest-environment}
 
-<ApiMeta addedVersion="0.11.1" />
-
-When an Rsbuild plugin runs inside Rstest, it can get the Rstest exposed API through [`api.useExposed`](https://rsbuild.rs/plugins/dev/core) from the Rsbuild Plugin API and call `modifyRstestConfig` to adjust the Rstest config for the current project.
-
-This API is exposed in both Node Mode and Browser Mode projects. Both modes use the `rstest` Rsbuild caller name, so plugins can guard on `api.context.callerName === 'rstest'` when they run inside Rstest.
-
-This API is intended for framework integrations and toolchain plugins. When a plugin already knows the current framework, Rsbuild environment, or project conventions, it can centrally add project config such as test entries, exclude rules, setup files, aliases, defines, or `testEnvironment` so users do not need to duplicate the same information in their Rstest config.
+Rsbuild plugins can run in different tools. Use [`api.context.callerName`](https://rsbuild.rs/api/javascript-api/instance#contextcallername) to detect whether the current plugin is running in Rstest before using Rstest-specific behavior.
 
 ```ts title="rstest-plugin.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
-import type { RstestExposeAPI } from '@rstest/core';
 
 export const myPlugin = (): RsbuildPlugin => ({
   name: 'my-plugin',
@@ -50,16 +43,75 @@ export const myPlugin = (): RsbuildPlugin => ({
       return;
     }
 
+    // Rstest-specific plugin behavior
+  },
+});
+```
+
+Rstest exposes its integration APIs through [`api.useExposed('rstest')`](https://rsbuild.rs/plugins/dev/core). `RstestExposeAPI` is exported from `@rstest/core` as the type of these APIs.
+
+## Read Rstest config in Rsbuild plugins \{#get-rstest-config}
+
+<ApiMeta addedVersion="0.11.2" />
+
+Use `getRstestConfig` to read a snapshot of the resolved Rstest config for the current Rsbuild environment. It combines the normalized global Rstest config with the current project's config: project-scoped values take precedence, while global-only options such as `pool`, `reporters`, and `output.distPath` are retained.
+
+```ts title="rstest-plugin.ts"
+import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RstestExposeAPI } from '@rstest/core';
+
+export const myPlugin = (): RsbuildPlugin => ({
+  name: 'read-rstest-config',
+  setup(api) {
+    const rstestConfig = api
+      .useExposed<RstestExposeAPI>('rstest')
+      ?.getRstestConfig();
+
+    if (!rstestConfig) {
+      return;
+    }
+
+    api.modifyRsbuildConfig((config) => ({
+      ...config,
+      source: {
+        ...config.source,
+        define: {
+          ...config.source?.define,
+          __RSTEST_PROJECT_NAME__: JSON.stringify(rstestConfig.name),
+        },
+      },
+    }));
+  },
+});
+```
+
+In multi-project mode, `getRstestConfig` returns the global config merged with the config of the project that owns the current Rsbuild environment. Mutating values on the returned snapshot does not change Rstest's internal config.
+
+**Type:** `() => Readonly<RstestConfig>`
+
+## Modify Rstest config in Rsbuild plugins \{#modify-rstest-config}
+
+<ApiMeta addedVersion="0.11.1" />
+
+Use `modifyRstestConfig` to adjust the Rstest config for the current project. This API is intended for framework integrations and toolchain plugins. When a plugin already knows the current framework, Rsbuild environment, or project conventions, it can centrally add project config such as test entries, exclude rules, setup files, aliases, defines, or `testEnvironment` so users do not need to duplicate the same information in their Rstest config.
+
+```ts title="rstest-plugin.ts"
+import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RstestExposeAPI } from '@rstest/core';
+
+export const myPlugin = (): RsbuildPlugin => ({
+  name: 'modify-rstest-config',
+  setup(api) {
     const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
     rstestApi?.modifyRstestConfig((config) => {
-      config.include = ['**/*.test.ts'];
+      config.include = ['**/*.plugin.test.ts'];
     });
   },
 });
 ```
 
-In multi-project mode, Rstest exposes one API for each Rsbuild environment. A plugin registered in one project only modifies that project's Rstest config and does not affect other projects.
+In multi-project mode, a plugin registered in one project can only modify that project's Rstest config and does not affect other projects.
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -79,9 +131,7 @@ export default defineConfig({
 });
 ```
 
-### Type definitions
-
-`RstestExposeAPI` is exported from `@rstest/core` and is the type of the API exposed by Rstest to Rsbuild plugins through `api.useExposed('rstest')`.
+### Type definition
 
 ```ts
 import type { RstestConfig } from '@rstest/core';
@@ -89,13 +139,11 @@ import type { RstestConfig } from '@rstest/core';
 export type ModifyRstestConfigCallback = (
   config: RstestConfig,
 ) => RstestConfig | void | Promise<RstestConfig | void>;
-
-export type RstestExposeAPI = {
-  modifyRstestConfig: (callback: ModifyRstestConfigCallback) => void;
-};
 ```
 
-`RstestConfig` is the same user-facing config shape accepted by `defineConfig`. You can either mutate the received `config` object directly or return a config fragment that matches the `RstestConfig` shape. Rstest merges, normalizes, and validates these changes again after the callback finishes. The callback can also be asynchronous.
+**Type:** `(callback: ModifyRstestConfigCallback) => void`
+
+`RstestConfig` is the same user-facing config shape accepted by `defineConfig`. With `modifyRstestConfig`, you can either mutate the received `config` object directly or return a config fragment that matches the `RstestConfig` shape. Rstest merges, normalizes, and validates these changes again after the callback finishes. The callback can also be asynchronous.
 
 Register `modifyRstestConfig` during the Rsbuild plugin `setup` phase. Do not register it from later Rsbuild config hooks such as `api.modifyRsbuildConfig`, because Rstest applies collected callbacks while resolving the Rsbuild config; callbacks registered inside those hooks are too late for the current resolution pass.
 

--- a/website/docs/en/config/build/plugins.mdx
+++ b/website/docs/en/config/build/plugins.mdx
@@ -54,7 +54,7 @@ Rstest exposes its integration APIs through [`api.useExposed('rstest')`](https:/
 
 <ApiMeta addedVersion="0.11.2" />
 
-Use `getRstestConfig` to read a snapshot of the resolved Rstest config for the current Rsbuild environment. It combines the current project's normalized config with global-only options such as `pool`, `reporters`, `shard`, and `output.distPath`.
+Use `getRstestConfig` to read the resolved Rstest config for the current Rsbuild environment. It combines the current project's normalized config with global and run-level options such as `pool`, `reporters`, `shard`, `update`, and `output.distPath`.
 
 ```ts title="rstest-plugin.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
@@ -85,7 +85,7 @@ export const myPlugin = (): RsbuildPlugin => ({
 });
 ```
 
-In multi-project mode, `getRstestConfig` returns the global config merged with the config of the project that owns the current Rsbuild environment. Mutating values on the returned snapshot does not change Rstest's internal config.
+In multi-project mode, `getRstestConfig` returns the effective global config merged with the config of the project that owns the current Rsbuild environment. Opaque values such as functions and provider-specific class instances retain their original identity and behavior.
 
 **Type:** `() => Readonly<ResolvedRstestConfig>`
 

--- a/website/docs/en/guide/basic/configure-rstest.mdx
+++ b/website/docs/en/guide/basic/configure-rstest.mdx
@@ -56,6 +56,12 @@ Rstest's build configuration inherits from Rsbuild. Therefore, in Rstest, you ca
 
 More configurations can be referred to [Build Configurations](/config/#build-configurations).
 
+### Read Rstest config in Rsbuild plugins \{#get-rstest-config}
+
+You can read the resolved Rstest config for the current Rsbuild environment through the API exposed by Rstest.
+
+See [Read Rstest config in Rsbuild plugins](/config/build/plugins#get-rstest-config) for usage and type definitions.
+
 ### Modify Rstest config in Rsbuild plugins \{#modify-rstest-config}
 
 You can modify the current Rstest project config in Rsbuild plugins through the API exposed by Rstest.
@@ -130,22 +136,9 @@ export default defineConfig({
 });
 ```
 
-If you are developing the Rsbuild plugin, you can use [api.context.callerName](https://rsbuild.rs/api/javascript-api/instance#contextcallername) to determine the current plugin is being called.
+### Detect Rstest in Rsbuild plugins
 
-```ts
-export const myPlugin = {
-  name: 'my-plugin',
-  setup(api) {
-    const { callerName } = api.context;
-
-    if (callerName === 'rstest') {
-      // ...
-    } else if (callerName === 'rsbuild') {
-      // ...
-    }
-  },
-};
-```
+If you are developing an Rsbuild plugin, see [Detect whether a plugin is running in Rstest](/config/build/plugins#detect-rstest-environment) to use `api.context.callerName` for environment-specific behavior.
 
 ## Configuration integration
 

--- a/website/docs/zh/config/build/plugins.mdx
+++ b/website/docs/zh/config/build/plugins.mdx
@@ -54,7 +54,7 @@ Rstest 通过 [`api.useExposed('rstest')`](https://rsbuild.rs/zh/plugins/dev/cor
 
 <ApiMeta addedVersion="0.11.2" />
 
-使用 `getRstestConfig` 读取当前 Rsbuild environment 最终 Rstest 配置的快照。该快照由经过规范化的 Rstest 全局配置与当前 project 配置合并而成：project 配置优先，同时保留 `pool`、`reporters`、`output.distPath` 等仅属于全局配置的选项。
+使用 `getRstestConfig` 读取当前 Rsbuild environment 最终 Rstest 配置的快照。该快照由当前 project 的规范化配置与 `pool`、`reporters`、`shard`、`output.distPath` 等全局配置合并而成。
 
 ```ts title="rstest-plugin.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
@@ -87,7 +87,7 @@ export const myPlugin = (): RsbuildPlugin => ({
 
 在多 project 模式下，`getRstestConfig` 返回全局配置与当前 Rsbuild environment 所属 project 配置合并后的结果。修改返回快照中的值不会改变 Rstest 的内部配置。
 
-**类型：** `() => Readonly<RstestConfig>`
+**类型：** `() => Readonly<ResolvedRstestConfig>`
 
 ## 在 Rsbuild 插件中修改 Rstest 配置 \{#modify-rstest-config}
 

--- a/website/docs/zh/config/build/plugins.mdx
+++ b/website/docs/zh/config/build/plugins.mdx
@@ -29,19 +29,12 @@ export default defineConfig({
 
 查看 Rsbuild 的 [插件列表](https://rsbuild.rs/zh/plugins/list/#%E5%AE%98%E6%96%B9%E6%8F%92%E4%BB%B6) 来发现可用的插件，这些插件也适用于 Rstest。
 
-## 在 Rsbuild 插件中修改 Rstest 配置 \{#modify-rstest-config}
+## 判断插件是否运行在 Rstest 中 \{#detect-rstest-environment}
 
-<ApiMeta addedVersion="0.11.1" />
-
-当 Rsbuild 插件运行在 Rstest 中时，可以通过 Rsbuild Plugin API 中的 [`api.useExposed`](https://rsbuild.rs/zh/plugins/dev/core) 获取 Rstest 暴露的 API，并调用 `modifyRstestConfig` 来调整当前 project 的 Rstest 配置。
-
-该 API 会同时在 Node Mode 和 Browser Mode project 中暴露。两种模式都会使用 `rstest` 作为 Rsbuild caller name，因此插件可以通过 `api.context.callerName === 'rstest'` 判断当前运行在 Rstest 中。
-
-这个 API 适合框架集成或工具链插件使用：当插件已经了解当前 framework、Rsbuild environment 或项目约定时，可以集中补充测试入口、排除规则、setup files、alias、define 或 `testEnvironment` 等 project 配置，避免用户在 Rstest 配置中重复声明同一套信息。
+Rsbuild 插件可以在不同的工具中运行。使用 [`api.context.callerName`](https://rsbuild.rs/zh/api/javascript-api/instance#contextcallername) 判断当前插件是否运行在 Rstest 中，再执行 Rstest 特有的逻辑。
 
 ```ts title="rstest-plugin.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
-import type { RstestExposeAPI } from '@rstest/core';
 
 export const myPlugin = (): RsbuildPlugin => ({
   name: 'my-plugin',
@@ -50,16 +43,75 @@ export const myPlugin = (): RsbuildPlugin => ({
       return;
     }
 
+    // Rstest 特有的插件逻辑
+  },
+});
+```
+
+Rstest 通过 [`api.useExposed('rstest')`](https://rsbuild.rs/zh/plugins/dev/core) 暴露集成 API。`RstestExposeAPI` 从 `@rstest/core` 导出，用于描述这些 API 的类型。
+
+## 在 Rsbuild 插件中读取 Rstest 配置 \{#get-rstest-config}
+
+<ApiMeta addedVersion="0.11.2" />
+
+使用 `getRstestConfig` 读取当前 Rsbuild environment 最终 Rstest 配置的快照。该快照由经过规范化的 Rstest 全局配置与当前 project 配置合并而成：project 配置优先，同时保留 `pool`、`reporters`、`output.distPath` 等仅属于全局配置的选项。
+
+```ts title="rstest-plugin.ts"
+import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RstestExposeAPI } from '@rstest/core';
+
+export const myPlugin = (): RsbuildPlugin => ({
+  name: 'read-rstest-config',
+  setup(api) {
+    const rstestConfig = api
+      .useExposed<RstestExposeAPI>('rstest')
+      ?.getRstestConfig();
+
+    if (!rstestConfig) {
+      return;
+    }
+
+    api.modifyRsbuildConfig((config) => ({
+      ...config,
+      source: {
+        ...config.source,
+        define: {
+          ...config.source?.define,
+          __RSTEST_PROJECT_NAME__: JSON.stringify(rstestConfig.name),
+        },
+      },
+    }));
+  },
+});
+```
+
+在多 project 模式下，`getRstestConfig` 返回全局配置与当前 Rsbuild environment 所属 project 配置合并后的结果。修改返回快照中的值不会改变 Rstest 的内部配置。
+
+**类型：** `() => Readonly<RstestConfig>`
+
+## 在 Rsbuild 插件中修改 Rstest 配置 \{#modify-rstest-config}
+
+<ApiMeta addedVersion="0.11.1" />
+
+使用 `modifyRstestConfig` 调整当前 project 的 Rstest 配置。这个 API 适合框架集成或工具链插件使用：当插件已经了解当前 framework、Rsbuild environment 或项目约定时，可以集中补充测试入口、排除规则、setup files、alias、define 或 `testEnvironment` 等 project 配置，避免用户在 Rstest 配置中重复声明同一套信息。
+
+```ts title="rstest-plugin.ts"
+import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RstestExposeAPI } from '@rstest/core';
+
+export const myPlugin = (): RsbuildPlugin => ({
+  name: 'modify-rstest-config',
+  setup(api) {
     const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
     rstestApi?.modifyRstestConfig((config) => {
-      config.include = ['**/*.test.ts'];
+      config.include = ['**/*.plugin.test.ts'];
     });
   },
 });
 ```
 
-在多 project 模式下，Rstest 会为每个 Rsbuild environment 暴露独立的 API。注册在某个 project 中的插件只会修改该 project 的 Rstest 配置，不会影响其他 project。
+在多 project 模式下，注册在某个 project 中的插件只会修改该 project 的 Rstest 配置，不会影响其他 project。
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -81,21 +133,17 @@ export default defineConfig({
 
 ### 类型说明
 
-`RstestExposeAPI` 从 `@rstest/core` 导出，用于描述 Rstest 通过 `api.useExposed('rstest')` 暴露给 Rsbuild 插件的 API。
-
 ```ts
 import type { RstestConfig } from '@rstest/core';
 
 export type ModifyRstestConfigCallback = (
   config: RstestConfig,
 ) => RstestConfig | void | Promise<RstestConfig | void>;
-
-export type RstestExposeAPI = {
-  modifyRstestConfig: (callback: ModifyRstestConfigCallback) => void;
-};
 ```
 
-`RstestConfig` 与 `defineConfig` 接收的配置类型一致。你可以直接修改回调收到的 `config` 对象，也可以返回一个符合 `RstestConfig` 结构的配置片段。Rstest 会在回调完成后重新合并、规范化并校验这些改动。该回调也可以是异步函数。
+**类型：** `(callback: ModifyRstestConfigCallback) => void`
+
+`RstestConfig` 与 `defineConfig` 接收的配置类型一致。使用 `modifyRstestConfig` 时，你可以直接修改回调收到的 `config` 对象，也可以返回一个符合 `RstestConfig` 结构的配置片段。Rstest 会在回调完成后重新合并、规范化并校验这些改动。该回调也可以是异步函数。
 
 请在 Rsbuild 插件的 `setup` 阶段注册 `modifyRstestConfig`。不要在 `api.modifyRsbuildConfig` 等更晚的 Rsbuild config hook 中注册它，因为 Rstest 会在解析 Rsbuild config 时应用已经收集到的回调；在这些 hook 内注册的回调对于当前解析流程来说已经太晚。
 

--- a/website/docs/zh/config/build/plugins.mdx
+++ b/website/docs/zh/config/build/plugins.mdx
@@ -54,7 +54,7 @@ Rstest 通过 [`api.useExposed('rstest')`](https://rsbuild.rs/zh/plugins/dev/cor
 
 <ApiMeta addedVersion="0.11.2" />
 
-使用 `getRstestConfig` 读取当前 Rsbuild environment 最终 Rstest 配置的快照。该快照由当前 project 的规范化配置与 `pool`、`reporters`、`shard`、`output.distPath` 等全局配置合并而成。
+使用 `getRstestConfig` 读取当前 Rsbuild environment 最终生效的 Rstest 配置。返回值由当前 project 的规范化配置与 `pool`、`reporters`、`shard`、`update`、`output.distPath` 等全局配置和运行级配置合并而成。
 
 ```ts title="rstest-plugin.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
@@ -85,7 +85,7 @@ export const myPlugin = (): RsbuildPlugin => ({
 });
 ```
 
-在多 project 模式下，`getRstestConfig` 返回全局配置与当前 Rsbuild environment 所属 project 配置合并后的结果。修改返回快照中的值不会改变 Rstest 的内部配置。
+在多 project 模式下，`getRstestConfig` 返回最终生效的全局配置与当前 Rsbuild environment 所属 project 配置合并后的结果。函数、provider 特有的类实例等 opaque value 会保留原始引用及行为。
 
 **类型：** `() => Readonly<ResolvedRstestConfig>`
 

--- a/website/docs/zh/guide/basic/configure-rstest.mdx
+++ b/website/docs/zh/guide/basic/configure-rstest.mdx
@@ -56,6 +56,12 @@ Rstest 的构建配置继承自 Rsbuild。因此，在 Rstest 中，你可以使
 
 更多配置可参考 [构建配置](/config/#build-configurations)。
 
+### 在 Rsbuild 插件中读取 Rstest 配置 \{#get-rstest-config}
+
+你可以通过 Rstest 暴露的 API 读取当前 Rsbuild environment 最终的 Rstest 配置。
+
+用法和类型说明请参考 [在 Rsbuild 插件中读取 Rstest 配置](/config/build/plugins#get-rstest-config)。
+
 ### 在 Rsbuild 插件中修改 Rstest 配置 \{#modify-rstest-config}
 
 你可以在 Rsbuild 插件中通过 Rstest 暴露的 API 修改当前 Rstest project 配置。
@@ -130,22 +136,9 @@ export default defineConfig({
 });
 ```
 
-如果你正在开发 Rsbuild 插件，你可以使用 [api.context.callerName](https://rsbuild.rs/zh/api/javascript-api/instance#contextcallername) 来判断当前插件被调用的环境。
+### 在 Rsbuild 插件中判断 Rstest 环境
 
-```ts
-export const myPlugin = {
-  name: 'my-plugin',
-  setup(api) {
-    const { callerName } = api.context;
-
-    if (callerName === 'rstest') {
-      // ...
-    } else if (callerName === 'rsbuild') {
-      // ...
-    }
-  },
-};
-```
+如果你正在开发 Rsbuild 插件，请参考[判断插件是否运行在 Rstest 中](/config/build/plugins#detect-rstest-environment)，通过 `api.context.callerName` 执行特定环境下的逻辑。
 
 ## 配置集成
 


### PR DESCRIPTION
## Summary

- Add a read-only `getRstestConfig` exposed API that returns the effective global and run-level Rstest config merged with the current project config for each Rsbuild environment.
- Preserve global and run-level options such as `pool`, `reporters`, `shard`, `update`, and `output.distPath`, while retaining the identity and behavior of opaque config values.
- Add Node and browser coverage and document environment detection, config reading, and config modification separately in English and Chinese.

## Example

```ts
import type { RsbuildPlugin } from '@rsbuild/core';
import type { RstestExposeAPI } from '@rstest/core';

export const myPlugin = (): RsbuildPlugin => ({
  name: 'read-rstest-config',
  setup(api) {
    const rstestConfig = api
      .useExposed<RstestExposeAPI>('rstest')
      ?.getRstestConfig();

    console.log(rstestConfig?.name);
  },
});
```

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
