### PR TITLE
test(e2e): make CLI output waits level-triggered

### DIFF
--- a/e2e/browser-mode/utils.ts
+++ b/e2e/browser-mode/utils.ts
@@ -1,6 +1,5 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import treeKill from 'tree-kill';
 import { runRstestCli } from '../scripts';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -84,22 +83,13 @@ const POSIX_PROCESS_CLEANUP_RETRY_COUNT = 20;
 type BrowserCli = Awaited<ReturnType<typeof runRstestCli>>['cli'];
 
 /**
- * Kill a spawned rstest process tree without adding a fixed post-kill delay.
- * The tree-kill callback is enough for POSIX cleanup; Windows cleanup retries are
- * handled by deleteFixtureTarget where file handle contention can surface.
+ * Kill a spawned rstest process tree before the fixture directory is removed.
+ * The `onTestFinished` hook fires too late for that ordering, so watch tests
+ * still call this explicitly; Windows file-handle contention is absorbed by
+ * `deleteFixtureTarget`'s retries.
  */
-export const killCliProcessTree = async (cli: BrowserCli): Promise<void> => {
-  const pid = cli.exec.process?.pid;
-  if (!pid) {
-    cli.exec.kill();
-    await sleep(50);
-    return;
-  }
-
-  await new Promise<void>((resolve) => {
-    treeKill(pid, 'SIGKILL', () => resolve());
-  });
-};
+export const killCliProcessTree = (cli: BrowserCli): Promise<void> =>
+  cli.killProcessTree();
 
 export const deleteFixtureTarget = async (
   fixtureFs: { delete: (targetPath: string) => void } | undefined,

--- a/e2e/scripts/index.ts
+++ b/e2e/scripts/index.ts
@@ -20,6 +20,8 @@ class Cli {
   private stderrListeners: Array<() => void> = [];
   private stdoutEnded: Promise<void>;
   private stderrEnded: Promise<void>;
+  /** tinyexec's own `kill`, captured before the tree-killing override below. */
+  private execKill: () => boolean;
 
   constructor(
     exec: Result,
@@ -66,20 +68,43 @@ class Cli {
       }
     });
 
-    const execKill = this.exec.kill.bind(this.exec);
+    this.execKill = this.exec.kill.bind(this.exec);
 
     this.exec.kill = () => {
       // Ensure we kill the entire process tree (important on Windows where child
       // processes may survive and keep the test worker alive).
-      const pid = this.exec.process?.pid;
-      if (pid) {
-        treeKill(pid, 'SIGKILL');
-        return true;
-      }
-
-      return execKill();
+      void this.killProcessTree();
+      return true;
     };
   }
+
+  /**
+   * Kill the process tree and resolve only once it is gone. A watch-mode CLI
+   * that outlives its test keeps holding the fixture's dev-server port and keeps
+   * rebuilding the fixture directory, so a retry of that test races a stale
+   * server over the same files — awaiting the kill is what stops one failed
+   * attempt from poisoning the next.
+   */
+  killProcessTree = (): Promise<void> => {
+    const child = this.exec.process;
+
+    // `tree-kill` spawns a `pgrep` per pid in the tree, and this runs in the
+    // finish hook of every CLI test — skip that walk for the already-exited
+    // processes that make up most of the suite.
+    if (child?.exitCode != null || child?.signalCode != null) {
+      return Promise.resolve();
+    }
+
+    const pid = child?.pid;
+    if (!pid) {
+      this.execKill();
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      treeKill(pid, 'SIGKILL', () => resolve());
+    });
+  };
 
   /**
    * Wait for stdout and stderr streams to end.
@@ -98,16 +123,23 @@ class Cli {
   };
 
   private waitForStd = (expect: string | RegExp, io: IoType): Promise<void> => {
+    const matched = () =>
+      typeof expect === 'string'
+        ? this[io].includes(expect)
+        : Boolean(this[io].match(expect));
+
+    // The buffer accumulates asynchronously, so the awaited output may already
+    // have landed before this call. Listeners only fire on the *next* chunk, so
+    // checking the buffer up front is what keeps a caller from waiting forever
+    // on a line the process has already printed and will never print again.
+    if (matched()) {
+      return Promise.resolve();
+    }
+
     return new Promise((resolve) => {
       this[`${io}Listeners`].push(() => {
-        if (typeof expect === 'string') {
-          if (this[io].includes(expect)) {
-            resolve(undefined);
-          }
-        } else {
-          if (this[io].match(expect)) {
-            resolve(undefined);
-          }
+        if (matched()) {
+          resolve(undefined);
         }
       });
     });
@@ -174,9 +206,7 @@ export async function runRstestCli({
 
   const cli = new Cli(exec, { stripAnsi });
 
-  (onTestFinished || onRstestFinished)(() => {
-    if (!cli.exec.killed) cli.exec.kill();
-  });
+  (onTestFinished || onRstestFinished)(() => cli.killProcessTree());
 
   (onTestFailed || onRstestFailed)?.(({ task }) => {
     if (task.result?.errors?.[0]) {


### PR DESCRIPTION
## Summary

Two browser watch e2e tests (`watchSetup`, `watchMultiProject`) timed out at 60s on the full post-merge matrix while passing on the reduced PR matrix, and passed again on retry.

The root cause is in the shared e2e CLI harness, not in watch mode. `Cli.waitForStd` registers a listener and only ever evaluates it on a *subsequent* stdout chunk — it never checks the buffer that has already accumulated. So `await cli.waitForStdout(x)` hangs forever when `x` arrived in the same chunk as the previously awaited line, which is exactly what happens under load between `Duration` and `Waiting for file changes...`. Older watch tests hid this behind `if (!cli.stdout.includes(x))` guards; the tests without that guard were the ones that flaked.

- `waitForStd` now checks the buffer up front, making every `waitForStdout`/`waitForStderr` caller level-triggered instead of edge-triggered. The existing manual guards keep working unchanged.
- `runRstestCli`'s finish hook now awaits a real process-tree kill. It previously fired `treeKill` without awaiting it (and its `!cli.exec.killed` guard was dead, since the override kills by pid and never flips tinyexec's `killed`), so a timed-out attempt could hand a live watch CLI — still holding the fixture's dev-server port and still rebuilding the fixture directory — to its own retry. Locally, a stray watch process left behind this way made 9 of 10 subsequent runs of the same fixture fail.
- `Cli.killProcessTree` is now the single kill implementation; the constructor's `exec.kill` override and `killCliProcessTree` delegate to it, and it skips the `pgrep` walk for already-exited children so the ~440 non-watch call sites pay nothing.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).