### PR TITLE
fix(core): restore withImplementation after errors

### DIFF
--- a/e2e/browser-mode/basic.test.ts
+++ b/e2e/browser-mode/basic.test.ts
@@ -11,6 +11,7 @@ describe('browser mode - basic', () => {
     expect(cli.stdout).toContain('events.test.ts');
     expect(cli.stdout).toContain('async.test.ts');
     expect(cli.stdout).toContain('fakeTimers.test.ts');
+    expect(cli.stdout).toContain('spy.test.ts');
     expect(cli.stdout).not.toContain('/scheduler.html');
   });
 

--- a/e2e/browser-mode/fixtures/basic/tests/spy.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/spy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, rstest } from '@rstest/core';
+
+describe('Spy', () => {
+  it('restores withImplementation after a synchronous callback throws', () => {
+    const spy = rstest.fn(() => 'original');
+    spy.mockImplementationOnce(() => 'once');
+
+    expect(() =>
+      spy.withImplementation(
+        () => 'temporary',
+        () => {
+          expect(spy()).toBe('temporary');
+          throw new Error('sync failure');
+        },
+      ),
+    ).toThrow('sync failure');
+
+    expect(spy()).toBe('once');
+    expect(spy()).toBe('original');
+  });
+
+  it('restores withImplementation after an asynchronous callback rejects', async () => {
+    const spy = rstest.fn(() => 'original');
+    spy.mockImplementationOnce(() => 'once');
+
+    await expect(
+      spy.withImplementation(
+        () => 'temporary',
+        async () => {
+          expect(spy()).toBe('temporary');
+          throw new Error('async failure');
+        },
+      ),
+    ).rejects.toThrow('async failure');
+
+    expect(spy()).toBe('once');
+    expect(spy()).toBe('original');
+  });
+});

--- a/e2e/browser-mode/fixtures/basic/tests/spy.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/spy.test.ts
@@ -36,4 +36,36 @@ describe('Spy', () => {
     expect(spy()).toBe('once');
     expect(spy()).toBe('original');
   });
+
+  it('keeps withImplementation active for a cross-realm Promise', async () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    try {
+      const iframeWindow = iframe.contentWindow;
+      if (!iframeWindow) {
+        throw new Error('Expected the iframe to have a window');
+      }
+
+      // lib.dom omits realm globals such as Promise from the Window interface.
+      const iframeGlobal = iframeWindow as Window & typeof globalThis;
+      const callbackPromise = iframeGlobal.Promise.resolve();
+      expect(callbackPromise).not.toBeInstanceOf(Promise);
+
+      const spy = rstest.fn(() => 'original');
+      spy.mockImplementationOnce(() => 'once');
+
+      const withImplReturn = spy.withImplementation(
+        () => 'temporary',
+        () => callbackPromise,
+      );
+
+      expect(spy()).toBe('temporary');
+      await withImplReturn;
+      expect(spy()).toBe('once');
+      expect(spy()).toBe('original');
+    } finally {
+      iframe.remove();
+    }
+  });
 });

--- a/e2e/spy/withImplementation.test.ts
+++ b/e2e/spy/withImplementation.test.ts
@@ -96,4 +96,40 @@ describe('test withImplementation', () => {
     logs.push('[1 - call myMockFn - 1]');
     expect(myMockFn()).toBe('original');
   });
+
+  it('restores the implementation after a synchronous callback throws', () => {
+    const myMockFn = rstest.fn(() => 'original');
+    myMockFn.mockImplementationOnce(() => 'once');
+
+    expect(() =>
+      myMockFn.withImplementation(
+        () => 'temporary',
+        () => {
+          expect(myMockFn()).toBe('temporary');
+          throw new Error('sync failure');
+        },
+      ),
+    ).toThrow('sync failure');
+
+    expect(myMockFn()).toBe('once');
+    expect(myMockFn()).toBe('original');
+  });
+
+  it('restores the implementation after an asynchronous callback rejects', async () => {
+    const myMockFn = rstest.fn(() => 'original');
+    myMockFn.mockImplementationOnce(() => 'once');
+
+    await expect(
+      myMockFn.withImplementation(
+        () => 'temporary',
+        async () => {
+          expect(myMockFn()).toBe('temporary');
+          throw new Error('async failure');
+        },
+      ),
+    ).rejects.toThrow('async failure');
+
+    expect(myMockFn()).toBe('once');
+    expect(myMockFn()).toBe('original');
+  });
 });

--- a/e2e/spy/withImplementation.test.ts
+++ b/e2e/spy/withImplementation.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'node:vm';
 import { afterAll, describe, expect, it, rstest } from '@rstest/core';
 
 const logs: string[] = [];
@@ -129,6 +130,24 @@ describe('test withImplementation', () => {
       ),
     ).rejects.toThrow('async failure');
 
