### PR TITLE
docs: complete mock API documentation

### DIFF
--- a/website/docs/en/api/runtime-api/rstest/mock-functions.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-functions.mdx
@@ -13,7 +13,7 @@ Rstest provides some utility functions to help you mock functions powered by [ti
 - **Type:**
 
 ```ts
-type FunctionLike = (...args: any[]) => any;
+type FunctionLike = (...args: any) => any;
 
 export interface Mock<
   T extends FunctionLike = FunctionLike,
@@ -217,24 +217,19 @@ expect(instance.getUser()).toEqual({ id: 2, name: 'Bob' });
 - **Type:**
 
 ```ts
-type MockedFn = (<T>(item: T, deep?: false) => Mocked<T>) &
-  (<T>(item: T, deep: true) => MaybeMockedDeep<T>) &
-  (<T>(item: T, options: { partial?: false; deep?: false }) => Mocked<T>) &
-  (<T>(
-    item: T,
-    options: { partial?: false; deep: true },
-  ) => MaybeMockedDeep<T>) &
-  (<T>(
-    item: T,
-    options: { partial: true; deep?: false },
-  ) => MaybePartiallyMocked<T>) &
-  (<T>(
-    item: T,
-    options: { partial: true; deep: true },
-  ) => MaybePartiallyMockedDeep<T>);
+type MockedFn = <T>(
+  item: T,
+  deepOrOptions?: boolean | { partial?: boolean; deep?: boolean },
+) =>
+  | Mocked<T>
+  | MaybeMockedDeep<T>
+  | MaybePartiallyMocked<T>
+  | MaybePartiallyMockedDeep<T>;
 ```
 
 A type helper for TypeScript that wraps an object with mock types without changing its runtime behavior. This is useful when you have mocked a module and want proper type hints for the mock methods.
+
+The inferred return type follows the options: `{ deep: true }` applies mock types recursively, while `{ partial: true }` uses the partial mock variants.
 
 See the [`Mocked`](/api/javascript-api/types#mocked) type for annotating mocked objects and modules.
 

--- a/website/docs/en/api/runtime-api/rstest/mock-functions.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-functions.mdx
@@ -13,14 +13,21 @@ Rstest provides some utility functions to help you mock functions powered by [ti
 - **Type:**
 
 ```ts
-export interface Mock<T extends Function> extends MockInstance<T> {
+type FunctionLike = (...args: any[]) => any;
+
+export interface Mock<
+  T extends FunctionLike = FunctionLike,
+> extends MockInstance<T> {
+  new (...args: Parameters<T>): ReturnType<T>;
   (...args: Parameters<T>): ReturnType<T>;
 }
 
-export type MockFn = <T extends Function>(fn?: T) => Mock<T>;
+export type MockFn = <T extends FunctionLike = FunctionLike>(fn?: T) => Mock<T>;
 ```
 
 Creates a spy on a function.
+
+See the [`Mock`](/api/javascript-api/types#mock) type for annotating callable mock functions.
 
 ```ts
 const sayHi = rs.fn((name: string) => `hi ${name}`);
@@ -38,14 +45,16 @@ expect(sayHi).toHaveBeenCalledTimes(1);
 - **Type:**
 
 ```ts
-export type SpyFn = (
-  obj: Record<string, any>,
-  methodName: string,
+export type SpyFn = <T extends Record<string, any>, K extends keyof T>(
+  obj: T,
+  methodName: K,
   accessType?: 'get' | 'set',
-) => MockInstance;
+) => MockInstance<T[K]>;
 ```
 
 Creates a spy on a method of an object.
+
+See the [`MockInstance`](/api/javascript-api/types#mockinstance) type for the control API returned by a spy.
 
 ```ts
 const sayHi = () => 'hi';
@@ -208,13 +217,26 @@ expect(instance.getUser()).toEqual({ id: 2, name: 'Bob' });
 - **Type:**
 
 ```ts
-type MockedFn = <T>(
-  item: T,
-  deep?: boolean | { partial?: boolean; deep?: boolean },
-) => Mocked<T>;
+type MockedFn = (<T>(item: T, deep?: false) => Mocked<T>) &
+  (<T>(item: T, deep: true) => MaybeMockedDeep<T>) &
+  (<T>(item: T, options: { partial?: false; deep?: false }) => Mocked<T>) &
+  (<T>(
+    item: T,
+    options: { partial?: false; deep: true },
+  ) => MaybeMockedDeep<T>) &
+  (<T>(
+    item: T,
+    options: { partial: true; deep?: false },
+  ) => MaybePartiallyMocked<T>) &
+  (<T>(
+    item: T,
+    options: { partial: true; deep: true },
+  ) => MaybePartiallyMockedDeep<T>);
 ```
 
 A type helper for TypeScript that wraps an object with mock types without changing its runtime behavior. This is useful when you have mocked a module and want proper type hints for the mock methods.
+
+See the [`Mocked`](/api/javascript-api/types#mocked) type for annotating mocked objects and modules.
 
 ```ts
 import { myModule } from './myModule';

--- a/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
@@ -401,7 +401,7 @@ In this example, `rs.hoisted` allows you to create a mock function using `rs.fn(
 
 - **Type:** `<T = Record<string, unknown>>(path: string) => Promise<T>`
 
-Loads the original implementation of a module even if it has already been mocked. Use `rs.importActual` when you want a partial mock so you can merge the real exports with your overrides.
+Loads the original implementation of an ESM module asynchronously, even if it has already been mocked. Use `rs.importActual` when asynchronous test code needs to bypass a module mock. For a CommonJS module loaded through `require()`, use [`rs.requireActual`](#rsrequireactual).
 
 ```ts title="src/sum.test.ts"
 rs.mock('./sum');
@@ -412,7 +412,7 @@ it('test', async () => {
 });
 ```
 
-Rstest also exposes a synchronous `importActual` option for static imports. Add the [import attribute](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with) `with { rstest: 'importActual' }` to load the real module as the file evaluates:
+For a partial ESM mock in a synchronous `rs.mock` factory, add the [import attribute](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with) `with { rstest: 'importActual' }` to a static import. This loads the real module as the file evaluates, so the factory can merge the real exports with its overrides:
 
 ```ts title="src/api.test.ts"
 import * as apiActual from './api' with { rstest: 'importActual' };
@@ -424,16 +424,53 @@ rs.mock('./api', () => ({
 }));
 ```
 
+## rs.requireActual
+
+- **Type:** `<T = Record<string, unknown>>(path: string) => T`
+
+Loads the original implementation of a CommonJS module synchronously, even if it has already been mocked. Use `rs.requireActual` when code consumes the module through `require()`, or when a synchronous mock factory needs the real exports. For an ESM module loaded through `import`, use [`rs.importActual`](#rsimportactual).
+
+```ts title="src/math.test.ts"
+rs.mockRequire('./math.cjs', () => ({
+  sum: () => 100,
+}));
+
+test('loads the original CommonJS module', () => {
+  const actualMath =
+    rs.requireActual<typeof import('./math.cjs')>('./math.cjs');
+
+  expect(rs.isMockFunction(actualMath.sum)).toBe(false);
+  expect(actualMath.sum(1, 2)).toBe(3);
+});
+```
+
 ## rs.importMock
 
 - **Type:** `<T = Record<string, unknown>>(path: string) => Promise<T>`
 
-Imports a module and all its properties as mock implementations.
+Loads an ESM module asynchronously and returns it with all properties, including nested properties, replaced by mock implementations. Use `rs.importMock` when a test needs an auto-mocked module directly. For a CommonJS module loaded through `require()`, use [`rs.requireMock`](#rsrequiremock).
 
-```ts title="src/sum.test.ts"
-it('test', async () => {
-  const mockedModule = await rs.importMock('./sum');
-  expect(mockedModule.sum2(1, 2)).toBe(103);
+```ts title="src/api.test.ts"
+test('loads an ESM module as mocks', async () => {
+  const mockedApi = await rs.importMock<typeof import('./api')>('./api');
+
+  mockedApi.fetchUser('1');
+  expect(mockedApi.fetchUser).toHaveBeenCalledWith('1');
+});
+```
+
+## rs.requireMock
+
+- **Type:** `<T = Record<string, unknown>>(path: string) => T`
+
+Loads a CommonJS module synchronously and returns it with all properties, including nested properties, replaced by mock implementations. Use `rs.requireMock` when the target is consumed through `require()` and the test needs the mocked module immediately. For an ESM module loaded through `import`, use [`rs.importMock`](#rsimportmock).
+
+```ts title="src/math.test.ts"
+test('loads a CommonJS module as mocks', () => {
+  const mockedMath = rs.requireMock<typeof import('./math.cjs')>('./math.cjs');
+
+  mockedMath.sum(1, 2);
+  expect(mockedMath.sum).toHaveBeenCalledWith(1, 2);
 });
 ```
 
@@ -478,7 +515,7 @@ Same as `rs.unmock`, but it is not hoisted to the top of the file. The next impo
 
 ## rs.resetModules
 
-- **Type:** `resetModules: () => RstestUtilities`
+- **Type:** `() => RstestUtilities`
 
 Clears the cache of all modules. This allows modules to be re-executed when re-imported. This is useful for isolating the state of modules shared between different tests.
 

--- a/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/en/api/runtime-api/rstest/mock-modules.mdx
@@ -430,14 +430,15 @@ rs.mock('./api', () => ({
 
 Loads the original implementation of a CommonJS module synchronously, even if it has already been mocked. Use `rs.requireActual` when code consumes the module through `require()`, or when a synchronous mock factory needs the real exports. For an ESM module loaded through `import`, use [`rs.importActual`](#rsimportactual).
 
-```ts title="src/math.test.ts"
+```js title="src/math.test.cjs"
+const { expect, rs, test } = require('@rstest/core');
+
 rs.mockRequire('./math.cjs', () => ({
   sum: () => 100,
 }));
 
 test('loads the original CommonJS module', () => {
-  const actualMath =
-    rs.requireActual<typeof import('./math.cjs')>('./math.cjs');
+  const actualMath = rs.requireActual('./math.cjs');
 
   expect(rs.isMockFunction(actualMath.sum)).toBe(false);
   expect(actualMath.sum(1, 2)).toBe(3);
@@ -448,13 +449,15 @@ test('loads the original CommonJS module', () => {
 
 - **Type:** `<T = Record<string, unknown>>(path: string) => Promise<T>`
 
-Loads an ESM module asynchronously and returns it with all properties, including nested properties, replaced by mock implementations. Use `rs.importMock` when a test needs an auto-mocked module directly. For a CommonJS module loaded through `require()`, use [`rs.requireMock`](#rsrequiremock).
+Loads an ESM module asynchronously and replaces its function exports, including nested functions, with mock functions. Primitive values are preserved, while arrays become empty arrays. Use `rs.importMock` when a test needs an auto-mocked module directly. For a CommonJS module loaded through `require()`, use [`rs.requireMock`](#rsrequiremock).
 
 ```ts title="src/api.test.ts"
 test('loads an ESM module as mocks', async () => {
-  const mockedApi = await rs.importMock<typeof import('./api')>('./api');
+  const api = await rs.importMock<typeof import('./api')>('./api');
+  const mockedApi = rs.mocked(api, true);
 
-  mockedApi.fetchUser('1');
+  mockedApi.fetchUser.mockResolvedValue({ id: '1', name: 'Alice' });
+  await mockedApi.fetchUser('1');
   expect(mockedApi.fetchUser).toHaveBeenCalledWith('1');
 });
 ```
@@ -463,14 +466,16 @@ test('loads an ESM module as mocks', async () => {
 
 - **Type:** `<T = Record<string, unknown>>(path: string) => T`
 
-Loads a CommonJS module synchronously and returns it with all properties, including nested properties, replaced by mock implementations. Use `rs.requireMock` when the target is consumed through `require()` and the test needs the mocked module immediately. For an ESM module loaded through `import`, use [`rs.importMock`](#rsimportmock).
+Loads a CommonJS module synchronously and replaces its exported functions, including nested functions, with mock functions. Primitive values are preserved, while arrays become empty arrays. Use `rs.requireMock` when the target is consumed through `require()` and the test needs the mocked module immediately. For an ESM module loaded through `import`, use [`rs.importMock`](#rsimportmock).
 
-```ts title="src/math.test.ts"
+```js title="src/math.test.cjs"
+const { expect, rs, test } = require('@rstest/core');
+
 test('loads a CommonJS module as mocks', () => {
-  const mockedMath = rs.requireMock<typeof import('./math.cjs')>('./math.cjs');
+  const mockedMath = rs.requireMock('./math.cjs');
 
-  mockedMath.sum(1, 2);
-  expect(mockedMath.sum).toHaveBeenCalledWith(1, 2);
+  mockedMath.sum.mockReturnValue(100);
+  expect(mockedMath.sum(1, 2)).toBe(100);
 });
 ```
 

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -127,7 +127,7 @@ test('overrides one export', () => {
 - [rs.importMock()](/api/runtime-api/rstest/mock-modules#rsimportmock) asynchronously loads an ESM module and returns a Promise. Use it with `await` for modules consumed through `import`.
 - [rs.requireMock()](/api/runtime-api/rstest/mock-modules#rsrequiremock) synchronously loads a CommonJS module. Use it for modules consumed through `require()`.
 
-Both APIs replace functions and nested properties with mocks, which lets the test configure selected exports or assert their calls immediately. Match the API to the module entry your code uses, especially when a package provides separate ESM and CommonJS entries.
+Both APIs replace function exports and nested functions with mocks. Primitive values are preserved, while arrays become empty arrays. In TypeScript, pass the returned module to `rs.mocked(module, true)` before calling mock control methods such as `mockReturnValue`. Match the API to the module entry your code uses, especially when a package provides separate ESM and CommonJS entries.
 
 ### Spy on a whole module
 

--- a/website/docs/en/guide/basic/mock.mdx
+++ b/website/docs/en/guide/basic/mock.mdx
@@ -55,6 +55,26 @@ test('only mocks later imports', async () => {
 });
 ```
 
+### Share values with a hoisted mock factory
+
+Because `rs.mock()` is hoisted, its factory cannot read variables initialized later through normal module execution. Use [rs.hoisted()](/api/runtime-api/rstest/mock-modules#rshoisted) when the factory and test assertions need to share the same mock function or value.
+
+```ts title="api.test.ts"
+import { expect, rs, test } from '@rstest/core';
+import { fetchUser } from './api';
+
+const mocks = rs.hoisted(() => ({
+  fetchUser: rs.fn().mockResolvedValue({ id: '1', name: 'Alice' }),
+}));
+
+rs.mock('./api', () => ({ fetchUser: mocks.fetchUser }));
+
+test('shares the mock with the factory', async () => {
+  await fetchUser('1');
+  expect(mocks.fetchUser).toHaveBeenCalledWith('1');
+});
+```
+
 ### Mock CommonJS modules
 
 If a dependency is loaded through `require()`, you can use [rs.mockRequire()](/api/runtime-api/rstest/mock-modules#rsmockrequire) or [rs.doMockRequire()](/api/runtime-api/rstest/mock-modules#rsdomockrequire).
@@ -100,6 +120,15 @@ test('overrides one export', () => {
 });
 ```
 
+### Load a mocked module
+
+`rs.mock()` configures what import-based loads receive. When a test instead needs the auto-mocked module object directly, use one of these APIs:
+
+- [rs.importMock()](/api/runtime-api/rstest/mock-modules#rsimportmock) asynchronously loads an ESM module and returns a Promise. Use it with `await` for modules consumed through `import`.
+- [rs.requireMock()](/api/runtime-api/rstest/mock-modules#rsrequiremock) synchronously loads a CommonJS module. Use it for modules consumed through `require()`.
+
+Both APIs replace functions and nested properties with mocks, which lets the test configure selected exports or assert their calls immediately. Match the API to the module entry your code uses, especially when a package provides separate ESM and CommonJS entries.
+
 ### Spy on a whole module
 
 If you want to keep the real implementation and still assert calls, you can use `{ spy: true }`.
@@ -120,7 +149,13 @@ Note that the spy only tracks calls made **through an export** — calls between
 
 ### Partially mock modules
 
-If you want one export to keep the real implementation and another export to be replaced, you can use [importActual](/api/runtime-api/rstest/mock-modules#rsimportactual).
+Use the matching API when a mocked module still needs some or all of its real exports:
+
+- Add `with { rstest: 'importActual' }` to a static ESM import when a hoisted, synchronous `rs.mock()` factory needs the real exports.
+- Use [rs.importActual()](/api/runtime-api/rstest/mock-modules#rsimportactual) to load the original ESM module asynchronously inside a test.
+- Use [rs.requireActual()](/api/runtime-api/rstest/mock-modules#rsrequireactual) to load the original CommonJS module synchronously, including from a synchronous mock factory.
+
+The static ESM form is useful for replacing one export while keeping the others:
 
 ```ts title="date-utils.test.ts"
 import { expect, rs, test } from '@rstest/core';
@@ -138,7 +173,7 @@ test('keeps parseDate real', () => {
 });
 ```
 
-Note that factory functions are hoisted, so they should not read values that are initialized later in the same file.
+Note that factory functions are hoisted, so values shared with the factory must come from a static `importActual` import or [`rs.hoisted()`](#share-values-with-a-hoisted-mock-factory).
 
 ### Reuse manual mocks from `__mocks__`
 
@@ -267,6 +302,12 @@ test('mocks nested methods', async () => {
 If you want to keep the original nested implementations while still recording calls, you can pass `{ spy: true }`.
 
 For the full API and more examples, see [Mock functions](/api/runtime-api/rstest/mock-functions) and [MockInstance](/api/runtime-api/rstest/mock-instance).
+
+## Type and identify mock functions
+
+[rs.mocked()](/api/runtime-api/rstest/mock-functions#rsmocked) returns the same value at runtime and only tells TypeScript to treat it as mocked. Use it when an auto-mocked module or object still has its original static type.
+
+[rs.isMockFunction()](/api/runtime-api/rstest/mock-functions#rsismockfunction) performs a runtime check. Use it when test logic needs to determine whether a function is currently a mock; it also narrows the function to `MockInstance` in TypeScript.
 
 ## Clear mock state
 

--- a/website/docs/zh/api/runtime-api/rstest/mock-functions.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-functions.mdx
@@ -13,7 +13,7 @@ Rstest 基于 [tinyspy](https://github.com/tinylibs/tinyspy) 提供了一些工�
 - **类型：**
 
 ```ts
-type FunctionLike = (...args: any[]) => any;
+type FunctionLike = (...args: any) => any;
 
 export interface Mock<
   T extends FunctionLike = FunctionLike,
@@ -218,24 +218,19 @@ expect(instance.getUser()).toEqual({ id: 2, name: 'Bob' });
 - **类型：**
 
 ```ts
-type MockedFn = (<T>(item: T, deep?: false) => Mocked<T>) &
-  (<T>(item: T, deep: true) => MaybeMockedDeep<T>) &
-  (<T>(item: T, options: { partial?: false; deep?: false }) => Mocked<T>) &
-  (<T>(
-    item: T,
-    options: { partial?: false; deep: true },
-  ) => MaybeMockedDeep<T>) &
-  (<T>(
-    item: T,
-    options: { partial: true; deep?: false },
-  ) => MaybePartiallyMocked<T>) &
-  (<T>(
-    item: T,
-    options: { partial: true; deep: true },
-  ) => MaybePartiallyMockedDeep<T>);
+type MockedFn = <T>(
+  item: T,
+  deepOrOptions?: boolean | { partial?: boolean; deep?: boolean },
+) =>
+  | Mocked<T>
+  | MaybeMockedDeep<T>
+  | MaybePartiallyMocked<T>
+  | MaybePartiallyMockedDeep<T>;
 ```
 
 一个 TypeScript 类型辅助函数，用于将对象包装为 mock 类型而不改变其运行时行为。当你 mock 了一个模块并想要获得正确的 mock 方法类型提示时，这很有用。
+
+推导出的返回类型会随选项变化：`{ deep: true }` 会递归应用 mock 类型，`{ partial: true }` 则使用 partial mock 类型。
 
 如果需要为 mock 对象或模块标注类型，请参考 [`Mocked`](/api/javascript-api/types#mocked) 类型。
 

--- a/website/docs/zh/api/runtime-api/rstest/mock-functions.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-functions.mdx
@@ -13,14 +13,21 @@ Rstest 基于 [tinyspy](https://github.com/tinylibs/tinyspy) 提供了一些工�
 - **类型：**
 
 ```ts
-export interface Mock<T extends Function> extends MockInstance<T> {
+type FunctionLike = (...args: any[]) => any;
+
+export interface Mock<
+  T extends FunctionLike = FunctionLike,
+> extends MockInstance<T> {
+  new (...args: Parameters<T>): ReturnType<T>;
   (...args: Parameters<T>): ReturnType<T>;
 }
 
-export type MockFn = <T extends Function>(fn?: T) => Mock<T>;
+export type MockFn = <T extends FunctionLike = FunctionLike>(fn?: T) => Mock<T>;
 ```
 
 创建一个 mock 函数。
+
+如果需要为可调用的 mock 函数标注类型，请参考 [`Mock`](/api/javascript-api/types#mock) 类型。
 
 ```ts
 const sayHi = rs.fn((name: string) => `hi ${name}`);
@@ -38,14 +45,16 @@ expect(sayHi).toHaveBeenCalledTimes(1);
 - **类型：**
 
 ```ts
-export type SpyFn = (
-  obj: Record<string, any>,
-  methodName: string,
+export type SpyFn = <T extends Record<string, any>, K extends keyof T>(
+  obj: T,
+  methodName: K,
   accessType?: 'get' | 'set',
-) => MockInstance;
+) => MockInstance<T[K]>;
 ```
 
 对一个对象的方法进行 mock。
+
+关于 spy 返回的控制 API，请参考 [`MockInstance`](/api/javascript-api/types#mockinstance) 类型。
 
 ```ts
 const sayHi = () => 'hi';
@@ -209,13 +218,26 @@ expect(instance.getUser()).toEqual({ id: 2, name: 'Bob' });
 - **类型：**
 
 ```ts
-type MockedFn = <T>(
-  item: T,
-  deep?: boolean | { partial?: boolean; deep?: boolean },
-) => Mocked<T>;
+type MockedFn = (<T>(item: T, deep?: false) => Mocked<T>) &
+  (<T>(item: T, deep: true) => MaybeMockedDeep<T>) &
+  (<T>(item: T, options: { partial?: false; deep?: false }) => Mocked<T>) &
+  (<T>(
+    item: T,
+    options: { partial?: false; deep: true },
+  ) => MaybeMockedDeep<T>) &
+  (<T>(
+    item: T,
+    options: { partial: true; deep?: false },
+  ) => MaybePartiallyMocked<T>) &
+  (<T>(
+    item: T,
+    options: { partial: true; deep: true },
+  ) => MaybePartiallyMockedDeep<T>);
 ```
 
 一个 TypeScript 类型辅助函数，用于将对象包装为 mock 类型而不改变其运行时行为。当你 mock 了一个模块并想要获得正确的 mock 方法类型提示时，这很有用。
+
+如果需要为 mock 对象或模块标注类型，请参考 [`Mocked`](/api/javascript-api/types#mocked) 类型。
 
 ```ts
 import { myModule } from './myModule';

--- a/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
@@ -432,14 +432,15 @@ rs.mock('./api', () => ({
 
 同步加载 CommonJS 模块的原始实现，即使该模块已经被 mock。当代码通过 `require()` 使用模块，或者同步 mock factory 需要真实导出时，可以使用 `rs.requireActual`。如果 ESM 模块通过 `import` 加载，请使用 [`rs.importActual`](#rsimportactual)。
 
-```ts title="src/math.test.ts"
+```js title="src/math.test.cjs"
+const { expect, rs, test } = require('@rstest/core');
+
 rs.mockRequire('./math.cjs', () => ({
   sum: () => 100,
 }));
 
 test('loads the original CommonJS module', () => {
-  const actualMath =
-    rs.requireActual<typeof import('./math.cjs')>('./math.cjs');
+  const actualMath = rs.requireActual('./math.cjs');
 
   expect(rs.isMockFunction(actualMath.sum)).toBe(false);
   expect(actualMath.sum(1, 2)).toBe(3);
@@ -450,13 +451,15 @@ test('loads the original CommonJS module', () => {
 
 - **类型：** `<T = Record<string, unknown>>(path: string) => Promise<T>`
 
-异步加载 ESM 模块，并将其所有属性（包括嵌套属性）替换为 mock 实现后返回。当测试需要直接获得自动 mock 的模块时，可以使用 `rs.importMock`。如果 CommonJS 模块通过 `require()` 加载，请使用 [`rs.requireMock`](#rsrequiremock)。
+异步加载 ESM 模块，并将其导出的函数（包括嵌套函数）替换为 mock 函数。原始值会保留，数组则会变为空数组。当测试需要直接获得自动 mock 的模块时，可以使用 `rs.importMock`。如果 CommonJS 模块通过 `require()` 加载，请使用 [`rs.requireMock`](#rsrequiremock)。
 
 ```ts title="src/api.test.ts"
 test('loads an ESM module as mocks', async () => {
-  const mockedApi = await rs.importMock<typeof import('./api')>('./api');
+  const api = await rs.importMock<typeof import('./api')>('./api');
+  const mockedApi = rs.mocked(api, true);
 
-  mockedApi.fetchUser('1');
+  mockedApi.fetchUser.mockResolvedValue({ id: '1', name: 'Alice' });
+  await mockedApi.fetchUser('1');
   expect(mockedApi.fetchUser).toHaveBeenCalledWith('1');
 });
 ```
@@ -465,14 +468,16 @@ test('loads an ESM module as mocks', async () => {
 
 - **类型：** `<T = Record<string, unknown>>(path: string) => T`
 
-同步加载 CommonJS 模块，并将其所有属性（包括嵌套属性）替换为 mock 实现后返回。当目标通过 `require()` 使用，并且测试需要立即获得 mock 模块时，可以使用 `rs.requireMock`。如果 ESM 模块通过 `import` 加载，请使用 [`rs.importMock`](#rsimportmock)。
+同步加载 CommonJS 模块，并将其导出的函数（包括嵌套函数）替换为 mock 函数。原始值会保留，数组则会变为空数组。当目标通过 `require()` 使用，并且测试需要立即获得 mock 模块时，可以使用 `rs.requireMock`。如果 ESM 模块通过 `import` 加载，请使用 [`rs.importMock`](#rsimportmock)。
 
-```ts title="src/math.test.ts"
+```js title="src/math.test.cjs"
+const { expect, rs, test } = require('@rstest/core');
+
 test('loads a CommonJS module as mocks', () => {
-  const mockedMath = rs.requireMock<typeof import('./math.cjs')>('./math.cjs');
+  const mockedMath = rs.requireMock('./math.cjs');
 
-  mockedMath.sum(1, 2);
-  expect(mockedMath.sum).toHaveBeenCalledWith(1, 2);
+  mockedMath.sum.mockReturnValue(100);
+  expect(mockedMath.sum(1, 2)).toBe(100);
 });
 ```
 

--- a/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
+++ b/website/docs/zh/api/runtime-api/rstest/mock-modules.mdx
@@ -403,7 +403,7 @@ it('hoisted', () => {
 
 - **类型：** `<T = Record<string, unknown>>(path: string) => Promise<T>`
 
-无视一个模块是否被 mock，导入其原始的模块。如果你想 mock 模块的部分实现，可以使用 `rs.importActual` 来获取原始模块的实现与 mock 的实现进行合并进行部分 mock。
+异步加载 ESM 模块的原始实现，即使该模块已经被 mock。异步测试代码需要绕过模块 mock 时，可以使用 `rs.importActual`。如果 CommonJS 模块通过 `require()` 加载，请使用 [`rs.requireActual`](#rsrequireactual)。
 
 ```ts title="src/sum.test.ts"
 rs.mock('./sum');
@@ -414,7 +414,7 @@ it('test', async () => {
 });
 ```
 
-Rstest 也提供了同步的 `importActual` 能力，允许你在同步的 `import` 语句中导入未被 mock 的模块实现。使用方法是在 `import` 语句中添加 `with { rstest: 'importActual' }` 的 [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with)：
+如果要在同步的 `rs.mock` factory 中对 ESM 模块做部分 mock，可以为静态 import 添加 `with { rstest: 'importActual' }` [import attribute](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with)。这样会在文件执行时加载真实模块，让 factory 可以合并真实导出与覆盖实现：
 
 ```ts title="src/api.test.ts"
 import * as apiActual from './api' with { rstest: 'importActual' };
@@ -426,16 +426,53 @@ rs.mock('./api', () => ({
 }));
 ```
 
+## rs.requireActual
+
+- **类型：** `<T = Record<string, unknown>>(path: string) => T`
+
+同步加载 CommonJS 模块的原始实现，即使该模块已经被 mock。当代码通过 `require()` 使用模块，或者同步 mock factory 需要真实导出时，可以使用 `rs.requireActual`。如果 ESM 模块通过 `import` 加载，请使用 [`rs.importActual`](#rsimportactual)。
+
+```ts title="src/math.test.ts"
+rs.mockRequire('./math.cjs', () => ({
+  sum: () => 100,
+}));
+
+test('loads the original CommonJS module', () => {
+  const actualMath =
+    rs.requireActual<typeof import('./math.cjs')>('./math.cjs');
+
+  expect(rs.isMockFunction(actualMath.sum)).toBe(false);
+  expect(actualMath.sum(1, 2)).toBe(3);
+});
+```
+
 ## rs.importMock
 
 - **类型：** `<T = Record<string, unknown>>(path: string) => Promise<T>`
 
-导入一个模块及其所有属性的 mock 实现。
+异步加载 ESM 模块，并将其所有属性（包括嵌套属性）替换为 mock 实现后返回。当测试需要直接获得自动 mock 的模块时，可以使用 `rs.importMock`。如果 CommonJS 模块通过 `require()` 加载，请使用 [`rs.requireMock`](#rsrequiremock)。
 
-```ts title="src/sum.test.ts"
-it('test', async () => {
-  const mockedModule = await rs.importMock('./sum');
-  expect(mockedModule.sum2(1, 2)).toBe(103);
+```ts title="src/api.test.ts"
+test('loads an ESM module as mocks', async () => {
+  const mockedApi = await rs.importMock<typeof import('./api')>('./api');
+
+  mockedApi.fetchUser('1');
+  expect(mockedApi.fetchUser).toHaveBeenCalledWith('1');
+});
+```
+
+## rs.requireMock
+
+- **类型：** `<T = Record<string, unknown>>(path: string) => T`
+
+同步加载 CommonJS 模块，并将其所有属性（包括嵌套属性）替换为 mock 实现后返回。当目标通过 `require()` 使用，并且测试需要立即获得 mock 模块时，可以使用 `rs.requireMock`。如果 ESM 模块通过 `import` 加载，请使用 [`rs.importMock`](#rsimportmock)。
+
+```ts title="src/math.test.ts"
+test('loads a CommonJS module as mocks', () => {
+  const mockedMath = rs.requireMock<typeof import('./math.cjs')>('./math.cjs');
+
+  mockedMath.sum(1, 2);
+  expect(mockedMath.sum).toHaveBeenCalledWith(1, 2);
 });
 ```
 
@@ -480,7 +517,7 @@ it('test', async () => {
 
 ## rs.resetModules
 
-- **类型：** `resetModules: () => RstestUtilities`
+- **类型：** `() => RstestUtilities`
 
 清除所有模块的缓存。这允许在重新导入时重新执行模块。这在隔离不同测试中共享的模块的状态时非常有用。
 

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -127,7 +127,7 @@ test('overrides one export', () => {
 - [rs.importMock()](/api/runtime-api/rstest/mock-modules#rsimportmock) 异步加载 ESM 模块并返回 Promise。对于通过 `import` 使用的模块，需要配合 `await` 使用。
 - [rs.requireMock()](/api/runtime-api/rstest/mock-modules#rsrequiremock) 同步加载 CommonJS 模块。它适用于通过 `require()` 使用的模块。
 
-这两个 API 都会将函数和嵌套属性替换为 mock，让测试可以立即配置指定导出或断言其调用。选择 API 时应匹配代码实际使用的模块 entry，尤其是一个包分别提供 ESM 和 CommonJS entry 时。
+这两个 API 都会将导出的函数和嵌套函数替换为 mock。原始值会保留，数组则会变为空数组。在 TypeScript 中，调用 `mockReturnValue` 等 mock 控制方法之前，需要先将返回的模块传给 `rs.mocked(module, true)`。选择 API 时应匹配代码实际使用的模块 entry，尤其是一个包分别提供 ESM 和 CommonJS entry 时。
 
 ### Spy 整个模块
 

--- a/website/docs/zh/guide/basic/mock.mdx
+++ b/website/docs/zh/guide/basic/mock.mdx
@@ -55,6 +55,26 @@ test('only mocks later imports', async () => {
 });
 ```
 
+### 与提升的 mock factory 共享值
+
+由于 `rs.mock()` 会被提升，它的 factory 无法读取模块按正常顺序执行时才初始化的变量。当 factory 和测试断言需要共享同一个 mock 函数或值时，可以使用 [rs.hoisted()](/api/runtime-api/rstest/mock-modules#rshoisted)。
+
+```ts title="api.test.ts"
+import { expect, rs, test } from '@rstest/core';
+import { fetchUser } from './api';
+
+const mocks = rs.hoisted(() => ({
+  fetchUser: rs.fn().mockResolvedValue({ id: '1', name: 'Alice' }),
+}));
+
+rs.mock('./api', () => ({ fetchUser: mocks.fetchUser }));
+
+test('shares the mock with the factory', async () => {
+  await fetchUser('1');
+  expect(mocks.fetchUser).toHaveBeenCalledWith('1');
+});
+```
+
 ### Mock CommonJS 模块
 
 如果依赖是通过 `require()` 加载的，可以使用 [rs.mockRequire()](/api/runtime-api/rstest/mock-modules#rsmockrequire) 或 [rs.doMockRequire()](/api/runtime-api/rstest/mock-modules#rsdomockrequire)。
@@ -100,6 +120,15 @@ test('overrides one export', () => {
 });
 ```
 
+### 加载 mock 的模块
+
+`rs.mock()` 用于配置通过 import 加载时获得的模块。如果测试需要直接获得自动 mock 的模块对象，可以使用下面这些 API：
+
+- [rs.importMock()](/api/runtime-api/rstest/mock-modules#rsimportmock) 异步加载 ESM 模块并返回 Promise。对于通过 `import` 使用的模块，需要配合 `await` 使用。
+- [rs.requireMock()](/api/runtime-api/rstest/mock-modules#rsrequiremock) 同步加载 CommonJS 模块。它适用于通过 `require()` 使用的模块。
+
+这两个 API 都会将函数和嵌套属性替换为 mock，让测试可以立即配置指定导出或断言其调用。选择 API 时应匹配代码实际使用的模块 entry，尤其是一个包分别提供 ESM 和 CommonJS entry 时。
+
 ### Spy 整个模块
 
 如果你希望保留真实实现，同时提供调用断言能力，可以使用 `{ spy: true }`。
@@ -120,7 +149,13 @@ test('keeps the real implementation while tracking calls', () => {
 
 ### 部分 mock 模块
 
-如果你要做部分 mock，让一个导出保留真实实现、另一个导出被替换，可以使用 [importActual](/api/runtime-api/rstest/mock-modules#rsimportactual)。
+当被 mock 的模块仍需要部分或全部真实导出时，应根据模块的加载方式选择对应的 API：
+
+- 当提升的同步 `rs.mock()` factory 需要真实导出时，为静态 ESM import 添加 `with { rstest: 'importActual' }`。
+- 使用 [rs.importActual()](/api/runtime-api/rstest/mock-modules#rsimportactual) 在测试中异步加载原始 ESM 模块。
+- 使用 [rs.requireActual()](/api/runtime-api/rstest/mock-modules#rsrequireactual) 同步加载原始 CommonJS 模块，也可以在同步 mock factory 中使用。
+
+静态 ESM 形式适合只替换一个导出，同时保留其余导出的场景：
 
 ```ts title="date-utils.test.ts"
 import { expect, rs, test } from '@rstest/core';
@@ -138,7 +173,7 @@ test('keeps parseDate real', () => {
 });
 ```
 
-需要注意的是，由于 factory 会被提升，factory 内不应该访问同文件中稍后才初始化的值。
+需要注意的是，由于 factory 会被提升，与 factory 共享的值必须来自静态 `importActual` import 或 [`rs.hoisted()`](#与提升的-mock-factory-共享值)。
 
 ### 复用 `__mocks__` 里的手写 mock
 
@@ -267,6 +302,12 @@ test('mocks nested methods', async () => {
 如果你希望保留嵌套方法的原始实现，同时记录调用，可以传入 `{ spy: true }`。
 
 关于完整 API 和更多示例，可以参考 [Mock functions](/api/runtime-api/rstest/mock-functions) 和 [MockInstance](/api/runtime-api/rstest/mock-instance)。
+
+## 标注与识别 mock 函数
+
+[rs.mocked()](/api/runtime-api/rstest/mock-functions#rsmocked) 在运行时返回同一个值，只用于告诉 TypeScript 将其视为 mock。自动 mock 的模块或对象仍保留原始静态类型时，可以使用它。
+
+[rs.isMockFunction()](/api/runtime-api/rstest/mock-functions#rsismockfunction) 会执行运行时检查。当测试逻辑需要判断一个函数当前是否为 mock 时，可以使用它；在 TypeScript 中，它也会将函数类型收窄为 `MockInstance`。
 
 ## 清理 mock 状态
 


### PR DESCRIPTION
## Summary

This PR completes the Mock documentation so users can choose the correct APIs for ESM and CommonJS modules, including hoisted and synchronous use cases.

- Document `importMock` / `requireMock`, `importActual` / `requireActual`, and `rs.hoisted` usage.
- Align the documented `rs.fn`, `rs.spyOn`, `rs.mocked`, and `rs.resetModules` signatures with the exported types.
- Keep the English and Chinese API references and guide in sync.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).