### PR TITLE
test(playwright): remove nested Rstest runs

### DIFF
--- a/e2e/playwright/fixtures/cleanup-failure.test.ts
+++ b/e2e/playwright/fixtures/cleanup-failure.test.ts
@@ -1,0 +1,33 @@
+import { join } from 'node:path';
+import { expect, test as base } from '@rstest/playwright';
+import type { APIRequestContext } from 'playwright';
+
+let request: APIRequestContext;
+let url: string;
+
+const cleanupFailureTest = base.extend<{ userCleanup: undefined }>({
+  userCleanup: async (_, use) => {
+    await use(undefined);
+    throw new Error('user cleanup failed');
+  },
+});
+
+cleanupFailureTest.sequential(
+  'uses request and serve before cleanup failure',
+  async ({ request: currentRequest, serve, userCleanup }) => {
+    expect(userCleanup).toBeUndefined();
+    request = currentRequest;
+    url = (await serve(join(import.meta.dirname, 'package.json'))).url;
+
+    const response = await request.get(url);
+    expect(response.ok()).toBe(true);
+  },
+);
+
+base.sequential('verifies request and serve cleanup', async () => {
+  await expect(request.get(url)).rejects.toThrow(
+    'Target page, context or browser has been closed',
+  );
+  await expect(fetch(url)).rejects.toThrow();
+  console.log('RSTEST_PLAYWRIGHT_CLEANUP_OK');
+});

--- a/e2e/playwright/index.test.ts
+++ b/e2e/playwright/index.test.ts
@@ -160,6 +160,22 @@ describe('@rstest/playwright', () => {
     expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_FAILURE_DIAGNOSTICS_OK');
   });
 
