### PR TITLE
fix(core): preserve mocked class static members

### DIFF
--- a/e2e/mock/tests/mockObject.test.ts
+++ b/e2e/mock/tests/mockObject.test.ts
@@ -145,6 +145,21 @@ describe('rs.mockObject', () => {
     expect(rs.isMockFunction(MockedClass)).toBe(true);
   });
 
+  test('mocks static class methods', () => {
+    class OriginalClass {
+      static getValue(): number {
+        return 42;
+      }
+    }
+
+    const MockedClass = rs.mockObject(OriginalClass);
+    expect(rs.isMockFunction(MockedClass.getValue)).toBe(true);
+    expect(MockedClass.getValue()).toBeUndefined();
+
+    MockedClass.getValue.mockReturnValue(100);
+    expect(MockedClass.getValue()).toBe(100);
+  });
+
   // Special object types tests
   test('preserves Date objects', () => {
     const date = new Date('2024-01-01');
@@ -312,5 +327,26 @@ describe('rs.mocked', () => {
       mocked(1);
     expect(callsWithoutReceiver).toBeTypeOf('function');
     expect(callsDeep).toBeTypeOf('function');
+  });
+
+  test('Mocked<T> preserves class static members', () => {
+    class Service {
+      static label = 'service';
+      static getValue(): number {
+        return 42;
+      }
+    }
+
+    const asRealClass = (mocked: Mocked<typeof Service>): typeof Service =>
+      mocked;
+    const readsStaticProperty = (mocked: Mocked<typeof Service>): string =>
+      mocked.label;
+    const configuresStaticMethod = (mocked: Mocked<typeof Service>): void => {
+      mocked.getValue.mockReturnValue(100);
+    };
+
+    expect(asRealClass).toBeTypeOf('function');
+    expect(readsStaticProperty).toBeTypeOf('function');
+    expect(configuresStaticMethod).toBeTypeOf('function');
   });
 });

--- a/e2e/mock/tests/mockObject.test.ts
+++ b/e2e/mock/tests/mockObject.test.ts
@@ -147,6 +147,11 @@ describe('rs.mockObject', () => {
 
   test('mocks static class methods', () => {
     class OriginalClass {
+      static api = {
+        getValue(): number {
+          return 42;
+        },
+      };
       static getValue(): number {
         return 42;
       }
@@ -158,6 +163,12 @@ describe('rs.mockObject', () => {
 
     MockedClass.getValue.mockReturnValue(100);
     expect(MockedClass.getValue()).toBe(100);
+
+    expect(rs.isMockFunction(MockedClass.api.getValue)).toBe(true);
+    expect(MockedClass.api.getValue()).toBeUndefined();
+
+    MockedClass.api.getValue.mockReturnValue(200);
+    expect(MockedClass.api.getValue()).toBe(200);
   });
 
   // Special object types tests
@@ -331,6 +342,11 @@ describe('rs.mocked', () => {
 
   test('Mocked<T> preserves class static members', () => {
     class Service {
+      static api = {
+        getValue(): number {
+          return 42;
+        },
+      };
       static label = 'service';
       static getValue(): number {
         return 42;
@@ -344,9 +360,14 @@ describe('rs.mocked', () => {
     const configuresStaticMethod = (mocked: Mocked<typeof Service>): void => {
       mocked.getValue.mockReturnValue(100);
     };
+    type DeepMockedService = ReturnType<typeof rs.mockObject<typeof Service>>;
+    const configuresDeepStaticMethod = (mocked: DeepMockedService): void => {
+      mocked.api.getValue.mockReturnValue(200);
+    };
 
     expect(asRealClass).toBeTypeOf('function');
     expect(readsStaticProperty).toBeTypeOf('function');
     expect(configuresStaticMethod).toBeTypeOf('function');
+    expect(configuresDeepStaticMethod).toBeTypeOf('function');
   });
 });

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -239,12 +239,18 @@ type MockProcedure = (...args: any[]) => any;
 type Constructor<T = any> = new (...args: any[]) => T;
 
 // Mocked class constructor type - preserves both the constructor signature and mock capabilities
-export type MockedClass<T extends Constructor> = Mock<
+type MockedClassBase<T extends Constructor> = Mock<
   (...args: ConstructorParameters<T>) => InstanceType<T>
 > & {
   new (...args: ConstructorParameters<T>): InstanceType<T>;
   prototype: InstanceType<T>;
-} & MockedObject<T>;
+};
+
+export type MockedClass<T extends Constructor> = MockedClassBase<T> &
+  MockedObject<T>;
+
+type MockedClassDeep<T extends Constructor> = MockedClassBase<T> &
+  MockedObjectDeep<T>;
 
 type Methods<T> = {
   [K in keyof T]: T[K] extends MockProcedure ? K : never;
@@ -299,7 +305,7 @@ export type Mocked<T> = T extends Constructor
       : T;
 
 export type MaybeMockedDeep<T> = T extends Constructor
-  ? MockedClass<T>
+  ? MockedClassDeep<T>
   : T extends MockProcedure
     ? MockedFunctionDeep<T>
     : T extends object
@@ -315,7 +321,7 @@ export type MaybePartiallyMocked<T> = T extends Constructor
       : T;
 
 export type MaybePartiallyMockedDeep<T> = T extends Constructor
-  ? MockedClass<T>
+  ? MockedClassDeep<T>
   : T extends MockProcedure
     ? MockedFunctionDeep<T>
     : T extends object

--- a/packages/core/src/types/mock.ts
+++ b/packages/core/src/types/mock.ts
@@ -244,7 +244,7 @@ export type MockedClass<T extends Constructor> = Mock<
 > & {
   new (...args: ConstructorParameters<T>): InstanceType<T>;
   prototype: InstanceType<T>;
-};
+} & MockedObject<T>;
 
 type Methods<T> = {
   [K in keyof T]: T[K] extends MockProcedure ? K : never;


### PR DESCRIPTION
## Summary

- Preserve static properties on `Mocked<typeof Class>` and type static methods as mocks, matching the existing runtime behavior.
- Add runtime and type-level regression coverage for mocked class statics.

## Related Links

Closes #1598

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).