### PR TITLE
fix(vscode): stop notifying when @rstest/core is not installed

### DIFF
--- a/packages/vscode/src/coreResolution.ts
+++ b/packages/vscode/src/coreResolution.ts
@@ -10,10 +10,21 @@
  * does not resolve is a setting the user has to fix, so it is notified.
  */
 
-export function isModuleNotFoundError(error: unknown): boolean {
+// Whether `specifier` itself is what could not be found. `MODULE_NOT_FOUND`
+// alone is too broad: a package that is installed but whose entry file is gone
+// (an interrupted install, or a workspace link that has not been built) throws
+// it too, and that must not be reported as "not installed". Node names the
+// resolved file in that case and the requested specifier in this one, so the
+// message is what separates them. A future Node wording change therefore fails
+// towards reporting rather than towards silence.
+export function isModuleNotFoundError(
+  error: unknown,
+  specifier: string,
+): boolean {
   return (
     error instanceof Error &&
-    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND' &&
+    error.message.startsWith(`Cannot find module '${specifier}'`)
   );
 }
 

--- a/packages/vscode/src/coreResolution.ts
+++ b/packages/vscode/src/coreResolution.ts
@@ -1,0 +1,30 @@
+/**
+ * Helpers for reporting a failed `@rstest/core` resolution.
+ *
+ * A missing `@rstest/core` never reaches a notification: it is the normal state
+ * of a freshly cloned repository, and discovery resolves core for every config
+ * file without the user asking. It goes to the output channel instead, phrased
+ * here — Node's own `MODULE_NOT_FOUND` message embeds the require stack of
+ * whoever called `require.resolve`, which for a bundled extension is its `dist`
+ * path plus the VS Code extension host, and says nothing about what to do.
+ */
+
+export function isModuleNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+  );
+}
+
+export function formatCoreNotFoundMessage({
+  searchedFrom,
+  configuredPackagePath,
+}: {
+  searchedFrom: string;
+  configuredPackagePath?: string;
+}): string {
+  if (configuredPackagePath) {
+    return `Cannot find "@rstest/core" at the configured "rstest.rstestPackagePath": ${configuredPackagePath}. Update the setting to point at an installed "@rstest/core" package.json.`;
+  }
+  return `Cannot find "@rstest/core" from ${searchedFrom}. Install the project dependencies, then refresh the Test Explorer. If Rstest is installed elsewhere, set "rstest.rstestPackagePath" to its package.json.`;
+}

--- a/packages/vscode/src/coreResolution.ts
+++ b/packages/vscode/src/coreResolution.ts
@@ -1,12 +1,13 @@
 /**
  * Helpers for reporting a failed `@rstest/core` resolution.
  *
- * A missing `@rstest/core` never reaches a notification: it is the normal state
- * of a freshly cloned repository, and discovery resolves core for every config
- * file without the user asking. It goes to the output channel instead, phrased
- * here — Node's own `MODULE_NOT_FOUND` message embeds the require stack of
- * whoever called `require.resolve`, which for a bundled extension is its `dist`
- * path plus the VS Code extension host, and says nothing about what to do.
+ * Both messages replace Node's own `MODULE_NOT_FOUND` text, which embeds the
+ * require stack of whoever called `require.resolve` — for a bundled extension
+ * its `dist` path plus the VS Code extension host — and says nothing about what
+ * to do. They differ in where they end up: an uninstalled core is the normal
+ * state of a freshly cloned repository and is resolved for every config file
+ * without the user asking, so it is only logged; a `rstestPackagePath` that
+ * does not resolve is a setting the user has to fix, so it is notified.
  */
 
 export function isModuleNotFoundError(error: unknown): boolean {
@@ -16,15 +17,12 @@ export function isModuleNotFoundError(error: unknown): boolean {
   );
 }
 
