### PR TITLE
docs: clarify Rstest testing framework positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
   <a href="https://codspeed.io/web-infra-dev/rstest?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed" /></a>
 </p>
 
-Rstest is a JavaScript testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
+Rstest is a fast, modern JavaScript testing framework powered by Rspack. It provides Jest-compatible APIs and out-of-the-box support for TypeScript, ESM, CJS, and more.
 
-Rstest offers full Jest-compatible APIs while providing native, out-of-the-box support for TypeScript, ESM, and more, ensuring a modern and efficient testing experience.
+Rstest works with any JavaScript or TypeScript project. Projects using Rspack, Rsbuild, or Rslib can additionally reuse their existing build configuration for consistent transforms and module resolution.
 
 ## 📖 Documentation
 

--- a/website/docs/en/guide/start/features.mdx
+++ b/website/docs/en/guide/start/features.mdx
@@ -4,7 +4,7 @@ description: Explore Rstest features for build-integrated testing, including Rst
 
 # Features
 
-Rstest brings testing into the Rsbuild and Rspack build pipeline. It reuses build configuration where possible, runs tests through a bundle-based execution model, and provides the core testing features needed for local development and CI.
+Rstest provides a complete JavaScript testing workflow for local development and CI, including Jest-compatible APIs, mocking, snapshots, coverage, and browser testing. Powered by Rspack, it can also reuse build configuration and run tests through a bundle-based execution model.
 
 ## Reuse existing build setup
 

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -1,12 +1,12 @@
 ---
-description: Rstest is a JavaScript testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem,  enabling seamless integration into existing Rspack-based projects.
+description: Rstest is a fast, modern JavaScript testing framework powered by Rspack, with Jest-compatible APIs and first-class support for JavaScript and TypeScript projects.
 ---
 
 # Introduction
 
-Rstest is a JavaScript testing framework powered by Rspack. It delivers comprehensive, first-class support for the Rspack ecosystem, enabling seamless integration into existing Rspack-based projects.
+Rstest is a fast, modern JavaScript testing framework powered by Rspack. It provides Jest-compatible APIs and out-of-the-box support for TypeScript, ESM, CJS, and more.
 
-Rstest offers full Jest-compatible APIs while providing native, out-of-the-box support for TypeScript, ESM, CJS, and more, ensuring a modern and efficient testing experience.
+Rstest works with any JavaScript or TypeScript project. Projects using Rspack, Rsbuild, or Rslib can additionally reuse their existing build configuration for consistent transforms and module resolution.
 
 ## ✨ Why Rstest
 

--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -1,8 +1,9 @@
 ---
-description: Rspack based testing framework. Rstest docs cover CLI, configuration, runtime APIs, browser testing, migration, and integration guides.
+description: Rstest is a fast, modern JavaScript testing framework powered by Rspack. Explore its CLI, configuration, runtime APIs, browser testing, migration, and integrations.
 pageType: home
+titleSuffix: ' - JavaScript Testing Framework'
 
 hero:
   name: Rstest
-  text: Rspack based testing framework
+  text: JavaScript testing framework
 ---

--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -1,9 +1,9 @@
 ---
 description: Rstest is a fast, modern JavaScript testing framework powered by Rspack. Explore its CLI, configuration, runtime APIs, browser testing, migration, and integrations.
 pageType: home
-titleSuffix: ' - JavaScript Testing Framework'
+titleSuffix: ' - Fast, Modern JavaScript Testing Framework'
 
 hero:
   name: Rstest
-  text: JavaScript testing framework
+  text: JavaScript Testing Accelerated by Rspack
 ---

--- a/website/docs/zh/guide/start/features.mdx
+++ b/website/docs/zh/guide/start/features.mdx
@@ -4,7 +4,7 @@ description: 了解 Rstest 面向构建一体化测试提供的能力，包括 R
 
 # 功能导航
 
