### PR TITLE
fix(core): support object URLs for DOM blobs

### DIFF
--- a/e2e/dom/fixtures/test/domScriptUrl.test.ts
+++ b/e2e/dom/fixtures/test/domScriptUrl.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@rstest/core';
+
+test('should expose object URLs to scripts in the jsdom realm', () => {
+  const script = document.createElement('script');
+  script.textContent = `
+    document.documentElement.dataset.objectUrl = URL.createObjectURL(
+      new Blob(['script blob'], { type: 'text/plain' }),
+    );
+    document.documentElement.dataset.urlSearchParamsRealm = String(
+      new URL('https://example.test/?key=value').searchParams
+        instanceof URLSearchParams,
+    );
+  `;
+  document.head.appendChild(script);
+
+  const url = document.documentElement.dataset.objectUrl!;
+  expect(url).toMatch(/^blob:nodedata:/);
+  expect(document.documentElement.dataset.urlSearchParamsRealm).toBe('true');
+  URL.revokeObjectURL(url);
+});

--- a/e2e/dom/fixtures/test/objectUrl.test.ts
+++ b/e2e/dom/fixtures/test/objectUrl.test.ts
@@ -1,0 +1,28 @@
+import { Blob as NodeBlob } from 'node:buffer';
+import { expect, test } from '@rstest/core';
+
+test('should create object URLs from Blob and File implementations', () => {
+  expect(
+    new URL('https://example.test/?key=value').searchParams,
+  ).toBeInstanceOf(URLSearchParams);
+
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  const IframeBlob = (iframe.contentWindow as unknown as { Blob: typeof Blob })
+    .Blob;
+
+  const objects = [
+    new Blob(['blob'], { type: 'text/plain' }),
+    new File(['file'], 'file.txt', { type: 'text/plain' }),
+    new IframeBlob(['iframe blob'], { type: 'text/plain' }),
+    new NodeBlob(['node blob'], { type: 'text/plain' }) as unknown as Blob,
+  ];
+
+  for (const object of objects) {
+    const url = URL.createObjectURL(object);
+    expect(url).toMatch(/^blob:nodedata:/);
+    URL.revokeObjectURL(url);
+  }
+
+  iframe.remove();
+});

--- a/e2e/dom/index.test.ts
+++ b/e2e/dom/index.test.ts
@@ -78,6 +78,16 @@ describe('jsdom', () => {
     const { expectExecSuccess } = await runCli('test/storage', 'jsdom');
     await expectExecSuccess();
   });
+
+  it('should create object URLs from jsdom Blob and File', async () => {
+    const { expectExecSuccess } = await runCli('test/objectUrl', 'jsdom');
+    await expectExecSuccess();
+  });
+
+  it('should expose object URLs to scripts in the jsdom realm', async () => {
+    const { expectExecSuccess } = await runCli('test/domScriptUrl', 'jsdom');
+    await expectExecSuccess();
+  });
 });
 
 describe('happy-dom', () => {
@@ -110,6 +120,11 @@ describe('happy-dom', () => {
 
   it('should run TextEncoder correctly in happy-dom', async () => {
     const { expectExecSuccess } = await runCli('test/textEncoder', 'happy-dom');
+    await expectExecSuccess();
+  });
+
+  it('should create object URLs from happy-dom Blob and File', async () => {
+    const { expectExecSuccess } = await runCli('test/objectUrl', 'happy-dom');
     await expectExecSuccess();
   });
 });

--- a/packages/core/src/runtime/worker/env/happyDom.ts
+++ b/packages/core/src/runtime/worker/env/happyDom.ts
@@ -1,7 +1,11 @@
 import type { Window as HappyDOMWindow } from 'happy-dom';
 import type { TestEnvironment } from '../../../types';
 import { checkPkgInstalled } from '../../util';
-import { addDefaultErrorHandler, installGlobal } from './utils';
+import {
+  addDefaultErrorHandler,
+  installGlobal,
+  installObjectURLTracker,
+} from './utils';
 
 type HappyDOMOptions = ConstructorParameters<typeof HappyDOMWindow>[0];
 
@@ -21,10 +25,13 @@ export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
         url: options.url || 'http://localhost:3000',
         console: console && global.console ? global.console : undefined,
       });