+  it('cleans up request and serve fixtures after another fixture fails', async () => {
+    const { cli, expectExecFailed } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'cleanup-failure.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecFailed();
+    expect(cli.log).toContain('user cleanup failed');
+    expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_CLEANUP_OK');
+  });
+
   it('does not write retained traces for passing tests', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/packages/playwright/tests/fixture.test.ts
+++ b/packages/playwright/tests/fixture.test.ts
@@ -1,4 +1,4 @@
-import { execFile, type ExecFileOptions } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
@@ -26,36 +26,8 @@ const debugOptions = {
 
 const execFileAsync = promisify(execFile);
 
-const runRstestSubprocess = (args: string[], options: ExecFileOptions = {}) =>
-  execFileAsync(process.execPath, args, {
-    ...options,
-    env: {
-      ...process.env,
-      ...options.env,
-      GITHUB_STEP_SUMMARY: undefined,
-    },
-  });
-
 const createPlaywrightTempRoot = () =>
   mkdtemp(join(__dirname, '../.tmp-rstest-playwright-'));
-
-const writePlaywrightFixtureProject = async (root: string) => {
-  await mkdir(root, { recursive: true });
-  await writeFile(
-    join(root, 'rstest.config.mjs'),
-    `
-      import { defineConfig } from '@rstest/core';
-      import { withRslibConfig } from ${JSON.stringify(join(__dirname, '../../adapter-rslib/src/index.ts').replaceAll('\\', '/'))};
-
-      export default defineConfig({
-        extends: withRslibConfig({ cwd: ${JSON.stringify(join(__dirname, '..').replaceAll('\\', '/'))} }),
-        globals: true,
-        include: ['<rootDir>/**/*.test.mjs'],
-        source: { tsconfigPath: ${JSON.stringify(join(__dirname, '../tests/tsconfig.json').replaceAll('\\', '/'))} },
-      });
-    `,
-  );
-};
 
 const writeNodeImportablePlaywrightSource = async (root: string) => {
   await mkdir(root, { recursive: true });
@@ -474,44 +446,13 @@ test(
 test(
   'resolves relative static server entries from the project root',
   { timeout: 30_000 },
-  async () => {
-    const root = await createPlaywrightTempRoot();
+  async ({ request, serve }) => {
+    const { url } = await serve('./package.json');
+    const response = await request.get(url);
 
-    try {
-      await writePlaywrightFixtureProject(root);
-      const testDir = join(root, 'test');
-      await mkdir(join(root, 'dist'), { recursive: true });
-      await mkdir(testDir, { recursive: true });
-      await writeFile(join(root, 'dist/index.html'), '<h1>relative</h1>');
-
-      const fixturePath = join(testDir, 'relative.test.mjs');
-      await writeFile(
-        fixturePath,
-        `
-          import { test, expect } from ${JSON.stringify(join(__dirname, '../src/index.ts').replaceAll('\\', '/'))};
-
-          test('serves a file relative to the project root', async ({ request, serve }) => {
-            const { url } = await serve('./dist/index.html');
-            const response = await request.get(url);
-
-            expect(await response.text()).toBe('<h1>relative</h1>');
-          });
-        `,
-      );
-
-      await runRstestSubprocess(
-        [
-          join(__dirname, '../../core/bin/rstest.js'),
-          '--root',
-          root,
-          '--config',
-          './rstest.config.mjs',
-        ],
-        { cwd: root },
-      );
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    expect(await response.json()).toMatchObject({
+      name: '@rstest/playwright',
+    });
   },
 );
 
@@ -559,65 +500,3 @@ test(
     await server.close();
   },
 );
-
-test('cleans up request and serve fixtures after a failed cleanup', async () => {
-  const root = await createPlaywrightTempRoot();
-
-  try {
-    await writePlaywrightFixtureProject(root);
-    await writeFile(join(root, 'index.html'), '<h1>ok</h1>');
-
-    const fixturePath = join(root, 'cleanup.test.mjs');
-    await writeFile(
-      fixturePath,
-      `
-        import { test, expect } from ${JSON.stringify(join(__dirname, '../src/index.ts').replaceAll('\\', '/'))};
-
-        let request;
-        let url;
-
-        const cleanupFailureTest = test.extend({
-          userCleanup: async (_, use) => {
-            await use(undefined);
-            throw new Error('user cleanup failed');
-          },
-        });
-
-        cleanupFailureTest.sequential('uses request and serve before cleanup failure', async ({ request: currentRequest, serve, userCleanup }) => {
-          expect(userCleanup).toBeUndefined();
-          request = currentRequest;
-          url = (await serve(${JSON.stringify(join(root, 'index.html'))})).url;
-
-          const response = await request.get(url);
-          expect(response.ok()).toBe(true);
-        });
-
-        test.sequential('verifies cleanup', async () => {
-          await expect(request.get('https://example.com')).rejects.toThrow();
-          await expect(fetch(url)).rejects.toThrow();
-          console.log('RSTEST_PLAYWRIGHT_CLEANUP_OK');
-        });
-      `,
-    );
-
-    const { stdout, stderr } = await runRstestSubprocess(
-      [
-        join(__dirname, '../../core/bin/rstest.js'),
-        '--root',
-        root,
-        '--config',
-        './rstest.config.mjs',
-      ],
-      { cwd: root },
-    ).catch(
-      (error: { message?: string; stderr?: string; stdout?: string }) => ({
-        stderr: `${error.message ?? ''}\n${error.stderr ?? ''}`,
-        stdout: error.stdout ?? '',
-      }),
-    );
-
-    expect(`${stdout}\n${stderr}`).toContain('RSTEST_PLAYWRIGHT_CLEANUP_OK');
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-});


### PR DESCRIPTION
## Summary

Package-level Playwright tests currently start nested Rstest processes, adding unnecessary compilation work and making the cleanup regression susceptible to the default 5-second test timeout. This PR moves the teardown-failure scenario to the existing Playwright e2e suite, tests project-root-relative `serve` resolution directly, and removes the external network dependency from cleanup verification.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).