-Rstest 将测试融入 Rsbuild 与 Rspack 构建链路。它会尽可能复用构建配置，通过基于 bundle 的执行模型运行测试，并提供本地开发和 CI 所需的核心测试能力。
+Rstest 为本地开发与 CI 提供完整的 JavaScript 测试工作流，包括兼容 Jest 的 API、Mock、快照、覆盖率与浏览器测试。Rstest 由 Rspack 驱动，还可以复用构建配置，并通过基于 bundle 的执行模型运行测试。
 
 ## 复用现有构建配置
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -1,12 +1,12 @@
 ---
-description: Rstest 是一个基于 Rspack 的 JavaScript 测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
+description: Rstest 是由 Rspack 驱动的快速、现代 JavaScript 测试框架，提供兼容 Jest 的 API，并全面支持 JavaScript 与 TypeScript 项目。
 ---
 
 # 介绍
 
-Rstest 是一个基于 Rspack 的 JavaScript 测试框架，它为 Rspack 生态提供了全面、一流的支持，能够轻松集成到现有的 Rspack 项目中。
+Rstest 是一个由 Rspack 驱动的快速、现代 JavaScript 测试框架，提供兼容 Jest 的 API，并对 TypeScript、ESM、CJS 等提供开箱即用支持。
 
-Rstest 提供兼容 Jest 的 API，同时提供对 TypeScript、ESM、CJS 等的原生、开箱即用支持，确保现代高效的测试体验。
+Rstest 可用于任何 JavaScript 或 TypeScript 项目。使用 Rspack、Rsbuild 或 Rslib 的项目还可以复用现有构建配置，让代码转换和模块解析在构建与测试中保持一致。
 
 ## ✨ 为什么选择 Rstest
 

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -1,9 +1,9 @@
 ---
 description: Rstest 是由 Rspack 驱动的快速、现代 JavaScript 测试框架。文档涵盖 CLI、配置、运行时 API、浏览器测试、迁移与集成指南。
 pageType: home
-titleSuffix: ' - JavaScript 测试框架'
+titleSuffix: ' - 快速、现代的 JavaScript 测试框架'
 
 hero:
   name: Rstest
-  text: JavaScript 测试框架
+  text: JavaScript 测试，由 Rspack 加速
 ---

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -1,9 +1,9 @@
 ---
-description: 基于 Rspack 的测试框架。Rstest 文档涵盖 CLI、配置、运行时 API、浏览器测试、迁移与集成指南。
+description: Rstest 是由 Rspack 驱动的快速、现代 JavaScript 测试框架。文档涵盖 CLI、配置、运行时 API、浏览器测试、迁移与集成指南。
 pageType: home
-titleSuffix: ' - 基于 Rspack 的测试框架'
+titleSuffix: ' - JavaScript 测试框架'
 
 hero:
   name: Rstest