+      const cleanupObjectURLs = installObjectURLTracker(
+        win.URL as unknown as typeof URL,
+      );
 
       const cleanupGlobal = installGlobal(global, win, {
         // jsdom doesn't support Request and Response, but happy-dom does
-        additionalKeys: ['Request', 'Response', 'MessagePort', 'fetch'],
+        additionalKeys: ['Request', 'Response', 'MessagePort', 'fetch', 'URL'],
       });
 
       const cleanupHandler = addDefaultErrorHandler(
@@ -34,6 +41,7 @@ export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
       return {
         async teardown() {
           cleanupHandler();
+          cleanupObjectURLs();
           if (win.close && win.happyDOM.abort) {
             await win.happyDOM.abort();
             win.close();

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -1,12 +1,89 @@
-import type { ConstructorOptions } from 'jsdom';
+import { Blob as NodeBlob } from 'node:buffer';
+import { URL as NodeURL } from 'node:url';
+import type { ConstructorOptions, DOMWindow } from 'jsdom';
 import type { TestEnvironment } from '../../../types';
 import { checkPkgInstalled } from '../../util';
-import { addDefaultErrorHandler, installGlobal } from './utils';
+import {
+  addDefaultErrorHandler,
+  installGlobal,
+  installObjectURLTracker,
+} from './utils';
 
 type JSDOMOptions = ConstructorOptions & {
   html?: string | ArrayBufferLike;
   console?: boolean;
 };
+
+type JSDOMBlobImpl = {
+  _buffer?: Uint8Array;
+  _bytes?: Uint8Array;
+};
+
+function installJSDOMObjectURL(window: DOMWindow): () => void {
+  const implSymbol = Object.getOwnPropertySymbols(new window.Blob())[0]!;
+  const URLConstructor = window.URL as typeof URL;
+  const createDescriptor = Object.getOwnPropertyDescriptor(
+    URLConstructor,
+    'createObjectURL',
+  );
+  const revokeDescriptor = Object.getOwnPropertyDescriptor(
+    URLConstructor,
+    'revokeObjectURL',
+  );
+
+  if (typeof URLConstructor.createObjectURL !== 'function') {
+    Object.defineProperty(URLConstructor, 'createObjectURL', {
+      value(blob: NodeBlob | Blob | MediaSource): string {
+        // The private Symbol(impl) is shared by Blob wrappers from other jsdom
+        // realms, unlike their constructors.
+        const impl = (blob as unknown as Record<symbol, JSDOMBlobImpl>)[
+          implSymbol
+        ];
+        const bytes = impl?._buffer ?? impl?._bytes;
+        if (bytes) {
+          return NodeURL.createObjectURL(
+            new NodeBlob([bytes], { type: (blob as Blob).type }),
+          );
+        }
+        return NodeURL.createObjectURL(blob as NodeBlob);
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (typeof URLConstructor.revokeObjectURL !== 'function') {
+    Object.defineProperty(URLConstructor, 'revokeObjectURL', {
+      value(url: string): void {
+        NodeURL.revokeObjectURL(url);
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  const cleanupObjectURLs = installObjectURLTracker(URLConstructor);
+  return () => {
+    cleanupObjectURLs();
+    if (createDescriptor) {
+      Object.defineProperty(
+        URLConstructor,
+        'createObjectURL',
+        createDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(URLConstructor, 'createObjectURL');
+    }
+    if (revokeDescriptor) {
+      Object.defineProperty(
+        URLConstructor,
+        'revokeObjectURL',
+        revokeDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(URLConstructor, 'revokeObjectURL');
+    }
+  };
+}
 
 export const environment: TestEnvironment<typeof globalThis> = {
   name: 'jsdom',
@@ -26,8 +103,10 @@ export const environment: TestEnvironment<typeof globalThis> = {
       resources,
       console = false,
       cookieJar = false,
+      beforeParse,
       ...restOptions
     } = options as JSDOMOptions;
+    let cleanupObjectURLs = () => {};
     const dom = new JSDOM(html, {
       pretendToBeVisual,
       resources:
@@ -44,15 +123,22 @@ export const environment: TestEnvironment<typeof globalThis> = {
       contentType,
       userAgent,
       ...restOptions,
+      beforeParse(window) {
+        beforeParse?.(window);
+        cleanupObjectURLs = installJSDOMObjectURL(window);
+      },
     });
 
-    const cleanupGlobal = installGlobal(global, dom.window);
+    const cleanupGlobal = installGlobal(global, dom.window, {
+      additionalKeys: ['URL', 'URLSearchParams'],
+    });
 
     const cleanupHandler = addDefaultErrorHandler(global as unknown as Window);
 
     return {
       teardown() {
         cleanupHandler();
+        cleanupObjectURLs();
         dom.window.close();
         cleanupGlobal();
       },

--- a/packages/core/src/runtime/worker/env/utils.ts
+++ b/packages/core/src/runtime/worker/env/utils.ts
@@ -27,6 +27,68 @@ function isClassLike(name: string) {
   return name[0] && name.startsWith(name[0].toUpperCase());
 }
 
+export function installObjectURLTracker(
+  URLConstructor: typeof URL,
+): () => void {
+  const objectURLs = new Set<string>();
+  const createDescriptor = Object.getOwnPropertyDescriptor(
+    URLConstructor,
+    'createObjectURL',
+  );
+  const revokeDescriptor = Object.getOwnPropertyDescriptor(
+    URLConstructor,
+    'revokeObjectURL',
+  );
+  const createObjectURL = URLConstructor.createObjectURL;
+  const revokeObjectURL = URLConstructor.revokeObjectURL;
+
+  Object.defineProperties(URLConstructor, {
+    createObjectURL: {
+      value(object: Blob | MediaSource) {
+        const url = createObjectURL.call(URLConstructor, object);
+        objectURLs.add(url);
+        return url;
+      },
+      configurable: true,
+      writable: true,
+    },
+    revokeObjectURL: {
+      value(url: string) {
+        objectURLs.delete(url);
+        revokeObjectURL.call(URLConstructor, url);
+      },
+      configurable: true,
+      writable: true,
+    },
+  });
+
+  return () => {
+    for (const url of objectURLs) {
+      revokeObjectURL.call(URLConstructor, url);
+    }
+    objectURLs.clear();
+
+    if (createDescriptor) {
+      Object.defineProperty(
+        URLConstructor,
+        'createObjectURL',
+        createDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(URLConstructor, 'createObjectURL');
+    }
+    if (revokeDescriptor) {
+      Object.defineProperty(
+        URLConstructor,
+        'revokeObjectURL',
+        revokeDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(URLConstructor, 'revokeObjectURL');
+    }
+  };
+}
+
 export function installGlobal(
   global: any,
   win: any,

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@rstest/core';
+import type { DOMWindow } from 'jsdom';
+import { environment } from '../../../../src/runtime/worker/env/jsdom';
+
+test('should preserve URL customizations from beforeParse', async () => {
+  const testGlobal = { console, URL, URLSearchParams } as typeof globalThis;
+  const originalURL = testGlobal.URL;
+  const { teardown } = await environment.setup(testGlobal, {
+    beforeParse(window: DOMWindow) {
+      const OriginalURL = window.URL as typeof URL;
+      class CustomURL extends OriginalURL {}
+      Object.defineProperty(CustomURL, 'beforeParseMarker', { value: true });
+      window.URL = CustomURL;
+    },
+  });
+
+  try {
+    expect(
+      (testGlobal.URL as typeof URL & { beforeParseMarker: boolean })
+        .beforeParseMarker,
+    ).toBe(true);
+    expect(
+      new testGlobal.URL('https://example.test/?key=value').searchParams,
+    ).toBeInstanceOf(testGlobal.URLSearchParams);
+
+    const objectURL = testGlobal.URL.createObjectURL(
+      new testGlobal.Blob(['blob']),
+    );
+    expect(objectURL).toMatch(/^blob:/);
+    testGlobal.URL.revokeObjectURL(objectURL);
+  } finally {
+    await teardown(testGlobal);
+  }
+
+  expect(testGlobal.URL).toBe(originalURL);
+});

--- a/packages/core/tests/runtime/worker/env/utils.test.ts
+++ b/packages/core/tests/runtime/worker/env/utils.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@rstest/core';
+import { installObjectURLTracker } from '../../../../src/runtime/worker/env/utils';
+
+test('should revoke remaining object URLs and restore methods', () => {
+  const revoked: string[] = [];
+  let nextId = 0;
+  class TestURL extends URL {
+    static override createObjectURL(): string {
+      return `blob:test:${nextId++}`;
+    }
+
+    static override revokeObjectURL(url: string): void {
+      revoked.push(url);
+    }
+  }
+
+  const originalCreateObjectURL = TestURL.createObjectURL;
+  const originalRevokeObjectURL = TestURL.revokeObjectURL;
+  const cleanup = installObjectURLTracker(TestURL);
+  const revokedByUser = TestURL.createObjectURL(new Blob());
+  const revokedByCleanup = TestURL.createObjectURL(new Blob());
+
+  TestURL.revokeObjectURL(revokedByUser);
+  cleanup();
+
+  expect(revoked).toEqual([revokedByUser, revokedByCleanup]);
+  expect(TestURL.createObjectURL).toBe(originalCreateObjectURL);
+  expect(TestURL.revokeObjectURL).toBe(originalRevokeObjectURL);
+});


### PR DESCRIPTION
## Summary

- Fix `URL.createObjectURL` rejecting jsdom and happy-dom `Blob`/`File` instances when the Node `URL` and DOM blob implementations come from different realms.
- Add a jsdom-compatible `URL` wrapper that converts jsdom blob storage to a Node `Blob`, and expose happy-dom's existing compatible `URL`.
- Add end-to-end coverage for jsdom and happy-dom with environment `Blob`, `File`, and Node `Blob` inputs.

This is an internal environment compatibility fix with no public API or configuration changes.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).