### PR TITLE
docs: clarify RSTEST in browser mode

### DIFF
--- a/website/docs/en/api/runtime-api/environment-variables.mdx
+++ b/website/docs/en/api/runtime-api/environment-variables.mdx
@@ -20,15 +20,17 @@ if (import.meta.env.NODE_ENV === 'test') {
 
 ## `RSTEST`
 
-`process.env.RSTEST` is set to `'true'` whenever the test runner is active. Use it to gate test-only branches in source code.
+Available as both `process.env.RSTEST` and `import.meta.env.RSTEST` across all test environments, including [browser mode](/guide/browser-testing/). The value is set to `'true'` whenever the test runner is active, so you can use it to gate test-only branches in source code.
+
+In browser mode, Rstest replaces these expressions at build time but does not add a global `process` object. Prefer `import.meta.env.RSTEST` in browser-compatible ESM source code, and do not guard access with `typeof process !== 'undefined'` because that condition remains `false` in the browser.
 
 ```ts
-if (process.env.RSTEST) {
+if (import.meta.env.RSTEST === 'true') {
   // running under Rstest
 }
 ```
 
-For production builds, define `process.env.RSTEST` as `false` so the bundler can eliminate the dead branch — see [Detect Rstest environment](/guide/basic/configure-rstest#detect-rstest-environment).
+For production builds, define the expression used by your source code as `false` so the bundler can eliminate the dead branch — see [Detect Rstest environment](/guide/basic/configure-rstest#detect-rstest-environment).
 
 For [in-source tests](/config/test/include-source), prefer `import.meta.rstest` — it exposes the Rstest test API directly and is `undefined` in production builds.
 

--- a/website/docs/en/guide/basic/configure-rstest.mdx
+++ b/website/docs/en/guide/basic/configure-rstest.mdx
@@ -113,16 +113,17 @@ This means that you need to choose SWC plugins that match the current `swc_core`
 
 ## Detect Rstest environment
 
-You can use `process.env.RSTEST` to detect whether it is an Rstest test environment to apply different configurations/codes in your tests.
+You can use `import.meta.env.RSTEST` or `process.env.RSTEST` to detect whether code is running under Rstest. Both values are `'true'` in every test environment, including browser mode.
+
+Prefer `import.meta.env.RSTEST` in browser-compatible ESM source code. Browser mode replaces these expressions at build time but does not add a global `process` object, so do not guard access with `typeof process !== 'undefined'`.
 
 ```ts
-if (process.env.RSTEST) {
-  // 'true' will be returned in the rstest environment
+if (import.meta.env.RSTEST === 'true') {
   // do something...
 }
 ```
 
-It should be noted that if you use `process.env.RSTEST` in your source code, define `process.env.RSTEST` as `false` in your build configuration (such as `rsbuild.config.ts`) during production builds, this will help the bundler eliminate dead code.
+When building the source code for production, define the expressions you use as `false` in your build configuration (such as `rsbuild.config.ts`). This allows the bundler to eliminate the test-only branches as dead code.
 
 ```diff title=rsbuild.config.ts
 import { defineConfig } from '@rsbuild/core';
@@ -131,6 +132,7 @@ export default defineConfig({
   source: {
     define: {
 +      'process.env.RSTEST': false,
++      'import.meta.env.RSTEST': false,
     },
   },
 });

--- a/website/docs/zh/api/runtime-api/environment-variables.mdx
+++ b/website/docs/zh/api/runtime-api/environment-variables.mdx
@@ -20,15 +20,17 @@ if (import.meta.env.NODE_ENV === 'test') {
 
 ## `RSTEST`
 
-Rstest 在执行测试时会把 `process.env.RSTEST` 设为 `'true'`，可以用来在源码中标记仅在测试中执行的代码分支。
+`process.env.RSTEST` 和 `import.meta.env.RSTEST` 在所有测试环境（包括 [browser mode](/guide/browser-testing/)）下都可用。Rstest 在执行测试时会把它们设为 `'true'`，可以用来在源码中标记仅在测试中执行的代码分支。
+
+在 browser mode 下，Rstest 会在构建时替换这些表达式，但不会添加全局 `process` 对象。在兼容浏览器的 ESM 源码中，推荐使用 `import.meta.env.RSTEST`。不要先通过 `typeof process !== 'undefined'` 判断是否可用，因为该条件在浏览器中仍为 `false`。
 
 ```ts
-if (process.env.RSTEST) {
+if (import.meta.env.RSTEST === 'true') {
   // 运行在 Rstest 中
 }
 ```
 
-在生产构建中把 `process.env.RSTEST` 替换为 `false`，这样打包工具就能消除对应的死代码 — 详见 [检测 Rstest 环境](/guide/basic/configure-rstest#检测-rstest-环境)。
+在生产构建中，把源码使用的表达式替换为 `false`，这样打包工具就能消除对应的死代码 — 详见 [检测 Rstest 环境](/guide/basic/configure-rstest#检测-rstest-环境)。
 
 如果想把测试代码直接写在源文件里，更推荐使用 [`import.meta.rstest`](/config/test/include-source) — 它直接暴露 Rstest 的测试 API，并且在生产构建中为 `undefined`。
 

--- a/website/docs/zh/guide/basic/configure-rstest.mdx
+++ b/website/docs/zh/guide/basic/configure-rstest.mdx
@@ -113,16 +113,17 @@ export default defineConfig({
 
 ## 检测 Rstest 环境
 
-你可以使用 `process.env.RSTEST` 来检测是否是 Rstest 测试环境以应用不同的配置 / 代码在你的测试中。
+你可以使用 `import.meta.env.RSTEST` 或 `process.env.RSTEST` 判断代码是否运行在 Rstest 中。在所有测试环境（包括 browser mode）下，这两个值都是 `'true'`。
+
+在兼容浏览器的 ESM 源码中，推荐使用 `import.meta.env.RSTEST`。browser mode 会在构建时替换这些表达式，但不会添加全局 `process` 对象，因此不要先通过 `typeof process !== 'undefined'` 判断是否可用。
 
 ```ts
-if (process.env.RSTEST) {
-  // 在 rstest 环境下将会返回 'true'
+if (import.meta.env.RSTEST === 'true') {
   // do something...
 }
 ```
 
-需要注意的是，如果你使用 `process.env.RSTEST` 在你的源码中，在生产环境构建时，在你的构建配置（如 `rsbuild.config.ts`）中将 `process.env.RSTEST` 定义为 `false`，这样将有助于打包工具消除无用代码。
+生产构建源码时，需要在构建配置（如 `rsbuild.config.ts`）中把用到的表达式定义为 `false`。这样打包工具就能把仅用于测试的分支作为死代码消除。
 
 ```diff title=rsbuild.config.ts
 import { defineConfig } from '@rsbuild/core';
@@ -131,6 +132,7 @@ export default defineConfig({
   source: {
     define: {
 +      'process.env.RSTEST': false,
++      'import.meta.env.RSTEST': false,
     },
   },
 });


### PR DESCRIPTION
## Summary

This PR clarifies how `RSTEST` environment detection works in browser mode. It documents that `process.env.RSTEST` and `import.meta.env.RSTEST` are replaced at build time without exposing a global `process` object, recommends `import.meta.env.RSTEST` for browser-compatible ESM source, and updates the production `define` examples in both English and Chinese.

## Related Links

- https://github.com/web-infra-dev/rstest/issues/1590

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).