### PR TITLE
chore: add verify skill and tighten agent harness conventions

### DIFF
--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -22,7 +22,7 @@ Decide what the task actually is before doing any work.
 Gather the real inputs and ground every claim in something you read **this session** — never answer from memory or impression.
 
 - For GitHub issues/PRs/checks/reviews, read the linked context before editing; do not implement from the title alone.
-- For external repros, read README/scripts/deps and reproduce with the smallest command first.
+- For external repros, reproduce with the smallest command first (workflow: `testing` → External repro projects).
 - Identify the smallest user-visible behavior, the affected package(s), and the validation path.
 - Behavioral, root-cause, version, or package-name claims must cite `path:line` — never answer from recall.
 - To answer "how does vitest/jest/rsbuild/rspack behave?", read the **latest upstream source, not the built `node_modules` dist**: if a local clone exists (e.g. `~/Projects/vitest`), bring it up to the latest default branch before reading (`git pull` — a `git fetch` alone leaves the working tree stale); otherwise shallow-clone fresh (vitest → `vitest-dev/vitest`; rsbuild/rspack → `web-infra-dev/{rsbuild,rspack}`; `npm view <pkg> repository` finds others). Prefer a subagent for the lookup.
@@ -63,7 +63,7 @@ Make the smallest **design** change that resolves the root cause — this is whe
 
 Every behavioral change — feature or bug fix — must have a corresponding e2e test. Unit tests alone are not enough; e2e tests verify the full CLI → runner → reporter pipeline.
 
-Decide _whether_ test work is required here. For test layout, fixture strategy, rebuild requirements, and exact commands, switch to the `testing` skill.
+Decide _whether_ test work is required here. For test layout, fixture strategy, rebuild requirements, and exact commands, switch to the `testing` skill. For what counts as **evidence** that the change works — forbidden proxy signals, per-change-shape observation standards — defer to the `verify` skill rather than restating its rules here.
 
 ### When Test Work Is Required
 
@@ -138,10 +138,7 @@ Documentation is not a follow-up task — it ships with the code. **Do not merge
 
 ### Docs Conventions
 
-- All docs exist in **both** `en/` and `zh/` — update both languages.
-- Use Rspress frontmatter conventions (see existing docs for examples).
-- When adding `ApiMeta` markers for a new API or config option, default `addedVersion` to the current package version with its patch segment incremented by 1. For example, if `@rstest/core` is currently `0.10.6`, a newly documented core API should use `<ApiMeta addedVersion="0.10.7" />`.
-- Include code examples that are copy-pasteable.
+- Writing style, format, bilingual sync, and `ApiMeta` marker rules are owned by `website/AGENTS.md` — read it before editing docs rather than restating its rules here.
 - **Signature fidelity:** if you changed a public type in `packages/core/src/types/`, or edited a `**Type:**` / `**类型：**` block, run the `api-doc-sync` skill. The doc signatures are hand-written copies of the real types and drift silently (missing overloads, wrong arg order, en/zh divergence); `api-doc-sync` grounds them against source and `tsc`.
 
 ## Self-Check Before Committing

--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -12,7 +12,6 @@ description: Use when asked to create a pull request for this repository. It hel
    Use a descriptive branch name, preferably `feat-<topic>` or `fix-<topic>`.
 
 2. Review local changes with `git status --short`.
-   Do not revert unrelated user changes.
    Before creating the PR, ensure the intended changes are committed and never commit directly on the default branch.
 
 3. Check PR readiness before writing:

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -7,6 +7,8 @@ metadata:
 
 # Testing Workflow
 
