### PR TITLE
fix(core): validate hook fixture availability

### DIFF
--- a/e2e/browser-mode/error.test.ts
+++ b/e2e/browser-mode/error.test.ts
@@ -63,4 +63,15 @@ describe('browser mode - error handling', () => {
       'UNHANDLED_BROWSER_REJECTION',
     );
   });
+
+  it('reports hook fixtures missing from browser tests', async () => {
+    const { cli, expectExecFailed } = await runBrowserCli('error', {
+      args: ['tests/hookFixtureMismatch.test.ts'],
+    });
+
+    await expectExecFailed();
+    const output = `${cli.stdout}\n${cli.stderr}`;
+    expect(output).toContain('Hook has unknown fixture "browserValue"');
+    expect(output).not.toContain('browser hook received a missing fixture');
+  });
 });

--- a/e2e/browser-mode/fixtures/error/tests/hookFixtureMismatch.test.ts
+++ b/e2e/browser-mode/fixtures/error/tests/hookFixtureMismatch.test.ts
@@ -1,0 +1,18 @@
+import { beforeEach, test } from '@rstest/core';
+
+type BrowserFixtures = {
+  browserValue: string;
+};
+
+const browserTest = test.extend<BrowserFixtures>({
+  browserValue: 'browser',
+});
+
+beforeEach<BrowserFixtures>(({ browserValue }) => {
+  if (browserValue === undefined) {
+    throw new Error('browser hook received a missing fixture');
+  }
+});
+
+browserTest('provides the browser hook fixture', () => {});
+test('does not provide the browser hook fixture', () => {});

--- a/e2e/playwright/fixtures/hook-fixture-mismatch.test.ts
+++ b/e2e/playwright/fixtures/hook-fixture-mismatch.test.ts
@@ -1,0 +1,18 @@
+import { test as base } from '@rstest/playwright';
+
+type CustomFixtures = {
+  customValue: string;
+};
+
+const extended = base.extend<CustomFixtures>({
+  customValue: 'custom',
+});
+
+extended.beforeEach<CustomFixtures>(({ customValue }) => {
+  if (customValue === undefined) {
+    throw new Error('Playwright hook received a missing fixture');
+  }
+});
+
+extended('provides the custom fixture', () => {});
+base('does not provide the custom fixture', () => {});

--- a/e2e/playwright/index.test.ts
+++ b/e2e/playwright/index.test.ts
@@ -176,6 +176,23 @@ describe('@rstest/playwright', () => {
     expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_CLEANUP_OK');
   });
 
+  it('reports extended hook fixtures missing from base tests', async () => {
+    const { cli, expectExecFailed } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'hook-fixture-mismatch.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecFailed();
+    const output = `${cli.stdout}\n${cli.stderr}`;
+    expect(output).toContain('Hook has unknown fixture "customValue"');
+    expect(output).not.toContain('Playwright hook received a missing fixture');
+  });
+
   it('does not write retained traces for passing tests', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/e2e/test-api/extend.hookFixtureMismatch.test.ts
+++ b/e2e/test-api/extend.hookFixtureMismatch.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+it('reports hook fixtures missing from tests in the suite', async () => {
+  const { cli, expectExecFailed, expectStderrLog } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', 'fixtures/hookFixtureMismatch.test.ts'],
+    options: {
+      nodeOptions: {
+        cwd: __dirname,
+      },
+    },
+  });
+
+  await expectExecFailed();
+  expectStderrLog(/Hook has unknown fixture "extendedValue"/);
+  expectStderrLog(/Hook has unknown fixture "firstValue"/);
+  expectStderrLog(/Hook has unknown fixture "cleanupValue"/);
+  expect(`${cli.stdout}\n${cli.stderr}`).not.toContain('received a missing');
+});

--- a/e2e/test-api/fixtures/hookFixtureMismatch.test.ts
+++ b/e2e/test-api/fixtures/hookFixtureMismatch.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, test } from '@rstest/core';
+
+describe('extended and plain tests', () => {
+  type ExtendedFixtures = {
+    extendedValue: string;
+  };
+
+  const extendedTest = test.extend<ExtendedFixtures>({
+    extendedValue: 'extended',
+  });
+
+  beforeEach<ExtendedFixtures>(({ extendedValue }) => {
+    if (extendedValue === undefined) {
+      throw new Error('hook callback received a missing extendedValue');
+    }
+  });
+
+  extendedTest('provides the hook fixture', () => {});
+  test('does not provide the hook fixture', () => {});
+});
+
+describe('incompatible extended tests', () => {
+  type FirstFixtures = {
+    firstValue: string;
+  };
+
+  const firstTest = test.extend<FirstFixtures>({
+    firstValue: 'first',
+  });
+  const secondTest = test.extend({
+    secondValue: 'second',
+  });
+
+  afterEach<FirstFixtures>(({ firstValue }) => {
+    if (firstValue === undefined) {
+      throw new Error('afterEach received a missing firstValue');
+    }
+  });
+
+  firstTest('provides the first hook fixture', () => {});
+  secondTest('does not provide the first hook fixture', () => {});
+});
+
+describe('beforeEach cleanup', () => {
+  type CleanupFixtures = {
+    cleanupValue: string;
+  };
+
+  const cleanupTest = test.extend<CleanupFixtures>({
+    cleanupValue: 'cleanup',
+  });
+
+  beforeEach<CleanupFixtures>(() => {
+    return ({ cleanupValue }) => {
+      if (cleanupValue === undefined) {
+        throw new Error('cleanup received a missing cleanupValue');
+      }
+    };
+  });
+
+  cleanupTest('provides the cleanup fixture', () => {});
+  test('does not provide the cleanup fixture', () => {});
+});

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -75,6 +75,7 @@ const fixturePropsCache = new WeakMap<
   FixtureCallback,
   { namedContext?: string[]; destructuredContext?: string[] }
 >();
