### PR TITLE
fix(core): clean up DOM environment timers

### DIFF
--- a/e2e/dom/fixtures/test/timers.test.ts
+++ b/e2e/dom/fixtures/test/timers.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@rstest/core';
+
+test('pending timers are scoped to the DOM environment', () => {
+  const timeout = setTimeout(() => {}, 60_000);
+  const interval = setInterval(() => {}, 60_000);
+
+  expect(timeout).toBeInstanceOf(Object);
+  expect(interval).toBeInstanceOf(Object);
+});

--- a/e2e/dom/index.test.ts
+++ b/e2e/dom/index.test.ts
@@ -88,6 +88,11 @@ describe('jsdom', () => {
     const { expectExecSuccess } = await runCli('test/domScriptUrl', 'jsdom');
     await expectExecSuccess();
   });
+
+  it('should clean up pending timers', async () => {
+    const { expectExecSuccess } = await runCli('test/timers', 'jsdom');
+    await expectExecSuccess();
+  });
 });
 
 describe('happy-dom', () => {
@@ -125,6 +130,11 @@ describe('happy-dom', () => {
 
   it('should create object URLs from happy-dom Blob and File', async () => {
     const { expectExecSuccess } = await runCli('test/objectUrl', 'happy-dom');
+    await expectExecSuccess();
+  });
+
+  it('should clean up pending timers', async () => {
+    const { expectExecSuccess } = await runCli('test/timers', 'happy-dom');
     await expectExecSuccess();
   });
 });

--- a/packages/core/src/runtime/worker/env/happyDom.ts
+++ b/packages/core/src/runtime/worker/env/happyDom.ts
@@ -5,6 +5,8 @@ import {
   addDefaultErrorHandler,
   installGlobal,
   installObjectURLTracker,
+  installTimerTracking,
+  type NodeTimerPrimitives,
 } from './utils';
 
 type HappyDOMOptions = ConstructorParameters<typeof HappyDOMWindow>[0];
@@ -16,6 +18,12 @@ export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
       checkPkgInstalled('happy-dom');
 
       const { Window, GlobalWindow } = await import('happy-dom');
+      const nodeTimers: NodeTimerPrimitives = {
+        clearInterval: global.clearInterval ?? globalThis.clearInterval,
+        clearTimeout: global.clearTimeout ?? globalThis.clearTimeout,
+        setInterval: global.setInterval ?? globalThis.setInterval,
+        setTimeout: global.setTimeout ?? globalThis.setTimeout,
+      };
       // Prefer GlobalWindow to run happy-dom in the global scope so globals like
       // TextEncoder and Uint8Array are correctly exposed; fall back to Window for
       // backward compatibility with older happy-dom versions that lack GlobalWindow.
@@ -33,6 +41,7 @@ export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
         // jsdom doesn't support Request and Response, but happy-dom does
         additionalKeys: ['Request', 'Response', 'MessagePort', 'fetch', 'URL'],
       });