+This skill owns the **mechanics**: how to run and write tests, fixtures, and builds. Whether a change needs test work is routed by the `development` skill; what counts as evidence that a change works is defined by the `verify` skill.
+
 ## Running tests
 
 ### Package/unit tests from repository root (single file — preferred)

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: verify
+description: Behavioral verification rules for claiming a change works. Use before reporting any fix/feature as done, when tempted to conclude from typecheck or unit-test results alone, when deciding what evidence a change needs, or when a test result looks suspicious (stale build, flaky pass, snapshot churn).
+metadata:
+  internal: true
+---
+
+# Verify Behavior, Not Proxies
+
+A change is verified only when you have **observed the real behavior change** — the actual CLI output, reporter output, or exit code — not when a proxy signal went green. This skill owns exactly one concern: **what counts as evidence**. How to run things lives in the `testing` skill; what work a change requires (including the Flip-and-Verify regression protocol) lives in the `development` skill — don't expect commands or checklists here.
+
+## Forbidden proxies
+
+None of these, alone, justify claiming a behavioral change works:
+
+- **Typecheck / lint green.** Proves the types compose, not that the behavior changed.
+- **Unit tests green.** They exercise source via the workspace runner, not the built CLI → runner → reporter pipeline users run.
+- **"My new test passes."** A test that passes both before and after the fix proves nothing — it must flip (protocol: `development` → Flip-and-Verify).
+- **"The code path is clearly hit."** Reading the code and reasoning that it must work is prediction, not observation.
+- **Snapshot updated with `-u`.** Regeneration makes tests green by definition; green-after-update is not evidence (update policy: `testing` → Snapshot policy).
+- **Build succeeded.** Compiling is not running.
+- **A tool accepted your config.** Silently-ignored options look identical to working ones — prove the rule/option fires by observing it reject or change something (inject a violation, toggle the option).
+
+If verification is genuinely impossible (needs real CI, a specific OS, a headed browser you can't run), say so explicitly instead of substituting a proxy.
+
+## The observation loop
+
+1. **Start from fresh build state.** E2E and fixture runs consume built output; if a result contradicts your expectation, suspect a stale or half-finished build before suspecting the code (rebuild procedure: `testing` → Rebuild before E2E).
+2. **Drive the real binary on the smallest repro.** Run the actual `rstest` CLI the way a user would — an e2e fixture, not an import of internal functions (run forms: `testing` → Running tests).
+3. **Observe the output, not the summary.** Read the reporter output for the specific behavior you changed, and check the exit code (`echo $?`) when the change affects pass/fail semantics.
+4. **Observe both directions when feasible.** See the broken behavior without your change and the fixed behavior with it — a fix you never saw fail is unverified.
+
+## What to observe, by change shape
+
+| Change touches                      | Minimum real observation                                                                     |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- |
+| Core runtime / runner / pool        | A targeted e2e run plus its exit code, on a fixture that exercises the changed behavior      |
+| Reporter / console output           | The actual stdout/stderr the CLI prints, not just assertion results                          |
+| CLI flags / config options          | Two runs — with and without the option — confirming the behavior differs                     |
+| Browser mode                        | A browser e2e run (headless is the default; see `testing` → Browser E2E)                     |
+| Adapters (rsbuild / rslib / rspack) | A fixture run through the adapter, confirming the transformed config takes effect at runtime |
+| Coverage providers                  | The emitted report content, not just "the run succeeded"                                     |
+| Watch mode                          | An actual watch session reacting to a file change, not a one-shot run                        |
+| Lint rules / hooks / gates          | The gate firing on an injected violation with the intended message, then passing when clean  |
+
+## False-signal gotchas
+
+- **A pass on re-run after a fail** may be flakiness, not a fix. Re-run the exact failing command; if results alternate with no code change, report it as flaky rather than fixed.
+- **Inexplicable fixture behavior** is usually stale state, not logic — stale `dist`, persistent fixture output, shared cwd (mechanisms and cleanup: `testing`).
+- **Absence of a failure is weak evidence.** "It didn't error" only counts if you confirmed the run actually reached the changed code path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,10 +101,7 @@ _Note_: E2E tests and examples consume built package output. Rebuild affected pa
 - Use camelCase for locals, PascalCase for types/components, and SCREAMING_SNAKE_CASE for constants.
 - Avoid namespace imports like `import * as foo from 'foo'` unless the module shape requires it.
 - Prefer existing local patterns over introducing new abstractions.
-- Do not add comments that restate the code; comment only non-obvious intent or constraints.
-- Avoid unnecessary defensive runtime checks when TypeScript already guarantees the type.
-- Minimize `as` casts and `any`; never let `any` leak into exported APIs, config types, or cross-package contracts.
-- Avoid one-use abstractions unless they materially improve readability.
+- In-file TypeScript quality rules (restating comments, defensive checks, `as`/`any`, one-use abstractions, drift prevention) are owned by the `typescript` skill — apply it when writing `.ts`/`.tsx`/`.mts` files.
 
 ## Skills
 
@@ -115,6 +112,7 @@ Available workflow skills in `.agents/skills/`:
 | development                | Feature / bug-fix checklist for scope review and workflow routing                 |
 | testing                    | Testing workflow for the rstest monorepo (run tests, write tests, debug failures) |
 | typescript                 | TypeScript anti-slop guardrails for `.ts`, `.tsx`, and `.mts` files               |
+| verify                     | Behavioral verification rules before claiming a change works (no proxy signals)   |
 | pr-creator                 | Create a PR for the current branch                                                |
 | create-draft-release-notes | Create or update draft GitHub releases and organize generated release notes       |
 | create-release-blog        | Draft bilingual release blog posts from a version range                           |

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -53,5 +53,6 @@ pnpm --filter @rstest/core typecheck
 
 - Don't bypass the worker pool for test execution
 - Don't use `console.log` directly; use the logger utilities
+- Don't call timer globals (`setTimeout` etc.) directly in `src/runtime/` — user tests may enable fake timers; use `getRealTimers()` from `runtime/util` (lint-enforced via `no-restricted-syntax`)
 - Don't fan runner lifecycle events out to reporters or `stateManager` directly; route them through `RunnerEventSink`
 - Don't add a `RuntimeConfig` field without declaring its node/browser disposition in `executorCapabilities`

--- a/packages/core/src/runtime/api/poll.ts
+++ b/packages/core/src/runtime/api/poll.ts
@@ -90,8 +90,8 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
                   const obj = await fn();
                   util.flag(assertion, 'object', obj);
                   resolve(await assertionFunction.call(assertion, ...args));
-                  clearTimeout(intervalId);
-                  clearTimeout(timeoutId);
+                  getRealTimers().clearTimeout!(intervalId);
+                  getRealTimers().clearTimeout!(timeoutId);
                 } catch (err) {
                   lastError = err;
                   if (!util.flag(assertion, '_isLastPollAttempt')) {
@@ -100,7 +100,7 @@ export function createExpectPoll(expect: RstestExpect): RstestExpect['poll'] {
                 }
               };
               const timeoutId = getRealTimers().setTimeout!(() => {
-                clearTimeout(intervalId);
+                getRealTimers().clearTimeout!(intervalId);
                 util.flag(assertion, '_isLastPollAttempt', true);
                 const rejectWithCause = (cause: any) => {
                   reject(

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -307,10 +307,10 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
 
     try {
       const result = await Promise.race([fn(...args), timeoutPromise]);
-      if (timeoutId) clearTimeout(timeoutId);
+      if (timeoutId) getRealTimers().clearTimeout!(timeoutId);
       return result;
     } catch (error) {
-      if (timeoutId) clearTimeout(timeoutId);
+      if (timeoutId) getRealTimers().clearTimeout!(timeoutId);
       throw error;
     }
   }) as T;

--- a/rslint.config.mts
+++ b/rslint.config.mts
@@ -16,4 +16,27 @@ export default defineConfig([
       '@typescript-eslint/no-require-imports': 'off',
     },
   },
+  {
+    // Runtime code executes inside the user's test environment, where fake
+    // timers (rstest.useFakeTimers) replace the timer globals. Framework
+    // timers must go through the real-timer registry, or they leak / misfire
+    // once a test enables fake timers.
+    files: ['packages/core/src/runtime/**'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        ...[
+          'setTimeout',
+          'clearTimeout',
+          'setInterval',
+          'clearInterval',
+          'setImmediate',
+          'clearImmediate',
+        ].map((name) => ({
+          selector: `CallExpression[callee.name='${name}']`,
+          message: `Fake timers replace the ${name} global in user tests. Use getRealTimers() from runtime/util (extend REAL_TIMERS there if it lacks ${name}).`,
+        })),
+      ],
+    },
+  },
 ]);

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -21,8 +21,10 @@ pnpm gen:release-image  # Generate a release's banner + og image (see below)
 
 Each release blog needs **two** images, generated together so they share one gradient:
 