+const functionPropertyNames = new Set(Object.getOwnPropertyNames(() => {}));
 
 export function setFixtureCallbackSource(
   callback: (...args: any[]) => any,
@@ -88,14 +89,7 @@ export const createFixtureResolver = (
   context: Record<string, any>,
   cleanups: (() => Promise<void>)[] = [],
 ): FixtureResolver => {
-  if (!test.fixtures) {
-    return {
-      cancelPendingFixtures: () => undefined,
-      resolveTestFixtures: () => Promise.resolve(),
-      resolveHookFixtures: () => Promise.resolve({ status: 'resolved' }),
-    };
-  }
-
+  const fixtures = test.fixtures ?? {};
   const doneMap = new Set<string>();
   const cancelledFixtures = new Set<string>();
   const failedFixtures = new Set<string>();
@@ -128,7 +122,7 @@ export const createFixtureResolver = (
     try {
       if (deps?.length) {
         for (const dep of deps) {
-          await useFixture(dep, test.fixtures![dep]!);
+          await useFixture(dep, fixtures[dep]!);
         }
       }
 
@@ -185,7 +179,7 @@ export const createFixtureResolver = (
     usedKeys: string[],
     includeAuto: boolean,
   ) => {
-    for (const [name, params] of Object.entries(test.fixtures ?? {})) {
+    for (const [name, params] of Object.entries(fixtures)) {
       const shouldResolve =
         usedKeys.includes(name) || (includeAuto && params.options?.auto);
       if (!shouldResolve) {
@@ -212,10 +206,23 @@ export const createFixtureResolver = (
       return { teardownStarted };
     },
     resolveTestFixtures: (fn) =>
-      resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], true),
+      test.fixtures
+        ? resolveFixtureNames(fn ? getFixtureUsedProps(fn) : [], true)
+        : Promise.resolve(),
     resolveHookFixtures: async (fn) => {
       try {
-        await resolveFixtureNames(getFixtureUsedProps(fn, true), false);
+        const usedKeys = getFixtureUsedProps(fn, true);
+        const missingFixture = usedKeys.find(
+          (name) =>
+            !Object.hasOwn(fixtures, name) &&
+            (!Object.hasOwn(context, name) || functionPropertyNames.has(name)),
+        );
+        if (missingFixture) {
+          throw new Error(
+            `Hook has unknown fixture "${missingFixture}". Every test in the hook's suite must provide it.`,
+          );
+        }
+        await resolveFixtureNames(usedKeys, false);
       } catch (error) {
         if (error instanceof PreviouslyFailedFixtureError) {
           return { status: 'skipped' };

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -126,6 +126,58 @@ describe('createFixtureResolver', () => {
     expect(context).toEqual({ task: { name: 'test' } });
   });
 
+  it('allows TestContext properties in destructured hooks', async () => {
+    const context = Object.assign(() => {}, { task: { name: 'test' } });
+    const resolver = createFixtureResolver({} as any, context);
+
+    await expect(
+      resolver.resolveHookFixtures(({ task }: any) => task.name),
+    ).resolves.toEqual({ status: 'resolved' });
+  });
+
+  it('does not treat Function properties as TestContext properties', async () => {
+    const context = Object.assign(() => {}, { task: { name: 'test' } });
+    const resolver = createFixtureResolver({} as any, context);
+
+    await expect(
+      resolver.resolveHookFixtures(({ name }: any) => name),
+    ).rejects.toThrow('Hook has unknown fixture "name"');
+  });
+
+  it('rejects hook fixtures missing from the current test', async () => {
+    const resolver = createFixtureResolver({} as any, {
+      task: { name: 'plain test' },
+    });
+
+    await expect(
+      resolver.resolveHookFixtures(({ custom }: any) => custom),
+    ).rejects.toThrow(
+      'Hook has unknown fixture "custom". Every test in the hook\'s suite must provide it.',
+    );
+  });
+
+  it('validates all hook fixtures before starting requested fixture setup', async () => {
+    let setupAttempts = 0;
+    const fixtures = normalizeFixtures({
+      available: [
+        async (_context: any, use: any) => {
+          setupAttempts++;
+          await use('available');
+        },
+      ],
+    } as any);
+    const resolver = createFixtureResolver({ fixtures } as any, {
+      task: { name: 'test' },
+    });
+
+    await expect(
+      resolver.resolveHookFixtures(
+        ({ available, missing }: any) => available ?? missing,
+      ),
+    ).rejects.toThrow('Hook has unknown fixture "missing"');
+    expect(setupAttempts).toBe(0);
+  });
+
   it('resolves fixtures directly destructured by hooks', async () => {
     const context: Record<string, any> = {};
     const fixtures = normalizeFixtures({ fixture: 'fixture' } as any);

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -91,7 +91,7 @@ describe('dashboard', () => {
 });
 ```
 
-Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
+Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook; otherwise, Rstest fails that test before invoking the hook and reports the missing fixture. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
 
 Declare fixture dependencies through direct object destructuring in the hook parameter. Destructuring a named context inside the hook body does not request fixtures. Rest properties and default values are not supported in fixture-aware callbacks.
 

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -452,7 +452,7 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 
 Declare hook fixture dependencies directly in the callback parameter, for example `beforeEach(({ db }) => {})`. A named hook context such as `beforeEach((context) => {})` remains valid for accessing the regular `TestContext`, but destructuring `context` inside the function body does not initialize lazy fixtures.
 
-Core hooks are suite-level APIs, so provide the fixture context type explicitly and register the hook in a suite whose tests use the matching extended test API:
+Core hooks are suite-level APIs, so provide the fixture context type explicitly and register the hook in a suite whose tests use the matching extended test API. If a test in the suite does not provide a requested fixture, Rstest fails that test before invoking the hook and reports the missing fixture:
 
 ```ts
 import { beforeEach, describe, test } from '@rstest/core';

--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -141,7 +141,7 @@ describe('dashboard', () => {
 });
 ```
 
-Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
+Hooks are scoped to their `describe` block, not to an extended test object. Every test in the block must provide the fixtures requested by the hook; otherwise, Rstest fails that test before invoking the hook and reports the missing fixture. The same behavior applies to `afterEach` and to cleanup functions returned by `beforeEach`. Fixture instances are shared across the hooks and test body for one test attempt, then torn down in reverse setup order.
 
 Declare fixture dependencies through direct object destructuring in the hook parameter. Destructuring a named context inside the hook body does not request fixtures. Rest properties and default values are not supported in fixture-aware callbacks.
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -452,7 +452,7 @@ testWithApi('fetch profile', async ({ baseURL, token, expect }) => {
 
 Hook 必须直接在 callback 参数中声明 fixture 依赖，例如 `beforeEach(({ db }) => {})`。`beforeEach((context) => {})` 这类 named hook context 仍可用于访问常规 `TestContext`，但在函数体内解构 `context` 不会初始化惰性 fixture。
 
-Core hooks 是 suite 级 API，因此需要显式传入 fixture context 类型，并在使用对应 extended test API 的 suite 内注册 hook：
+Core hooks 是 suite 级 API，因此需要显式传入 fixture context 类型，并在使用对应 extended test API 的 suite 内注册 hook。如果 suite 中的某个测试没有提供 hook 请求的 fixture，Rstest 会在调用 hook 前让该测试失败，并报告缺失的 fixture：
 
 ```ts
 import { beforeEach, describe, test } from '@rstest/core';

--- a/website/docs/zh/guide/advanced/playwright.mdx
+++ b/website/docs/zh/guide/advanced/playwright.mdx
@@ -141,7 +141,7 @@ describe('dashboard', () => {
 });
 ```
 
-Hook 的作用域是所在的 `describe` block，而不是某个 extended test 对象。因此，该 block 内的每个测试都必须提供 hook 请求的 fixture。`afterEach` 和 `beforeEach` 返回的 cleanup 函数同样支持这一行为。在一次 test attempt 内，hooks 与测试函数共享 fixture 实例，最后按 setup 的反序执行 teardown。
+Hook 的作用域是所在的 `describe` block，而不是某个 extended test 对象。因此，该 block 内的每个测试都必须提供 hook 请求的 fixture；否则，Rstest 会在调用 hook 前让该测试失败，并报告缺失的 fixture。`afterEach` 和 `beforeEach` 返回的 cleanup 函数同样支持这一行为。在一次 test attempt 内，hooks 与测试函数共享 fixture 实例，最后按 setup 的反序执行 teardown。
 
 请在 hook 参数中通过直接对象解构声明 fixture 依赖。在 hook 函数体内解构 named context 不会请求 fixture。使用 fixture 的 callback 不支持 rest property 和默认值。
 


### PR DESCRIPTION
## Summary

- Fail a per-test hook before invoking its callback when the current test does not provide a directly requested fixture, instead of passing `undefined`.
- Keep hooks suite-scoped and document that every test in scope must provide the requested fixtures.
- Cover Node, browser mode, and `@rstest/playwright` mixed-test scenarios.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1606
- https://github.com/web-infra-dev/rstest/pull/1604#discussion_r3643374810

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).