### PR TITLE
release: 0.11.3

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/playwright",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Playwright fixture integration for Rstest",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
## What's Changed
### New Features 🎉
* feat(browser): support module mocking, includeSource and console format parity by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1580
### Performance 🚀
* perf(coverage-v8): reduce coverage conversion memory by @9aoy in https://github.com/web-infra-dev/rstest/pull/1593
### Bug Fixes 🐞
* fix(core): make jsdom/happy-dom web storage usable on Node 25+ by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1584
* fix(core): support object URLs for DOM blobs by @9aoy in https://github.com/web-infra-dev/rstest/pull/1585
* fix(coverage-v8): transform untested TypeScript files by @9aoy in https://github.com/web-infra-dev/rstest/pull/1586
* fix(core): clean up DOM environment timers by @9aoy in https://github.com/web-infra-dev/rstest/pull/1592
### Document 📖
* docs: reorder guide sidebar sections by @9aoy in https://github.com/web-infra-dev/rstest/pull/1587
* docs: clarify RSTEST in browser mode by @9aoy in https://github.com/web-infra-dev/rstest/pull/1594
* docs: complete mock API documentation by @9aoy in https://github.com/web-infra-dev/rstest/pull/1595
### Other Changes
* chore: add verify skill and tighten agent harness conventions by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1588
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1591
* release: 0.11.3 by @9aoy in https://github.com/web-infra-dev/rstest/pull/1597

**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.11.2...v0.11.3