-- **banner** — `4096x1152`, no tagline, the in-page `<img>` at the top of the post. Committed to `docs/public/` and referenced by a site-relative path (`/rstest-banner-v<ver>.png`).
-- **og image** — `2400x1260`, optional tagline, the social-share card. Committed to [rstackjs/rstack-design-resources](https://github.com/rstackjs/rstack-design-resources) under `rstest/` and served by the `assets.rspack.rs` CDN. `rspress.config.ts` wires `og:image` per blog route: `blog/announcing-<major>-<minor>` → `assets.rspack.rs/rstest/rstest-og-image-v<major>-<minor>.png`.
+- **banner** — `4096x1152`, no tagline, the in-page `<img>` at the top of the post, referenced by its CDN URL (`assets.rspack.rs/rstest/rstest-banner-v<major>-<minor>.png`).
+- **og image** — `2400x1260`, optional tagline, the social-share card. `rspress.config.ts` wires `og:image` per blog route: `blog/announcing-<major>-<minor>` → `assets.rspack.rs/rstest/rstest-og-image-v<major>-<minor>.png`.
+
+Both images are committed to [rstackjs/rstack-design-resources](https://github.com/rstackjs/rstack-design-resources) under `rstest/` and served by the `assets.rspack.rs` CDN. Always refer to that repo by its GitHub URL — collaborators keep local clones at different paths.
 
 The templates live **in this repo**; design-resources stays a passive PNG store.
 
@@ -34,7 +36,7 @@ The templates live **in this repo**; design-resources stays a passive PNG store.
 
 1. Run `pnpm gen:release-image --version <ver> [--description "<tagline>"] --out-dir <dir>` from `website/`. The gradient is randomized every run — re-run until both images look good.
 2. Compress both PNGs with [TinyPNG](https://tinypng.com) (or Squoosh / ImageOptim / `pngquant`) — the raw resvg output is ~200 KB and palette quantization typically drops it to ~1/4 the size with no visible loss.
-3. Put the banner in `docs/public/`. Commit the og image to the design-resources repo under `rstest/` and open a PR — that repo is the only place og images are stored. After CDN deploy it is reachable at `assets.rspack.rs/rstest/rstest-og-image-v<ver>.png`.
+3. Commit both images to the design-resources repo under `rstest/` and open a PR — that repo is the only place release images are stored (the generation `--out-dir` is just a local staging spot). After CDN deploy they are reachable at `assets.rspack.rs/rstest/rstest-{banner,og-image}-v<major>-<minor>.png`.
 
 ### Do
 
@@ -45,7 +47,7 @@ The templates live **in this repo**; design-resources stays a passive PNG store.
 ### Don't
 
 - Don't depend on packages like `geist` that pull in framework peer deps (`next>=13.2`); commit raw `.ttf` files directly instead
-- Don't commit og images into this repo; they belong in design-resources (the banner is the one exception — it lives in `docs/public/`)
+- Don't commit release images (banner or og) into this repo; they belong in design-resources
 - Don't bake the logo into a static asset; always fetch the SVG so logo updates propagate automatically
 
 ## Writing style guidelines
@@ -90,7 +92,7 @@ When writing or editing documentation, follow these principles:
 - First mention of a new package: include GitHub link
 - Keep technical terms in English (e.g., Context, Hook, Provider, CI)
 - For TypeScript API signatures in docs, prefer `T[]` over `Array<T>`. For unions that allow either a single value or an array, prefer `A | B | (A | B)[]` over `A | B | Array<A | B>`.
-- When documenting a newly added API or config option, add an `ApiMeta` version marker near that section. Import it with `import { ApiMeta } from '@components/ApiMeta';` and render it as `<ApiMeta addedVersion="x.y.z" />`.
+- When documenting a newly added API or config option, add an `ApiMeta` version marker near that section. Import it with `import { ApiMeta } from '@components/ApiMeta';` and render it as `<ApiMeta addedVersion="x.y.z" />`. Default `addedVersion` to the owning package's current version with its patch segment incremented by 1 (e.g. `@rstest/core` at `0.10.6` → `<ApiMeta addedVersion="0.10.7" />`).
 - If a config option has a corresponding CLI flag, surface it alongside type and default in both EN and ZH, matching the style of neighboring config pages.
 - **Punctuation by language**: In `docs/zh/`, use full-width punctuation (`：，。；（）`) for Chinese prose — including the `**类型：**` / `**默认值：**` / `**CLI：**` metadata lines and `**标签**：` bullet lead-ins. Keep half-width only inside code and inline code. In `docs/en/`, use half-width punctuation only. In both languages, keep the metadata colon inside the bold (`**Type:**` / `**类型：**`, not `**Type**:`).
 


### PR DESCRIPTION
## Summary

This PR strengthens the repository's agent harness — the AGENTS.md / skills layer that guides automated contributors — around two principles: every guideline has a single owning document, and conventions worth keeping are machine-enforced rather than remembered.

- **New `verify` skill** (`.agents/skills/verify/`): defines what counts as evidence when claiming a change works — forbidden proxy signals (typecheck/unit-test green, snapshot `-u`, silently-accepted config), per-change-shape observation minimums, and false-signal gotchas. Commands stay in `testing`; the regression protocol stays in `development`.
- **Single-source-of-truth pass** over `.agents/skills/` and `AGENTS.md` files: duplicated rules replaced with pointers to their owner (TS quality → `typescript` skill, docs/ApiMeta conventions → `website/AGENTS.md`, run mechanics → `testing` skill), and `website/AGENTS.md` release-image notes corrected to match actual practice (both banner and og image live in the design-resources repo, referenced by CDN URL).
- **Lint-enforced runtime convention**: a scoped `no-restricted-syntax` rule rejects bare timer-global calls in `packages/core/src/runtime/`, pointing to `getRealTimers()` — runtime code executes inside the user's test environment where fake timers replace those globals.

Landing the lint rule surfaced two existing violations that are real bugs: `wrapTimeout` and `expect.poll` created timers via `getRealTimers().setTimeout` but cancelled them with the bare `clearTimeout`, which cannot cancel real timers once a test enables fake timers (leaked test-timeout timer; `expect.poll` kept re-running its callback after resolving). Both call sites are fixed here.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).