-  text: 基于 Rspack 的测试框架
+  text: JavaScript 测试框架
 ---

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -8,36 +8,36 @@
     "zh": "快速上手"
   },
   "subtitle": {
-    "en": "JavaScript Testing Framework",
-    "zh": "JavaScript 测试框架"
+    "en": "JavaScript Testing Accelerated by Rspack",
+    "zh": "JavaScript 测试，由 Rspack 加速"
   },
   "slogan": {
-    "en": "Fast, modern testing powered by Rspack",
-    "zh": "由 Rspack 驱动，提供快速、现代的测试体验"
+    "en": "Jest-compatible, ready out of the box.",
+    "zh": "兼容 Jest API，开箱即用。"
   },
   "reuseBuildConfig": {
-    "en": "Reuse your build setup",
-    "zh": "复用现有构建配置"
+    "en": "Reuse build configuration",
+    "zh": "复用构建配置"
   },
   "reuseBuildConfigDesc": {
-    "en": "Use existing Rsbuild or Rspack config so aliases, transforms, and plugins stay consistent in tests.",
-    "zh": "直接使用 Rsbuild 或 Rspack 配置，让 alias、transform 和插件能力在测试中保持一致。"
+    "en": "Reuse Rsbuild or Rspack aliases, transforms, and plugins instead of maintaining a separate test setup.",
+    "zh": "复用 Rsbuild 或 Rspack 的 alias、转换与插件，无需重复维护测试配置。"
   },
   "productionAccurateTesting": {
-    "en": "Test through the build pipeline",
-    "zh": "沿用构建链路测试"
+    "en": "Build-aligned testing",
+    "zh": "与构建一致的测试"
   },
   "productionAccurateTestingDesc": {
-    "en": "Run tests through Rspack's bundling model to match production behavior more closely.",
-    "zh": "通过 Rspack 的 bundle 模型运行测试，让测试行为更贴近生产产物。"
+    "en": "Run tests through Rspack's bundling model so transforms and module resolution stay closer to production.",
+    "zh": "通过 Rspack 的 bundle 模型运行测试，让代码转换和模块解析更贴近生产环境。"
   },
   "blazingFast": {
     "en": "Fast by design",
     "zh": "高效执行"
   },
   "blazingFastDesc": {
-    "en": "Rspack-powered bundling keeps startup and reruns fast, even in larger projects.",
-    "zh": "基于 Rspack 的构建与优化能力，在大型项目中也能保持快速启动和重新运行。"
+    "en": "Rspack-powered compilation keeps test startup and reruns fast.",
+    "zh": "由 Rspack 驱动的编译让测试启动与重新运行保持快速。"
   },
   "realBrowserTesting": {
     "en": "Real browser testing",
@@ -52,15 +52,15 @@
     "zh": "现代能力默认可用"
   },
   "modernByDefaultDesc": {
-    "en": "TypeScript, ESM, CJS, CSS Modules, and modern JavaScript work out of the box.",
-    "zh": "TypeScript、ESM、CJS、CSS Modules 和现代 JavaScript 开箱即用。"
+    "en": "Test TypeScript, ESM, CJS, and CSS Modules without configuring a separate transform pipeline.",
+    "zh": "无需单独配置转换链路，即可测试 TypeScript、ESM、CJS 和 CSS Modules。"
   },
   "testingReady": {
-    "en": "Familiar testing APIs",
-    "zh": "熟悉的测试 API"
+    "en": "Jest-compatible APIs",
+    "zh": "兼容 Jest 的 API"
   },
   "testingReadyDesc": {
-    "en": "Use Jest-compatible assertions, snapshots, mocks, coverage, and lifecycle hooks out of the box.",
-    "zh": "兼容 Jest 的断言、快照、Mock、覆盖率和生命周期钩子等能力开箱即用。"
+    "en": "Use familiar assertions, snapshots, and mocks, with coverage and lifecycle hooks built in.",
+    "zh": "使用熟悉的断言、快照与 Mock API，并内置覆盖率和生命周期钩子。"
   }
 }

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -8,12 +8,12 @@
     "zh": "快速上手"
   },
   "subtitle": {
-    "en": "Rspack-based Testing Framework",
-    "zh": "由 Rspack 驱动的测试框架"
+    "en": "JavaScript Testing Framework",
+    "zh": "JavaScript 测试框架"
   },
   "slogan": {
-    "en": "Provide first-class support for Rspack ecosystem",
-    "zh": "为 Rspack 生态提供全面、一流的支持"
+    "en": "Fast, modern testing powered by Rspack",
+    "zh": "由 Rspack 驱动，提供快速、现代的测试体验"
   },
   "reuseBuildConfig": {
     "en": "Reuse your build setup",
@@ -56,11 +56,11 @@
     "zh": "TypeScript、ESM、CJS、CSS Modules 和现代 JavaScript 开箱即用。"
   },
   "testingReady": {
-    "en": "Testing essentials included",
-    "zh": "核心测试能力内置"
+    "en": "Familiar testing APIs",
+    "zh": "熟悉的测试 API"
   },
   "testingReadyDesc": {
-    "en": "Assertions, snapshots, mocks, coverage, and lifecycle hooks are ready when you start.",
-    "zh": "断言、快照、Mock、覆盖率和生命周期钩子等能力开箱即用。"
+    "en": "Use Jest-compatible assertions, snapshots, mocks, coverage, and lifecycle hooks out of the box.",
+    "zh": "兼容 Jest 的断言、快照、Mock、覆盖率和生命周期钩子等能力开箱即用。"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -10,7 +10,7 @@ import pluginSitemap from 'rspress-plugin-sitemap';
 
 const siteUrl = 'https://rstest.rs';
 const description =
-  'Rstest is a JavaScript testing framework powered by Rspack';
+  'Rstest is a fast, modern JavaScript testing framework powered by Rspack';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
@@ -66,7 +66,7 @@ export default defineConfig({
       {
         lang: 'zh',
         label: '简体中文',
-        description: 'Rstest 是由 Rspack 驱动的 JavaScript 测试框架',
+        description: 'Rstest 是由 Rspack 驱动的快速、现代 JavaScript 测试框架',
       },
     ],
   },

--- a/website/theme/components/Features.tsx
+++ b/website/theme/components/Features.tsx
@@ -12,12 +12,12 @@ export function Features() {
     {
       title: t('testingReady'),
       details: t('testingReadyDesc'),
-      icon: '🧰',
+      icon: '🧪',
     },
     {
       title: t('modernByDefault'),
       details: t('modernByDefaultDesc'),
-      icon: '🧠',
+      icon: '✨',
     },
     {
       title: t('blazingFast'),
@@ -27,12 +27,12 @@ export function Features() {
     {
       title: t('reuseBuildConfig'),
       details: t('reuseBuildConfigDesc'),
-      icon: '♻️',
+      icon: '🔁',
     },
     {
       title: t('productionAccurateTesting'),
       details: t('productionAccurateTestingDesc'),
-      icon: '🎯',
+      icon: '🏗️',
     },
     {
       title: t('realBrowserTesting'),

--- a/website/theme/components/Features.tsx
+++ b/website/theme/components/Features.tsx
@@ -10,6 +10,21 @@ export function Features() {
   const t = useI18n<typeof import('i18n')>();
   const features = [
     {
+      title: t('testingReady'),
+      details: t('testingReadyDesc'),
+      icon: '🧰',
+    },
+    {
+      title: t('modernByDefault'),
+      details: t('modernByDefaultDesc'),
+      icon: '🧠',
+    },
+    {
+      title: t('blazingFast'),
+      details: t('blazingFastDesc'),
+      icon: '⚡',
+    },
+    {
       title: t('reuseBuildConfig'),
       details: t('reuseBuildConfigDesc'),
       icon: '♻️',
@@ -18,21 +33,6 @@ export function Features() {
       title: t('productionAccurateTesting'),
       details: t('productionAccurateTestingDesc'),
       icon: '🎯',
-    },
-    {
-      title: t('blazingFast'),
-      details: t('blazingFastDesc'),
-      icon: '⚡',
-    },
-    {
-      title: t('modernByDefault'),
-      details: t('modernByDefaultDesc'),
-      icon: '🧠',
-    },
-    {
-      title: t('testingReady'),
-      details: t('testingReadyDesc'),
-      icon: '🧰',
     },
     {
       title: t('realBrowserTesting'),


### PR DESCRIPTION
## Summary

- Position Rstest clearly as a fast, modern JavaScript testing framework across the homepage, SEO metadata, README, and introduction docs.
- Present Rspack as the underlying engine and an additional integration advantage instead of the product category.
- Reorder homepage features to lead with familiar testing APIs, modern defaults, and performance.

## Related Links

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).