-export function formatCoreNotFoundMessage({
-  searchedFrom,
-  configuredPackagePath,
-}: {
-  searchedFrom: string;
-  configuredPackagePath?: string;
-}): string {
-  if (configuredPackagePath) {
-    return `Cannot find "@rstest/core" at the configured "rstest.rstestPackagePath": ${configuredPackagePath}. Update the setting to point at an installed "@rstest/core" package.json.`;
-  }
+export function formatCoreNotFoundMessage(searchedFrom: string): string {
   return `Cannot find "@rstest/core" from ${searchedFrom}. Install the project dependencies, then refresh the Test Explorer. If Rstest is installed elsewhere, set "rstest.rstestPackagePath" to its package.json.`;
+}
+
+export function formatConfiguredCoreNotFoundMessage(
+  configuredPackagePath: string,
+): string {
+  return `Cannot find "@rstest/core" at the configured "rstest.rstestPackagePath": ${configuredPackagePath}. Update the setting to point at an installed "@rstest/core" package.json.`;
 }

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -131,7 +131,7 @@ export class RstestApi {
     try {
       return require.resolve(specifier, { paths: [this.cwd] });
     } catch (e) {
-      if (!isModuleNotFoundError(e)) throw e;
+      if (!isModuleNotFoundError(e, specifier)) throw e;
       if (configuredPackagePath) {
         throw new Error(
           formatConfiguredCoreNotFoundMessage(configuredPackagePath),

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -6,6 +6,7 @@ import regexpEscape from 'core-js-pure/actual/regexp/escape';
 import vscode from 'vscode';
 import { getConfigValue } from './config';
 import {
+  formatConfiguredCoreNotFoundMessage,
   formatCoreNotFoundMessage,
   isModuleNotFoundError,
 } from './coreResolution';
@@ -120,8 +121,9 @@ export class RstestApi {
   // `@rstest/core` is not installed at all — the normal state of a repository
   // whose dependencies are not installed yet, so it is written to the output
   // channel and never raised as a notification. This is the only place that
-  // policy lives; any other resolution failure is rethrown for the caller to
-  // report. `configuredPackagePath` only shapes the logged message.
+  // policy lives, and it deliberately does not cover `configuredPackagePath`:
+  // a `rstestPackagePath` that does not resolve is a setting the user got
+  // wrong, so it is rethrown for the caller to report like any other failure.
   private resolveFromCwd(
     specifier: string,
     configuredPackagePath?: string,
@@ -130,14 +132,12 @@ export class RstestApi {
       return require.resolve(specifier, { paths: [this.cwd] });
     } catch (e) {
       if (!isModuleNotFoundError(e)) throw e;
-      // Node's own message is dropped on purpose: its require stack points at
-      // the extension bundle, not at anything the user can act on.
-      logger.error(
-        formatCoreNotFoundMessage({
-          searchedFrom: this.cwd,
-          configuredPackagePath,
-        }),
-      );
+      if (configuredPackagePath) {
+        throw new Error(
+          formatConfiguredCoreNotFoundMessage(configuredPackagePath),
+        );
+      }
+      logger.error(formatCoreNotFoundMessage(this.cwd));
       return undefined;
     }
   }

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -5,12 +5,17 @@ import { type BirpcReturn, createBirpc } from 'birpc';
 import regexpEscape from 'core-js-pure/actual/regexp/escape';
 import vscode from 'vscode';
 import { getConfigValue } from './config';
+import {
+  formatCoreNotFoundMessage,
+  isModuleNotFoundError,
+} from './coreResolution';
 import type { RstestDiagnostics } from './diagnostics';
 import type { TestErrorStore } from './errorStore';
 import { logger } from './logger';
 import type { Project } from './project';
 import { runInTerminal as sendToTerminal, shellQuote } from './terminal';
 import { TestRunReporter } from './testRunReporter';
+import { toErrorMessage } from './utils';
 import {
   formatCoreVersionWarningMessage,
   shouldWarnCoreVersion,
@@ -25,6 +30,9 @@ export const runningWorkers = new Set<BirpcReturn<Worker, TestRunReporter>>();
 // the debugger would attach to the wrong endpoint. Prefer an explicit IPv4
 // literal over `localhost` so both ends agree.
 const DEFAULT_DEBUG_HOST = '127.0.0.1';
+
+// The specifier used when `rstestPackagePath` is unset.
+const CORE_PACKAGE_JSON = '@rstest/core/package.json';
 
 // Probe whether a fixed inspector port can be bound. `--inspect-wait=host:port`
 // does not fall back when the port is taken: Node reports address-in-use and
@@ -84,18 +92,18 @@ export class RstestApi {
     };
   }
 
-  // Resolve the `@rstest/core` package.json specifier honoring a configured
-  // `rstestPackagePath`: the bare package spec when it is not set, or the
-  // validated absolute path to the configured package.json. Shared by the
-  // worker resolution and the terminal CLI resolution.
-  private resolveConfiguredPackageJson(): string {
+  // The validated absolute path to the package.json a `rstestPackagePath`
+  // setting points at, or `undefined` when the setting is unset and the bare
+  // `CORE_PACKAGE_JSON` specifier applies. Shared by the worker resolution and
+  // the terminal CLI resolution, which both also report the configured path.
+  private resolveConfiguredPackageJson(): string | undefined {
     // TODO: support Yarn PnP
     let configuredPackagePath = getConfigValue(
       'rstestPackagePath',
       this.workspace,
     );
     if (!configuredPackagePath) {
-      return '@rstest/core/package.json';
+      return undefined;
     }
     configuredPackagePath = this.expandWorkspaceFolder(configuredPackagePath);
     if (!configuredPackagePath.endsWith('package.json')) {
@@ -108,20 +116,46 @@ export class RstestApi {
       : path.resolve(this.workspace.uri.fsPath, configuredPackagePath);
   }
 
+  // Resolve `specifier` from the config file's directory. `undefined` means
+  // `@rstest/core` is not installed at all — the normal state of a repository
+  // whose dependencies are not installed yet, so it is written to the output
+  // channel and never raised as a notification. This is the only place that
+  // policy lives; any other resolution failure is rethrown for the caller to
+  // report. `configuredPackagePath` only shapes the logged message.
+  private resolveFromCwd(
+    specifier: string,
+    configuredPackagePath?: string,
+  ): string | undefined {
+    try {
+      return require.resolve(specifier, { paths: [this.cwd] });
+    } catch (e) {
+      if (!isModuleNotFoundError(e)) throw e;
+      // Node's own message is dropped on purpose: its require stack points at
+      // the extension bundle, not at anything the user can act on.
+      logger.error(
+        formatCoreNotFoundMessage({
+          searchedFrom: this.cwd,
+          configuredPackagePath,
+        }),
+      );
+      return undefined;
+    }
+  }
+
+  // Returns '' when resolution failed. Every such branch has already reported
+  // itself — silently for a missing core, with a notification otherwise — so
+  // callers must fail quietly rather than report again.
   private resolveRstestPath(): string {
     try {
-      const packageJson = this.resolveConfiguredPackageJson();
-      const configured = packageJson !== '@rstest/core/package.json';
+      const configured = this.resolveConfiguredPackageJson();
+      const packageJson = configured ?? CORE_PACKAGE_JSON;
       if (configured) {
-        logger.debug('Using configured rstestPackagePath:', packageJson);
+        logger.debug('Using configured rstestPackagePath:', configured);
       }
 
-      const nodeExport = require.resolve(
-        configured ? dirname(packageJson) : '@rstest/core',
-        {
-          paths: [this.cwd],
-        },
-      );
+      // `dirname` turns either package.json specifier into its package entry.
+      const nodeExport = this.resolveFromCwd(dirname(packageJson), configured);
+      if (!nodeExport) return '';
 
       let corePackageJsonPath: string;
       try {
@@ -159,7 +193,7 @@ export class RstestApi {
 
       return nodeExport;
     } catch (e) {
-      vscode.window.showErrorMessage((e as any).toString());
+      vscode.window.showErrorMessage(toErrorMessage(e));
       throw e;
     }
   }
@@ -167,10 +201,13 @@ export class RstestApi {
   // Resolve the rstest CLI executable (its package `bin`) for the terminal run
   // mode, honoring a configured `rstestPackagePath` the same way as the worker
   // resolution above.
-  private resolveRstestBin(): string {
-    const pkgJsonPath = require.resolve(this.resolveConfiguredPackageJson(), {
-      paths: [this.cwd],
-    });
+  private resolveRstestBin(): string | undefined {
+    const configured = this.resolveConfiguredPackageJson();
+    const pkgJsonPath = this.resolveFromCwd(
+      configured ?? CORE_PACKAGE_JSON,
+      configured,
+    );
+    if (!pkgJsonPath) return undefined;
     const pkg = require(pkgJsonPath) as {
       bin?: string | Record<string, string>;
     };
@@ -280,8 +317,7 @@ export class RstestApi {
       })
       .catch((error) => {
         if (!token.isCancellationRequested) {
-          const message =
-            error instanceof Error ? error.message : String(error);
+          const message = toErrorMessage(error);
           logger.error('Failed to run tests', error);
           run.appendOutput(`\n[rstest] ${message}\n`.replaceAll('\n', '\r\n'));
           vscode.window.showErrorMessage(`Rstest test run failed: ${message}`);
@@ -299,15 +335,18 @@ export class RstestApi {
     await promise;
   }
 
-  private buildCliCommand({
-    fileFilter,
-    testCaseNamePath,
-    isSuite,
-  }: {
-    fileFilter?: string;
-    testCaseNamePath?: string[];
-    isSuite?: boolean;
-  }): string {
+  private buildCliCommand(
+    rstestBin: string,
+    {
+      fileFilter,
+      testCaseNamePath,
+      isSuite,
+    }: {
+      fileFilter?: string;
+      testCaseNamePath?: string[];
+      isSuite?: boolean;
+    },
+  ): string {
     const { nodeExecutable, nodeExecArgs } = this.resolveNodeCommand();
 
     // Prefer a path relative to the run cwd for readability; fall back to the
@@ -332,7 +371,7 @@ export class RstestApi {
     // `-c` is resolved relative to the process cwd, which is `this.cwd`.
     args.push('-c', relativeToCwd(this.configFilePath));
 
-    return [nodeExecutable, ...nodeExecArgs, this.resolveRstestBin(), ...args]
+    return [nodeExecutable, ...nodeExecArgs, rstestBin, ...args]
       .map(shellQuote)
       .join(' ');
   }
@@ -344,10 +383,11 @@ export class RstestApi {
   }): void {
     let command: string;
     try {
-      command = this.buildCliCommand(options);
+      const rstestBin = this.resolveRstestBin();
+      if (!rstestBin) return;
+      command = this.buildCliCommand(rstestBin, options);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Rstest: ${message}`);
+      vscode.window.showErrorMessage(`Rstest: ${toErrorMessage(error)}`);
       return;
     }
     sendToTerminal(command, {

--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -1,3 +1,7 @@
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function isTestFile(filename: string): boolean {
   const regex = /.*\.(test|spec)\.(c|m)?[jt]sx?$/;
   return regex.test(filename);

--- a/packages/vscode/tests/unit/coreResolution.test.ts
+++ b/packages/vscode/tests/unit/coreResolution.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from '@rstest/core';
 import {
   formatConfiguredCoreNotFoundMessage,
@@ -5,25 +8,50 @@ import {
   isModuleNotFoundError,
 } from '../../src/coreResolution';
 
+// Resolve for real rather than hand-building an error object: the predicate
+// reads a message Node owns, so a fake error would only assert itself.
+const resolveError = (specifier: string, from: string): unknown => {
+  try {
+    require.resolve(specifier, { paths: [from] });
+  } catch (e) {
+    return e;
+  }
+  throw new Error(`expected "${specifier}" not to resolve`);
+};
+
 describe('isModuleNotFoundError', () => {
-  // The extension detects the failure Node actually throws, so resolve a
-  // missing package for real rather than hand-building an error object.
-  it('should detect a real resolution failure', () => {
-    let error: unknown;
-    try {
-      require.resolve('@rstest/definitely-not-installed', {
-        paths: [__dirname],
-      });
-    } catch (e) {
-      error = e;
-    }
-    expect(isModuleNotFoundError(error)).toBe(true);
+  it('should detect a package that is not installed', () => {
+    const specifier = '@rstest/definitely-not-installed';
+    expect(
+      isModuleNotFoundError(resolveError(specifier, __dirname), specifier),
+    ).toBe(true);
+  });
+
+  it('should reject a package whose entry file is missing', () => {
+    // An interrupted install, or a workspace link that has not been built:
+    // installed, but unusable. Node reports the missing file, not the package.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-vscode-'));
+    const pkgDir = path.join(root, 'node_modules', 'broken-package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      '{"name":"broken-package","version":"1.0.0","main":"./gone.js"}',
+    );
+
+    expect(
+      isModuleNotFoundError(
+        resolveError('broken-package', root),
+        'broken-package',
+      ),
+    ).toBe(false);
+
+    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it('should ignore other errors', () => {
-    expect(isModuleNotFoundError(new Error('boom'))).toBe(false);
-    expect(isModuleNotFoundError('MODULE_NOT_FOUND')).toBe(false);
-    expect(isModuleNotFoundError(undefined)).toBe(false);
+    expect(isModuleNotFoundError(new Error('boom'), 'boom')).toBe(false);
+    expect(isModuleNotFoundError('MODULE_NOT_FOUND', 'x')).toBe(false);
+    expect(isModuleNotFoundError(undefined, 'x')).toBe(false);
   });
 });
 

--- a/packages/vscode/tests/unit/coreResolution.test.ts
+++ b/packages/vscode/tests/unit/coreResolution.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  formatCoreNotFoundMessage,
+  isModuleNotFoundError,
+} from '../../src/coreResolution';
+
+describe('isModuleNotFoundError', () => {
+  // The extension detects the failure Node actually throws, so resolve a
+  // missing package for real rather than hand-building an error object.
+  it('should detect a real resolution failure', () => {
+    let error: unknown;
+    try {
+      require.resolve('@rstest/definitely-not-installed', {
+        paths: [__dirname],
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(isModuleNotFoundError(error)).toBe(true);
+  });
+
+  it('should ignore other errors', () => {
+    expect(isModuleNotFoundError(new Error('boom'))).toBe(false);
+    expect(isModuleNotFoundError('MODULE_NOT_FOUND')).toBe(false);
+    expect(isModuleNotFoundError(undefined)).toBe(false);
+  });
+});
+
+describe('formatCoreNotFoundMessage', () => {
+  it('should point at the configured package path instead of the install hint', () => {
+    const message = formatCoreNotFoundMessage({
+      searchedFrom: '/repo/app',
+      configuredPackagePath: '/repo/vendor/core/package.json',
+    });
+    expect(message).toContain('/repo/vendor/core/package.json');
+    expect(message).not.toContain('Install the project dependencies');
+  });
+});

--- a/packages/vscode/tests/unit/coreResolution.test.ts
+++ b/packages/vscode/tests/unit/coreResolution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 import {
+  formatConfiguredCoreNotFoundMessage,
   formatCoreNotFoundMessage,
   isModuleNotFoundError,
 } from '../../src/coreResolution';
@@ -26,13 +27,15 @@ describe('isModuleNotFoundError', () => {
   });
 });
 
-describe('formatCoreNotFoundMessage', () => {
+describe('core-not-found messages', () => {
   it('should point at the configured package path instead of the install hint', () => {
-    const message = formatCoreNotFoundMessage({
-      searchedFrom: '/repo/app',
-      configuredPackagePath: '/repo/vendor/core/package.json',
-    });
+    const message = formatConfiguredCoreNotFoundMessage(
+      '/repo/vendor/core/package.json',
+    );
     expect(message).toContain('/repo/vendor/core/package.json');
     expect(message).not.toContain('Install the project dependencies');
+    expect(formatCoreNotFoundMessage('/repo/app')).toContain(
+      'Install the project dependencies',
+    );
   });
 });

--- a/packages/vscode/tests/unit/master.test.ts
+++ b/packages/vscode/tests/unit/master.test.ts
@@ -1,0 +1,102 @@
+import os from 'node:os';
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import { RstestApi } from '../../src/master';
+
+// Everything the extension surfaces: notifications the user cannot miss, the
+// output channel, and the terminal a "Run in Terminal" would open.
+const shownMessages: string[] = [];
+const loggedErrors: string[] = [];
+const createdTerminals: string[] = [];
+
+rs.mock('vscode', () => {
+  const channel = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (message: string) => loggedErrors.push(message),
+    show: () => {},
+    dispose: () => {},
+  };
+  const vscode = {
+    TestRunProfileKind: { Run: 1, Debug: 2, Coverage: 3 },
+    FileCoverage: class {},
+    Position: class {},
+    Range: class {},
+    Uri: {
+      file: (fsPath: string) => ({
+        fsPath,
+        toString: () => `file://${fsPath}`,
+      }),
+    },
+    extensions: { getExtension: () => undefined },
+    window: {
+      createOutputChannel: () => channel,
+      createTerminal: (options: { name: string }) => {
+        createdTerminals.push(options.name);
+        return { show: () => {}, sendText: () => {}, dispose: () => {} };
+      },
+      onDidCloseTerminal: () => ({ dispose: () => {} }),
+      showErrorMessage: (message: string) => shownMessages.push(message),
+      showWarningMessage: (message: string) => shownMessages.push(message),
+      showInformationMessage: (message: string) => shownMessages.push(message),
+    },
+    workspace: {
+      getConfiguration: () => ({ get: () => undefined }),
+      onDidChangeConfiguration: () => ({ dispose: () => {} }),
+    },
+  };
+  return { ...vscode, default: vscode };
+});
+
+// A directory outside the repository, so Node's upward resolution cannot reach
+// the workspace `node_modules` and `@rstest/core` is genuinely missing.
+const noCoreDir = os.tmpdir();
+
+const createApi = () => {
+  const workspace = { uri: { fsPath: noCoreDir } };
+  return new RstestApi(
+    workspace as any,
+    noCoreDir,
+    `${noCoreDir}/rstest.config.ts`,
+    {} as any,
+  );
+};
+
+describe('RstestApi with a missing @rstest/core', () => {
+  beforeEach(() => {
+    shownMessages.length = 0;
+    loggedErrors.length = 0;
+    createdTerminals.length = 0;
+  });
+
+  it('should log an actionable message instead of notifying, while discovering projects', async () => {
+    await expect(createApi().getNormalizedConfig()).rejects.toThrow(
+      'Failed to resolve rstest path',
+    );
+    expect(shownMessages).toEqual([]);
+    const logged = loggedErrors.join('\n');
+    expect(logged).toContain(`Cannot find "@rstest/core" from ${noCoreDir}`);
+    expect(logged).toContain('Install the project dependencies');
+    expect(logged).not.toContain('Require stack');
+  });
+
+  it('should stay silent while listing tests', async () => {
+    await expect(createApi().listTests()).rejects.toThrow(
+      'Failed to resolve rstest path',
+    );
+    expect(shownMessages).toEqual([]);
+  });
+
+  it('should stay silent while running tests', async () => {
+    await expect(
+      createApi().runTest({ run: {} as any, token: {} as any }),
+    ).rejects.toThrow('Failed to resolve rstest path');
+    expect(shownMessages).toEqual([]);
+  });
+
+  it('should stay silent, and open no terminal, for a terminal run', () => {
+    createApi().runInTerminal({});
+    expect(shownMessages).toEqual([]);
+    expect(createdTerminals).toEqual([]);
+  });
+});

--- a/packages/vscode/tests/unit/master.test.ts
+++ b/packages/vscode/tests/unit/master.test.ts
@@ -1,5 +1,7 @@
+import fs from 'node:fs';
 import os from 'node:os';
-import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { RstestApi } from '../../src/master';
 
 // Everything the extension surfaces: notifications the user cannot miss, the
@@ -55,12 +57,12 @@ rs.mock('vscode', () => {
 // the workspace `node_modules` and `@rstest/core` is genuinely missing.
 const noCoreDir = os.tmpdir();
 
-const createApi = () => {
-  const workspace = { uri: { fsPath: noCoreDir } };
+const createApi = (cwd = noCoreDir) => {
+  const workspace = { uri: { fsPath: cwd } };
   return new RstestApi(
     workspace as any,
-    noCoreDir,
-    `${noCoreDir}/rstest.config.ts`,
+    cwd,
+    `${cwd}/rstest.config.ts`,
     {} as any,
   );
 };
@@ -102,6 +104,38 @@ describe('RstestApi with a missing @rstest/core', () => {
     createApi().runInTerminal({});
     expect(shownMessages).toEqual([]);
     expect(createdTerminals).toEqual([]);
+  });
+});
+
+// Installed but unusable — an interrupted install, or a workspace link that
+// has not been built. Advising an install would be wrong, and staying silent
+// would hide a broken state the user has to repair.
+describe('RstestApi with an unusable @rstest/core', () => {
+  let root: string;
+
+  beforeEach(() => {
+    shownMessages.length = 0;
+    loggedErrors.length = 0;
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-vscode-'));
+    const pkgDir = path.join(root, 'node_modules', '@rstest', 'core');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      '{"name":"@rstest/core","version":"9.9.9","main":"./gone.js"}',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('should notify instead of reporting it as not installed', async () => {
+    await expect(createApi(root).getNormalizedConfig()).rejects.toThrow();
+    expect(shownMessages).toHaveLength(1);
+    expect(shownMessages[0]).toContain('gone.js');
+    expect(loggedErrors.join('\n')).not.toContain(
+      'Install the project dependencies',
+    );
   });
 });
 

--- a/packages/vscode/tests/unit/master.test.ts
+++ b/packages/vscode/tests/unit/master.test.ts
@@ -7,6 +7,7 @@ import { RstestApi } from '../../src/master';
 const shownMessages: string[] = [];
 const loggedErrors: string[] = [];
 const createdTerminals: string[] = [];
+const settings: Record<string, unknown> = {};
 
 rs.mock('vscode', () => {
   const channel = {
@@ -41,7 +42,9 @@ rs.mock('vscode', () => {
       showInformationMessage: (message: string) => shownMessages.push(message),
     },
     workspace: {
-      getConfiguration: () => ({ get: () => undefined }),
+      getConfiguration: () => ({
+        get: (key: string) => settings[key],
+      }),
       onDidChangeConfiguration: () => ({ dispose: () => {} }),
     },
   };
@@ -67,6 +70,7 @@ describe('RstestApi with a missing @rstest/core', () => {
     shownMessages.length = 0;
     loggedErrors.length = 0;
     createdTerminals.length = 0;
+    for (const key of Object.keys(settings)) delete settings[key];
   });
 
   it('should log an actionable message instead of notifying, while discovering projects', async () => {
@@ -97,6 +101,32 @@ describe('RstestApi with a missing @rstest/core', () => {
   it('should stay silent, and open no terminal, for a terminal run', () => {
     createApi().runInTerminal({});
     expect(shownMessages).toEqual([]);
+    expect(createdTerminals).toEqual([]);
+  });
+});
+
+// A configured `rstestPackagePath` that does not resolve is not the
+// "dependencies are not installed yet" state — the user picked that path and
+// has to fix it, so silence would strand them.
+describe('RstestApi with an unresolvable rstestPackagePath', () => {
+  const configured = `${noCoreDir}/vendor/core/package.json`;
+
+  beforeEach(() => {
+    shownMessages.length = 0;
+    settings.rstestPackagePath = configured;
+  });
+
+  it('should notify while discovering projects', async () => {
+    await expect(createApi().getNormalizedConfig()).rejects.toThrow();
+    expect(shownMessages).toHaveLength(1);
+    expect(shownMessages[0]).toContain('rstest.rstestPackagePath');
+    expect(shownMessages[0]).toContain(configured);
+  });
+
+  it('should notify for a terminal run', () => {
+    createApi().runInTerminal({});
+    expect(shownMessages).toHaveLength(1);
+    expect(shownMessages[0]).toContain('rstest.rstestPackagePath');
     expect(createdTerminals).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Opening a folder that contains an `rstest.config.*` but no installed dependencies raised a raw Node `MODULE_NOT_FOUND` notification. It fired during project discovery, with no user interaction, and showed the extension's own bundle path plus `extensionHostProcess.js` — nothing the user can act on. A freshly cloned repository before `install` is a normal intermediate state, so it should not interrupt.

- A missing `@rstest/core` now only reaches the extension's output channel, phrased with the directory it was searched from and what to do about it. No entry point notifies: discovery, `listTests`, an in-editor run, or "Run in Terminal" (which no longer opens a terminal it cannot fill).
- Every other resolution failure keeps its current notification — an outdated core whose `package.json` is not exported, and a misconfigured `rstest.rstestPackagePath`.
- The silent-vs-report policy lives in one resolution primitive shared by the worker and the CLI resolution, rather than at each call site.

## Related Links

Closes #1608

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