+    expect(myMockFn()).toBe('once');
+    expect(myMockFn()).toBe('original');
+  });
+
+  it('keeps the temporary implementation until a cross-realm Promise resolves', async () => {
+    const callbackPromise: Promise<void> = runInNewContext('Promise.resolve()');
+    expect(callbackPromise).not.toBeInstanceOf(Promise);
+
+    const myMockFn = rstest.fn(() => 'original');
+    myMockFn.mockImplementationOnce(() => 'once');
+
+    const withImplReturn = myMockFn.withImplementation(
+      () => 'temporary',
+      () => callbackPromise,
+    );
+
+    expect(myMockFn()).toBe('temporary');
+    await withImplReturn;
     expect(myMockFn()).toBe('once');
     expect(myMockFn()).toBe('original');
   });

--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -116,17 +116,19 @@ export const initSpy = (
         mockImplementationOnce = originalMockImplementationOnce;
       };
 
-      const result = cb();
+      try {
+        const result = cb();
 
-      if (result instanceof Promise) {
-        return result.then(() => {
-          reset();
-          return spyFn;
-        });
+        if (result instanceof Promise) {
+          return result.finally(reset).then(() => spyFn);
+        }
+
+        reset();
+        return spyFn;
+      } catch (error) {
+        reset();
+        throw error;
       }
-
-      reset();
-      return spyFn;
     }
 
     spyFn.withImplementation = withImplementation;

--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -119,8 +119,17 @@ export const initSpy = (
       try {
         const result = cb();
 
-        if (result instanceof Promise) {
-          return result.finally(reset).then(() => spyFn);
+        if (result && typeof result.then === 'function') {
+          return result.then(
+            () => {
+              reset();
+              return spyFn;
+            },
+            (error: unknown) => {
+              reset();
+              throw error;
+            },
+          );
         }
 
         reset();

--- a/packages/core/tests/runtime/api/spy.test.ts
+++ b/packages/core/tests/runtime/api/spy.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'node:vm';
 import { describe, expect, it } from '@rstest/core';
 import { initSpy } from '../../../src/runtime/api/spy';
 
@@ -166,6 +167,25 @@ describe('initSpy withImplementation', () => {
       ),
     ).rejects.toThrow('async failure');
 
+    expect(spy()).toBe('once');
+    expect(spy()).toBe('original');
+  });
+
+  it('keeps the temporary implementation until a cross-realm Promise resolves', async () => {
+    const callbackPromise: Promise<void> = runInNewContext('Promise.resolve()');
+    expect(callbackPromise).not.toBeInstanceOf(Promise);
+
+    const { fn } = initSpy();
+    const spy = fn(() => 'original');
+    spy.mockImplementationOnce(() => 'once');
+
+    const withImplReturn = spy.withImplementation(
+      () => 'temporary',
+      () => callbackPromise,
+    );
+
+    expect(spy()).toBe('temporary');
+    await withImplReturn;
     expect(spy()).toBe('once');
     expect(spy()).toBe('original');
   });

--- a/packages/core/tests/runtime/api/spy.test.ts
+++ b/packages/core/tests/runtime/api/spy.test.ts
@@ -131,6 +131,46 @@ describe('initSpy reset semantics', () => {
   });
 });
 
+describe('initSpy withImplementation', () => {
+  it('restores the implementation after a synchronous callback throws', () => {
+    const { fn } = initSpy();
+    const spy = fn(() => 'original');
+    spy.mockImplementationOnce(() => 'once');
+
+    expect(() =>
+      spy.withImplementation(
+        () => 'temporary',
+        () => {
+          expect(spy()).toBe('temporary');
+          throw new Error('sync failure');
+        },
+      ),
+    ).toThrow('sync failure');
+
+    expect(spy()).toBe('once');
+    expect(spy()).toBe('original');
+  });
+
+  it('restores the implementation after an asynchronous callback rejects', async () => {
+    const { fn } = initSpy();
+    const spy = fn(() => 'original');
+    spy.mockImplementationOnce(() => 'once');
+
+    await expect(
+      spy.withImplementation(
+        () => 'temporary',
+        async () => {
+          expect(spy()).toBe('temporary');
+          throw new Error('async failure');
+        },
+      ),
+    ).rejects.toThrow('async failure');
+
+    expect(spy()).toBe('once');
+    expect(spy()).toBe('original');
+  });
+});
+
 describe('initSpy spyOn', () => {
   it('replaces a method while preserving original behavior and restores it', () => {
     const { spyOn } = initSpy();


### PR DESCRIPTION
## Summary

`withImplementation` currently leaves the temporary implementation installed when its callback throws or rejects, and also discards queued one-time implementations. This PR restores both the original implementation and the `mockImplementationOnce` queue on synchronous and asynchronous failures, with Node and browser regression coverage.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).