### PR TITLE
feat(core): support fixtures in hooks

### DIFF
--- a/e2e/browser-mode/basic.test.ts
+++ b/e2e/browser-mode/basic.test.ts
@@ -12,6 +12,7 @@ describe('browser mode - basic', () => {
     expect(cli.stdout).toContain('async.test.ts');
     expect(cli.stdout).toContain('fakeTimers.test.ts');
     expect(cli.stdout).toContain('spy.test.ts');
+    expect(cli.stdout).toContain('fixtures.test.ts');
     expect(cli.stdout).not.toContain('/scheduler.html');
   });
 

--- a/e2e/browser-mode/fixtures/basic/tests/fixtures.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/fixtures.test.ts
@@ -24,8 +24,8 @@ const browserTest = test.extend<HookFixtures>({
   },
 });
 
-beforeEach<HookFixtures>((_ref) => {
-  const { element } = _ref;
+beforeEach<HookFixtures>(async ({ element }) => {
+  await Promise.resolve();
   expect(element.textContent).toBe('fixture');
   events.push('beforeEach');
 });

--- a/e2e/browser-mode/fixtures/basic/tests/fixtures.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/fixtures.test.ts
@@ -24,7 +24,8 @@ const browserTest = test.extend<HookFixtures>({
   },
 });
 
-beforeEach<HookFixtures>(({ element }) => {
+beforeEach<HookFixtures>((_ref) => {
+  const { element } = _ref;
   expect(element.textContent).toBe('fixture');
   events.push('beforeEach');
 });

--- a/e2e/browser-mode/fixtures/basic/tests/fixtures.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/fixtures.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, afterEach, beforeEach, expect, test } from '@rstest/core';
+
+type HookFixtures = {
+  element: HTMLDivElement;
+  label: string;
+};
+
+const events: string[] = [];
+
+const browserTest = test.extend<HookFixtures>({
+  element: async (_, use) => {
+    const element = document.createElement('div');
+    element.textContent = 'fixture';
+    document.body.appendChild(element);
+    events.push('setup:element');
+    await use(element);
+    element.remove();
+    events.push('teardown:element');
+  },
+  label: async (_, use) => {
+    events.push('setup:label');
+    await use('afterEach');
+    events.push('teardown:label');
+  },
+});
+
+beforeEach<HookFixtures>(({ element }) => {
+  expect(element.textContent).toBe('fixture');
+  events.push('beforeEach');
+});
+
+afterEach<HookFixtures>(({ label }) => {
+  events.push(label);
+});
+
+browserTest('resolves fixtures used only by browser hooks', () => {
+  events.push('test');
+});
+
+afterAll(() => {
+  expect(events).toEqual([
+    'setup:element',
+    'beforeEach',
+    'test',
+    'setup:label',
+    'afterEach',
+    'teardown:label',
+    'teardown:element',
+  ]);
+});

--- a/e2e/test-api/extend.hookTimeout.test.ts
+++ b/e2e/test-api/extend.hookTimeout.test.ts
@@ -1,0 +1,21 @@
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+it('includes hook fixture setup in the hook timeout', async () => {
+  const { cli, expectStderrLog } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/hookFixtureTimeout.test', '--hookTimeout=20'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await cli.exec;
+
+  expect(cli.exec.process?.exitCode).toBe(1);
+  expectStderrLog(/Error: beforeEach hook timed out in 20ms/);
+  expectStderrLog(/Error: afterEach hook timed out in 20ms/);
+  expectStderrLog(/Error: beforeEach hook timed out in 30ms/);
+});

--- a/e2e/test-api/extend.hookTimeout.test.ts
+++ b/e2e/test-api/extend.hookTimeout.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from '@rstest/core';
 import { runRstestCli } from '../scripts';
 
 it('includes hook fixture setup in the hook timeout', async () => {
-  const { cli, expectStderrLog } = await runRstestCli({
+  const { cli, expectLog, expectStderrLog } = await runRstestCli({
     command: 'rstest',
     args: ['run', 'fixtures/hookFixtureTimeout.test', '--hookTimeout=20'],
     options: {
@@ -18,4 +18,6 @@ it('includes hook fixture setup in the hook timeout', async () => {
   expectStderrLog(/Error: beforeEach hook timed out in 20ms/);
   expectStderrLog(/Error: afterEach hook timed out in 20ms/);
   expectStderrLog(/Error: beforeEach hook timed out in 30ms/);
+  expectStderrLog(/Error: late fixture teardown failed/);
+  expectLog(/Tests 4 failed \| 1 passed/);
 });

--- a/e2e/test-api/extend.hooks.test.ts
+++ b/e2e/test-api/extend.hooks.test.ts
@@ -54,13 +54,14 @@ const hookTest = test.extend<HookFixtures>({
   },
 });
 
-beforeEach<HookFixtures>((context) => {
-  // A compiler's output can preserve this comment before destructuring.
-  const { task } = context;
-  const { name } = context.task;
+beforeEach((context) => {
+  expect(context.task.name).toBe('resolves fixtures used only by hooks');
+  events.push('beforeEach:context');
+});
+
+beforeEach<HookFixtures>(({ beforeValue, task }) => {
+  const { name } = task;
   const closingBrace = /}/;
-  let beforeValue = '';
-  ({ beforeValue } = context);
   expect(task.name).toBe('resolves fixtures used only by hooks');
   expect(name).toBe('resolves fixtures used only by hooks');
   expect(beforeValue).toBe('before:base');
@@ -68,16 +69,14 @@ beforeEach<HookFixtures>((context) => {
   events.push(`beforeEach:${beforeValue}`);
 
   return {
-    cleanup(cleanupContext: TestContext & HookFixtures) {
-      const { task } = cleanupContext;
-      const { cleanupValue } = cleanupContext;
+    cleanup({ cleanupValue, task }: TestContext & HookFixtures) {
       expect(task.name).toBe('resolves fixtures used only by hooks');
       events.push(`cleanup:${cleanupValue}`);
     },
   }.cleanup;
 });
 
-afterEach<HookFixtures>(({ afterValue = 'fallback' }) => {
+afterEach<HookFixtures>(({ afterValue }) => {
   events.push(`afterEach:${afterValue}`);
 });
 
@@ -88,6 +87,7 @@ hookTest('resolves fixtures used only by hooks', () => {
 afterAll(() => {
   expect(events).toEqual([
     'setup:auto',
+    'beforeEach:context',
     'setup:base',
     'setup:before',
     'beforeEach:before:base',

--- a/e2e/test-api/extend.hooks.test.ts
+++ b/e2e/test-api/extend.hooks.test.ts
@@ -6,6 +6,7 @@ type HookFixtures = {
   beforeValue: string;
   afterValue: string;
   cleanupValue: string;
+  name: string;
 };
 
 const events: string[] = [];
@@ -39,13 +40,21 @@ const hookTest = test.extend<HookFixtures>({
     await use('cleanup');
     events.push('teardown:cleanup');
   },
+  name: async (_, use) => {
+    events.push('setup:name');
+    await use('fixture name');
+    events.push('teardown:name');
+  },
 });
 
 beforeEach<HookFixtures>((context) => {
   // A compiler's output can preserve this comment before destructuring.
-  const { task } = context;
+  const { task, ...rest } = context;
+  const { name } = context.task;
   const { beforeValue } = context;
   expect(task.name).toBe('resolves fixtures used only by hooks');
+  expect(name).toBe('resolves fixtures used only by hooks');
+  expect(rest.beforeValue).toBe('before:base');
   events.push(`beforeEach:${beforeValue}`);
 
   return (cleanupContext) => {

--- a/e2e/test-api/extend.hooks.test.ts
+++ b/e2e/test-api/extend.hooks.test.ts
@@ -56,14 +56,14 @@ const hookTest = test.extend<HookFixtures>({
 
 beforeEach<HookFixtures>((context) => {
   // A compiler's output can preserve this comment before destructuring.
-  const { task, ...rest } = context;
+  const { task } = context;
   const { name } = context.task;
   const closingBrace = /}/;
   let beforeValue = '';
   ({ beforeValue } = context);
   expect(task.name).toBe('resolves fixtures used only by hooks');
   expect(name).toBe('resolves fixtures used only by hooks');
-  expect(rest.beforeValue).toBe('before:base');
+  expect(beforeValue).toBe('before:base');
   expect(closingBrace.test('}')).toBe(true);
   events.push(`beforeEach:${beforeValue}`);
 

--- a/e2e/test-api/extend.hooks.test.ts
+++ b/e2e/test-api/extend.hooks.test.ts
@@ -1,4 +1,11 @@
-import { afterAll, afterEach, beforeEach, expect, test } from '@rstest/core';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  expect,
+  test,
+  type TestContext,
+} from '@rstest/core';
 
 type HookFixtures = {
   autoValue: undefined;
@@ -51,21 +58,26 @@ beforeEach<HookFixtures>((context) => {
   // A compiler's output can preserve this comment before destructuring.
   const { task, ...rest } = context;
   const { name } = context.task;
-  const { beforeValue } = context;
+  const closingBrace = /}/;
+  let beforeValue = '';
+  ({ beforeValue } = context);
   expect(task.name).toBe('resolves fixtures used only by hooks');
   expect(name).toBe('resolves fixtures used only by hooks');
   expect(rest.beforeValue).toBe('before:base');
+  expect(closingBrace.test('}')).toBe(true);
   events.push(`beforeEach:${beforeValue}`);
 
-  return (cleanupContext) => {
-    const { task } = cleanupContext;
-    const { cleanupValue } = cleanupContext;
-    expect(task.name).toBe('resolves fixtures used only by hooks');
-    events.push(`cleanup:${cleanupValue}`);
-  };
+  return {
+    cleanup(cleanupContext: TestContext & HookFixtures) {
+      const { task } = cleanupContext;
+      const { cleanupValue } = cleanupContext;
+      expect(task.name).toBe('resolves fixtures used only by hooks');
+      events.push(`cleanup:${cleanupValue}`);
+    },
+  }.cleanup;
 });
 
-afterEach<HookFixtures>(({ afterValue }) => {
+afterEach<HookFixtures>(({ afterValue = 'fallback' }) => {
   events.push(`afterEach:${afterValue}`);
 });
 

--- a/e2e/test-api/extend.hooks.test.ts
+++ b/e2e/test-api/extend.hooks.test.ts
@@ -41,10 +41,16 @@ const hookTest = test.extend<HookFixtures>({
   },
 });
 
-beforeEach<HookFixtures>(({ beforeValue }) => {
+beforeEach<HookFixtures>((context) => {
+  const { task } = context;
+  const { beforeValue } = context;
+  expect(task.name).toBe('resolves fixtures used only by hooks');
   events.push(`beforeEach:${beforeValue}`);
 
-  return ({ cleanupValue }) => {
+  return (cleanupContext) => {
+    const { task } = cleanupContext;
+    const { cleanupValue } = cleanupContext;
+    expect(task.name).toBe('resolves fixtures used only by hooks');
     events.push(`cleanup:${cleanupValue}`);
   };
 });

--- a/e2e/test-api/extend.hooks.test.ts
+++ b/e2e/test-api/extend.hooks.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, afterEach, beforeEach, expect, test } from '@rstest/core';
+
+type HookFixtures = {
+  autoValue: undefined;
+  baseValue: string;
+  beforeValue: string;
+  afterValue: string;
+  cleanupValue: string;
+};
+
+const events: string[] = [];
+
+const hookTest = test.extend<HookFixtures>({
+  autoValue: [
+    async (_, use) => {
+      events.push('setup:auto');
+      await use(undefined);
+      events.push('teardown:auto');
+    },
+    { auto: true },
+  ],
+  baseValue: async (_, use) => {
+    events.push('setup:base');
+    await use('base');
+    events.push('teardown:base');
+  },
+  beforeValue: async ({ baseValue }, use) => {
+    events.push('setup:before');
+    await use(`before:${baseValue}`);
+    events.push('teardown:before');
+  },
+  afterValue: async (_, use) => {
+    events.push('setup:after');
+    await use('after');
+    events.push('teardown:after');
+  },
+  cleanupValue: async (_, use) => {
+    events.push('setup:cleanup');
+    await use('cleanup');
+    events.push('teardown:cleanup');
+  },
+});
+
+beforeEach<HookFixtures>(({ beforeValue }) => {
+  events.push(`beforeEach:${beforeValue}`);
+
+  return ({ cleanupValue }) => {
+    events.push(`cleanup:${cleanupValue}`);
+  };
+});
+
+afterEach<HookFixtures>(({ afterValue }) => {
+  events.push(`afterEach:${afterValue}`);
+});
+
+hookTest('resolves fixtures used only by hooks', () => {
+  events.push('test');
+});
+
+afterAll(() => {
+  expect(events).toEqual([
+    'setup:auto',
+    'setup:base',
+    'setup:before',
+    'beforeEach:before:base',
+    'test',
+    'setup:after',
+    'afterEach:after',
+    'setup:cleanup',
+    'cleanup:cleanup',
+    'teardown:cleanup',
+    'teardown:after',
+    'teardown:before',
+    'teardown:base',
+    'teardown:auto',
+  ]);
+});

--- a/e2e/test-api/extend.hooks.test.ts
+++ b/e2e/test-api/extend.hooks.test.ts
@@ -42,6 +42,7 @@ const hookTest = test.extend<HookFixtures>({
 });
 
 beforeEach<HookFixtures>((context) => {
+  // A compiler's output can preserve this comment before destructuring.
   const { task } = context;
   const { beforeValue } = context;
   expect(task.name).toBe('resolves fixtures used only by hooks');

--- a/e2e/test-api/fixtures/fixtureSetupHookCleanup.test.ts
+++ b/e2e/test-api/fixtures/fixtureSetupHookCleanup.test.ts
@@ -1,19 +1,39 @@
-import { afterEach, test } from '@rstest/core';
+import { afterEach, describe, test } from '@rstest/core';
 
-const failingTest = test.extend<{ failing: string }>({
-  failing: async () => {
-    throw new Error('fixture setup failed');
-  },
+describe('failed test fixture', () => {
+  const failingTest = test.extend<{ failing: string }>({
+    failing: async () => {
+      throw new Error('test fixture setup failed');
+    },
+  });
+
+  afterEach(() => {
+    console.log('later afterEach ran after test fixture failure');
+  });
+
+  afterEach<{ failing: string }>(({ failing }) => {
+    console.log(failing);
+  });
+
+  failingTest('fails during fixture setup', ({ failing }) => {
+    console.log(failing);
+  });
 });
 
-afterEach(() => {
-  console.log('later afterEach ran');
-});
+describe('failed afterEach fixture', () => {
+  const failingTest = test.extend<{ failing: string }>({
+    failing: async () => {
+      throw new Error('afterEach fixture setup failed');
+    },
+  });
 
-afterEach<{ failing: string }>(({ failing }) => {
-  console.log(failing);
-});
+  afterEach(() => {
+    console.log('later afterEach ran after afterEach fixture failure');
+  });
 
-failingTest('fails during fixture setup', ({ failing }) => {
-  console.log(failing);
+  afterEach<{ failing: string }>(({ failing }) => {
+    console.log(failing);
+  });
+
+  failingTest('fails during afterEach fixture setup', () => {});
 });

--- a/e2e/test-api/fixtures/fixtureSetupHookCleanup.test.ts
+++ b/e2e/test-api/fixtures/fixtureSetupHookCleanup.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, test } from '@rstest/core';
+
+const failingTest = test.extend<{ failing: string }>({
+  failing: async () => {
+    throw new Error('fixture setup failed');
+  },
+});
+
+afterEach(() => {
+  console.log('later afterEach ran');
+});
+
+afterEach<{ failing: string }>(({ failing }) => {
+  console.log(failing);
+});
+
+failingTest('fails during fixture setup', ({ failing }) => {
+  console.log(failing);
+});

--- a/e2e/test-api/fixtures/hookFixtureTimeout.test.ts
+++ b/e2e/test-api/fixtures/hookFixtureTimeout.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, test } from '@rstest/core';
+import { afterEach, beforeEach, describe, expect, test } from '@rstest/core';
 
 const never = () => new Promise<never>(() => {});
+const wait = (duration: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, duration));
 
 describe('beforeEach fixture timeout', () => {
   const timeoutTest = test.extend<{ slowFixture: string }>({
@@ -40,4 +42,28 @@ describe('beforeEach cleanup fixture timeout', () => {
   );
 
   timeoutTest('times out cleanup fixture setup', () => {});
+});
+
+let lateTeardownFinished = false;
+
+describe('late fixture teardown', () => {
+  const timeoutTest = test.extend<{ slowFixture: string }>({
+    slowFixture: async (_context, use) => {
+      await wait(70);
+      await use('slow');
+      await wait(80);
+      lateTeardownFinished = true;
+      throw new Error('late fixture teardown failed');
+    },
+  });
+
+  beforeEach<{ slowFixture: string }>(({ slowFixture }) => {
+    void slowFixture;
+  }, 50);
+
+  timeoutTest('times out before fixture setup completes', () => {});
+});
+
+test('waits for late fixture teardown before continuing', () => {
+  expect(lateTeardownFinished).toBe(true);
 });

--- a/e2e/test-api/fixtures/hookFixtureTimeout.test.ts
+++ b/e2e/test-api/fixtures/hookFixtureTimeout.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, test } from '@rstest/core';
+
+const never = () => new Promise<never>(() => {});
+
+describe('beforeEach fixture timeout', () => {
+  const timeoutTest = test.extend<{ slowFixture: string }>({
+    slowFixture: async () => never(),
+  });
+
+  beforeEach<{ slowFixture: string }>(({ slowFixture }) => {
+    void slowFixture;
+  });
+
+  timeoutTest('times out fixture setup', () => {});
+});
+
+describe('afterEach fixture timeout', () => {
+  const timeoutTest = test.extend<{ slowFixture: string }>({
+    slowFixture: async () => never(),
+  });
+
+  afterEach<{ slowFixture: string }>(({ slowFixture }) => {
+    void slowFixture;
+  });
+
+  timeoutTest('times out fixture setup', () => {});
+});
+
+describe('beforeEach cleanup fixture timeout', () => {
+  const timeoutTest = test.extend<{ slowFixture: string }>({
+    slowFixture: async () => never(),
+  });
+
+  beforeEach<{ slowFixture: string }>(
+    () =>
+      ({ slowFixture }: { slowFixture: string }) => {
+        void slowFixture;
+      },
+    30,
+  );
+
+  timeoutTest('times out cleanup fixture setup', () => {});
+});

--- a/e2e/test-api/index.test.ts
+++ b/e2e/test-api/index.test.ts
@@ -54,4 +54,22 @@ describe('Test API', () => {
       logs.find((log) => log.includes('Tests 1 passed | 3 skipped')),
     ).toBeTruthy();
   });
+
+  it('continues afterEach hooks after fixture setup fails', async () => {
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/fixtureSetupHookCleanup.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: dirname(fileURLToPath(import.meta.url)),
+        },
+      },
+    });
+    await cli.exec;
+
+    expect(cli.exec.process?.exitCode).toBe(1);
+    expect(`${cli.stdout}\n${cli.stderr}`).toContain('later afterEach ran');
+    expect(cli.stderr).toContain('fixture setup failed');
+    expect(cli.stderr).not.toContain('Circular fixture dependency');
+  });
 });

--- a/e2e/test-api/index.test.ts
+++ b/e2e/test-api/index.test.ts
@@ -68,8 +68,14 @@ describe('Test API', () => {
     await cli.exec;
 
     expect(cli.exec.process?.exitCode).toBe(1);
-    expect(`${cli.stdout}\n${cli.stderr}`).toContain('later afterEach ran');
-    expect(cli.stderr).toContain('fixture setup failed');
+    expect(`${cli.stdout}\n${cli.stderr}`).toContain(
+      'later afterEach ran after test fixture failure',
+    );
+    expect(`${cli.stdout}\n${cli.stderr}`).toContain(
+      'later afterEach ran after afterEach fixture failure',
+    );
+    expect(cli.stderr).toContain('test fixture setup failed');
+    expect(cli.stderr).toContain('afterEach fixture setup failed');
     expect(cli.stderr).not.toContain('Circular fixture dependency');
   });
 });

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1954,6 +1954,19 @@ const createBrowserRuntime = async ({
                     },
                   },
                   tools: {
+                    swc: (swcConfig) => {
+                      // Fixture dependency discovery reads callback parameters
+                      // through Function#toString(). Playwright's supported
+                      // browsers all support parameter destructuring, so keep
+                      // that syntax intact in the browser test bundle.
+                      swcConfig.env ??= {};
+                      swcConfig.env.exclude = Array.from(
+                        new Set([
+                          ...(swcConfig.env.exclude ?? []),
+                          'transform-parameters',
+                        ]),
+                      );
+                    },
                     rspack: (rspackConfig) => {
                       rspackConfig.mode = 'development';
                       // Web parameterization of the node mock transform:

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -227,464 +227,52 @@ export const createFixtureResolver = (
   };
 };
 
-function splitByComma(s: string) {
-  const filtered = filterOutNonCode(s);
+function splitByComma(s: string): string[] {
   const result: string[] = [];
   const stack: string[] = [];
   let start = 0;
   for (let i = 0; i < s.length; i++) {
-    const char = filtered[i];
-    if (char === '{' || char === '[' || char === '(') {
-      stack.push(char === '{' ? '}' : char === '[' ? ']' : ')');
-    } else if (char === stack[stack.length - 1]) {
+    if (s[i] === '{' || s[i] === '[') {
+      stack.push(s[i] === '{' ? '}' : ']');
+    } else if (s[i] === stack[stack.length - 1]) {
       stack.pop();
-    } else if (!stack.length && char === ',') {
+    } else if (!stack.length && s[i] === ',') {
       const token = s.substring(start, i).trim();
-      if (token) result.push(token);
+      if (token) {
+        result.push(token);
+      }
       start = i + 1;
     }
   }
   const lastToken = s.substring(start).trim();
-  if (lastToken) result.push(lastToken);
+  if (lastToken) {
+    result.push(lastToken);
+  }
   return result;
 }
 
-const REGEX_PREFIX_KEYWORDS = new Set([
-  'await',
-  'case',
-  'delete',
-  'do',
-  'else',
-  'in',
-  'instanceof',
-  'new',
-  'of',
-  'return',
-  'throw',
-  'typeof',
-  'void',
-  'yield',
-]);
-
-function canStartRegex(text: readonly string[], index: number): boolean {
-  let cursor = index - 1;
-  while (cursor >= 0 && /\s/.test(text[cursor]!)) {
-    cursor--;
-  }
-  if (cursor < 0) {
-    return true;
-  }
-
-  const previous = text[cursor]!;
-  if ('([{=,:;!&|?+-*%^~<>'.includes(previous)) {
-    return true;
-  }
-  if (!/[$\w]/.test(previous)) {
-    return false;
-  }
-
-  const end = cursor + 1;
-  while (cursor >= 0 && /[$\w]/.test(text[cursor]!)) {
-    cursor--;
-  }
-  return REGEX_PREFIX_KEYWORDS.has(text.slice(cursor + 1, end).join(''));
-}
-
-function filterOutNonCode(s: string): string {
-  const result = [...s];
+function filterOutComments(s: string): string {
+  const result: string[] = [];
   let commentState: 'none' | 'singleline' | 'multiline' = 'none';
-  let quote: '"' | "'" | '`' | undefined;
-
   for (let i = 0; i < s.length; ++i) {
-    const char = s[i]!;
     if (commentState === 'singleline') {
-      if (char === '\n') {
+      if (s[i] === '\n') {
         commentState = 'none';
-      } else {
-        result[i] = ' ';
       }
     } else if (commentState === 'multiline') {
-      if (char === '*' && s[i + 1] === '/') {
-        result[i] = ' ';
-        result[i + 1] = ' ';
+      if (s[i - 1] === '*' && s[i] === '/') {
         commentState = 'none';
-        i++;
-      } else {
-        result[i] = char === '\n' ? '\n' : ' ';
       }
-    } else if (quote) {
-      if (char === '\\') {
-        result[i] = ' ';
-        if (i + 1 < s.length) {
-          i++;
-          result[i] = s[i] === '\n' ? '\n' : ' ';
-        }
-      } else {
-        if (char === quote) {
-          quote = undefined;
-        }
-        result[i] = char === '\n' ? '\n' : ' ';
-      }
+    } else if (s[i] === '/' && s[i + 1] === '/') {
+      commentState = 'singleline';
+    } else if (s[i] === '/' && s[i + 1] === '*') {
+      commentState = 'multiline';
+      i += 2;
     } else {
-      if (char === '/' && s[i + 1] === '/') {
-        result[i] = ' ';
-        result[i + 1] = ' ';
-        commentState = 'singleline';
-        i++;
-      } else if (char === '/' && s[i + 1] === '*') {
-        result[i] = ' ';
-        result[i + 1] = ' ';
-        commentState = 'multiline';
-        i++;
-      } else if (char === '/' && canStartRegex(result, i)) {
-        result[i] = ' ';
-        let inCharacterClass = false;
-        for (i++; i < s.length; i++) {
-          const regexChar = s[i]!;
-          result[i] = regexChar === '\n' ? '\n' : ' ';
-          if (regexChar === '\\') {
-            if (i + 1 < s.length) {
-              i++;
-              result[i] = s[i] === '\n' ? '\n' : ' ';
-            }
-          } else if (regexChar === '[') {
-            inCharacterClass = true;
-          } else if (regexChar === ']') {
-            inCharacterClass = false;
-          } else if (regexChar === '/' && !inCharacterClass) {
-            while (i + 1 < s.length && /[A-Za-z]/.test(s[i + 1]!)) {
-              i++;
-              result[i] = ' ';
-            }
-            break;
-          }
-        }
-      } else if (char === '"' || char === "'" || char === '`') {
-        quote = char;
-        result[i] = ' ';
-      }
+      result.push(s[i]!);
     }
   }
   return result.join('');
-}
-
-function getDestructuredFixtureProps(param: string): string[] | undefined {
-  if (param[0] !== '{' || !param.endsWith('}')) {
-    return undefined;
-  }
-
-  const props = splitByComma(param.substring(1, param.length - 1)).map(
-    (prop) => {
-      const filtered = filterOutNonCode(prop);
-      const stack: string[] = [];
-      let separator = -1;
-      for (let index = 0; index < filtered.length; index++) {
-        const char = filtered[index];
-        if (char === '{' || char === '[' || char === '(') {
-          stack.push(char === '{' ? '}' : char === '[' ? ']' : ')');
-        } else if (char === stack[stack.length - 1]) {
-          stack.pop();
-        } else if (!stack.length && (char === ':' || char === '=')) {
-          separator = index;
-          break;
-        }
-      }
-      return separator === -1
-        ? prop.trim()
-        : prop.substring(0, separator).trim();
-    },
-  );
-  return props;
-}
-
-function findClosingDelimiter(
-  text: string,
-  openingIndex: number,
-  opening: string,
-  closing: string,
-): number | undefined {
-  let depth = 0;
-  for (let index = openingIndex; index < text.length; index++) {
-    if (text[index] === opening) {
-      depth++;
-    } else if (text[index] === closing) {
-      depth--;
-      if (depth === 0) {
-        return index;
-      }
-    }
-  }
-  return undefined;
-}
-
-function findOpeningDelimiter(
-  text: string,
-  closingIndex: number,
-  opening: string,
-  closing: string,
-): number | undefined {
-  let depth = 0;
-  for (let index = closingIndex; index >= 0; index--) {
-    if (text[index] === closing) {
-      depth++;
-    } else if (text[index] === opening) {
-      depth--;
-      if (depth === 0) {
-        return index;
-      }
-    }
-  }
-  return undefined;
-}
-
-function skipWhitespace(text: string, start: number): number {
-  let index = start;
-  while (index < text.length && /\s/.test(text[index]!)) {
-    index++;
-  }
-  return index;
-}
-
-function skipWhitespaceBackwards(text: string, start: number): number {
-  let index = start;
-  while (index >= 0 && /\s/.test(text[index]!)) {
-    index--;
-  }
-  return index;
-}
-
-function isWordAt(text: string, index: number, word: string): boolean {
-  return (
-    text.startsWith(word, index) &&
-    !/[$\w]/.test(text[index - 1] ?? '') &&
-    !/[$\w]/.test(text[index + word.length] ?? '')
-  );
-}
-
-function getPreviousWord(text: string, start: number): string {
-  let cursor = skipWhitespaceBackwards(text, start);
-  const end = cursor + 1;
-  while (cursor >= 0 && /[$\w]/.test(text[cursor]!)) {
-    cursor--;
-  }
-  return text.slice(cursor + 1, end);
-}
-
-function findExpressionEnd(
-  text: string,
-  expressionStart: number,
-  bodyEnd: number,
-): number {
-  const stack: string[] = [];
-  for (let index = expressionStart; index < bodyEnd; index++) {
-    const char = text[index];
-    if (char === '{' || char === '[' || char === '(') {
-      stack.push(char === '{' ? '}' : char === '[' ? ']' : ')');
-    } else if (char === stack[stack.length - 1]) {
-      stack.pop();
-    } else if (!stack.length && (char === ',' || char === ';')) {
-      return index - 1;
-    } else if (!stack.length && char === '\n') {
-      const nextLine = text.slice(skipWhitespace(text, index + 1));
-      if (
-        /^(?:class|const|for|function|if|let|return|switch|throw|try|var|while)\b/.test(
-          nextLine,
-        )
-      ) {
-        return index - 1;
-      }
-    }
-  }
-  return bodyEnd - 1;
-}
-
-function getNestedFunctionRanges(
-  text: string,
-  bodyStart: number,
-  bodyEnd: number,
-): [number, number][] {
-  const ranges: [number, number][] = [];
-  const controlKeywords = new Set([
-    'catch',
-    'for',
-    'if',
-    'switch',
-    'while',
-    'with',
-  ]);
-
-  for (let index = bodyStart + 1; index < bodyEnd; index++) {
-    if (isWordAt(text, index, 'function')) {
-      const paramsStart = text.indexOf('(', index + 'function'.length);
-      if (paramsStart === -1 || paramsStart >= bodyEnd) {
-        continue;
-      }
-      const paramsEnd = findClosingDelimiter(text, paramsStart, '(', ')');
-      const nestedBodyStart =
-        paramsEnd === undefined ? bodyEnd : skipWhitespace(text, paramsEnd + 1);
-      if (text[nestedBodyStart] !== '{') {
-        continue;
-      }
-      const nestedBodyEnd = findClosingDelimiter(
-        text,
-        nestedBodyStart,
-        '{',
-        '}',
-      );
-      if (nestedBodyEnd !== undefined && nestedBodyEnd <= bodyEnd) {
-        ranges.push([nestedBodyStart, nestedBodyEnd]);
-        index = nestedBodyEnd;
-      }
-      continue;
-    }
-
-    if (text[index] === '=' && text[index + 1] === '>') {
-      const nestedBodyStart = skipWhitespace(text, index + 2);
-      const nestedBodyEnd =
-        text[nestedBodyStart] === '{'
-          ? findClosingDelimiter(text, nestedBodyStart, '{', '}')
-          : findExpressionEnd(text, nestedBodyStart, bodyEnd);
-      if (nestedBodyEnd !== undefined && nestedBodyEnd <= bodyEnd) {
-        ranges.push([nestedBodyStart, nestedBodyEnd]);
-        index = nestedBodyEnd;
-      }
-      continue;
-    }
-
-    if (text[index] !== '{') {
-      continue;
-    }
-    const paramsEnd = skipWhitespaceBackwards(text, index - 1);
-    if (text[paramsEnd] !== ')') {
-      continue;
-    }
-    const paramsStart = findOpeningDelimiter(text, paramsEnd, '(', ')');
-    if (paramsStart === undefined) {
-      continue;
-    }
-    const previousWord = getPreviousWord(text, paramsStart - 1);
-    if (controlKeywords.has(previousWord)) {
-      continue;
-    }
-    const nestedBodyEnd = findClosingDelimiter(text, index, '{', '}');
-    if (nestedBodyEnd !== undefined && nestedBodyEnd <= bodyEnd) {
-      ranges.push([index, nestedBodyEnd]);
-      index = nestedBodyEnd;
-    }
-  }
-
-  return ranges;
-}
-
-function getCallbackParams(
-  text: string,
-): { params: string; signatureEnd: number } | undefined {
-  const singleParamMatch = /^(?:async\s+)?([$A-Z_a-z][$\w]*)\s*=>/.exec(text);
-  if (singleParamMatch) {
-    return {
-      params: singleParamMatch[1]!,
-      signatureEnd: singleParamMatch[0].length,
-    };
-  }
-
-  const paramsStart = text.indexOf('(');
-  if (paramsStart === -1) {
-    return undefined;
-  }
-  const paramsEnd = findClosingDelimiter(text, paramsStart, '(', ')');
-  if (paramsEnd === undefined) {
-    return undefined;
-  }
-  return {
-    params: text.slice(paramsStart + 1, paramsEnd),
-    signatureEnd: paramsEnd + 1,
-  };
-}
-
-function isContextAssignment(
-  text: string,
-  closingIndex: number,
-  param: string,
-): boolean {
-  let cursor = skipWhitespace(text, closingIndex + 1);
-  if (text[cursor] !== '=') {
-    return false;
-  }
-  cursor = skipWhitespace(text, cursor + 1);
-  if (!text.startsWith(param, cursor)) {
-    return false;
-  }
-  const next = text[cursor + param.length];
-  if (/[$\w]/.test(next ?? '')) {
-    return false;
-  }
-  const memberStart = skipWhitespace(text, cursor + param.length);
-  return !(
-    text[memberStart] === '.' ||
-    text[memberStart] === '[' ||
-    text.startsWith('?.', memberStart)
-  );
-}
-
-function getNamedContextFixtureProps(
-  text: string,
-  param: string,
-  signatureEnd: number,
-): string[] {
-  let bodyStart = skipWhitespace(text, signatureEnd);
-  if (text.startsWith('=>', bodyStart)) {
-    bodyStart = skipWhitespace(text, bodyStart + 2);
-  }
-  if (text[bodyStart] !== '{') {
-    return [];
-  }
-  const bodyEnd = findClosingDelimiter(text, bodyStart, '{', '}');
-  if (bodyEnd === undefined) {
-    return [];
-  }
-
-  const nestedFunctionRanges = getNestedFunctionRanges(
-    text,
-    bodyStart,
-    bodyEnd,
-  );
-  const props = new Set<string>();
-  let rangeIndex = 0;
-
-  for (let index = bodyStart + 1; index < bodyEnd; index++) {
-    while (
-      nestedFunctionRanges[rangeIndex] &&
-      index > nestedFunctionRanges[rangeIndex]![1]
-    ) {
-      rangeIndex++;
-    }
-    const nestedRange = nestedFunctionRanges[rangeIndex];
-    if (nestedRange && index >= nestedRange[0]) {
-      index = nestedRange[1];
-      rangeIndex++;
-      continue;
-    }
-    if (text[index] !== '{') {
-      continue;
-    }
-    const closingIndex = findClosingDelimiter(text, index, '{', '}');
-    if (closingIndex === undefined || closingIndex > bodyEnd) {
-      break;
-    }
-    if (!isContextAssignment(text, closingIndex, param)) {
-      continue;
-    }
-
-    const destructuredProps =
-      getDestructuredFixtureProps(text.slice(index, closingIndex + 1)) ?? [];
-    assertNoRestProperty(destructuredProps);
-    for (const prop of destructuredProps) {
-      props.add(prop);
-    }
-    index = closingIndex;
-  }
-
-  return [...props];
 }
 
 function getFixtureCallbackSource(fn: FixtureCallback): FixtureCallback {
@@ -697,52 +285,66 @@ function getFixtureCallbackSource(fn: FixtureCallback): FixtureCallback {
   return source;
 }
 
-function assertNoRestProperty(props: string[]): void {
+function fixtureParamError(firstParam: string | undefined): Error {
+  return new Error(
+    `First argument must use the object destructuring pattern: ${firstParam}`,
+  );
+}
+
+function parseFixtureUsedProps(
+  fn: FixtureCallback,
+  allowNamedContext: boolean,
+): string[] {
+  const text = filterOutComments(fn.toString()).trim();
+  const singleParamArrow = /^(?:async\s+)?([$A-Z_a-z][$\w]*)\s*=>/.exec(text);
+  if (singleParamArrow) {
+    const firstParam = singleParamArrow[1];
+    if (allowNamedContext || firstParam?.startsWith('_')) {
+      return [];
+    }
+    throw fixtureParamError(firstParam);
+  }
+
+  const match = /(?:async)?(?:\s+function)?[^(]*\(([^)]*)/.exec(text);
+  if (!match) {
+    return [];
+  }
+  const trimmedParams = match[1]!.trim();
+  if (!trimmedParams) {
+    return [];
+  }
+
+  const [firstParam] = splitByComma(trimmedParams);
+  if (firstParam?.[0] !== '{' || !firstParam.endsWith('}')) {
+    if (allowNamedContext || firstParam?.startsWith('_')) {
+      return [];
+    }
+    throw fixtureParamError(firstParam);
+  }
+  if (/}\s*=/.test(firstParam)) {
+    throw new Error(
+      `Default values are not supported for the fixture context: ${firstParam}`,
+    );
+  }
+
+  const props = splitByComma(
+    firstParam.substring(1, firstParam.length - 1),
+  ).map((prop) => {
+    if (prop.includes('=')) {
+      throw new Error(
+        `Default values are not supported in fixture destructuring: ${prop}`,
+      );
+    }
+    const colon = prop.indexOf(':');
+    return colon === -1 ? prop.trim() : prop.substring(0, colon).trim();
+  });
   const restProperty = props.find((prop) => prop.startsWith('...'));
   if (restProperty) {
     throw new Error(
       `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
     );
   }
-}
-
-function parseFixtureUsedProps(
-  fn: (...args: any[]) => any,
-  allowNamedContext: boolean,
-): string[] {
-  const text = filterOutNonCode(fn.toString()).trim();
-  const signature = getCallbackParams(text);
-  if (!signature) {
-    return [];
-  }
-  const trimmedParams = signature.params.trim();
-  if (!trimmedParams) {
-    return [];
-  }
-  const [firstParam] = splitByComma(trimmedParams);
-  const props = getDestructuredFixtureProps(firstParam ?? '');
-  if (props) {
-    assertNoRestProperty(props);
-    return props;
-  }
-
-  if (/^[$A-Z_a-z][$\w]*$/.test(firstParam ?? '')) {
-    const transformedProps = getNamedContextFixtureProps(
-      text,
-      firstParam!,
-      signature.signatureEnd,
-    );
-    if (transformedProps.length) {
-      return transformedProps;
-    }
-    if (firstParam!.startsWith('_') || allowNamedContext) {
-      return [];
-    }
-  }
-
-  throw new Error(
-    `First argument must use the object destructuring pattern: ${firstParam}`,
-  );
+  return props;
 }
 
 /**

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -191,56 +191,58 @@ function splitByComma(s: string) {
   return result;
 }
 
-function filterOutComments(s: string): string {
+function filterOutCommentsAndStrings(s: string): string {
   const result: string[] = [];
   let commentState: 'none' | 'singleline' | 'multiline' = 'none';
-  for (let i = 0; i < s.length; ++i) {
-    if (commentState === 'singleline') {
-      if (s[i] === '\n') commentState = 'none';
-    } else if (commentState === 'multiline') {
-      if (s[i - 1] === '*' && s[i] === '/') commentState = 'none';
-    } else if (commentState === 'none') {
-      if (s[i] === '/' && s[i + 1] === '/') {
-        commentState = 'singleline';
-      } else if (s[i] === '/' && s[i + 1] === '*') {
-        commentState = 'multiline';
-        i += 2;
-      } else {
-        result.push(s[i]!);
-      }
-    }
-  }
-  return result.join('');
-}
-
-function filterOutStrings(s: string): string {
-  const result: string[] = [];
   let quote: '"' | "'" | '`' | undefined;
 
-  for (let i = 0; i < s.length; i++) {
+  for (let i = 0; i < s.length; ++i) {
     const char = s[i]!;
-    if (quote) {
-      if (char === '\\') {
+    if (commentState === 'singleline') {
+      if (char === '\n') {
+        commentState = 'none';
+        result.push('\n');
+      } else {
+        result.push(' ');
+      }
+    } else if (commentState === 'multiline') {
+      if (char === '*' && s[i + 1] === '/') {
         result.push(' ', ' ');
+        commentState = 'none';
         i++;
-        continue;
+      } else {
+        result.push(char === '\n' ? '\n' : ' ');
       }
-      if (char === quote) {
-        quote = undefined;
+    } else if (quote) {
+      if (char === '\\') {
+        result.push(' ');
+        if (i + 1 < s.length) {
+          i++;
+          result.push(s[i] === '\n' ? '\n' : ' ');
+        }
+      } else {
+        if (char === quote) {
+          quote = undefined;
+        }
+        result.push(char === '\n' ? '\n' : ' ');
       }
-      result.push(char === '\n' ? '\n' : ' ');
-      continue;
+    } else {
+      if (char === '/' && s[i + 1] === '/') {
+        result.push(' ', ' ');
+        commentState = 'singleline';
+        i++;
+      } else if (char === '/' && s[i + 1] === '*') {
+        result.push(' ', ' ');
+        commentState = 'multiline';
+        i++;
+      } else if (char === '"' || char === "'" || char === '`') {
+        quote = char;
+        result.push(' ');
+      } else {
+        result.push(char);
+      }
     }
-
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char;
-      result.push(' ');
-      continue;
-    }
-
-    result.push(char);
   }
-
   return result.join('');
 }
 
@@ -445,7 +447,7 @@ function getFixtureUsedProps(
   fn: (...args: any[]) => any,
   allowNamedContext = false,
 ): string[] {
-  const text = filterOutComments(filterOutStrings(fn.toString())).trim();
+  const text = filterOutCommentsAndStrings(fn.toString()).trim();
   const parenthesizedMatch =
     /^(?:async\s+)?(?:function(?:\s+[$A-Z_a-z][$\w]*)?\s*|[$A-Z_a-z][$\w]*\s*)?\(([^)]*)\)/.exec(
       text,

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -700,10 +700,6 @@ function parseFixtureUsedProps(
     return props;
   }
 
-  if (firstParam?.startsWith('_')) {
-    return [];
-  }
-
   if (/^[$A-Z_a-z][$\w]*$/.test(firstParam ?? '')) {
     const transformedProps = getNamedContextFixtureProps(
       text,
@@ -713,7 +709,7 @@ function parseFixtureUsedProps(
     if (transformedProps.length) {
       return transformedProps;
     }
-    if (allowNamedContext) {
+    if (firstParam!.startsWith('_') || allowNamedContext) {
       return [];
     }
   }

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -60,8 +60,10 @@ export const normalizeFixtures = (
 
 export type FixtureResolver = {
   resolveTestFixtures: (fn?: (...args: any[]) => any) => Promise<void>;
-  resolveHookFixtures: (fn: (...args: any[]) => any) => Promise<void>;
+  resolveHookFixtures: (fn: (...args: any[]) => any) => Promise<void | false>;
 };
+
+class PreviouslyFailedFixtureError extends Error {}
 
 export const createFixtureResolver = (
   test: TestCase,
@@ -76,6 +78,7 @@ export const createFixtureResolver = (
   }
 
   const doneMap = new Set<string>();
+  const failedFixtures = new Set<string>();
   const pendingMap = new Set<string>();
 
   const useFixture = async (
@@ -84,6 +87,9 @@ export const createFixtureResolver = (
   ) => {
     if (doneMap.has(name)) {
       return;
+    }
+    if (failedFixtures.has(name)) {
+      throw new PreviouslyFailedFixtureError(name);
     }
     if (pendingMap.has(name)) {
       throw new Error(`Circular fixture dependency: ${name}`);
@@ -97,35 +103,40 @@ export const createFixtureResolver = (
     }
 
     pendingMap.add(name);
-
-    if (deps?.length) {
-      for (const dep of deps) {
-        await useFixture(dep, test.fixtures![dep]!);
+    try {
+      if (deps?.length) {
+        for (const dep of deps) {
+          await useFixture(dep, test.fixtures![dep]!);
+        }
       }
+
+      // This API behavior follows Vitest & Playwright
+      // but why not return cleanup function?
+      await new Promise<void>((fixtureResolve, fixtureReject) => {
+        let useDone: (() => void) | undefined;
+        const block = Promise.resolve().then(() =>
+          fixtureValue(context, async (value: any) => {
+            context[name] = value;
+            cleanups.unshift(() => {
+              useDone?.();
+              return block;
+            });
+            fixtureResolve();
+            return new Promise<void>((useFnResolve) => {
+              useDone = useFnResolve;
+            });
+          }),
+        );
+        block.catch(fixtureReject);
+      });
+
+      doneMap.add(name);
+    } catch (error) {
+      failedFixtures.add(name);
+      throw error;
+    } finally {
+      pendingMap.delete(name);
     }
-
-    // This API behavior follows Vitest & Playwright
-    // but why not return cleanup function?
-    await new Promise<void>((fixtureResolve, fixtureReject) => {
-      let useDone: (() => void) | undefined;
-      const block = Promise.resolve().then(() =>
-        fixtureValue(context, async (value: any) => {
-          context[name] = value;
-          cleanups.unshift(() => {
-            useDone?.();
-            return block;
-          });
-          fixtureResolve();
-          return new Promise<void>((useFnResolve) => {
-            useDone = useFnResolve;
-          });
-        }),
-      );
-      block.catch(fixtureReject);
-    });
-
-    doneMap.add(name);
-    pendingMap.delete(name);
   };
 
   const resolveFixtureNames = async (
@@ -146,8 +157,17 @@ export const createFixtureResolver = (
   return {
     resolveTestFixtures: (fn) =>
       resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], true),
-    resolveHookFixtures: (fn) =>
-      resolveFixtureNames(getFixtureUsedProps(fn, true), false),
+    resolveHookFixtures: async (fn) => {
+      try {
+        await resolveFixtureNames(getFixtureUsedProps(fn, true), false);
+      } catch (error) {
+        if (error instanceof PreviouslyFailedFixtureError) {
+          return false;
+        }
+        throw error;
+      }
+      return undefined;
+    },
   };
 };
 
@@ -251,6 +271,157 @@ function getDestructuredFixtureProps(param: string): string[] | undefined {
   return props;
 }
 
+function findClosingDelimiter(
+  text: string,
+  openingIndex: number,
+  opening: string,
+  closing: string,
+): number | undefined {
+  let depth = 0;
+  for (let index = openingIndex; index < text.length; index++) {
+    if (text[index] === opening) {
+      depth++;
+    } else if (text[index] === closing) {
+      depth--;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return undefined;
+}
+
+function skipWhitespace(text: string, start: number): number {
+  let index = start;
+  while (index < text.length && /\s/.test(text[index]!)) {
+    index++;
+  }
+  return index;
+}
+
+function getNestedFunctionRanges(
+  text: string,
+  bodyStart: number,
+  bodyEnd: number,
+): [number, number][] {
+  const ranges: [number, number][] = [];
+  const addBodyRange = (openingIndex: number) => {
+    const closingIndex = findClosingDelimiter(text, openingIndex, '{', '}');
+    if (closingIndex !== undefined && closingIndex <= bodyEnd) {
+      ranges.push([openingIndex, closingIndex]);
+      return closingIndex;
+    }
+    return openingIndex;
+  };
+
+  const arrowPattern = /=>\s*\{/g;
+  arrowPattern.lastIndex = bodyStart + 1;
+  let arrowMatch: RegExpExecArray | null;
+  while ((arrowMatch = arrowPattern.exec(text))) {
+    if (arrowMatch.index >= bodyEnd) {
+      break;
+    }
+    const openingIndex = arrowMatch.index + arrowMatch[0].lastIndexOf('{');
+    arrowPattern.lastIndex = addBodyRange(openingIndex) + 1;
+  }
+
+  const functionPattern = /\bfunction\b/g;
+  functionPattern.lastIndex = bodyStart + 1;
+  let functionMatch: RegExpExecArray | null;
+  while ((functionMatch = functionPattern.exec(text))) {
+    if (functionMatch.index >= bodyEnd) {
+      break;
+    }
+    let cursor = skipWhitespace(
+      text,
+      functionMatch.index + functionMatch[0].length,
+    );
+    if (text[cursor] === '*') {
+      cursor = skipWhitespace(text, cursor + 1);
+    }
+    const nameMatch = /^[$A-Z_a-z][$\w]*/.exec(text.slice(cursor));
+    if (nameMatch) {
+      cursor = skipWhitespace(text, cursor + nameMatch[0].length);
+    }
+    if (text[cursor] !== '(') {
+      continue;
+    }
+    const paramsEnd = findClosingDelimiter(text, cursor, '(', ')');
+    if (paramsEnd === undefined) {
+      continue;
+    }
+    const openingIndex = skipWhitespace(text, paramsEnd + 1);
+    if (text[openingIndex] === '{') {
+      functionPattern.lastIndex = addBodyRange(openingIndex) + 1;
+    }
+  }
+
+  return ranges;
+}
+
+function getNamedContextFixtureProps(
+  text: string,
+  param: string,
+  signatureEnd: number,
+): string[] {
+  let bodyStart = skipWhitespace(text, signatureEnd);
+  if (text.startsWith('=>', bodyStart)) {
+    bodyStart = skipWhitespace(text, bodyStart + 2);
+  }
+  if (text[bodyStart] !== '{') {
+    return [];
+  }
+  const bodyEnd = findClosingDelimiter(text, bodyStart, '{', '}');
+  if (bodyEnd === undefined) {
+    return [];
+  }
+
+  const nestedFunctionRanges = getNestedFunctionRanges(
+    text,
+    bodyStart,
+    bodyEnd,
+  );
+  const escapedParam = param.replaceAll('$', '\\$');
+  const assignmentPattern = new RegExp(`^\\s*=\\s*${escapedParam}(?![$\\w])`);
+  const declarationPattern = /\b(?:const|let|var)\s*\{/g;
+  declarationPattern.lastIndex = bodyStart + 1;
+  const props = new Set<string>();
+
+  let declarationMatch: RegExpExecArray | null;
+  while ((declarationMatch = declarationPattern.exec(text))) {
+    if (declarationMatch.index >= bodyEnd) {
+      break;
+    }
+    const declarationIndex = declarationMatch.index;
+    const nestedRange = nestedFunctionRanges.find(
+      ([start, end]) => declarationIndex > start && declarationIndex < end,
+    );
+    if (nestedRange) {
+      declarationPattern.lastIndex = nestedRange[1] + 1;
+      continue;
+    }
+
+    const openingIndex =
+      declarationIndex + declarationMatch[0].lastIndexOf('{');
+    const closingIndex = findClosingDelimiter(text, openingIndex, '{', '}');
+    if (closingIndex === undefined || closingIndex > bodyEnd) {
+      break;
+    }
+    declarationPattern.lastIndex = closingIndex + 1;
+    if (!assignmentPattern.test(text.slice(closingIndex + 1, bodyEnd + 1))) {
+      continue;
+    }
+
+    for (const prop of getDestructuredFixtureProps(
+      text.slice(openingIndex, closingIndex + 1),
+    ) ?? []) {
+      props.add(prop);
+    }
+  }
+
+  return [...props];
+}
+
 /**
  * This method is modified based on source found in
  * https://github.com/microsoft/playwright/blob/3584e722237488c07dd23bbf12966f5509bf25c6/packages/playwright/src/common/fixtures.ts#L272
@@ -274,7 +445,7 @@ function getFixtureUsedProps(
   fn: (...args: any[]) => any,
   allowNamedContext = false,
 ): string[] {
-  const text = filterOutComments(fn.toString()).trim();
+  const text = filterOutComments(filterOutStrings(fn.toString())).trim();
   const parenthesizedMatch =
     /^(?:async\s+)?(?:function(?:\s+[$A-Z_a-z][$\w]*)?\s*|[$A-Z_a-z][$\w]*\s*)?\(([^)]*)\)/.exec(
       text,
@@ -297,24 +468,17 @@ function getFixtureUsedProps(
   }
 
   if (/^[$A-Z_a-z][$\w]*$/.test(firstParam ?? '')) {
-    const escapedParam = firstParam!.replaceAll('$', '\\$');
-    const destructurePattern = new RegExp(
-      `(?:const|let|var)\\s*\\{([^}]*)\\}\\s*=\\s*${escapedParam}(?![$\\w])`,
-      'g',
-    );
-    const transformedProps = new Set<string>();
-    let hasTransformedDestructure = false;
-    for (const match of filterOutStrings(text).matchAll(destructurePattern)) {
-      const props = getDestructuredFixtureProps(`{${match[1]}}`);
-      if (props) {
-        hasTransformedDestructure = true;
-        for (const prop of props) {
-          transformedProps.add(prop);
-        }
+    const signatureEnd =
+      parenthesizedMatch?.[0].length ?? singleParamMatch?.[0].length;
+    if (signatureEnd !== undefined) {
+      const transformedProps = getNamedContextFixtureProps(
+        text,
+        firstParam!,
+        signatureEnd,
+      );
+      if (transformedProps.length) {
+        return transformedProps;
       }
-    }
-    if (hasTransformedDestructure) {
-      return [...transformedProps];
     }
     if (allowNamedContext) {
       return [];

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -300,13 +300,21 @@ function getFixtureUsedProps(
     const escapedParam = firstParam!.replaceAll('$', '\\$');
     const destructurePattern = new RegExp(
       `(?:const|let|var)\\s*\\{([^}]*)\\}\\s*=\\s*${escapedParam}(?![$\\w])`,
+      'g',
     );
-    const destructureMatch = destructurePattern.exec(filterOutStrings(text));
-    const transformedProps = getDestructuredFixtureProps(
-      destructureMatch ? `{${destructureMatch[1]}}` : '',
-    );
-    if (transformedProps) {
-      return transformedProps;
+    const transformedProps = new Set<string>();
+    let hasTransformedDestructure = false;
+    for (const match of filterOutStrings(text).matchAll(destructurePattern)) {
+      const props = getDestructuredFixtureProps(`{${match[1]}}`);
+      if (props) {
+        hasTransformedDestructure = true;
+        for (const prop of props) {
+          transformedProps.add(prop);
+        }
+      }
+    }
+    if (hasTransformedDestructure) {
+      return [...transformedProps];
     }
     if (allowNamedContext) {
       return [];

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -264,12 +264,6 @@ function getDestructuredFixtureProps(param: string): string[] | undefined {
         : prop.substring(0, separator).trim();
     },
   );
-  const restProperty = props.find((prop) => prop.startsWith('...'));
-  if (restProperty) {
-    throw new Error(
-      `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
-    );
-  }
   return props;
 }
 
@@ -384,7 +378,9 @@ function getNamedContextFixtureProps(
     bodyEnd,
   );
   const escapedParam = param.replaceAll('$', '\\$');
-  const assignmentPattern = new RegExp(`^\\s*=\\s*${escapedParam}(?![$\\w])`);
+  const assignmentPattern = new RegExp(
+    `^\\s*=\\s*${escapedParam}(?![$\\w])(?!\\s*(?:\\.|\\[|\\?\\.))`,
+  );
   const declarationPattern = /\b(?:const|let|var)\s*\{/g;
   declarationPattern.lastIndex = bodyStart + 1;
   const props = new Set<string>();
@@ -417,7 +413,9 @@ function getNamedContextFixtureProps(
     for (const prop of getDestructuredFixtureProps(
       text.slice(openingIndex, closingIndex + 1),
     ) ?? []) {
-      props.add(prop);
+      if (!prop.startsWith('...')) {
+        props.add(prop);
+      }
     }
   }
 
@@ -462,6 +460,12 @@ function getFixtureUsedProps(
   const [firstParam] = splitByComma(trimmedParams);
   const props = getDestructuredFixtureProps(firstParam ?? '');
   if (props) {
+    const restProperty = props.find((prop) => prop.startsWith('...'));
+    if (restProperty) {
+      throw new Error(
+        `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
+      );
+    }
     return props;
   }
 

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -59,8 +59,8 @@ export const normalizeFixtures = (
 };
 
 export type FixtureResolver = {
-  resolveAutoFixtures: () => Promise<void>;
-  resolveFixtures: (fn?: (...args: any[]) => any) => Promise<void>;
+  resolveTestFixtures: (fn?: (...args: any[]) => any) => Promise<void>;
+  resolveHookFixtures: (fn: (...args: any[]) => any) => Promise<void>;
 };
 
 export const createFixtureResolver = (
@@ -70,8 +70,8 @@ export const createFixtureResolver = (
 ): FixtureResolver => {
   if (!test.fixtures) {
     return {
-      resolveAutoFixtures: () => Promise.resolve(),
-      resolveFixtures: () => Promise.resolve(),
+      resolveTestFixtures: () => Promise.resolve(),
+      resolveHookFixtures: () => Promise.resolve(),
     };
   }
 
@@ -128,11 +128,13 @@ export const createFixtureResolver = (
     pendingMap.delete(name);
   };
 
-  const resolveFixtureNames = async (usedKeys: string[], auto: boolean) => {
+  const resolveFixtureNames = async (
+    usedKeys: string[],
+    includeAuto: boolean,
+  ) => {
     for (const [name, params] of Object.entries(test.fixtures ?? {})) {
-      const shouldResolve = auto
-        ? params.options?.auto
-        : usedKeys.includes(name);
+      const shouldResolve =
+        usedKeys.includes(name) || (includeAuto && params.options?.auto);
       if (!shouldResolve) {
         continue;
       }
@@ -142,9 +144,10 @@ export const createFixtureResolver = (
   };
 
   return {
-    resolveAutoFixtures: () => resolveFixtureNames([], true),
-    resolveFixtures: (fn) =>
-      resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], false),
+    resolveTestFixtures: (fn) =>
+      resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], true),
+    resolveHookFixtures: (fn) =>
+      resolveFixtureNames(getFixtureUsedProps(fn, true), false),
   };
 };
 
@@ -267,11 +270,21 @@ function getDestructuredFixtureProps(param: string): string[] | undefined {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-function getFixtureUsedProps(fn: (...args: any[]) => any): string[] {
-  const text = filterOutComments(fn.toString());
-  const match = /(?:async)?(?:\s+function)?[^(]*\(([^)]*)/.exec(text);
-  if (!match) return [];
-  const trimmedParams = match[1]!.trim();
+function getFixtureUsedProps(
+  fn: (...args: any[]) => any,
+  allowNamedContext = false,
+): string[] {
+  const text = filterOutComments(fn.toString()).trim();
+  const parenthesizedMatch =
+    /^(?:async\s+)?(?:function(?:\s+[$A-Z_a-z][$\w]*)?\s*|[$A-Z_a-z][$\w]*\s*)?\(([^)]*)\)/.exec(
+      text,
+    );
+  const singleParamMatch = parenthesizedMatch
+    ? undefined
+    : /^(?:async\s+)?([$A-Z_a-z][$\w]*)\s*=>/.exec(text);
+  const params = parenthesizedMatch?.[1] ?? singleParamMatch?.[1];
+  if (params === undefined) return [];
+  const trimmedParams = params.trim();
   if (!trimmedParams) return [];
   const [firstParam] = splitByComma(trimmedParams);
   const props = getDestructuredFixtureProps(firstParam ?? '');
@@ -294,6 +307,9 @@ function getFixtureUsedProps(fn: (...args: any[]) => any): string[] {
     );
     if (transformedProps) {
       return transformedProps;
+    }
+    if (allowNamedContext) {
+      return [];
     }
   }
 

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -59,11 +59,29 @@ export const normalizeFixtures = (
 };
 
 export type FixtureResolver = {
+  cancelPendingFixtures: () => void;
   resolveTestFixtures: (fn?: (...args: any[]) => any) => Promise<void>;
-  resolveHookFixtures: (fn: (...args: any[]) => any) => Promise<void | false>;
+  resolveHookFixtures: (
+    fn: (...args: any[]) => any,
+  ) => Promise<{ status: 'resolved' } | { status: 'skipped' }>;
 };
 
 class PreviouslyFailedFixtureError extends Error {}
+
+type FixtureCallback = (...args: any[]) => any;
+
+const callbackSources = new WeakMap<FixtureCallback, FixtureCallback>();
+const fixturePropsCache = new WeakMap<
+  FixtureCallback,
+  { namedContext?: string[]; destructuredContext?: string[] }
+>();
+
+export function setFixtureCallbackSource(
+  callback: (...args: any[]) => any,
+  source: (...args: any[]) => any,
+): void {
+  callbackSources.set(callback, source);
+}
 
 export const createFixtureResolver = (
   test: TestCase,
@@ -72,12 +90,14 @@ export const createFixtureResolver = (
 ): FixtureResolver => {
   if (!test.fixtures) {
     return {
+      cancelPendingFixtures: () => {},
       resolveTestFixtures: () => Promise.resolve(),
-      resolveHookFixtures: () => Promise.resolve(),
+      resolveHookFixtures: () => Promise.resolve({ status: 'resolved' }),
     };
   }
 
   const doneMap = new Set<string>();
+  const cancelledFixtures = new Set<string>();
   const failedFixtures = new Set<string>();
   const pendingMap = new Set<string>();
 
@@ -116,6 +136,10 @@ export const createFixtureResolver = (
         let useDone: (() => void) | undefined;
         const block = Promise.resolve().then(() =>
           fixtureValue(context, async (value: any) => {
+            if (cancelledFixtures.has(name)) {
+              fixtureResolve();
+              return;
+            }
             context[name] = value;
             cleanups.unshift(() => {
               useDone?.();
@@ -130,6 +154,9 @@ export const createFixtureResolver = (
         block.catch(fixtureReject);
       });
 
+      if (cancelledFixtures.has(name)) {
+        throw new PreviouslyFailedFixtureError(name);
+      }
       doneMap.add(name);
     } catch (error) {
       failedFixtures.add(name);
@@ -155,6 +182,12 @@ export const createFixtureResolver = (
   };
 
   return {
+    cancelPendingFixtures: () => {
+      for (const name of pendingMap) {
+        cancelledFixtures.add(name);
+        failedFixtures.add(name);
+      }
+    },
     resolveTestFixtures: (fn) =>
       resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], true),
     resolveHookFixtures: async (fn) => {
@@ -162,25 +195,27 @@ export const createFixtureResolver = (
         await resolveFixtureNames(getFixtureUsedProps(fn, true), false);
       } catch (error) {
         if (error instanceof PreviouslyFailedFixtureError) {
-          return false;
+          return { status: 'skipped' };
         }
         throw error;
       }
-      return undefined;
+      return { status: 'resolved' };
     },
   };
 };
 
 function splitByComma(s: string) {
+  const filtered = filterOutNonCode(s);
   const result: string[] = [];
   const stack: string[] = [];
   let start = 0;
   for (let i = 0; i < s.length; i++) {
-    if (s[i] === '{' || s[i] === '[') {
-      stack.push(s[i] === '{' ? '}' : ']');
-    } else if (s[i] === stack[stack.length - 1]) {
+    const char = filtered[i];
+    if (char === '{' || char === '[' || char === '(') {
+      stack.push(char === '{' ? '}' : char === '[' ? ']' : ')');
+    } else if (char === stack[stack.length - 1]) {
       stack.pop();
-    } else if (!stack.length && s[i] === ',') {
+    } else if (!stack.length && char === ',') {
       const token = s.substring(start, i).trim();
       if (token) result.push(token);
       start = i + 1;
@@ -191,8 +226,49 @@ function splitByComma(s: string) {
   return result;
 }
 
-function filterOutCommentsAndStrings(s: string): string {
-  const result: string[] = [];
+const REGEX_PREFIX_KEYWORDS = new Set([
+  'await',
+  'case',
+  'delete',
+  'do',
+  'else',
+  'in',
+  'instanceof',
+  'new',
+  'of',
+  'return',
+  'throw',
+  'typeof',
+  'void',
+  'yield',
+]);
+
+function canStartRegex(text: readonly string[], index: number): boolean {
+  let cursor = index - 1;
+  while (cursor >= 0 && /\s/.test(text[cursor]!)) {
+    cursor--;
+  }
+  if (cursor < 0) {
+    return true;
+  }
+
+  const previous = text[cursor]!;
+  if ('([{=,:;!&|?+-*%^~<>'.includes(previous)) {
+    return true;
+  }
+  if (!/[$\w]/.test(previous)) {
+    return false;
+  }
+
+  const end = cursor + 1;
+  while (cursor >= 0 && /[$\w]/.test(text[cursor]!)) {
+    cursor--;
+  }
+  return REGEX_PREFIX_KEYWORDS.has(text.slice(cursor + 1, end).join(''));
+}
+
+function filterOutNonCode(s: string): string {
+  const result = [...s];
   let commentState: 'none' | 'singleline' | 'multiline' = 'none';
   let quote: '"' | "'" | '`' | undefined;
 
@@ -201,45 +277,68 @@ function filterOutCommentsAndStrings(s: string): string {
     if (commentState === 'singleline') {
       if (char === '\n') {
         commentState = 'none';
-        result.push('\n');
       } else {
-        result.push(' ');
+        result[i] = ' ';
       }
     } else if (commentState === 'multiline') {
       if (char === '*' && s[i + 1] === '/') {
-        result.push(' ', ' ');
+        result[i] = ' ';
+        result[i + 1] = ' ';
         commentState = 'none';
         i++;
       } else {
-        result.push(char === '\n' ? '\n' : ' ');
+        result[i] = char === '\n' ? '\n' : ' ';
       }
     } else if (quote) {
       if (char === '\\') {
-        result.push(' ');
+        result[i] = ' ';
         if (i + 1 < s.length) {
           i++;
-          result.push(s[i] === '\n' ? '\n' : ' ');
+          result[i] = s[i] === '\n' ? '\n' : ' ';
         }
       } else {
         if (char === quote) {
           quote = undefined;
         }
-        result.push(char === '\n' ? '\n' : ' ');
+        result[i] = char === '\n' ? '\n' : ' ';
       }
     } else {
       if (char === '/' && s[i + 1] === '/') {
-        result.push(' ', ' ');
+        result[i] = ' ';
+        result[i + 1] = ' ';
         commentState = 'singleline';
         i++;
       } else if (char === '/' && s[i + 1] === '*') {
-        result.push(' ', ' ');
+        result[i] = ' ';
+        result[i + 1] = ' ';
         commentState = 'multiline';
         i++;
+      } else if (char === '/' && canStartRegex(result, i)) {
+        result[i] = ' ';
+        let inCharacterClass = false;
+        for (i++; i < s.length; i++) {
+          const regexChar = s[i]!;
+          result[i] = regexChar === '\n' ? '\n' : ' ';
+          if (regexChar === '\\') {
+            if (i + 1 < s.length) {
+              i++;
+              result[i] = s[i] === '\n' ? '\n' : ' ';
+            }
+          } else if (regexChar === '[') {
+            inCharacterClass = true;
+          } else if (regexChar === ']') {
+            inCharacterClass = false;
+          } else if (regexChar === '/' && !inCharacterClass) {
+            while (i + 1 < s.length && /[A-Za-z]/.test(s[i + 1]!)) {
+              i++;
+              result[i] = ' ';
+            }
+            break;
+          }
+        }
       } else if (char === '"' || char === "'" || char === '`') {
         quote = char;
-        result.push(' ');
-      } else {
-        result.push(char);
+        result[i] = ' ';
       }
     }
   }
@@ -253,11 +352,19 @@ function getDestructuredFixtureProps(param: string): string[] | undefined {
 
   const props = splitByComma(param.substring(1, param.length - 1)).map(
     (prop) => {
-      const colon = prop.indexOf(':');
-      const equals = prop.indexOf('=');
-      let separator = colon;
-      if (separator === -1 || (equals !== -1 && equals < separator)) {
-        separator = equals;
+      const filtered = filterOutNonCode(prop);
+      const stack: string[] = [];
+      let separator = -1;
+      for (let index = 0; index < filtered.length; index++) {
+        const char = filtered[index];
+        if (char === '{' || char === '[' || char === '(') {
+          stack.push(char === '{' ? '}' : char === '[' ? ']' : ')');
+        } else if (char === stack[stack.length - 1]) {
+          stack.pop();
+        } else if (!stack.length && (char === ':' || char === '=')) {
+          separator = index;
+          break;
+        }
       }
       return separator === -1
         ? prop.trim()
@@ -287,6 +394,26 @@ function findClosingDelimiter(
   return undefined;
 }
 
+function findOpeningDelimiter(
+  text: string,
+  closingIndex: number,
+  opening: string,
+  closing: string,
+): number | undefined {
+  let depth = 0;
+  for (let index = closingIndex; index >= 0; index--) {
+    if (text[index] === closing) {
+      depth++;
+    } else if (text[index] === opening) {
+      depth--;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return undefined;
+}
+
 function skipWhitespace(text: string, start: number): number {
   let index = start;
   while (index < text.length && /\s/.test(text[index]!)) {
@@ -295,64 +422,185 @@ function skipWhitespace(text: string, start: number): number {
   return index;
 }
 
+function skipWhitespaceBackwards(text: string, start: number): number {
+  let index = start;
+  while (index >= 0 && /\s/.test(text[index]!)) {
+    index--;
+  }
+  return index;
+}
+
+function isWordAt(text: string, index: number, word: string): boolean {
+  return (
+    text.startsWith(word, index) &&
+    !/[$\w]/.test(text[index - 1] ?? '') &&
+    !/[$\w]/.test(text[index + word.length] ?? '')
+  );
+}
+
+function getPreviousWord(text: string, start: number): string {
+  let cursor = skipWhitespaceBackwards(text, start);
+  const end = cursor + 1;
+  while (cursor >= 0 && /[$\w]/.test(text[cursor]!)) {
+    cursor--;
+  }
+  return text.slice(cursor + 1, end);
+}
+
+function findExpressionEnd(
+  text: string,
+  expressionStart: number,
+  bodyEnd: number,
+): number {
+  const stack: string[] = [];
+  for (let index = expressionStart; index < bodyEnd; index++) {
+    const char = text[index];
+    if (char === '{' || char === '[' || char === '(') {
+      stack.push(char === '{' ? '}' : char === '[' ? ']' : ')');
+    } else if (char === stack[stack.length - 1]) {
+      stack.pop();
+    } else if (!stack.length && (char === ',' || char === ';')) {
+      return index - 1;
+    } else if (!stack.length && char === '\n') {
+      const nextLine = text.slice(skipWhitespace(text, index + 1));
+      if (
+        /^(?:class|const|for|function|if|let|return|switch|throw|try|var|while)\b/.test(
+          nextLine,
+        )
+      ) {
+        return index - 1;
+      }
+    }
+  }
+  return bodyEnd - 1;
+}
+
 function getNestedFunctionRanges(
   text: string,
   bodyStart: number,
   bodyEnd: number,
 ): [number, number][] {
   const ranges: [number, number][] = [];
-  const addBodyRange = (openingIndex: number) => {
-    const closingIndex = findClosingDelimiter(text, openingIndex, '{', '}');
-    if (closingIndex !== undefined && closingIndex <= bodyEnd) {
-      ranges.push([openingIndex, closingIndex]);
-      return closingIndex;
-    }
-    return openingIndex;
-  };
+  const controlKeywords = new Set([
+    'catch',
+    'for',
+    'if',
+    'switch',
+    'while',
+    'with',
+  ]);
 
-  const arrowPattern = /=>\s*\{/g;
-  arrowPattern.lastIndex = bodyStart + 1;
-  let arrowMatch: RegExpExecArray | null;
-  while ((arrowMatch = arrowPattern.exec(text))) {
-    if (arrowMatch.index >= bodyEnd) {
-      break;
-    }
-    const openingIndex = arrowMatch.index + arrowMatch[0].lastIndexOf('{');
-    arrowPattern.lastIndex = addBodyRange(openingIndex) + 1;
-  }
-
-  const functionPattern = /\bfunction\b/g;
-  functionPattern.lastIndex = bodyStart + 1;
-  let functionMatch: RegExpExecArray | null;
-  while ((functionMatch = functionPattern.exec(text))) {
-    if (functionMatch.index >= bodyEnd) {
-      break;
-    }
-    let cursor = skipWhitespace(
-      text,
-      functionMatch.index + functionMatch[0].length,
-    );
-    if (text[cursor] === '*') {
-      cursor = skipWhitespace(text, cursor + 1);
-    }
-    const nameMatch = /^[$A-Z_a-z][$\w]*/.exec(text.slice(cursor));
-    if (nameMatch) {
-      cursor = skipWhitespace(text, cursor + nameMatch[0].length);
-    }
-    if (text[cursor] !== '(') {
+  for (let index = bodyStart + 1; index < bodyEnd; index++) {
+    if (isWordAt(text, index, 'function')) {
+      const paramsStart = text.indexOf('(', index + 'function'.length);
+      if (paramsStart === -1 || paramsStart >= bodyEnd) {
+        continue;
+      }
+      const paramsEnd = findClosingDelimiter(text, paramsStart, '(', ')');
+      const nestedBodyStart =
+        paramsEnd === undefined ? bodyEnd : skipWhitespace(text, paramsEnd + 1);
+      if (text[nestedBodyStart] !== '{') {
+        continue;
+      }
+      const nestedBodyEnd = findClosingDelimiter(
+        text,
+        nestedBodyStart,
+        '{',
+        '}',
+      );
+      if (nestedBodyEnd !== undefined && nestedBodyEnd <= bodyEnd) {
+        ranges.push([nestedBodyStart, nestedBodyEnd]);
+        index = nestedBodyEnd;
+      }
       continue;
     }
-    const paramsEnd = findClosingDelimiter(text, cursor, '(', ')');
-    if (paramsEnd === undefined) {
+
+    if (text[index] === '=' && text[index + 1] === '>') {
+      const nestedBodyStart = skipWhitespace(text, index + 2);
+      const nestedBodyEnd =
+        text[nestedBodyStart] === '{'
+          ? findClosingDelimiter(text, nestedBodyStart, '{', '}')
+          : findExpressionEnd(text, nestedBodyStart, bodyEnd);
+      if (nestedBodyEnd !== undefined && nestedBodyEnd <= bodyEnd) {
+        ranges.push([nestedBodyStart, nestedBodyEnd]);
+        index = nestedBodyEnd;
+      }
       continue;
     }
-    const openingIndex = skipWhitespace(text, paramsEnd + 1);
-    if (text[openingIndex] === '{') {
-      functionPattern.lastIndex = addBodyRange(openingIndex) + 1;
+
+    if (text[index] !== '{') {
+      continue;
+    }
+    const paramsEnd = skipWhitespaceBackwards(text, index - 1);
+    if (text[paramsEnd] !== ')') {
+      continue;
+    }
+    const paramsStart = findOpeningDelimiter(text, paramsEnd, '(', ')');
+    if (paramsStart === undefined) {
+      continue;
+    }
+    const previousWord = getPreviousWord(text, paramsStart - 1);
+    if (controlKeywords.has(previousWord)) {
+      continue;
+    }
+    const nestedBodyEnd = findClosingDelimiter(text, index, '{', '}');
+    if (nestedBodyEnd !== undefined && nestedBodyEnd <= bodyEnd) {
+      ranges.push([index, nestedBodyEnd]);
+      index = nestedBodyEnd;
     }
   }
 
   return ranges;
+}
+
+function getCallbackParams(
+  text: string,
+): { params: string; signatureEnd: number } | undefined {
+  const singleParamMatch = /^(?:async\s+)?([$A-Z_a-z][$\w]*)\s*=>/.exec(text);
+  if (singleParamMatch) {
+    return {
+      params: singleParamMatch[1]!,
+      signatureEnd: singleParamMatch[0].length,
+    };
+  }
+
+  const paramsStart = text.indexOf('(');
+  if (paramsStart === -1) {
+    return undefined;
+  }
+  const paramsEnd = findClosingDelimiter(text, paramsStart, '(', ')');
+  if (paramsEnd === undefined) {
+    return undefined;
+  }
+  return {
+    params: text.slice(paramsStart + 1, paramsEnd),
+    signatureEnd: paramsEnd + 1,
+  };
+}
+
+function isContextAssignment(
+  text: string,
+  closingIndex: number,
+  param: string,
+): boolean {
+  let cursor = skipWhitespace(text, closingIndex + 1);
+  if (text[cursor] !== '=') {
+    return false;
+  }
+  cursor = skipWhitespace(text, cursor + 1);
+  if (!text.startsWith(param, cursor)) {
+    return false;
+  }
+  const next = text[cursor + param.length];
+  if (/[$\w]/.test(next ?? '')) {
+    return false;
+  }
+  const memberStart = skipWhitespace(text, cursor + param.length);
+  return !(
+    text[memberStart] === '.' ||
+    text[memberStart] === '[' ||
+    text.startsWith('?.', memberStart)
+  );
 }
 
 function getNamedContextFixtureProps(
@@ -377,49 +625,102 @@ function getNamedContextFixtureProps(
     bodyStart,
     bodyEnd,
   );
-  const escapedParam = param.replaceAll('$', '\\$');
-  const assignmentPattern = new RegExp(
-    `^\\s*=\\s*${escapedParam}(?![$\\w])(?!\\s*(?:\\.|\\[|\\?\\.))`,
-  );
-  const declarationPattern = /\b(?:const|let|var)\s*\{/g;
-  declarationPattern.lastIndex = bodyStart + 1;
   const props = new Set<string>();
+  let rangeIndex = 0;
 
-  let declarationMatch: RegExpExecArray | null;
-  while ((declarationMatch = declarationPattern.exec(text))) {
-    if (declarationMatch.index >= bodyEnd) {
-      break;
+  for (let index = bodyStart + 1; index < bodyEnd; index++) {
+    while (
+      nestedFunctionRanges[rangeIndex] &&
+      index > nestedFunctionRanges[rangeIndex]![1]
+    ) {
+      rangeIndex++;
     }
-    const declarationIndex = declarationMatch.index;
-    const nestedRange = nestedFunctionRanges.find(
-      ([start, end]) => declarationIndex > start && declarationIndex < end,
-    );
-    if (nestedRange) {
-      declarationPattern.lastIndex = nestedRange[1] + 1;
+    const nestedRange = nestedFunctionRanges[rangeIndex];
+    if (nestedRange && index >= nestedRange[0]) {
+      index = nestedRange[1];
+      rangeIndex++;
       continue;
     }
-
-    const openingIndex =
-      declarationIndex + declarationMatch[0].lastIndexOf('{');
-    const closingIndex = findClosingDelimiter(text, openingIndex, '{', '}');
+    if (text[index] !== '{') {
+      continue;
+    }
+    const closingIndex = findClosingDelimiter(text, index, '{', '}');
     if (closingIndex === undefined || closingIndex > bodyEnd) {
       break;
     }
-    declarationPattern.lastIndex = closingIndex + 1;
-    if (!assignmentPattern.test(text.slice(closingIndex + 1, bodyEnd + 1))) {
+    if (!isContextAssignment(text, closingIndex, param)) {
       continue;
     }
 
     for (const prop of getDestructuredFixtureProps(
-      text.slice(openingIndex, closingIndex + 1),
+      text.slice(index, closingIndex + 1),
     ) ?? []) {
       if (!prop.startsWith('...')) {
         props.add(prop);
       }
     }
+    index = closingIndex;
   }
 
   return [...props];
+}
+
+function getFixtureCallbackSource(fn: FixtureCallback): FixtureCallback {
+  const seen = new Set<FixtureCallback>();
+  let source = fn;
+  while (callbackSources.has(source) && !seen.has(source)) {
+    seen.add(source);
+    source = callbackSources.get(source)!;
+  }
+  return source;
+}
+
+function parseFixtureUsedProps(
+  fn: (...args: any[]) => any,
+  allowNamedContext: boolean,
+): string[] {
+  const text = filterOutNonCode(fn.toString()).trim();
+  const signature = getCallbackParams(text);
+  if (!signature) {
+    return [];
+  }
+  const trimmedParams = signature.params.trim();
+  if (!trimmedParams) {
+    return [];
+  }
+  const [firstParam] = splitByComma(trimmedParams);
+  const props = getDestructuredFixtureProps(firstParam ?? '');
+  if (props) {
+    const restProperty = props.find((prop) => prop.startsWith('...'));
+    if (restProperty) {
+      throw new Error(
+        `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
+      );
+    }
+    return props;
+  }
+
+  if (firstParam?.startsWith('_')) {
+    return [];
+  }
+
+  if (/^[$A-Z_a-z][$\w]*$/.test(firstParam ?? '')) {
+    const transformedProps = getNamedContextFixtureProps(
+      text,
+      firstParam!,
+      signature.signatureEnd,
+    );
+    if (transformedProps.length) {
+      return transformedProps;
+    }
+    if (allowNamedContext) {
+      return [];
+    }
+  }
+
+  throw new Error(
+    `First argument must use the object destructuring pattern: ${firstParam}`,
+  );
 }
 
 /**
@@ -445,53 +746,19 @@ function getFixtureUsedProps(
   fn: (...args: any[]) => any,
   allowNamedContext = false,
 ): string[] {
-  const text = filterOutCommentsAndStrings(fn.toString()).trim();
-  const parenthesizedMatch =
-    /^(?:async\s+)?(?:function(?:\s+[$A-Z_a-z][$\w]*)?\s*|[$A-Z_a-z][$\w]*\s*)?\(([^)]*)\)/.exec(
-      text,
-    );
-  const singleParamMatch = parenthesizedMatch
-    ? undefined
-    : /^(?:async\s+)?([$A-Z_a-z][$\w]*)\s*=>/.exec(text);
-  const params = parenthesizedMatch?.[1] ?? singleParamMatch?.[1];
-  if (params === undefined) return [];
-  const trimmedParams = params.trim();
-  if (!trimmedParams) return [];
-  const [firstParam] = splitByComma(trimmedParams);
-  const props = getDestructuredFixtureProps(firstParam ?? '');
-  if (props) {
-    const restProperty = props.find((prop) => prop.startsWith('...'));
-    if (restProperty) {
-      throw new Error(
-        `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
-      );
-    }
-    return props;
+  const source = getFixtureCallbackSource(fn);
+  let cached = fixturePropsCache.get(source);
+  const cacheKey = allowNamedContext ? 'namedContext' : 'destructuredContext';
+  if (cached?.[cacheKey]) {
+    return cached[cacheKey]!;
   }
 
-  if (firstParam?.startsWith('_')) {
-    return [];
-  }
-
-  if (/^[$A-Z_a-z][$\w]*$/.test(firstParam ?? '')) {
-    const signatureEnd =
-      parenthesizedMatch?.[0].length ?? singleParamMatch?.[0].length;
-    if (signatureEnd !== undefined) {
-      const transformedProps = getNamedContextFixtureProps(
-        text,
-        firstParam!,
-        signatureEnd,
-      );
-      if (transformedProps.length) {
-        return transformedProps;
-      }
-    }
-    if (allowNamedContext) {
-      return [];
-    }
-  }
-
-  throw new Error(
-    `First argument must use the object destructuring pattern: ${firstParam}`,
+  const props = parseFixtureUsedProps(
+    source as (...args: any[]) => any,
+    allowNamedContext,
   );
+  cached ??= {};
+  cached[cacheKey] = props;
+  fixturePropsCache.set(source, cached);
+  return props;
 }

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -58,23 +58,25 @@ export const normalizeFixtures = (
   };
 };
 
-export const handleFixtures = async (
+export type FixtureResolver = {
+  resolveAutoFixtures: () => Promise<void>;
+  resolveFixtures: (fn?: (...args: any[]) => any) => Promise<void>;
+};
+
+export const createFixtureResolver = (
   test: TestCase,
   context: Record<string, any>,
   cleanups: (() => Promise<void>)[] = [],
-): Promise<{
-  cleanups: (() => Promise<void>)[];
-}> => {
+): FixtureResolver => {
   if (!test.fixtures) {
-    return { cleanups };
+    return {
+      resolveAutoFixtures: () => Promise.resolve(),
+      resolveFixtures: () => Promise.resolve(),
+    };
   }
 
   const doneMap = new Set<string>();
   const pendingMap = new Set<string>();
-
-  const usedKeys: string[] = test.originalFn
-    ? getFixtureUsedProps(test.originalFn)
-    : [];
 
   const useFixture = async (
     name: string,
@@ -126,17 +128,24 @@ export const handleFixtures = async (
     pendingMap.delete(name);
   };
 
-  for (const [name, params] of Object.entries(test.fixtures)) {
-    // call fixture on demand
-    const shouldAdd = params.options?.auto || usedKeys.includes(name);
-    if (!shouldAdd) {
-      continue;
+  const resolveFixtureNames = async (usedKeys: string[], auto: boolean) => {
+    for (const [name, params] of Object.entries(test.fixtures ?? {})) {
+      const shouldResolve = auto
+        ? params.options?.auto
+        : usedKeys.includes(name);
+      if (!shouldResolve) {
+        continue;
+      }
+
+      await useFixture(name, params);
     }
+  };
 
-    await useFixture(name, params);
-  }
-
-  return { cleanups };
+  return {
+    resolveAutoFixtures: () => resolveFixtureNames([], true),
+    resolveFixtures: (fn) =>
+      resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], false),
+  };
 };
 
 function splitByComma(s: string) {
@@ -181,6 +190,64 @@ function filterOutComments(s: string): string {
   return result.join('');
 }
 
+function filterOutStrings(s: string): string {
+  const result: string[] = [];
+  let quote: '"' | "'" | '`' | undefined;
+
+  for (let i = 0; i < s.length; i++) {
+    const char = s[i]!;
+    if (quote) {
+      if (char === '\\') {
+        result.push(' ', ' ');
+        i++;
+        continue;
+      }
+      if (char === quote) {
+        quote = undefined;
+      }
+      result.push(char === '\n' ? '\n' : ' ');
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      result.push(' ');
+      continue;
+    }
+
+    result.push(char);
+  }
+
+  return result.join('');
+}
+
+function getDestructuredFixtureProps(param: string): string[] | undefined {
+  if (param[0] !== '{' || !param.endsWith('}')) {
+    return undefined;
+  }
+
+  const props = splitByComma(param.substring(1, param.length - 1)).map(
+    (prop) => {
+      const colon = prop.indexOf(':');
+      const equals = prop.indexOf('=');
+      let separator = colon;
+      if (separator === -1 || (equals !== -1 && equals < separator)) {
+        separator = equals;
+      }
+      return separator === -1
+        ? prop.trim()
+        : prop.substring(0, separator).trim();
+    },
+  );
+  const restProperty = props.find((prop) => prop.startsWith('...'));
+  if (restProperty) {
+    throw new Error(
+      `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
+    );
+  }
+  return props;
+}
+
 /**
  * This method is modified based on source found in
  * https://github.com/microsoft/playwright/blob/3584e722237488c07dd23bbf12966f5509bf25c6/packages/playwright/src/common/fixtures.ts#L272
@@ -207,25 +274,30 @@ function getFixtureUsedProps(fn: (...args: any[]) => any): string[] {
   const trimmedParams = match[1]!.trim();
   if (!trimmedParams) return [];
   const [firstParam] = splitByComma(trimmedParams);
-  if (firstParam?.[0] !== '{' || !firstParam.endsWith('}')) {
-    if (firstParam?.startsWith('_')) {
-      return [];
+  const props = getDestructuredFixtureProps(firstParam ?? '');
+  if (props) {
+    return props;
+  }
+
+  if (firstParam?.startsWith('_')) {
+    return [];
+  }
+
+  if (/^[$A-Z_a-z][$\w]*$/.test(firstParam ?? '')) {
+    const escapedParam = firstParam!.replaceAll('$', '\\$');
+    const destructurePattern = new RegExp(
+      `(?:const|let|var)\\s*\\{([^}]*)\\}\\s*=\\s*${escapedParam}(?![$\\w])`,
+    );
+    const destructureMatch = destructurePattern.exec(filterOutStrings(text));
+    const transformedProps = getDestructuredFixtureProps(
+      destructureMatch ? `{${destructureMatch[1]}}` : '',
+    );
+    if (transformedProps) {
+      return transformedProps;
     }
-    throw new Error(
-      `First argument must use the object destructuring pattern: ${firstParam}`,
-    );
   }
-  const props = splitByComma(
-    firstParam.substring(1, firstParam.length - 1),
-  ).map((prop) => {
-    const colon = prop.indexOf(':');
-    return colon === -1 ? prop.trim() : prop.substring(0, colon).trim();
-  });
-  const restProperty = props.find((prop) => prop.startsWith('...'));
-  if (restProperty) {
-    throw new Error(
-      `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
-    );
-  }
-  return props;
+
+  throw new Error(
+    `First argument must use the object destructuring pattern: ${firstParam}`,
+  );
 }

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -59,7 +59,7 @@ export const normalizeFixtures = (
 };
 
 export type FixtureResolver = {
-  cancelPendingFixtures: () => void;
+  cancelPendingFixtures: () => { teardownStarted: Promise<void> } | undefined;
   resolveTestFixtures: (fn?: (...args: any[]) => any) => Promise<void>;
   resolveHookFixtures: (
     fn: (...args: any[]) => any,
@@ -90,7 +90,7 @@ export const createFixtureResolver = (
 ): FixtureResolver => {
   if (!test.fixtures) {
     return {
-      cancelPendingFixtures: () => {},
+      cancelPendingFixtures: () => undefined,
       resolveTestFixtures: () => Promise.resolve(),
       resolveHookFixtures: () => Promise.resolve({ status: 'resolved' }),
     };
@@ -100,6 +100,8 @@ export const createFixtureResolver = (
   const cancelledFixtures = new Set<string>();
   const failedFixtures = new Set<string>();
   const pendingMap = new Set<string>();
+  const cancelFixtureSetups = new Map<string, () => void>();
+  const cancelledFixtureTeardownStarts = new Map<string, () => void>();
 
   const useFixture = async (
     name: string,
@@ -134,10 +136,16 @@ export const createFixtureResolver = (
       // but why not return cleanup function?
       await new Promise<void>((fixtureResolve, fixtureReject) => {
         let useDone: (() => void) | undefined;
+        let blockSettled = false;
+        cancelFixtureSetups.set(name, () => {
+          if (blockSettled) {
+            fixtureResolve();
+          }
+        });
         const block = Promise.resolve().then(() =>
           fixtureValue(context, async (value: any) => {
             if (cancelledFixtures.has(name)) {
-              fixtureResolve();
+              cancelledFixtureTeardownStarts.get(name)?.();
               return;
             }
             context[name] = value;
@@ -151,7 +159,12 @@ export const createFixtureResolver = (
             });
           }),
         );
-        block.catch(fixtureReject);
+        block.then(() => {
+          blockSettled = true;
+          if (cancelledFixtures.has(name)) {
+            fixtureResolve();
+          }
+        }, fixtureReject);
       });
 
       if (cancelledFixtures.has(name)) {
@@ -163,6 +176,8 @@ export const createFixtureResolver = (
       throw error;
     } finally {
       pendingMap.delete(name);
+      cancelFixtureSetups.delete(name);
+      cancelledFixtureTeardownStarts.delete(name);
     }
   };
 
@@ -183,10 +198,18 @@ export const createFixtureResolver = (
 
   return {
     cancelPendingFixtures: () => {
-      for (const name of pendingMap) {
-        cancelledFixtures.add(name);
-        failedFixtures.add(name);
+      if (pendingMap.size === 0) {
+        return undefined;
       }
+      const teardownStarted = new Promise<void>((notifyTeardownStarted) => {
+        for (const name of pendingMap) {
+          cancelledFixtures.add(name);
+          failedFixtures.add(name);
+          cancelledFixtureTeardownStarts.set(name, notifyTeardownStarted);
+          cancelFixtureSetups.get(name)?.();
+        }
+      });
+      return { teardownStarted };
     },
     resolveTestFixtures: (fn) =>
       resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], true),
@@ -652,12 +675,11 @@ function getNamedContextFixtureProps(
       continue;
     }
 
-    for (const prop of getDestructuredFixtureProps(
-      text.slice(index, closingIndex + 1),
-    ) ?? []) {
-      if (!prop.startsWith('...')) {
-        props.add(prop);
-      }
+    const destructuredProps =
+      getDestructuredFixtureProps(text.slice(index, closingIndex + 1)) ?? [];
+    assertNoRestProperty(destructuredProps);
+    for (const prop of destructuredProps) {
+      props.add(prop);
     }
     index = closingIndex;
   }
@@ -673,6 +695,15 @@ function getFixtureCallbackSource(fn: FixtureCallback): FixtureCallback {
     source = callbackSources.get(source)!;
   }
   return source;
+}
+
+function assertNoRestProperty(props: string[]): void {
+  const restProperty = props.find((prop) => prop.startsWith('...'));
+  if (restProperty) {
+    throw new Error(
+      `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
+    );
+  }
 }
 
 function parseFixtureUsedProps(
@@ -691,12 +722,7 @@ function parseFixtureUsedProps(
   const [firstParam] = splitByComma(trimmedParams);
   const props = getDestructuredFixtureProps(firstParam ?? '');
   if (props) {
-    const restProperty = props.find((prop) => prop.startsWith('...'));
-    if (restProperty) {
-      throw new Error(
-        `Rest property "${restProperty}" is not supported. List all used fixtures explicitly, separated by comma.`,
-      );
-    }
+    assertNoRestProperty(props);
     return props;
   }
 

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -191,20 +191,65 @@ export class TestRunner {
           }
       > => {
         let callbackStarted = false;
+        const runHook = async (callback: (...args: any[]) => any) => {
+          const resolution =
+            await fixtureResolver.resolveHookFixtures(callback);
+          if (resolution.status === 'skipped') {
+            return { status: 'skipped' as const };
+          }
+          callbackStarted = true;
+          const cleanup = await callback(test.context);
+          return { status: 'completed' as const, cleanup };
+        };
+        let hookExecution: ReturnType<typeof runHook> | undefined;
         try {
-          return await runWithTimeout(fn, async (callback) => {
-            const resolution =
-              await fixtureResolver.resolveHookFixtures(callback);
-            if (resolution.status === 'skipped') {
-              return { status: 'skipped' as const };
-            }
-            callbackStarted = true;
-            const cleanup = await callback(test.context);
-            return { status: 'completed' as const, cleanup };
+          return await runWithTimeout(fn, (callback) => {
+            hookExecution = runHook(callback);
+            return hookExecution;
           });
         } catch (error) {
-          if (!callbackStarted) {
-            fixtureResolver.cancelPendingFixtures();
+          const cancellation =
+            !callbackStarted && fixtureResolver.cancelPendingFixtures();
+          if (cancellation && hookExecution) {
+            const hookCompletion = hookExecution.then(
+              () => ({ status: 'completed' as const }),
+              (fixtureError: unknown) => ({
+                status: 'failed' as const,
+                error: fixtureError,
+              }),
+            );
+            const cancellationProgress = Promise.race([
+              hookCompletion.then((completion) => ({
+                status: 'completed' as const,
+                completion,
+              })),
+              cancellation.teardownStarted.then(() => ({
+                status: 'teardown-started' as const,
+              })),
+            ]);
+            const waitForCancellationProgress = inheritTimeout(
+              fn,
+              () => cancellationProgress,
+            );
+            fixtureCleanups.unshift(async () => {
+              let progress: Awaited<typeof cancellationProgress>;
+              try {
+                progress = await waitForCancellationProgress();
+              } catch {
+                // The original hook timeout is already reported. This timeout
+                // only bounds how long unfinished setup may delay the test.
+                return;
+              }
+              // Once `use` is reached, match normal fixture cleanup semantics:
+              // teardown must finish before the runner continues.
+              const completion =
+                progress.status === 'teardown-started'
+                  ? await hookCompletion
+                  : progress.completion;
+              if (completion.status === 'failed') {
+                throw completion.error;
+              }
+            });
           }
           return {
             status: 'failed',

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -295,7 +295,16 @@ export class TestRunner {
       test.context.task.result = result;
       try {
         for (const fn of afterEachFns) {
-          const shouldRun = await fixtureResolver.resolveHookFixtures(fn);
+          let shouldRun: void | false;
+          try {
+            shouldRun = await fixtureResolver.resolveHookFixtures(fn);
+          } catch (error) {
+            result.status = 'fail';
+            result.errors ??= [];
+            result.errors.push(...(await formatTestError(error)));
+            test.context.task.result = result;
+            continue;
+          }
           if (shouldRun === false) {
             continue;
           }

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -158,7 +158,7 @@ export class TestRunner {
       );
 
       try {
-        await fixtureResolver.resolveAutoFixtures();
+        await fixtureResolver.resolveTestFixtures(test.originalFn);
       } catch (error) {
         if (error instanceof TestSkipError) {
           skipped = true;
@@ -180,32 +180,10 @@ export class TestRunner {
       if (!result) {
         try {
           for (const fn of parentHooks.beforeEachListeners) {
-            await fixtureResolver.resolveFixtures(fn);
+            await fixtureResolver.resolveHookFixtures(fn);
             const cleanupFn = await fn(test.context);
             if (cleanupFn) cleanups.push(cleanupFn);
           }
-        } catch (error) {
-          if (error instanceof TestSkipError) {
-            skipped = true;
-            result = skipResult();
-          } else {
-            result = {
-              testId: test.testId,
-              status: 'fail' as const,
-              parentNames: test.parentNames,
-              name: test.name,
-              errors: await formatTestError(error, test),
-              testPath,
-              project,
-              meta: test.meta,
-            };
-          }
-        }
-      }
-
-      if (!result) {
-        try {
-          await fixtureResolver.resolveFixtures(test.originalFn);
         } catch (error) {
           if (error instanceof TestSkipError) {
             skipped = true;
@@ -317,7 +295,7 @@ export class TestRunner {
       test.context.task.result = result;
       try {
         for (const fn of afterEachFns) {
-          await fixtureResolver.resolveFixtures(fn);
+          await fixtureResolver.resolveHookFixtures(fn);
           await fn(test.context);
         }
       } catch (error) {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -32,7 +32,8 @@ import {
 import { createExpect } from '../api/expect';
 import { formatTestError, TestSkipError } from '../util';
 import type { TaskContext } from '../worker/taskContext';
-import { handleFixtures } from './fixtures';
+import { createFixtureResolver } from './fixtures';
+import type { FixtureResolver } from './fixtures';
 import { cloneTaskMeta } from './metadata';
 import {
   getTestStatus,
@@ -150,12 +151,14 @@ export class TestRunner {
         meta: test.meta,
       });
 
+      const fixtureResolver = this.beforeRunTest(
+        test,
+        snapshotClient.getSnapshotState(testPath),
+        fixtureCleanups,
+      );
+
       try {
-        await this.beforeRunTest(
-          test,
-          snapshotClient.getSnapshotState(testPath),
-          fixtureCleanups,
-        );
+        await fixtureResolver.resolveAutoFixtures();
       } catch (error) {
         if (error instanceof TestSkipError) {
           skipped = true;
@@ -177,9 +180,32 @@ export class TestRunner {
       if (!result) {
         try {
           for (const fn of parentHooks.beforeEachListeners) {
+            await fixtureResolver.resolveFixtures(fn);
             const cleanupFn = await fn(test.context);
             if (cleanupFn) cleanups.push(cleanupFn);
           }
+        } catch (error) {
+          if (error instanceof TestSkipError) {
+            skipped = true;
+            result = skipResult();
+          } else {
+            result = {
+              testId: test.testId,
+              status: 'fail' as const,
+              parentNames: test.parentNames,
+              name: test.name,
+              errors: await formatTestError(error, test),
+              testPath,
+              project,
+              meta: test.meta,
+            };
+          }
+        }
+      }
+
+      if (!result) {
+        try {
+          await fixtureResolver.resolveFixtures(test.originalFn);
         } catch (error) {
           if (error instanceof TestSkipError) {
             skipped = true;
@@ -291,6 +317,7 @@ export class TestRunner {
       test.context.task.result = result;
       try {
         for (const fn of afterEachFns) {
+          await fixtureResolver.resolveFixtures(fn);
           await fn(test.context);
         }
       } catch (error) {
@@ -827,11 +854,11 @@ export class TestRunner {
     );
   }
 
-  private async beforeRunTest(
+  private beforeRunTest(
     test: TestCase,
     snapshotState: SnapshotState,
     fixtureCleanups: (() => Promise<void>)[],
-  ): Promise<void> {
+  ): FixtureResolver {
     setState<MatcherState>(
       {
         assertionCalls: 0,
@@ -857,7 +884,7 @@ export class TestRunner {
       enumerable: false,
     });
 
-    await handleFixtures(test, context, fixtureCleanups);
+    return createFixtureResolver(test, context, fixtureCleanups);
   }
 
   private afterRunTest(test: TestCase): void {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -37,8 +37,10 @@ import type { FixtureResolver } from './fixtures';
 import { cloneTaskMeta } from './metadata';
 import {
   getTestStatus,
+  inheritTimeout,
   limitConcurrency,
   markAllTestAsSkipped,
+  runWithTimeout,
   sanitizeAttemptCount,
   wrapTimeout,
 } from './task';
@@ -177,15 +179,54 @@ export class TestRunner {
         }
       }
 
-      if (!result) {
-        try {
-          for (const fn of parentHooks.beforeEachListeners) {
-            await fixtureResolver.resolveHookFixtures(fn);
-            const cleanupFn = await fn(test.context);
-            if (cleanupFn) cleanups.push(cleanupFn);
+      const runPerTestHook = async (
+        fn: BeforeEachListener | AfterEachListener,
+      ): Promise<
+        | { status: 'completed'; cleanup?: AfterEachListener }
+        | { status: 'skipped' }
+        | {
+            status: 'failed';
+            phase: 'fixture' | 'callback';
+            error: unknown;
           }
+      > => {
+        let callbackStarted = false;
+        try {
+          return await runWithTimeout(fn, async (callback) => {
+            const resolution =
+              await fixtureResolver.resolveHookFixtures(callback);
+            if (resolution.status === 'skipped') {
+              return { status: 'skipped' as const };
+            }
+            callbackStarted = true;
+            const cleanup = await callback(test.context);
+            return { status: 'completed' as const, cleanup };
+          });
         } catch (error) {
-          if (error instanceof TestSkipError) {
+          if (!callbackStarted) {
+            fixtureResolver.cancelPendingFixtures();
+          }
+          return {
+            status: 'failed',
+            phase: callbackStarted ? 'callback' : 'fixture',
+            error,
+          };
+        }
+      };
+
+      if (!result) {
+        for (const fn of parentHooks.beforeEachListeners) {
+          const hookResult = await runPerTestHook(fn);
+          if (hookResult.status === 'completed') {
+            if (hookResult.cleanup) {
+              cleanups.push(inheritTimeout(fn, hookResult.cleanup));
+            }
+            continue;
+          }
+          if (hookResult.status === 'skipped') {
+            continue;
+          }
+          if (hookResult.error instanceof TestSkipError) {
             skipped = true;
             result = skipResult();
           } else {
@@ -194,12 +235,13 @@ export class TestRunner {
               status: 'fail' as const,
               parentNames: test.parentNames,
               name: test.name,
-              errors: await formatTestError(error, test),
+              errors: await formatTestError(hookResult.error, test),
               testPath,
               project,
               meta: test.meta,
             };
           }
+          break;
         }
       }
 
@@ -293,28 +335,21 @@ export class TestRunner {
         .concat(cleanups);
 
       test.context.task.result = result;
-      try {
-        for (const fn of afterEachFns) {
-          let shouldRun: void | false;
-          try {
-            shouldRun = await fixtureResolver.resolveHookFixtures(fn);
-          } catch (error) {
-            result.status = 'fail';
-            result.errors ??= [];
-            result.errors.push(...(await formatTestError(error)));
-            test.context.task.result = result;
-            continue;
-          }
-          if (shouldRun === false) {
-            continue;
-          }
-          await fn(test.context);
+      for (const fn of afterEachFns) {
+        const hookResult = await runPerTestHook(fn);
+        if (
+          hookResult.status === 'completed' ||
+          hookResult.status === 'skipped'
+        ) {
+          continue;
         }
-      } catch (error) {
         result.status = 'fail';
         result.errors ??= [];
-        result.errors.push(...(await formatTestError(error)));
+        result.errors.push(...(await formatTestError(hookResult.error)));
         test.context.task.result = result;
+        if (hookResult.phase === 'callback') {
+          break;
+        }
       }
 
       for (const fn of fixtureCleanups) {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -295,7 +295,10 @@ export class TestRunner {
       test.context.task.result = result;
       try {
         for (const fn of afterEachFns) {
-          await fixtureResolver.resolveHookFixtures(fn);
+          const shouldRun = await fixtureResolver.resolveHookFixtures(fn);
+          if (shouldRun === false) {
+            continue;
+          }
           await fn(test.context);
         }
       } catch (error) {

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -141,13 +141,13 @@ export class RunnerRuntime {
    * strictly checked — a contextual `void` would silently ignore an accidental
    * `Promise` return.
    */
-  private registerHook(
+  private registerHook<ExtraContext = object>(
     key: 'beforeAll' | 'afterAll' | 'beforeEach' | 'afterEach',
     fn:
       | AfterAllListener
       | BeforeAllListener
-      | AfterEachListener
-      | BeforeEachListener,
+      | AfterEachListener<ExtraContext>
+      | BeforeEachListener<ExtraContext>,
     timeout: number,
   ): void {
     registerTestSuiteListener(

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -296,7 +296,7 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
     return fn;
   }
 
-  return (async (...args: Parameters<T>) => {
+  const wrapped = async (...args: Parameters<T>) => {
     let timeoutId: NodeJS.Timeout | undefined;
     const timeoutPromise = new Promise((_, reject) => {
       timeoutId = getRealTimers().setTimeout!(() => {
@@ -320,7 +320,14 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
       if (timeoutId) getRealTimers().clearTimeout!(timeoutId);
       throw error;
     }
-  }) as T;
+  };
+
+  Object.defineProperty(wrapped, 'toString', {
+    configurable: true,
+    value: () => fn.toString(),
+  });
+
+  return wrapped as T;
 }
 
 export function limitConcurrency(

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -10,6 +10,7 @@ import type {
 import { ROOT_SUITE_NAME, TEST_DELIMITER } from '../../utils/constants';
 import { getTaskNameWithPrefix } from '../../utils/helper';
 import { getRealTimers } from '../util';
+import { setFixtureCallbackSource } from './fixtures';
 
 /**
  * Coerce a user-supplied retry/repeats count into a non-negative integer.
@@ -279,19 +280,26 @@ function makeError(message: string, stackTraceError?: Error): Error {
   return error;
 }
 
+type TimeoutOptions<T extends (...args: any[]) => any> = {
+  name: string;
+  fn: T;
+  timeout?: number;
+  getAssertionCalls?: () => number;
+  stackTraceError: Error;
+};
+
+const timeoutOptions = new WeakMap<
+  (...args: any[]) => any,
+  TimeoutOptions<(...args: any[]) => any>
+>();
+
 export function wrapTimeout<T extends (...args: any[]) => any>({
   name,
   fn,
   timeout,
   getAssertionCalls,
   stackTraceError,
-}: {
-  name: string;
-  fn: T;
-  timeout?: number;
-  getAssertionCalls?: () => number;
-  stackTraceError: Error;
-}): T {
+}: TimeoutOptions<T>): T {
   if (!timeout) {
     return fn;
   }
@@ -322,12 +330,46 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
     }
   };
 
-  Object.defineProperty(wrapped, 'toString', {
-    configurable: true,
-    value: () => fn.toString(),
+  timeoutOptions.set(wrapped, {
+    name,
+    fn,
+    timeout,
+    getAssertionCalls,
+    stackTraceError,
   });
+  setFixtureCallbackSource(wrapped, fn);
 
   return wrapped as T;
+}
+
+export async function runWithTimeout<T>(
+  fn: (...args: any[]) => any,
+  run: (callback: (...args: any[]) => any) => T | PromiseLike<T>,
+): Promise<T> {
+  const options = timeoutOptions.get(fn);
+  if (!options) {
+    return run(fn);
+  }
+
+  const wrapped = wrapTimeout({
+    ...options,
+    fn: () => run(options.fn),
+  });
+  return wrapped();
+}
+
+export function inheritTimeout<T extends (...args: any[]) => any>(
+  source: (...args: any[]) => any,
+  fn: T,
+): T {
+  const options = timeoutOptions.get(source);
+  if (!options) {
+    return fn;
+  }
+  return wrapTimeout({
+    ...options,
+    fn,
+  });
 }
 
 export function limitConcurrency(

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -248,8 +248,14 @@ export type RunnerAPI = {
   test: TestAPIs;
   beforeAll: (fn: BeforeAllListener, timeout?: number) => void;
   afterAll: (fn: AfterAllListener, timeout?: number) => void;
-  beforeEach: (fn: BeforeEachListener, timeout?: number) => void;
-  afterEach: (fn: AfterEachListener, timeout?: number) => void;
+  beforeEach: <ExtraContext = object>(
+    fn: BeforeEachListener<ExtraContext>,
+    timeout?: number,
+  ) => void;
+  afterEach: <ExtraContext = object>(
+    fn: AfterEachListener<ExtraContext>,
+    timeout?: number,
+  ) => void;
   onTestFinished: (fn: OnTestFinishedHandler, timeout?: number) => void;
   onTestFailed: (fn: OnTestFailedHandler, timeout?: number) => void;
 };

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -105,11 +105,13 @@ export type BeforeAllListener = (
   ctx: SuiteContext,
 ) => MaybePromise<void | AfterAllListener>;
 
-export type AfterEachListener = (ctx: TestContext) => MaybePromise<void>;
+export type AfterEachListener<ExtraContext = object> = (
+  ctx: TestContext & ExtraContext,
+) => MaybePromise<void>;
 
-export type BeforeEachListener = (
-  ctx: TestContext,
-) => MaybePromise<void | AfterEachListener>;
+export type BeforeEachListener<ExtraContext = object> = (
+  ctx: TestContext & ExtraContext,
+) => MaybePromise<void | AfterEachListener<ExtraContext>>;
 
 export type TestSuiteInfo = {
   testId: string;

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -122,7 +122,7 @@ describe('createFixtureResolver', () => {
 
     await expect(
       resolver.resolveHookFixtures((context: unknown) => context),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ status: 'resolved' });
   });
 
   it('collects fixtures from every named hook context destructuring', async () => {
@@ -222,6 +222,86 @@ describe('createFixtureResolver', () => {
     expect(context).toEqual({ beforeValue: 'before' });
   });
 
+  it('does not collect named context destructuring from object or class methods', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({
+      objectMethodValue: 'object method',
+      classMethodValue: 'class method',
+      beforeValue: 'before',
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () =>
+        '(ctx) => { const cleanup = { run() { const { objectMethodValue } = ctx; } }; class Cleanup { run() { const { classMethodValue } = ctx; } } const { beforeValue } = ctx; return [cleanup, Cleanup, beforeValue]; }',
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context).toEqual({ beforeValue: 'before' });
+  });
+
+  it('stops semicolon-free concise arrow ranges at the next statement', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({
+      cleanupValue: 'cleanup',
+      beforeValue: 'before',
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () => `(ctx) => {
+        const cleanup = () => ({ cleanupValue } = ctx)
+        const { beforeValue } = ctx
+        return [cleanup, beforeValue]
+      }`,
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context).toEqual({ beforeValue: 'before' });
+  });
+
+  it('finds named context destructuring after regular expression literals', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () =>
+        '(ctx) => { const closingBrace = /}/; const commentTokens = /https?:\\/\\//; const { fixture } = ctx; return [closingBrace, commentTokens, fixture]; }',
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context.fixture).toBe('fixture');
+  });
+
+  it('finds named context destructuring after division expressions', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () =>
+        '(ctx) => { const ratio = 4 / 2; const { fixture } = ctx; return [ratio, fixture]; }',
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context.fixture).toBe('fixture');
+  });
+
+  it('detects direct destructuring assignments from a named context', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () =>
+        '(ctx) => { let fixture; ({ fixture } = ctx); return fixture; }',
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context.fixture).toBe('fixture');
+  });
+
   it('parses balanced named context destructuring', async () => {
     const context: Record<string, any> = {};
     const fixtures = normalizeFixtures({
@@ -242,6 +322,37 @@ describe('createFixtureResolver', () => {
       settings: { mode: 'fixture' },
       page: 'page',
     });
+  });
+
+  it('parses parenthesized defaults in destructured callback params', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () => '({ fixture = createFixture() }) => { return fixture; }',
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context.fixture).toBe('fixture');
+  });
+
+  it('caches parsed fixture props across test attempts', async () => {
+    let parseCalls = 0;
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () => {
+        parseCalls++;
+        return '({ fixture }) => fixture';
+      },
+    });
+
+    await resolver.resolveHookFixtures(hook);
+    await resolver.resolveHookFixtures(hook);
+
+    expect(parseCalls).toBe(1);
   });
 
   it('activates auto and requested test fixtures', async () => {
@@ -337,9 +448,44 @@ describe('createFixtureResolver', () => {
     ).rejects.toThrow('fixture setup failed');
     await expect(
       resolver.resolveHookFixtures(({ failing }: any) => failing),
-    ).resolves.toBe(false);
+    ).resolves.toEqual({ status: 'skipped' });
 
     expect(setupAttempts).toBe(1);
+  });
+
+  it('tears down fixture setup that finishes after cancellation', async () => {
+    const events: string[] = [];
+    let continueSetup: (() => void) | undefined;
+    const setupPaused = new Promise<void>((resolve) => {
+      continueSetup = resolve;
+    });
+    const fixtures = normalizeFixtures({
+      slow: [
+        async (_context: any, use: any) => {
+          await setupPaused;
+          events.push('setup');
+          await use('slow');
+          events.push('teardown');
+        },
+      ],
+    } as any);
+    const context: Record<string, any> = {};
+    const cleanups: (() => Promise<void>)[] = [];
+    const resolver = createFixtureResolver(
+      { fixtures } as any,
+      context,
+      cleanups,
+    );
+
+    const resolution = resolver.resolveHookFixtures(({ slow }: any) => slow);
+    await Promise.resolve();
+    resolver.cancelPendingFixtures();
+    continueSetup!();
+
+    await expect(resolution).resolves.toEqual({ status: 'skipped' });
+    expect(events).toEqual(['setup', 'teardown']);
+    expect(context).toEqual({});
+    expect(cleanups).toEqual([]);
   });
 
   it('registers cleanups in reverse (unshift) order', async () => {

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -84,6 +84,20 @@ describe('normalizeFixtures param parsing (getFixtureUsedProps)', () => {
     expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
   });
 
+  it('detects compiler-moved destructuring for an unparenthesized arrow', () => {
+    const useFn = Object.assign(() => {}, {
+      toString: () =>
+        'param => { const { foo, bar: renamedBar } = param; return [foo, renamedBar]; }',
+    });
+    const result = normalizeFixtures({
+      used: [useFn],
+      foo: 1,
+      bar: 2,
+    } as any);
+
+    expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
+  });
+
   it('ignores destructuring text inside strings', () => {
     const useFn = (context: unknown) => `const { foo } = context`;
 
@@ -98,11 +112,20 @@ describe('createFixtureResolver', () => {
     const resolver = createFixtureResolver({} as any, {});
 
     await expect(
-      resolver.resolveFixtures((context: unknown) => context),
+      resolver.resolveTestFixtures((context: unknown) => context),
     ).resolves.toBeUndefined();
   });
 
-  it('activates auto fixtures and resolves callback fixtures on demand', async () => {
+  it('allows named hook contexts when the test has fixtures', async () => {
+    const fixtures = normalizeFixtures({ fixture: 1 } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, {});
+
+    await expect(
+      resolver.resolveHookFixtures((context: unknown) => context),
+    ).resolves.toBeUndefined();
+  });
+
+  it('activates auto and requested test fixtures', async () => {
     const order: string[] = [];
     const fixtures = normalizeFixtures({
       autoFix: [
@@ -133,8 +156,7 @@ describe('createFixtureResolver', () => {
     const cleanups: (() => Promise<void>)[] = [];
     const resolver = createFixtureResolver(test, context, cleanups);
 
-    await resolver.resolveAutoFixtures();
-    await resolver.resolveFixtures(({ usedFix }: any) => usedFix);
+    await resolver.resolveTestFixtures(({ usedFix }: any) => usedFix);
 
     expect(context.autoFix).toBe('A');
     expect(context.usedFix).toBe('U');
@@ -156,8 +178,8 @@ describe('createFixtureResolver', () => {
     const context: Record<string, any> = {};
     const resolver = createFixtureResolver({ fixtures } as any, context);
 
-    await resolver.resolveFixtures(({ shared }: any) => shared);
-    await resolver.resolveFixtures(({ shared }: any) => shared);
+    await resolver.resolveTestFixtures(({ shared }: any) => shared);
+    await resolver.resolveHookFixtures(({ shared }: any) => shared);
 
     expect(context.shared).toBe('value');
     expect(setups).toEqual(['shared']);
@@ -174,9 +196,9 @@ describe('createFixtureResolver', () => {
     } as any;
     const resolver = createFixtureResolver(test, {});
 
-    await expect(resolver.resolveFixtures(({ x }: any) => x)).rejects.toThrow(
-      /Circular fixture dependency/,
-    );
+    await expect(
+      resolver.resolveTestFixtures(({ x }: any) => x),
+    ).rejects.toThrow(/Circular fixture dependency/);
   });
 
   it('registers cleanups in reverse (unshift) order', async () => {
@@ -204,7 +226,7 @@ describe('createFixtureResolver', () => {
     const cleanups: (() => Promise<void>)[] = [];
     const resolver = createFixtureResolver(test, {}, cleanups);
 
-    await resolver.resolveAutoFixtures();
+    await resolver.resolveTestFixtures();
     for (const cleanup of cleanups) {
       await cleanup();
     }

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -98,6 +98,18 @@ describe('normalizeFixtures param parsing (getFixtureUsedProps)', () => {
     expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
   });
 
+  it('detects compiler-moved destructuring from an _-prefixed context', () => {
+    const useFn = Object.assign(() => {}, {
+      toString: () => '(_ref) => { const { foo } = _ref; return foo; }',
+    });
+    const result = normalizeFixtures({
+      used: [useFn],
+      foo: 1,
+    } as any);
+
+    expect(result.used.deps).toEqual(['foo']);
+  });
+
   it('ignores destructuring text inside strings', () => {
     const useFn = (context: unknown) => `const { foo } = context`;
 
@@ -137,6 +149,19 @@ describe('createFixtureResolver', () => {
     });
 
     expect(context).toEqual({ task: 'task', fixture: 'fixture' });
+  });
+
+  it('collects fixtures from an _-prefixed compiled hook context', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () => '(_ref) => { const { fixture } = _ref; }',
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context.fixture).toBe('fixture');
   });
 
   it('does not collect named context destructuring from member access', async () => {

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 import {
-  handleFixtures,
+  createFixtureResolver,
   normalizeFixtures,
 } from '../../../src/runtime/runner/fixtures';
 
@@ -69,10 +69,40 @@ describe('normalizeFixtures param parsing (getFixtureUsedProps)', () => {
     } as any);
     expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
   });
+
+  it('detects destructuring moved into the body by a compiler', () => {
+    const useFn = (param: { foo: number; bar: number }) => {
+      const { foo, bar: renamedBar } = param;
+      return [foo, renamedBar];
+    };
+    const result = normalizeFixtures({
+      used: [useFn],
+      foo: 1,
+      bar: 2,
+    } as any);
+
+    expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
+  });
+
+  it('ignores destructuring text inside strings', () => {
+    const useFn = (context: unknown) => `const { foo } = context`;
+
+    expect(() => normalizeFixtures({ used: [useFn], foo: 1 } as any)).toThrow(
+      /object destructuring pattern/,
+    );
+  });
 });
 
-describe('handleFixtures', () => {
-  it('activates auto fixtures and on-demand fixtures used by the test fn', async () => {
+describe('createFixtureResolver', () => {
+  it('does not parse callbacks when the test has no fixtures', async () => {
+    const resolver = createFixtureResolver({} as any, {});
+
+    await expect(
+      resolver.resolveFixtures((context: unknown) => context),
+    ).resolves.toBeUndefined();
+  });
+
+  it('activates auto fixtures and resolves callback fixtures on demand', async () => {
     const order: string[] = [];
     const fixtures = normalizeFixtures({
       autoFix: [
@@ -99,16 +129,38 @@ describe('handleFixtures', () => {
     const context: Record<string, any> = {};
     const test = {
       fixtures,
-      originalFn: ({ usedFix }: any) => usedFix,
     } as any;
+    const cleanups: (() => Promise<void>)[] = [];
+    const resolver = createFixtureResolver(test, context, cleanups);
 
-    const { cleanups } = await handleFixtures(test, context);
+    await resolver.resolveAutoFixtures();
+    await resolver.resolveFixtures(({ usedFix }: any) => usedFix);
 
     expect(context.autoFix).toBe('A');
     expect(context.usedFix).toBe('U');
     expect('unusedFix' in context).toBe(false);
     expect(order).toEqual(['auto', 'used']);
     expect(cleanups).toHaveLength(2);
+  });
+
+  it('shares fixture instances across hook and test callbacks', async () => {
+    const setups: string[] = [];
+    const fixtures = normalizeFixtures({
+      shared: [
+        async (_ctx: any, use: any) => {
+          setups.push('shared');
+          await use('value');
+        },
+      ],
+    } as any);
+    const context: Record<string, any> = {};
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+
+    await resolver.resolveFixtures(({ shared }: any) => shared);
+    await resolver.resolveFixtures(({ shared }: any) => shared);
+
+    expect(context.shared).toBe('value');
+    expect(setups).toEqual(['shared']);
   });
 
   it('throws on circular fixture dependencies', async () => {
@@ -119,10 +171,10 @@ describe('handleFixtures', () => {
 
     const test = {
       fixtures,
-      originalFn: ({ x }: any) => x,
     } as any;
+    const resolver = createFixtureResolver(test, {});
 
-    await expect(handleFixtures(test, {})).rejects.toThrow(
+    await expect(resolver.resolveFixtures(({ x }: any) => x)).rejects.toThrow(
       /Circular fixture dependency/,
     );
   });
@@ -148,10 +200,11 @@ describe('handleFixtures', () => {
 
     const test = {
       fixtures,
-      originalFn: () => {},
     } as any;
+    const cleanups: (() => Promise<void>)[] = [];
+    const resolver = createFixtureResolver(test, {}, cleanups);
 
-    const { cleanups } = await handleFixtures(test, {});
+    await resolver.resolveAutoFixtures();
     for (const cleanup of cleanups) {
       await cleanup();
     }

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -125,7 +125,7 @@ describe('createFixtureResolver', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('collects fixtures from every named hook context destructure', async () => {
+  it('collects fixtures from every named hook context destructuring', async () => {
     const context = { task: 'task' };
     const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
     const resolver = createFixtureResolver({ fixtures } as any, context);
@@ -137,6 +137,60 @@ describe('createFixtureResolver', () => {
     });
 
     expect(context).toEqual({ task: 'task', fixture: 'fixture' });
+  });
+
+  it('finds named context destructuring after strings with comment tokens', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () =>
+        "(ctx) => { const url = 'http://localhost'; const { fixture } = ctx; }",
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context.fixture).toBe('fixture');
+  });
+
+  it('does not collect named context destructuring from nested functions', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({
+      beforeValue: 'before',
+      arrowCleanupValue: 'arrow cleanup',
+      functionCleanupValue: 'function cleanup',
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () =>
+        '(ctx) => { if (true) { const { beforeValue } = ctx; } const cleanup = (ctx) => { const { arrowCleanupValue } = ctx; }; return function (ctx) { const { functionCleanupValue } = ctx; }; }',
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context).toEqual({ beforeValue: 'before' });
+  });
+
+  it('parses balanced named context destructuring', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({
+      options: { baseURL: 'http://localhost' },
+      settings: { mode: 'fixture' },
+      page: 'page',
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () =>
+        "(ctx) => { const { options: { baseURL }, settings = { mode: 'default' }, page } = ctx; }",
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context).toEqual({
+      options: { baseURL: 'http://localhost' },
+      settings: { mode: 'fixture' },
+      page: 'page',
+    });
   });
 
   it('activates auto and requested test fixtures', async () => {
@@ -213,6 +267,28 @@ describe('createFixtureResolver', () => {
     await expect(
       resolver.resolveTestFixtures(({ x }: any) => x),
     ).rejects.toThrow(/Circular fixture dependency/);
+  });
+
+  it('does not retry fixtures after setup failures', async () => {
+    let setupAttempts = 0;
+    const fixtures = normalizeFixtures({
+      failing: [
+        async () => {
+          setupAttempts++;
+          throw new Error('fixture setup failed');
+        },
+      ],
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, {});
+
+    await expect(
+      resolver.resolveTestFixtures(({ failing }: any) => failing),
+    ).rejects.toThrow('fixture setup failed');
+    await expect(
+      resolver.resolveHookFixtures(({ failing }: any) => failing),
+    ).resolves.toBe(false);
+
+    expect(setupAttempts).toBe(1);
   });
 
   it('registers cleanups in reverse (unshift) order', async () => {

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -139,6 +139,41 @@ describe('createFixtureResolver', () => {
     expect(context).toEqual({ task: 'task', fixture: 'fixture' });
   });
 
+  it('does not collect named context destructuring from member access', async () => {
+    let setupAttempts = 0;
+    const context = { task: { name: 'task name' } };
+    const fixtures = normalizeFixtures({
+      name: [
+        async (_context: any, use: any) => {
+          setupAttempts++;
+          await use('fixture name');
+        },
+      ],
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+
+    await resolver.resolveHookFixtures((ctx: any) => {
+      const { name } = ctx.task;
+      return name;
+    });
+
+    expect(setupAttempts).toBe(0);
+    expect(context).toEqual({ task: { name: 'task name' } });
+  });
+
+  it('ignores rest properties when scanning named hook contexts', async () => {
+    const context = { task: 'task' };
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+
+    await resolver.resolveHookFixtures((ctx: any) => {
+      const { fixture, ...rest } = ctx;
+      return [fixture, rest.task];
+    });
+
+    expect(context).toEqual({ task: 'task', fixture: 'fixture' });
+  });
+
   it('finds named context destructuring after strings with comment tokens', async () => {
     const context: Record<string, any> = {};
     const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -60,62 +60,35 @@ describe('normalizeFixtures param parsing (getFixtureUsedProps)', () => {
     );
   });
 
-  it('strips comments before parsing the destructured params', () => {
-    const useFn = ({ foo /* inline */, bar }: any) => [foo, bar];
-    const result = normalizeFixtures({
-      used: [useFn],
-      foo: 1,
-      bar: 2,
-    } as any);
-    expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
-  });
-
-  it('detects destructuring moved into the body by a compiler', () => {
-    const useFn = (param: { foo: number; bar: number }) => {
-      const { foo, bar: renamedBar } = param;
-      return [foo, renamedBar];
-    };
-    const result = normalizeFixtures({
-      used: [useFn],
-      foo: 1,
-      bar: 2,
-    } as any);
-
-    expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
-  });
-
-  it('detects compiler-moved destructuring for an unparenthesized arrow', () => {
-    const useFn = Object.assign(() => {}, {
-      toString: () =>
-        'param => { const { foo, bar: renamedBar } = param; return [foo, renamedBar]; }',
+  it('throws when a destructured fixture has a default value', () => {
+    const fixtureFn = Object.assign(() => {}, {
+      toString: () => '({ value = "default" }, use) => use(value)',
     });
+    expect(() =>
+      normalizeFixtures({ a: [fixtureFn], value: 1 } as any),
+    ).toThrow(/Default values are not supported/);
+  });
+
+  it('throws when the fixture context has a default value', () => {
+    const fixtureFn = Object.assign(() => {}, {
+      toString: () => '({ value } = {}, use) => use(value)',
+    });
+    expect(() =>
+      normalizeFixtures({ a: [fixtureFn], value: 1 } as any),
+    ).toThrow(/Default values are not supported/);
+  });
+
+  it('parses comments and aliases in destructured params', () => {
+    const useFn = ({ foo /* inline */, bar: renamedBar }: any) => [
+      foo,
+      renamedBar,
+    ];
     const result = normalizeFixtures({
       used: [useFn],
       foo: 1,
       bar: 2,
     } as any);
-
     expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
-  });
-
-  it('detects compiler-moved destructuring from an _-prefixed context', () => {
-    const useFn = Object.assign(() => {}, {
-      toString: () => '(_ref) => { const { foo } = _ref; return foo; }',
-    });
-    const result = normalizeFixtures({
-      used: [useFn],
-      foo: 1,
-    } as any);
-
-    expect(result.used.deps).toEqual(['foo']);
-  });
-
-  it('ignores destructuring text inside strings', () => {
-    const useFn = (context: unknown) => `const { foo } = context`;
-
-    expect(() => normalizeFixtures({ used: [useFn], foo: 1 } as any)).toThrow(
-      /object destructuring pattern/,
-    );
   });
 });
 
@@ -128,76 +101,39 @@ describe('createFixtureResolver', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('allows named hook contexts when the test has fixtures', async () => {
-    const fixtures = normalizeFixtures({ fixture: 1 } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, {});
-
-    await expect(
-      resolver.resolveHookFixtures((context: unknown) => context),
-    ).resolves.toEqual({ status: 'resolved' });
-  });
-
-  it('collects fixtures from every named hook context destructuring', async () => {
-    const context = { task: 'task' };
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-
-    await resolver.resolveHookFixtures((ctx: any) => {
-      const { task } = ctx;
-      const { fixture } = ctx;
-      return [task, fixture];
-    });
-
-    expect(context).toEqual({ task: 'task', fixture: 'fixture' });
-  });
-
-  it('collects fixtures from an _-prefixed compiled hook context', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () => '(_ref) => { const { fixture } = _ref; }',
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context.fixture).toBe('fixture');
-  });
-
-  it('does not collect named context destructuring from member access', async () => {
+  it('allows named hook contexts without inferring fixture dependencies', async () => {
     let setupAttempts = 0;
-    const context = { task: { name: 'task name' } };
+    const context = { task: { name: 'test' } };
     const fixtures = normalizeFixtures({
-      name: [
+      page: [
         async (_context: any, use: any) => {
           setupAttempts++;
-          await use('fixture name');
+          await use('page');
         },
       ],
     } as any);
     const resolver = createFixtureResolver({ fixtures } as any, context);
 
-    await resolver.resolveHookFixtures((ctx: any) => {
-      const { name } = ctx.task;
-      return name;
+    await resolver.resolveHookFixtures((hookContext: any) => {
+      const { page } = hookContext;
+      for (const hookContext of [{ page: 'local' }]) {
+        expect(hookContext.page).toBe('local');
+      }
+      return [hookContext.task.name, page];
     });
 
     expect(setupAttempts).toBe(0);
-    expect(context).toEqual({ task: { name: 'task name' } });
+    expect(context).toEqual({ task: { name: 'test' } });
   });
 
-  it('rejects rest properties when scanning named hook contexts', async () => {
-    const context = { task: 'task' };
+  it('resolves fixtures directly destructured by hooks', async () => {
+    const context: Record<string, any> = {};
     const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
     const resolver = createFixtureResolver({ fixtures } as any, context);
 
-    await expect(
-      resolver.resolveHookFixtures((ctx: any) => {
-        const { fixture, ...rest } = ctx;
-        return [fixture, rest.task];
-      }),
-    ).rejects.toThrow(/Rest property/);
-    expect(context).toEqual({ task: 'task' });
+    await resolver.resolveHookFixtures(({ fixture }: any) => fixture);
+
+    expect(context.fixture).toBe('fixture');
   });
 
   it('rejects rest properties in destructured hook parameters', async () => {
@@ -212,167 +148,26 @@ describe('createFixtureResolver', () => {
     ).rejects.toThrow(/Rest property/);
   });
 
-  it('finds named context destructuring after strings with comment tokens', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () =>
-        "(ctx) => { const url = 'http://localhost'; const { fixture } = ctx; }",
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context.fixture).toBe('fixture');
-  });
-
-  it('finds named context destructuring after comments with quotes', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () => `(ctx) => {
-        // don't hide fixtures
-        const { fixture } = ctx;
-      }`,
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context.fixture).toBe('fixture');
-  });
-
-  it('does not collect named context destructuring from nested functions', async () => {
-    const context: Record<string, any> = {};
+  it('rejects defaults instead of partially resolving fixture names', async () => {
     const fixtures = normalizeFixtures({
-      beforeValue: 'before',
-      arrowCleanupValue: 'arrow cleanup',
-      functionCleanupValue: 'function cleanup',
-    } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () =>
-        '(ctx) => { if (true) { const { beforeValue } = ctx; } const cleanup = (ctx) => { const { arrowCleanupValue } = ctx; }; return function (ctx) { const { functionCleanupValue } = ctx; }; }',
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context).toEqual({ beforeValue: 'before' });
-  });
-
-  it('does not collect named context destructuring from object or class methods', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({
-      objectMethodValue: 'object method',
-      classMethodValue: 'class method',
-      beforeValue: 'before',
-    } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () =>
-        '(ctx) => { const cleanup = { run() { const { objectMethodValue } = ctx; } }; class Cleanup { run() { const { classMethodValue } = ctx; } } const { beforeValue } = ctx; return [cleanup, Cleanup, beforeValue]; }',
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context).toEqual({ beforeValue: 'before' });
-  });
-
-  it('stops semicolon-free concise arrow ranges at the next statement', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({
-      cleanupValue: 'cleanup',
-      beforeValue: 'before',
-    } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () => `(ctx) => {
-        const cleanup = () => ({ cleanupValue } = ctx)
-        const { beforeValue } = ctx
-        return [cleanup, beforeValue]
-      }`,
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context).toEqual({ beforeValue: 'before' });
-  });
-
-  it('finds named context destructuring after regular expression literals', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () =>
-        '(ctx) => { const closingBrace = /}/; const commentTokens = /https?:\\/\\//; const { fixture } = ctx; return [closingBrace, commentTokens, fixture]; }',
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context.fixture).toBe('fixture');
-  });
-
-  it('finds named context destructuring after division expressions', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () =>
-        '(ctx) => { const ratio = 4 / 2; const { fixture } = ctx; return [ratio, fixture]; }',
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context.fixture).toBe('fixture');
-  });
-
-  it('detects direct destructuring assignments from a named context', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () =>
-        '(ctx) => { let fixture; ({ fixture } = ctx); return fixture; }',
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context.fixture).toBe('fixture');
-  });
-
-  it('parses balanced named context destructuring', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({
-      options: { baseURL: 'http://localhost' },
-      settings: { mode: 'fixture' },
+      title: 'title',
       page: 'page',
     } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () =>
-        "(ctx) => { const { options: { baseURL }, settings = { mode: 'default' }, page } = ctx; }",
+    const resolver = createFixtureResolver({ fixtures } as any, {});
+
+    const propertyDefault = Object.assign(() => {}, {
+      toString: () => '({ title = "🔒", page }) => page',
     });
+    await expect(resolver.resolveHookFixtures(propertyDefault)).rejects.toThrow(
+      /Default values are not supported/,
+    );
 
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context).toEqual({
-      options: { baseURL: 'http://localhost' },
-      settings: { mode: 'fixture' },
-      page: 'page',
+    const contextDefault = Object.assign(() => {}, {
+      toString: () => '({ page } = {}) => page',
     });
-  });
-
-  it('parses parenthesized defaults in destructured callback params', async () => {
-    const context: Record<string, any> = {};
-    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
-    const resolver = createFixtureResolver({ fixtures } as any, context);
-    const hook = Object.assign(() => {}, {
-      toString: () => '({ fixture = createFixture() }) => { return fixture; }',
-    });
-
-    await resolver.resolveHookFixtures(hook);
-
-    expect(context.fixture).toBe('fixture');
+    await expect(resolver.resolveHookFixtures(contextDefault)).rejects.toThrow(
+      /Default values are not supported/,
+    );
   });
 
   it('caches parsed fixture props across test attempts', async () => {

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -186,17 +186,30 @@ describe('createFixtureResolver', () => {
     expect(context).toEqual({ task: { name: 'task name' } });
   });
 
-  it('ignores rest properties when scanning named hook contexts', async () => {
+  it('rejects rest properties when scanning named hook contexts', async () => {
     const context = { task: 'task' };
     const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
     const resolver = createFixtureResolver({ fixtures } as any, context);
 
-    await resolver.resolveHookFixtures((ctx: any) => {
-      const { fixture, ...rest } = ctx;
-      return [fixture, rest.task];
-    });
+    await expect(
+      resolver.resolveHookFixtures((ctx: any) => {
+        const { fixture, ...rest } = ctx;
+        return [fixture, rest.task];
+      }),
+    ).rejects.toThrow(/Rest property/);
+    expect(context).toEqual({ task: 'task' });
+  });
 
-    expect(context).toEqual({ task: 'task', fixture: 'fixture' });
+  it('rejects rest properties in destructured hook parameters', async () => {
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, {});
+
+    await expect(
+      resolver.resolveHookFixtures(({ fixture, ...rest }: any) => [
+        fixture,
+        rest,
+      ]),
+    ).rejects.toThrow(/Rest property/);
   });
 
   it('finds named context destructuring after strings with comment tokens', async () => {
@@ -481,8 +494,16 @@ describe('createFixtureResolver', () => {
   it('tears down fixture setup that finishes after cancellation', async () => {
     const events: string[] = [];
     let continueSetup: (() => void) | undefined;
+    let continueTeardown: (() => void) | undefined;
     const setupPaused = new Promise<void>((resolve) => {
       continueSetup = resolve;
+    });
+    const teardownPaused = new Promise<void>((resolve) => {
+      continueTeardown = resolve;
+    });
+    let teardownStarted: (() => void) | undefined;
+    const teardownStartedPromise = new Promise<void>((resolve) => {
+      teardownStarted = resolve;
     });
     const fixtures = normalizeFixtures({
       slow: [
@@ -490,6 +511,9 @@ describe('createFixtureResolver', () => {
           await setupPaused;
           events.push('setup');
           await use('slow');
+          events.push('teardown:start');
+          teardownStarted!();
+          await teardownPaused;
           events.push('teardown');
         },
       ],
@@ -504,13 +528,54 @@ describe('createFixtureResolver', () => {
 
     const resolution = resolver.resolveHookFixtures(({ slow }: any) => slow);
     await Promise.resolve();
+    const cancellation = resolver.cancelPendingFixtures();
+    continueSetup!();
+
+    await expect(cancellation?.teardownStarted).resolves.toBeUndefined();
+    await teardownStartedPromise;
+    const resolutionSettled = await Promise.race([
+      resolution.then(() => true),
+      new Promise<false>((resolve) => {
+        setImmediate(() => resolve(false));
+      }),
+    ]);
+
+    expect(resolutionSettled).toBe(false);
+    continueTeardown!();
+    await expect(resolution).resolves.toEqual({ status: 'skipped' });
+    expect(events).toEqual(['setup', 'teardown:start', 'teardown']);
+    expect(context).toEqual({});
+    expect(cleanups).toEqual([]);
+  });
+
+  it('settles a cancelled fixture that returns without calling use', async () => {
+    let continueSetup: (() => void) | undefined;
+    const setupPaused = new Promise<void>((resolve) => {
+      continueSetup = resolve;
+    });
+    const fixtures = normalizeFixtures({
+      slow: [
+        async () => {
+          await setupPaused;
+        },
+      ],
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, {});
+
+    const resolution = resolver.resolveHookFixtures(({ slow }: any) => slow);
+    await Promise.resolve();
     resolver.cancelPendingFixtures();
     continueSetup!();
 
+    const resolutionSettled = await Promise.race([
+      resolution.then(() => true),
+      new Promise<false>((resolve) => {
+        setImmediate(() => resolve(false));
+      }),
+    ]);
+
+    expect(resolutionSettled).toBe(true);
     await expect(resolution).resolves.toEqual({ status: 'skipped' });
-    expect(events).toEqual(['setup', 'teardown']);
-    expect(context).toEqual({});
-    expect(cleanups).toEqual([]);
   });
 
   it('registers cleanups in reverse (unshift) order', async () => {

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -125,6 +125,20 @@ describe('createFixtureResolver', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('collects fixtures from every named hook context destructure', async () => {
+    const context = { task: 'task' };
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+
+    await resolver.resolveHookFixtures((ctx: any) => {
+      const { task } = ctx;
+      const { fixture } = ctx;
+      return [task, fixture];
+    });
+
+    expect(context).toEqual({ task: 'task', fixture: 'fixture' });
+  });
+
   it('activates auto and requested test fixtures', async () => {
     const order: string[] = [];
     const fixtures = normalizeFixtures({

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -153,6 +153,22 @@ describe('createFixtureResolver', () => {
     expect(context.fixture).toBe('fixture');
   });
 
+  it('finds named context destructuring after comments with quotes', async () => {
+    const context: Record<string, any> = {};
+    const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, context);
+    const hook = Object.assign(() => {}, {
+      toString: () => `(ctx) => {
+        // don't hide fixtures
+        const { fixture } = ctx;
+      }`,
+    });
+
+    await resolver.resolveHookFixtures(hook);
+
+    expect(context.fixture).toBe('fixture');
+  });
+
   it('does not collect named context destructuring from nested functions', async () => {
     const context: Record<string, any> = {};
     const fixtures = normalizeFixtures({

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -93,6 +93,8 @@ describe('dashboard', () => {
 
 Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
 
+Declare fixture dependencies through direct object destructuring in the hook parameter. Destructuring a named context inside the hook body does not request fixtures. Rest properties and default values are not supported in fixture-aware callbacks.
+
 ### `browser`
 
 Use `browser` when you need to create a custom browser context yourself:

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -59,6 +59,28 @@ test('page title', async ({ page }) => {
 
 The sections below show how each fixture is commonly used. `page` and `serve` link to the existing examples to avoid repeating the same code.
 
+### Using fixtures in hooks
+
+Hooks attached to an extended test infer and lazily initialize its fixtures. A fixture used only by a hook does not need `auto: true`:
+
+```ts
+import { expect, test } from '@rstest/playwright';
+
+const dashboardTest = test.extend({
+  route: '/dashboard',
+});
+
+dashboardTest.beforeEach(async ({ page, route }) => {
+  await page.goto(`http://localhost:3000${route}`);
+});
+
+dashboardTest('shows the dashboard', async ({ page }) => {
+  await expect(page.locator('h1')).toHaveText('Dashboard');
+});
+```
+
+The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
+
 ### `browser`
 
 Use `browser` when you need to create a custom browser context yourself:

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -61,25 +61,37 @@ The sections below show how each fixture is commonly used. `page` and `serve` li
 
 ### Using fixtures in hooks
 
-Hooks attached to an extended test infer and lazily initialize its fixtures. A fixture used only by a hook does not need `auto: true`:
+Suite-level hooks can request fixtures provided by the tests in that suite. Specify the hook's fixture context type explicitly; a fixture used only by a hook does not need `auto: true`:
 
 ```ts
-import { expect, test } from '@rstest/playwright';
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  type PlaywrightFixture,
+} from '@rstest/playwright';
 
-const dashboardTest = test.extend({
+type DashboardFixtures = PlaywrightFixture & {
+  route: string;
+};
+
+const dashboardTest = test.extend<{ route: string }>({
   route: '/dashboard',
 });
 
-dashboardTest.beforeEach(async ({ page, route }) => {
-  await page.goto(`http://localhost:3000${route}`);
-});
+describe('dashboard', () => {
+  beforeEach<DashboardFixtures>(async ({ page, route }) => {
+    await page.goto(`http://localhost:3000${route}`);
+  });
 
-dashboardTest('shows the dashboard', async ({ page }) => {
-  await expect(page.locator('h1')).toHaveText('Dashboard');
+  dashboardTest('shows the dashboard', async ({ page }) => {
+    await expect(page.locator('h1')).toHaveText('Dashboard');
+  });
 });
 ```
 
-The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
+Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
 
 ### `browser`
 

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -1467,15 +1467,34 @@ type MergeContext<ExtraContext, FixturesContext> = {
       : never;
 };
 
+type PlaywrightAfterEach<ExtraContext> = (
+  context: TestContext & ExtraContext,
+) => void | Promise<void>;
+
+type PlaywrightBeforeEach<ExtraContext> = (
+  context: TestContext & ExtraContext,
+) =>
+  | void
+  | PlaywrightAfterEach<ExtraContext>
+  | Promise<void | PlaywrightAfterEach<ExtraContext>>;
+
 export type PlaywrightTest<ExtraContext = PlaywrightFixture> =
   PlaywrightTestBase<ExtraContext> & {
     extend: <T extends Record<string, any> = object>(
       fixtures: PlaywrightFixtures<T, ExtraContext>,
     ) => PlaywrightTest<MergeContext<ExtraContext, T>>;
     afterAll: typeof rstestAfterAll;
-    afterEach: typeof rstestAfterEach;
+    /** Register an afterEach hook with access to this test's fixtures. */
+    afterEach: (
+      fn: PlaywrightAfterEach<ExtraContext>,
+      timeout?: number,
+    ) => void;
     beforeAll: typeof rstestBeforeAll;
-    beforeEach: typeof rstestBeforeEach;
+    /** Register a beforeEach hook with access to this test's fixtures. */
+    beforeEach: (
+      fn: PlaywrightBeforeEach<ExtraContext>,
+      timeout?: number,
+    ) => void;
     describe: typeof rstestDescribe;
     fail: PlaywrightTestBase<ExtraContext>;
   };

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -1467,34 +1467,15 @@ type MergeContext<ExtraContext, FixturesContext> = {
       : never;
 };
 
-type PlaywrightAfterEach<ExtraContext> = (
-  context: TestContext & ExtraContext,
-) => void | Promise<void>;
-
-type PlaywrightBeforeEach<ExtraContext> = (
-  context: TestContext & ExtraContext,
-) =>
-  | void
-  | PlaywrightAfterEach<ExtraContext>
-  | Promise<void | PlaywrightAfterEach<ExtraContext>>;
-
 export type PlaywrightTest<ExtraContext = PlaywrightFixture> =
   PlaywrightTestBase<ExtraContext> & {
     extend: <T extends Record<string, any> = object>(
       fixtures: PlaywrightFixtures<T, ExtraContext>,
     ) => PlaywrightTest<MergeContext<ExtraContext, T>>;
     afterAll: typeof rstestAfterAll;
-    /** Register an afterEach hook with access to this test's fixtures. */
-    afterEach: (
-      fn: PlaywrightAfterEach<ExtraContext>,
-      timeout?: number,
-    ) => void;
+    afterEach: typeof rstestAfterEach;
     beforeAll: typeof rstestBeforeAll;
-    /** Register a beforeEach hook with access to this test's fixtures. */
-    beforeEach: (
-      fn: PlaywrightBeforeEach<ExtraContext>,
-      timeout?: number,
-    ) => void;
+    beforeEach: typeof rstestBeforeEach;
     describe: typeof rstestDescribe;
     fail: PlaywrightTestBase<ExtraContext>;
   };

--- a/packages/playwright/tests/fixture.test.ts
+++ b/packages/playwright/tests/fixture.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { expect as coreExpect } from '@rstest/core';
-import { beforeEach, expect, test } from '../src';
+import { afterEach, beforeEach, expect, test } from '../src';
 import { getDebugOptions, resolveLaunchOptions } from '../src/fixture';
 import type { Browser, BrowserContext, Page } from 'playwright';
 import type {
@@ -302,7 +302,7 @@ test.extend({}).describe('extended test API', () => {
   hookExpectTest.describe('wrapped hooks', () => {
     const hookEvents: string[] = [];
 
-    hookExpectTest.beforeEach(async ({ hookTitle }) => {
+    beforeEach<{ hookTitle: string }>(async ({ hookTitle }) => {
       expect.assertions(2);
       expect(hookTitle).toBe('hook title');
       await expect(createPage(hookTitle)).toHaveTitle('hook title');
@@ -313,7 +313,7 @@ test.extend({}).describe('extended test API', () => {
       };
     });
 
-    hookExpectTest.afterEach(({ hookTitle }) => {
+    afterEach<{ hookTitle: string }>(({ hookTitle }) => {
       hookEvents.push(`afterEach:${hookTitle}`);
     });
 
@@ -329,6 +329,17 @@ test.extend({}).describe('extended test API', () => {
   });
 
   test.extend({}).beforeEach(() => {});
+
+  const assertExtendedHookTypes = () => {
+    const typedHookTest = test.extend<{ hookTitle: string }>({
+      hookTitle: 'hook title',
+    });
+    // @ts-expect-error Extended test hooks are suite-level and cannot safely infer one test API's fixtures.
+    typedHookTest.beforeEach(({ hookTitle }) => {
+      void hookTitle;
+    });
+  };
+  void assertExtendedHookTypes;
 
   test.extend({}).for<{ value: string }>`
     value

--- a/packages/playwright/tests/fixture.test.ts
+++ b/packages/playwright/tests/fixture.test.ts
@@ -300,13 +300,32 @@ test.extend({}).describe('extended test API', () => {
   });
 
   hookExpectTest.describe('wrapped hooks', () => {
-    hookExpectTest.beforeEach(async () => {
+    const hookEvents: string[] = [];
+
+    hookExpectTest.beforeEach(async ({ hookTitle }) => {
       expect.assertions(2);
-      expect('hook title').toBe('hook title');
-      await expect(createPage('hook title')).toHaveTitle('hook title');
+      expect(hookTitle).toBe('hook title');
+      await expect(createPage(hookTitle)).toHaveTitle('hook title');
+      hookEvents.push(`beforeEach:${hookTitle}`);
+
+      return ({ hookTitle }) => {
+        hookEvents.push(`cleanup:${hookTitle}`);
+      };
+    });
+
+    hookExpectTest.afterEach(({ hookTitle }) => {
+      hookEvents.push(`afterEach:${hookTitle}`);
     });
 
     hookExpectTest('counts Playwright assertions in extended hooks', () => {});
+
+    hookExpectTest.afterAll(() => {
+      expect(hookEvents).toEqual([
+        'beforeEach:hook title',
+        'afterEach:hook title',
+        'cleanup:hook title',
+      ]);
+    });
   });
 
   test.extend({}).beforeEach(() => {});

--- a/website/docs/en/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/en/api/runtime-api/test-api/hooks.mdx
@@ -94,7 +94,7 @@ beforeEach(async () => {
 
 The `beforeEach` and `afterEach` callbacks, as well as a cleanup returned by `beforeEach`, can use fixtures created with `test.extend`. Pass the fixture type as `ExtraContext`; Rstest initializes each fixture before the callback that first requests it. See [Using fixtures in hooks](/api/runtime-api/test-api/test#using-fixtures-in-hooks).
 
-List fixture dependencies explicitly in fixture-aware hook callbacks. Object rest properties such as `({ db, ...rest })` are not supported.
+List fixture dependencies through direct object destructuring in the hook parameter. Rstest does not infer dependencies from the hook body. Object rest properties and default values are not supported in fixture-aware callbacks.
 
 ## afterEach
 

--- a/website/docs/en/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/en/api/runtime-api/test-api/hooks.mdx
@@ -94,6 +94,8 @@ beforeEach(async () => {
 
 The `beforeEach` and `afterEach` callbacks, as well as a cleanup returned by `beforeEach`, can use fixtures created with `test.extend`. Pass the fixture type as `ExtraContext`; Rstest initializes each fixture before the callback that first requests it. See [Using fixtures in hooks](/api/runtime-api/test-api/test#using-fixtures-in-hooks).
 
+List fixture dependencies explicitly in fixture-aware hook callbacks. Object rest properties such as `({ db, ...rest })` are not supported.
+
 ## afterEach
 
 - **Type:** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => void | Promise<void>, timeout?: number) => void`

--- a/website/docs/en/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/en/api/runtime-api/test-api/hooks.mdx
@@ -61,7 +61,7 @@ afterAll(async (ctx) => {
 
 ## beforeEach
 
-- **Type:** `(fn: (ctx: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **Type:** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => MaybePromise<void | ((ctx: TestContext & ExtraContext) => MaybePromise<void>)>, timeout?: number) => void`
 
 See [`TestContext`](/api/runtime-api/test-api/test#testcontext) for the `ctx` fields (the same applies to the per-test hooks below).
 
@@ -90,9 +90,13 @@ beforeEach(async () => {
 });
 ```
 
+<ApiMeta addedVersion="0.11.4" />
+
+The `beforeEach` and `afterEach` callbacks, as well as a cleanup returned by `beforeEach`, can use fixtures created with `test.extend`. Pass the fixture type as `ExtraContext`; Rstest initializes each fixture before the callback that first requests it. See [Using fixtures in hooks](/api/runtime-api/test-api/test#using-fixtures-in-hooks).
+
 ## afterEach
 
-- **Type:** `(fn: (ctx: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **Type:** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => void | Promise<void>, timeout?: number) => void`
 
 Runs after each test in the current suite.
 

--- a/website/docs/en/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/en/api/runtime-api/test-api/hooks.mdx
@@ -61,7 +61,7 @@ afterAll(async (ctx) => {
 
 ## beforeEach
 
-- **Type:** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => MaybePromise<void | ((ctx: TestContext & ExtraContext) => MaybePromise<void>)>, timeout?: number) => void`
+- **Type:** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => void | ((ctx: TestContext & ExtraContext) => void | Promise<void>) | Promise<void | ((ctx: TestContext & ExtraContext) => void | Promise<void>)>, timeout?: number) => void`
 
 See [`TestContext`](/api/runtime-api/test-api/test#testcontext) for the `ctx` fields (the same applies to the per-test hooks below).
 

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -446,7 +446,7 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 
 <ApiMeta addedVersion="0.11.4" />
 
-`beforeEach`, `afterEach`, and a cleanup function returned by `beforeEach` can request fixtures. Fixtures remain lazy: Rstest initializes a fixture immediately before the first hook or test callback that requests it through object destructuring, shares that instance for the rest of the test attempt, and runs teardown after all per-test hooks finish.
+`beforeEach`, `afterEach`, and a cleanup function returned by `beforeEach` can request fixtures. Rstest initializes fixtures requested by the test callback before `beforeEach`, preserving the existing test setup order. A fixture requested only by a hook is initialized before that hook runs. The same instance is shared for the rest of the test attempt, then torn down after all per-test hooks finish.
 
 Core hooks are suite-level APIs, so provide the fixture context type explicitly and register the hook in a suite whose tests use the matching extended test API:
 

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -370,7 +370,7 @@ A fixture function receives two parameters:
 1. **context** — contains other fixtures as well as `TestContext` (`task`, `expect`, `onTestFinished`, `onTestFailed`). Use object destructuring to declare the dependencies you need.
 2. **use** — call `await use(value)` to pass the fixture value to the test.
 
-Fixture-aware callbacks must list every requested fixture explicitly. Object rest properties such as `({ db, ...rest })` are not supported in test callbacks, fixture functions, or per-test hooks because lazy fixture resolution cannot determine which fixtures the rest object requests.
+Fixture-aware callbacks must list every requested fixture explicitly through direct object destructuring in the callback parameter. Rstest does not infer dependencies from destructuring inside the function body. Object rest properties such as `({ db, ...rest })` and default values such as `({ db = fallback })` or `({ db } = {})` are not supported in test callbacks, fixture functions, or per-test hooks.
 
 Code before `await use(value)` is **setup**; code after it is **teardown** (runs after the test finishes).
 
@@ -449,6 +449,8 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 <ApiMeta addedVersion="0.11.4" />
 
 `beforeEach`, `afterEach`, and a cleanup function returned by `beforeEach` can request fixtures. Rstest initializes fixtures requested by the test callback before `beforeEach`, preserving the existing test setup order. A fixture requested only by a hook is initialized before that hook runs. The same instance is shared for the rest of the test attempt, then torn down after all per-test hooks finish.
+
+Declare hook fixture dependencies directly in the callback parameter, for example `beforeEach(({ db }) => {})`. A named hook context such as `beforeEach((context) => {})` remains valid for accessing the regular `TestContext`, but destructuring `context` inside the function body does not initialize lazy fixtures.
 
 Core hooks are suite-level APIs, so provide the fixture context type explicitly and register the hook in a suite whose tests use the matching extended test API:
 

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -370,6 +370,8 @@ A fixture function receives two parameters:
 1. **context** — contains other fixtures as well as `TestContext` (`task`, `expect`, `onTestFinished`, `onTestFailed`). Use object destructuring to declare the dependencies you need.
 2. **use** — call `await use(value)` to pass the fixture value to the test.
 
+Fixture-aware callbacks must list every requested fixture explicitly. Object rest properties such as `({ db, ...rest })` are not supported in test callbacks, fixture functions, or per-test hooks because lazy fixture resolution cannot determine which fixtures the rest object requests.
+
 Code before `await use(value)` is **setup**; code after it is **teardown** (runs after the test finishes).
 
 ```ts

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -442,9 +442,45 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 });
 ```
 
+### Using fixtures in hooks
+
+<ApiMeta addedVersion="0.11.4" />
+
+`beforeEach`, `afterEach`, and a cleanup function returned by `beforeEach` can request fixtures. Fixtures remain lazy: Rstest initializes a fixture immediately before the first hook or test callback that requests it through object destructuring, shares that instance for the rest of the test attempt, and runs teardown after all per-test hooks finish.
+
+Core hooks are suite-level APIs, so provide the fixture context type explicitly and register the hook in a suite whose tests use the matching extended test API:
+
+```ts
+import { beforeEach, describe, test } from '@rstest/core';
+
+interface DbFixtures {
+  db: Database;
+}
+
+describe('database tests', () => {
+  const dbTest = test.extend<DbFixtures>({
+    db: async ({}, use) => {
+      const db = await connectTestDb();
+      await use(db);
+      await db.close();
+    },
+  });
+
+  beforeEach<DbFixtures>(({ db }) => {
+    return async ({ db }) => {
+      await db.rollback();
+    };
+  });
+
+  dbTest('creates a user', async () => {
+    // db is initialized for beforeEach even though the test does not request it.
+  });
+});
+```
+
 ### Automatic fixtures (`auto`)
 
-Fixtures are lazy by default: they only run when destructured by the test function (or required by another fixture). To make a fixture run for every test automatically — even when not destructured — use the tuple syntax with `{ auto: true }`:
+Fixtures are lazy by default: they only run when requested through object destructuring by a test or per-test hook callback (or required by another fixture). To make a fixture run for every test automatically — even when no callback requests it — use the tuple syntax with `{ auto: true }`:
 
 ```ts
 import { test } from '@rstest/core';

--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -111,25 +111,37 @@ The sections below show how each fixture is commonly used. `page` and `serve` li
 
 <ApiMeta addedVersion="0.11.4" />
 
-Hooks attached to an extended test infer and lazily initialize its fixtures. A fixture used only by a hook does not need `auto: true`:
+Suite-level hooks can request fixtures provided by the tests in that suite. Specify the hook's fixture context type explicitly; a fixture used only by a hook does not need `auto: true`:
 
 ```ts
-import { expect, test } from '@rstest/playwright';
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  type PlaywrightFixture,
+} from '@rstest/playwright';
 
-const dashboardTest = test.extend({
+type DashboardFixtures = PlaywrightFixture & {
+  route: string;
+};
+
+const dashboardTest = test.extend<{ route: string }>({
   route: '/dashboard',
 });
 
-dashboardTest.beforeEach(async ({ page, route }) => {
-  await page.goto(`http://localhost:3000${route}`);
-});
+describe('dashboard', () => {
+  beforeEach<DashboardFixtures>(async ({ page, route }) => {
+    await page.goto(`http://localhost:3000${route}`);
+  });
 
-dashboardTest('shows the dashboard', async ({ page }) => {
-  await expect(page.locator('h1')).toHaveText('Dashboard');
+  dashboardTest('shows the dashboard', async ({ page }) => {
+    await expect(page.locator('h1')).toHaveText('Dashboard');
+  });
 });
 ```
 
-The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
+Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
 
 ### `browser`
 

--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -107,6 +107,30 @@ export default defineConfig({
 
 The sections below show how each fixture is commonly used. `page` and `serve` link to the existing examples to avoid repeating the same code.
 
+### Using fixtures in hooks
+
+<ApiMeta addedVersion="0.11.4" />
+
+Hooks attached to an extended test infer and lazily initialize its fixtures. A fixture used only by a hook does not need `auto: true`:
+
+```ts
+import { expect, test } from '@rstest/playwright';
+
+const dashboardTest = test.extend({
+  route: '/dashboard',
+});
+
+dashboardTest.beforeEach(async ({ page, route }) => {
+  await page.goto(`http://localhost:3000${route}`);
+});
+
+dashboardTest('shows the dashboard', async ({ page }) => {
+  await expect(page.locator('h1')).toHaveText('Dashboard');
+});
+```
+
+The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
+
 ### `browser`
 
 Use `browser` when you need to create a custom browser context yourself:

--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -143,6 +143,8 @@ describe('dashboard', () => {
 
 Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
 
+Declare fixture dependencies through direct object destructuring in the hook parameter. Destructuring a named context inside the hook body does not request fixtures. Rest properties and default values are not supported in fixture-aware callbacks.
+
 ### `browser`
 
 Use `browser` when you need to create a custom browser context yourself:

--- a/website/docs/zh/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/hooks.mdx
@@ -61,7 +61,7 @@ afterAll(async (ctx) => {
 
 ## beforeEach
 
-- **类型：** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => MaybePromise<void | ((ctx: TestContext & ExtraContext) => MaybePromise<void>)>, timeout?: number) => void`
+- **类型：** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => void | ((ctx: TestContext & ExtraContext) => void | Promise<void>) | Promise<void | ((ctx: TestContext & ExtraContext) => void | Promise<void>)>, timeout?: number) => void`
 
 `ctx` 的字段详见 [`TestContext`](/api/runtime-api/test-api/test#testcontext)(以下测试级 hook 同理)。
 

--- a/website/docs/zh/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/hooks.mdx
@@ -94,7 +94,7 @@ beforeEach(async () => {
 
 `beforeEach`、`afterEach` callback 以及 `beforeEach` 返回的 cleanup 函数都可以使用通过 `test.extend` 创建的 fixture。将 fixture 类型作为 `ExtraContext` 传入；Rstest 会在某个 callback 第一次请求 fixture 前完成初始化。详见[在 hook 中使用 fixture](/api/runtime-api/test-api/test#在-hook-中使用-fixture)。
 
-使用 fixture 的 hook callback 必须显式列出 fixture 依赖，不支持 `({ db, ...rest })` 这类对象 rest property。
+使用 fixture 的 hook callback 必须在 hook 参数中通过直接对象解构声明 fixture 依赖。Rstest 不会从 hook 函数体推断依赖。使用 fixture 的 callback 不支持对象 rest property 和默认值。
 
 ## afterEach
 

--- a/website/docs/zh/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/hooks.mdx
@@ -94,6 +94,8 @@ beforeEach(async () => {
 
 `beforeEach`、`afterEach` callback 以及 `beforeEach` 返回的 cleanup 函数都可以使用通过 `test.extend` 创建的 fixture。将 fixture 类型作为 `ExtraContext` 传入；Rstest 会在某个 callback 第一次请求 fixture 前完成初始化。详见[在 hook 中使用 fixture](/api/runtime-api/test-api/test#在-hook-中使用-fixture)。
 
+使用 fixture 的 hook callback 必须显式列出 fixture 依赖，不支持 `({ db, ...rest })` 这类对象 rest property。
+
 ## afterEach
 
 - **类型：** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => void | Promise<void>, timeout?: number) => void`

--- a/website/docs/zh/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/hooks.mdx
@@ -61,7 +61,7 @@ afterAll(async (ctx) => {
 
 ## beforeEach
 
-- **类型：** `(fn: (ctx: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **类型：** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => MaybePromise<void | ((ctx: TestContext & ExtraContext) => MaybePromise<void>)>, timeout?: number) => void`
 
 `ctx` 的字段详见 [`TestContext`](/api/runtime-api/test-api/test#testcontext)(以下测试级 hook 同理)。
 
@@ -90,9 +90,13 @@ beforeEach(async () => {
 });
 ```
 
+<ApiMeta addedVersion="0.11.4" />
+
+`beforeEach`、`afterEach` callback 以及 `beforeEach` 返回的 cleanup 函数都可以使用通过 `test.extend` 创建的 fixture。将 fixture 类型作为 `ExtraContext` 传入；Rstest 会在某个 callback 第一次请求 fixture 前完成初始化。详见[在 hook 中使用 fixture](/api/runtime-api/test-api/test#在-hook-中使用-fixture)。
+
 ## afterEach
 
-- **类型：** `(fn: (ctx: TestContext) => void | Promise<void>, timeout?: number) => void`
+- **类型：** `<ExtraContext = object>(fn: (ctx: TestContext & ExtraContext) => void | Promise<void>, timeout?: number) => void`
 
 在当前套件的每个测试之后运行。
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -442,9 +442,45 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 });
 ```
 
+### 在 hook 中使用 fixture
+
+<ApiMeta addedVersion="0.11.4" />
+
+`beforeEach`、`afterEach` 以及 `beforeEach` 返回的 cleanup 函数都可以请求 fixture。Fixture 仍然是按需执行的：Rstest 会在第一个解构该 fixture 的 hook 或测试 callback 前完成初始化，在本次 test attempt 的后续阶段共享同一个实例，并在所有 per-test hooks 结束后执行 teardown。
+
+Core hooks 是 suite 级 API，因此需要显式传入 fixture context 类型，并在使用对应 extended test API 的 suite 内注册 hook：
+
+```ts
+import { beforeEach, describe, test } from '@rstest/core';
+
+interface DbFixtures {
+  db: Database;
+}
+
+describe('database tests', () => {
+  const dbTest = test.extend<DbFixtures>({
+    db: async ({}, use) => {
+      const db = await connectTestDb();
+      await use(db);
+      await db.close();
+    },
+  });
+
+  beforeEach<DbFixtures>(({ db }) => {
+    return async ({ db }) => {
+      await db.rollback();
+    };
+  });
+
+  dbTest('creates a user', async () => {
+    // 即使测试函数没有请求 db，也会为 beforeEach 初始化它。
+  });
+});
+```
+
 ### 自动 fixture（`auto`）
 
-Fixture 默认是按需执行的：只有测试函数中解构了它（或被其他 fixture 依赖）才会运行。如果你希望某个 fixture 对每个测试都自动生效——即使测试没有解构它——可以使用元组语法并设置 `{ auto: true }`：
+Fixture 默认是按需执行的：只有测试或 per-test hook callback 中解构了它（或被其他 fixture 依赖）才会运行。如果你希望某个 fixture 对每个测试都自动生效——即使没有 callback 解构它——可以使用元组语法并设置 `{ auto: true }`：
 
 ```ts
 import { test } from '@rstest/core';

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -446,7 +446,7 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 
 <ApiMeta addedVersion="0.11.4" />
 
-`beforeEach`、`afterEach` 以及 `beforeEach` 返回的 cleanup 函数都可以请求 fixture。Fixture 仍然是按需执行的：Rstest 会在第一个解构该 fixture 的 hook 或测试 callback 前完成初始化，在本次 test attempt 的后续阶段共享同一个实例，并在所有 per-test hooks 结束后执行 teardown。
+`beforeEach`、`afterEach` 以及 `beforeEach` 返回的 cleanup 函数都可以请求 fixture。Rstest 会在 `beforeEach` 之前初始化测试 callback 请求的 fixture，以保持现有的测试 setup 顺序；仅由 hook 请求的 fixture 则会在该 hook 运行前初始化。同一个实例会在本次 test attempt 的后续阶段共享，并在所有 per-test hooks 结束后执行 teardown。
 
 Core hooks 是 suite 级 API，因此需要显式传入 fixture context 类型，并在使用对应 extended test API 的 suite 内注册 hook：
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -370,7 +370,7 @@ Fixture 函数接收两个参数：
 1. **context** — 包含其他 fixture 以及 `TestContext`（`task`、`expect`、`onTestFinished`、`onTestFailed`）。使用对象解构来声明你需要的依赖。
 2. **use** — 调用 `await use(value)` 把 fixture 的值传递给测试。
 
-使用 fixture 的 callback 必须显式列出所有请求的 fixture。测试 callback、fixture 函数和 per-test hook 不支持 `({ db, ...rest })` 这类对象 rest property，因为按需 fixture 解析无法确定 rest 对象请求了哪些 fixture。
+使用 fixture 的 callback 必须在 callback 参数中通过直接对象解构显式列出所有请求的 fixture。Rstest 不会从函数体内的解构推断依赖。测试 callback、fixture 函数和 per-test hook 不支持 `({ db, ...rest })` 这类对象 rest property，也不支持 `({ db = fallback })` 或 `({ db } = {})` 这类默认值。
 
 `await use(value)` 之前的代码是 **setup**，之后的代码是 **teardown**（测试结束后执行）。
 
@@ -449,6 +449,8 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 <ApiMeta addedVersion="0.11.4" />
 
 `beforeEach`、`afterEach` 以及 `beforeEach` 返回的 cleanup 函数都可以请求 fixture。Rstest 会在 `beforeEach` 之前初始化测试 callback 请求的 fixture，以保持现有的测试 setup 顺序；仅由 hook 请求的 fixture 则会在该 hook 运行前初始化。同一个实例会在本次 test attempt 的后续阶段共享，并在所有 per-test hooks 结束后执行 teardown。
+
+Hook 必须直接在 callback 参数中声明 fixture 依赖，例如 `beforeEach(({ db }) => {})`。`beforeEach((context) => {})` 这类 named hook context 仍可用于访问常规 `TestContext`，但在函数体内解构 `context` 不会初始化惰性 fixture。
 
 Core hooks 是 suite 级 API，因此需要显式传入 fixture context 类型，并在使用对应 extended test API 的 suite 内注册 hook：
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -370,6 +370,8 @@ Fixture 函数接收两个参数：
 1. **context** — 包含其他 fixture 以及 `TestContext`（`task`、`expect`、`onTestFinished`、`onTestFailed`）。使用对象解构来声明你需要的依赖。
 2. **use** — 调用 `await use(value)` 把 fixture 的值传递给测试。
 
+使用 fixture 的 callback 必须显式列出所有请求的 fixture。测试 callback、fixture 函数和 per-test hook 不支持 `({ db, ...rest })` 这类对象 rest property，因为按需 fixture 解析无法确定 rest 对象请求了哪些 fixture。
+
 `await use(value)` 之前的代码是 **setup**，之后的代码是 **teardown**（测试结束后执行）。
 
 ```ts

--- a/website/docs/zh/guide/advanced/playwright.mdx
+++ b/website/docs/zh/guide/advanced/playwright.mdx
@@ -111,25 +111,37 @@ export default defineConfig({
 
 <ApiMeta addedVersion="0.11.4" />
 
-挂载在 extended test 上的 hook 会自动推断并按需初始化对应 fixture。只在 hook 中使用的 fixture 不需要设置 `auto: true`：
+Suite 级 hook 可以请求该 suite 内测试所提供的 fixture。需要显式指定 hook 的 fixture context 类型；只在 hook 中使用的 fixture 不需要设置 `auto: true`：
 
 ```ts
-import { expect, test } from '@rstest/playwright';
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  type PlaywrightFixture,
+} from '@rstest/playwright';
 
-const dashboardTest = test.extend({
+type DashboardFixtures = PlaywrightFixture & {
+  route: string;
+};
+
+const dashboardTest = test.extend<{ route: string }>({
   route: '/dashboard',
 });
 
-dashboardTest.beforeEach(async ({ page, route }) => {
-  await page.goto(`http://localhost:3000${route}`);
-});
+describe('dashboard', () => {
+  beforeEach<DashboardFixtures>(async ({ page, route }) => {
+    await page.goto(`http://localhost:3000${route}`);
+  });
 
-dashboardTest('shows the dashboard', async ({ page }) => {
-  await expect(page.locator('h1')).toHaveText('Dashboard');
+  dashboardTest('shows the dashboard', async ({ page }) => {
+    await expect(page.locator('h1')).toHaveText('Dashboard');
+  });
 });
 ```
 
-`afterEach` 和 `beforeEach` 返回的 cleanup 函数同样支持这一行为。在一次 test attempt 内，hooks 与测试函数共享 fixture 实例，最后按 setup 的反序执行 teardown。
+Hook 的作用域是所在的 `describe` block，而不是某个 extended test 对象。因此，该 block 内的每个测试都必须提供 hook 请求的 fixture。`afterEach` 和 `beforeEach` 返回的 cleanup 函数同样支持这一行为。在一次 test attempt 内，hooks 与测试函数共享 fixture 实例，最后按 setup 的反序执行 teardown。
 
 ### `browser`
 

--- a/website/docs/zh/guide/advanced/playwright.mdx
+++ b/website/docs/zh/guide/advanced/playwright.mdx
@@ -107,6 +107,30 @@ export default defineConfig({
 
 下面说明每个 fixture 的常见用法。`page` 和 `serve` 会链接到已有示例，避免重复展示相同代码。
 
+### 在 hook 中使用 fixture
+
+<ApiMeta addedVersion="0.11.4" />
+
+挂载在 extended test 上的 hook 会自动推断并按需初始化对应 fixture。只在 hook 中使用的 fixture 不需要设置 `auto: true`：
+
+```ts
+import { expect, test } from '@rstest/playwright';
+
+const dashboardTest = test.extend({
+  route: '/dashboard',
+});
+
+dashboardTest.beforeEach(async ({ page, route }) => {
+  await page.goto(`http://localhost:3000${route}`);
+});
+
+dashboardTest('shows the dashboard', async ({ page }) => {
+  await expect(page.locator('h1')).toHaveText('Dashboard');
+});
+```
+
+`afterEach` 和 `beforeEach` 返回的 cleanup 函数同样支持这一行为。在一次 test attempt 内，hooks 与测试函数共享 fixture 实例，最后按 setup 的反序执行 teardown。
+
 ### `browser`
 
 当你需要自己创建自定义 browser context 时，可以使用 `browser`：

--- a/website/docs/zh/guide/advanced/playwright.mdx
+++ b/website/docs/zh/guide/advanced/playwright.mdx
@@ -143,6 +143,8 @@ describe('dashboard', () => {
 
 Hook 的作用域是所在的 `describe` block，而不是某个 extended test 对象。因此，该 block 内的每个测试都必须提供 hook 请求的 fixture。`afterEach` 和 `beforeEach` 返回的 cleanup 函数同样支持这一行为。在一次 test attempt 内，hooks 与测试函数共享 fixture 实例，最后按 setup 的反序执行 teardown。
 
+请在 hook 参数中通过直接对象解构声明 fixture 依赖。在 hook 函数体内解构 named context 不会请求 fixture。使用 fixture 的 callback 不支持 rest property 和默认值。
+
 ### `browser`
 
 当你需要自己创建自定义 browser context 时，可以使用 `browser`：


### PR DESCRIPTION
## Summary

Rstest currently resolves fixtures only from the test callback, so fixtures used exclusively by `beforeEach`, `afterEach`, or a returned cleanup require the unrelated `auto: true` option. This PR resolves fixtures lazily for every per-test callback while sharing one fixture instance pool per test attempt and preserving reverse-order teardown.

Fixture dependency discovery now follows the Playwright/Vitest contract: callbacks declare dependencies through direct object destructuring in their first parameter, while named hook contexts remain available for regular `TestContext` access. Browser builds preserve parameter destructuring so the same `Function#toString()`-based discovery works in Node and Playwright browser mode. Rest properties and default values remain explicitly unsupported.

It also adds typed fixture contexts for core and `@rstest/playwright` hooks and documents the behavior for v0.11.4.

```ts
describe('database tests', () => {
  const dbTest = test.extend<DbFixtures>({
    db: async ({}, use) => {
      const db = await connectTestDb();
      await use(db);
      await db.close();
    },
  });

  beforeEach<DbFixtures>(({ db }) => {
    return async ({ db }) => {
      await db.rollback();
    };
  });

  dbTest('creates a user', async () => {
    // db is initialized for beforeEach even though the test does not request it.
  });
});
```

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).