+      const cleanupTimers = installTimerTracking(global, nodeTimers);
 
       const cleanupHandler = addDefaultErrorHandler(
         global as unknown as Window,
@@ -41,6 +50,7 @@ export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
       return {
         async teardown() {
           cleanupHandler();
+          cleanupTimers();
           cleanupObjectURLs();
           if (win.close && win.happyDOM.abort) {
             await win.happyDOM.abort();

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -7,6 +7,8 @@ import {
   addDefaultErrorHandler,
   installGlobal,
   installObjectURLTracker,
+  installTimerTracking,
+  type NodeTimerPrimitives,
 } from './utils';
 
 type JSDOMOptions = ConstructorOptions & {
@@ -91,6 +93,12 @@ export const environment: TestEnvironment<typeof globalThis> = {
     checkPkgInstalled('jsdom');
     const { CookieJar, JSDOM, ResourceLoader, VirtualConsole } =
       await import('jsdom');
+    const nodeTimers: NodeTimerPrimitives = {
+      clearInterval: global.clearInterval ?? globalThis.clearInterval,
+      clearTimeout: global.clearTimeout ?? globalThis.clearTimeout,
+      setInterval: global.setInterval ?? globalThis.setInterval,
+      setTimeout: global.setTimeout ?? globalThis.setTimeout,
+    };
 
     const {
       html = '<!DOCTYPE html>',
@@ -132,6 +140,7 @@ export const environment: TestEnvironment<typeof globalThis> = {
     const cleanupGlobal = installGlobal(global, dom.window, {
       additionalKeys: ['URL', 'URLSearchParams'],
     });
+    const cleanupTimers = installTimerTracking(global, nodeTimers);
 
     const cleanupHandler = addDefaultErrorHandler(global as unknown as Window);
 
@@ -139,6 +148,7 @@ export const environment: TestEnvironment<typeof globalThis> = {
       teardown() {
         cleanupHandler();
         cleanupObjectURLs();
+        cleanupTimers();
         dom.window.close();
         cleanupGlobal();
       },

--- a/packages/core/src/runtime/worker/env/utils.ts
+++ b/packages/core/src/runtime/worker/env/utils.ts
@@ -1,4 +1,12 @@
+import { promisify } from 'node:util';
 import { KEYS } from './jsdomKeys';
+
+export type NodeTimerPrimitives = Pick<
+  typeof globalThis,
+  'clearInterval' | 'clearTimeout' | 'setInterval' | 'setTimeout'
+>;
+
+const TIMER_KEYS = ['setInterval', 'setTimeout'] as const;
 
 const SKIP_KEYS: string[] = ['window', 'self', 'top', 'parent'];
 
@@ -174,6 +182,88 @@ export function installGlobal(
     originals.forEach((descriptor, k) => {
       Object.defineProperty(global, k, descriptor);
     });
+  };
+}
+
+/**
+ * Keep Node timer handles scoped to one DOM environment so pending timers do
+ * not keep a worker alive after that environment has been torn down.
+ */
+export function installTimerTracking(
+  global: typeof globalThis,
+  nodeTimers: NodeTimerPrimitives,
+): () => void {
+  const timers = new Map<NodeJS.Timeout, (timer: NodeJS.Timeout) => void>();
+  const descriptors = new Map<
+    (typeof TIMER_KEYS)[number],
+    PropertyDescriptor
+  >();
+  let active = true;
+
+  const track = (
+    timer: NodeJS.Timeout,
+    clearTimer: (timer: NodeJS.Timeout) => void,
+  ): NodeJS.Timeout => {
+    if (active) {
+      timers.set(timer, clearTimer);
+    }
+    return timer;
+  };
+
+  const setTimeout = ((...args: unknown[]) =>
+    track(
+      Reflect.apply(nodeTimers.setTimeout, global, args) as NodeJS.Timeout,
+      nodeTimers.clearTimeout,
+    )) as NodeTimerPrimitives['setTimeout'];
+  const setInterval = ((...args: unknown[]) =>
+    track(
+      Reflect.apply(nodeTimers.setInterval, global, args) as NodeJS.Timeout,
+      nodeTimers.clearInterval,
+    )) as NodeTimerPrimitives['setInterval'];
+
+  const customPromisifyDescriptor = Object.getOwnPropertyDescriptor(
+    nodeTimers.setTimeout,
+    promisify.custom,
+  );
+  if (customPromisifyDescriptor) {
+    Object.defineProperty(
+      setTimeout,
+      promisify.custom,
+      customPromisifyDescriptor,
+    );
+  }
+
+  const trackedTimers = {
+    setInterval,
+    setTimeout,
+  };
+  for (const key of TIMER_KEYS) {
+    const descriptor = Object.getOwnPropertyDescriptor(global, key);
+    if (descriptor) {
+      descriptors.set(key, descriptor);
+    }
+    Object.defineProperty(global, key, {
+      configurable: true,
+      value: trackedTimers[key],
+      writable: true,
+    });
+  }
+
+  return () => {
+    active = false;
+    for (const [timer, clearTimer] of timers) {
+      clearTimer(timer);
+    }
+    timers.clear();
+
+    for (const key of TIMER_KEYS) {
+      const descriptor = descriptors.get(key);
+      if (descriptor) {
+        Object.defineProperty(global, key, descriptor);
+      } else {
+        Reflect.deleteProperty(global, key);
+      }
+    }
   };
 }
 

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -1,6 +1,66 @@
+import { promisify } from 'node:util';
 import { expect, test } from '@rstest/core';
 import type { DOMWindow } from 'jsdom';
 import { environment } from '../../../../src/runtime/worker/env/jsdom';
+
+const createTestGlobal = (): typeof globalThis =>
+  ({
+    clearInterval: globalThis.clearInterval,
+    clearTimeout: globalThis.clearTimeout,
+    console: globalThis.console,
+    fetch: globalThis.fetch,
+    setInterval: globalThis.setInterval,
+    setTimeout: globalThis.setTimeout,
+    URL: globalThis.URL,
+    URLSearchParams: globalThis.URLSearchParams,
+  }) as typeof globalThis;
+
+test('clears pending Node timers during jsdom teardown', async () => {
+  const testGlobal = createTestGlobal();
+  const nativeTimers = {
+    clearInterval: testGlobal.clearInterval,
+    clearTimeout: testGlobal.clearTimeout,
+    setInterval: testGlobal.setInterval,
+    setTimeout: testGlobal.setTimeout,
+  };
+  const clearedTimeouts: unknown[] = [];
+  const clearedIntervals: unknown[] = [];
+  testGlobal.clearTimeout = ((timer: NodeJS.Timeout) => {
+    clearedTimeouts.push(timer);
+    nativeTimers.clearTimeout(timer);
+  }) as typeof clearTimeout;
+  testGlobal.clearInterval = ((timer: NodeJS.Timeout) => {
+    clearedIntervals.push(timer);
+    nativeTimers.clearInterval(timer);
+  }) as typeof clearInterval;
+  const { teardown } = await environment.setup(testGlobal, {});
+  const timeout = testGlobal.setTimeout(() => {}, 60_000);
+  const interval = testGlobal.setInterval(() => {}, 60_000);
+  let tornDown = false;
+
+  try {
+    expect(timeout).toBeInstanceOf(Object);
+    expect(timeout.refresh).toBeTypeOf('function');
+    expect(interval).toBeInstanceOf(Object);
+    expect(promisify(testGlobal.setTimeout)).toBe(
+      promisify(nativeTimers.setTimeout),
+    );
+
+    await teardown(testGlobal);
+    tornDown = true;
+
+    expect(clearedTimeouts).toEqual([timeout]);
+    expect(clearedIntervals).toEqual([interval]);
+    expect(testGlobal.setTimeout).toBe(nativeTimers.setTimeout);
+    expect(testGlobal.setInterval).toBe(nativeTimers.setInterval);
+  } finally {
+    nativeTimers.clearTimeout(timeout);
+    nativeTimers.clearInterval(interval);
+    if (!tornDown) {
+      await teardown(testGlobal);
+    }
+  }
+});
 
 test('should preserve URL customizations from beforeParse', async () => {
   const testGlobal = { console, URL, URLSearchParams } as typeof globalThis;


### PR DESCRIPTION
## Summary

This PR replaces #1582 with a smaller short-term fix for Node callback timers that survive jsdom or happy-dom teardown.

- Capture the existing Node timer primitives before installing each DOM environment, wrap only `setTimeout` and `setInterval`, and clear the collected native `Timeout` handles during teardown.
- Keep Node handle semantics and the native `util.promisify.custom` hook. Completed or manually cleared handles stay in the per-environment collection and are safely cleared again at teardown, avoiding lifecycle method patching.
- Deliberately do not add worker-wide numeric-ID routing, Promise timer cancellation, `refresh`/`close`/`Symbol.dispose` patches, timer error remapping, or fake-timer changes. Those broader compatibility questions can be handled separately if needed.
- Cover the behavior with one focused unit regression and one shared E2E fixture exercised in both jsdom and happy-dom.

Validation:

- Regression flip: removing the teardown cleanup makes the focused test fail; restoring it passes.
- Node 20.20.0, 22.23.1, and 24.11.1 targeted tests: 2/2 passed on each version.
- Full unit suite: 943/943 passed.
- DOM E2E: 19/19 passed, including jsdom and happy-dom timer cleanup.
- semi-design BackTop with real `lottie-web` and no Lottie mock: 2/2 passed.
- Full workspace build, type/lint, formatting, spelling, dependency consistency, and `check-unused`: passed.

Release note:

> Fixed pending Node callback timers created in jsdom and happy-dom environments keeping Rstest workers alive after teardown. Rstest now clears native timeout and interval handles owned by each DOM environment while preserving Node `Timeout` handles and `promisify(setTimeout)` behavior.

## Related Links

- Replaces https://github.com/web-infra-dev/rstest/pull/1582

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).