### PR TITLE
fix(core): preserve config factory inference

### DIFF
--- a/e2e/types/projectConfig.ts
+++ b/e2e/types/projectConfig.ts
@@ -1,9 +1,4 @@
-import {
-  defineConfig,
-  defineInlineProject,
-  defineProject,
-  type ProjectConfig,
-} from '@rstest/core';
+import { defineConfig, defineInlineProject, defineProject } from '@rstest/core';
 
 export const inlineNodeProject = defineInlineProject({
   name: 'runtime-utils-node',
@@ -43,10 +38,16 @@ export const exportedProject = defineProject({
   include: ['tests/node/**/*.test.ts'],
 });
 
-export const exportedProjectFactory = defineProject((): ProjectConfig => ({
+export const exportedProjectFactory = defineProject(() => ({
   root: __dirname,
   testEnvironment: 'jsdom',
   include: ['tests/dom/**/*.test.ts'],
+}));
+
+export const exportedAsyncProjectFactory = defineProject(async () => ({
+  root: __dirname,
+  testEnvironment: 'node',
+  include: ['tests/node/**/*.test.ts'],
 }));
 
 export const exportedNestedProjects = defineProject({
@@ -82,6 +83,23 @@ export const exportedNestedProjectsFactory = defineProject(async () => ({
     }),
   ],
 }));
+
+export const exportedConfigFactory = defineConfig(() => ({
+  testEnvironment: 'node',
+}));
+
+export const exportedAsyncConfigFactory = defineConfig(async () => ({
+  testEnvironment: 'jsdom',
+}));
+
+// @ts-expect-error unknown config property
+defineConfig({ testEnvironment: 'node', testEnvironmnt: 'node' });
+
+// @ts-expect-error invalid test environment
+defineConfig(async () => ({ testEnvironment: 'invalid' }));
+
+// @ts-expect-error invalid project test environment
+defineProject(async () => ({ testEnvironment: 'invalid' }));
 
 export default defineConfig({
   projects: [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,9 +38,13 @@ export type RstestConfigExport =
  * This function helps you to autocomplete configuration types.
  * It accepts a Rstest config object, or a function that returns a config.
  */
+export function defineConfig<const Config extends RstestConfig>(
+  config: () => Config,
+): RstestConfigSyncFn;
+export function defineConfig<const Config extends RstestConfig>(
+  config: () => Promise<Config>,
+): RstestConfigAsyncFn;
 export function defineConfig(config: RstestConfig): RstestConfig;
-export function defineConfig(config: RstestConfigSyncFn): RstestConfigSyncFn;
-export function defineConfig(config: RstestConfigAsyncFn): RstestConfigAsyncFn;
 export function defineConfig(config: RstestConfigExport): RstestConfigExport;
 export function defineConfig(config: RstestConfigExport) {
   return config;
@@ -51,6 +55,7 @@ type NestedProjectConfig = {
 };
 
 type ExportedProjectConfig = ProjectConfig;
+type RstestProjectConfig = ExportedProjectConfig | NestedProjectConfig;
 
 type ProjectConfigAsyncFn = () => Promise<ExportedProjectConfig>;
 type NestedProjectConfigAsyncFn = () => Promise<NestedProjectConfig>;
@@ -58,8 +63,7 @@ type ProjectConfigSyncFn = () => ExportedProjectConfig;
 type NestedProjectConfigSyncFn = () => NestedProjectConfig;
 
 type RstestProjectConfigExport =
-  | ExportedProjectConfig
-  | NestedProjectConfig
+  | RstestProjectConfig
   | ProjectConfigSyncFn
   | NestedProjectConfigSyncFn
   | ProjectConfigAsyncFn
@@ -79,20 +83,20 @@ export function defineInlineProject(config: InlineProjectConfig) {
  * This function helps you to autocomplete project configuration types.
  * It accepts an inline or nested Rstest project config object, or a function that returns one.
  */
+export function defineProject<const Config extends RstestProjectConfig>(
+  config: () => Config,
+): Config extends NestedProjectConfig
+  ? NestedProjectConfigSyncFn
+  : ProjectConfigSyncFn;
+export function defineProject<const Config extends RstestProjectConfig>(
+  config: () => Promise<Config>,
+): Config extends NestedProjectConfig
+  ? NestedProjectConfigAsyncFn
+  : ProjectConfigAsyncFn;
 export function defineProject(
   config: ExportedProjectConfig,
 ): ExportedProjectConfig;
 export function defineProject(config: NestedProjectConfig): NestedProjectConfig;
-export function defineProject(config: ProjectConfigSyncFn): ProjectConfigSyncFn;
-export function defineProject(
-  config: NestedProjectConfigSyncFn,
-): NestedProjectConfigSyncFn;
-export function defineProject(
-  config: ProjectConfigAsyncFn,
-): ProjectConfigAsyncFn;
-export function defineProject(
-  config: NestedProjectConfigAsyncFn,
-): NestedProjectConfigAsyncFn;
 export function defineProject(config: RstestProjectConfigExport) {
   return config;
 }

--- a/website/docs/en/api/javascript-api/rstest-core.mdx
+++ b/website/docs/en/api/javascript-api/rstest-core.mdx
@@ -16,12 +16,15 @@ This function helps you to autocomplete configuration types. It accepts a Rstest
 
 ```ts
 function defineConfig(config: RstestConfig): RstestConfig;
-function defineConfig(config: RstestConfigSyncFn): RstestConfigSyncFn;
-function defineConfig(config: RstestConfigAsyncFn): RstestConfigAsyncFn;
-function defineConfig(config: RstestConfigExport): RstestConfigExport;
+function defineConfig(config: () => RstestConfig): () => RstestConfig;
+function defineConfig(
+  config: () => Promise<RstestConfig>,
+): () => Promise<RstestConfig>;
 ```
 
-- **Example:**
+- **Examples:**
+
+Pass a config object directly:
 
 ```ts
 import { defineConfig } from '@rstest/core';
@@ -35,6 +38,26 @@ export default defineConfig({
 });
 ```
 
+Return a config from a synchronous factory:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig(() => ({
+  testTimeout: 10000,
+}));
+```
+
+Return a config from an asynchronous factory:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig(async () => ({
+  testTimeout: 10000,
+}));
+```
+
 ## defineProject
 
 This function helps you to autocomplete configuration types for [Rstest Project](/guide/basic/projects). It accepts a Rstest project config object, or a function that returns a config.
@@ -46,21 +69,20 @@ type NestedProjectConfig = {
   projects: (InlineProjectConfig | string)[];
 };
 
-function defineProject(config: ProjectConfig): ProjectConfig;
-function defineProject(config: NestedProjectConfig): NestedProjectConfig;
-function defineProject(config: () => ProjectConfig): () => ProjectConfig;
+type ProjectConfigExport = ProjectConfig | NestedProjectConfig;
+
+function defineProject(config: ProjectConfigExport): ProjectConfigExport;
 function defineProject(
-  config: () => NestedProjectConfig,
-): () => NestedProjectConfig;
+  config: () => ProjectConfigExport,
+): () => ProjectConfigExport;
 function defineProject(
-  config: () => Promise<ProjectConfig>,
-): () => Promise<ProjectConfig>;
-function defineProject(
-  config: () => Promise<NestedProjectConfig>,
-): () => Promise<NestedProjectConfig>;
+  config: () => Promise<ProjectConfigExport>,
+): () => Promise<ProjectConfigExport>;
 ```
 
-- **Example:**
+- **Examples:**
+
+Pass a project config object directly:
 
 ```ts
 import { defineProject } from '@rstest/core';
@@ -68,6 +90,47 @@ import { defineProject } from '@rstest/core';
 export default defineProject({
   root: './apps/web',
   testTimeout: 15000,
+});
+```
+
+Return a project config from a synchronous factory:
+
+```ts
+import { defineProject } from '@rstest/core';
+
+export default defineProject(() => ({
+  root: './apps/web',
+  testEnvironment: 'node',
+}));
+```
+
+Return a project config from an asynchronous factory:
+
+```ts
+import { defineProject } from '@rstest/core';
+
+export default defineProject(async () => ({
+  root: './apps/web',
+  testEnvironment: 'node',
+}));
+```
+
+Define multiple nested projects:
+
+```ts
+import { defineProject } from '@rstest/core';
+
+export default defineProject({
+  projects: [
+    {
+      name: 'web',
+      root: './apps/web',
+    },
+    {
+      name: 'server',
+      root: './apps/server',
+    },
+  ],
 });
 ```
 

--- a/website/docs/en/api/javascript-api/rstest-core.mdx
+++ b/website/docs/en/api/javascript-api/rstest-core.mdx
@@ -71,7 +71,8 @@ type NestedProjectConfig = {
 
 type ProjectConfigExport = ProjectConfig | NestedProjectConfig;
 
-function defineProject(config: ProjectConfigExport): ProjectConfigExport;
+function defineProject(config: ProjectConfig): ProjectConfig;
+function defineProject(config: NestedProjectConfig): NestedProjectConfig;
 function defineProject(
   config: () => ProjectConfigExport,
 ): () => ProjectConfigExport;

--- a/website/docs/zh/api/javascript-api/rstest-core.mdx
+++ b/website/docs/zh/api/javascript-api/rstest-core.mdx
@@ -16,12 +16,15 @@ import { ApiMeta } from '@components/ApiMeta';
 
 ```ts
 function defineConfig(config: RstestConfig): RstestConfig;
-function defineConfig(config: RstestConfigSyncFn): RstestConfigSyncFn;
-function defineConfig(config: RstestConfigAsyncFn): RstestConfigAsyncFn;
-function defineConfig(config: RstestConfigExport): RstestConfigExport;
+function defineConfig(config: () => RstestConfig): () => RstestConfig;
+function defineConfig(
+  config: () => Promise<RstestConfig>,
+): () => Promise<RstestConfig>;
 ```
 
 - **示例：**
+
+直接传入配置对象：
 
 ```ts
 import { defineConfig } from '@rstest/core';
@@ -35,6 +38,26 @@ export default defineConfig({
 });
 ```
 
+通过同步 factory 返回配置：
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig(() => ({
+  testTimeout: 10000,
+}));
+```
+
+通过异步 factory 返回配置：
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig(async () => ({
+  testTimeout: 10000,
+}));
+```
+
 ## defineProject
 
 此函数可用于自动补全 [Rstest Project](/guide/basic/projects) 配置的类型。
@@ -46,21 +69,20 @@ type NestedProjectConfig = {
   projects: (InlineProjectConfig | string)[];
 };
 
-function defineProject(config: ProjectConfig): ProjectConfig;
-function defineProject(config: NestedProjectConfig): NestedProjectConfig;
-function defineProject(config: () => ProjectConfig): () => ProjectConfig;
+type ProjectConfigExport = ProjectConfig | NestedProjectConfig;
+
+function defineProject(config: ProjectConfigExport): ProjectConfigExport;
 function defineProject(
-  config: () => NestedProjectConfig,
-): () => NestedProjectConfig;
+  config: () => ProjectConfigExport,
+): () => ProjectConfigExport;
 function defineProject(
-  config: () => Promise<ProjectConfig>,
-): () => Promise<ProjectConfig>;
-function defineProject(
-  config: () => Promise<NestedProjectConfig>,
-): () => Promise<NestedProjectConfig>;
+  config: () => Promise<ProjectConfigExport>,
+): () => Promise<ProjectConfigExport>;
 ```
 
 - **示例：**
+
+直接传入项目配置对象：
 
 ```ts
 import { defineProject } from '@rstest/core';
@@ -68,6 +90,47 @@ import { defineProject } from '@rstest/core';
 export default defineProject({
   root: './apps/web',
   testTimeout: 15000,
+});
+```
+
+通过同步 factory 返回项目配置：
+
+```ts
+import { defineProject } from '@rstest/core';
+
+export default defineProject(() => ({
+  root: './apps/web',
+  testEnvironment: 'node',
+}));
+```
+
+通过异步 factory 返回项目配置：
+
+```ts
+import { defineProject } from '@rstest/core';
+
+export default defineProject(async () => ({
+  root: './apps/web',
+  testEnvironment: 'node',
+}));
+```
+
+定义多个嵌套项目：
+
+```ts
+import { defineProject } from '@rstest/core';
+
+export default defineProject({
+  projects: [
+    {
+      name: 'web',
+      root: './apps/web',
+    },
+    {
+      name: 'server',
+      root: './apps/server',
+    },
+  ],
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/rstest-core.mdx
+++ b/website/docs/zh/api/javascript-api/rstest-core.mdx
@@ -71,7 +71,8 @@ type NestedProjectConfig = {
 
 type ProjectConfigExport = ProjectConfig | NestedProjectConfig;
 
-function defineProject(config: ProjectConfigExport): ProjectConfigExport;
+function defineProject(config: ProjectConfig): ProjectConfig;
+function defineProject(config: NestedProjectConfig): NestedProjectConfig;
 function defineProject(
   config: () => ProjectConfigExport,
 ): () => ProjectConfigExport;


### PR DESCRIPTION
## Summary

- Fix `defineConfig` and `defineProject` overloads so synchronous and asynchronous config factories preserve literal config types without explicit annotations.
- Add type regression coverage and document object, synchronous factory, asynchronous factory, and nested project usage.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1787
- https://github.com/web-infra-dev/rsbuild/pull/8171

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).