### PR TITLE
ci: restore main push concurrency strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,8 @@ on:
         default: false
 
 concurrency:
-  # On push the group is keyed by ref (not sha), so consecutive merges to main
-  # coalesce onto the newest commit instead of queueing one full matrix per
-  # merge. event_name is part of the key so a manual dispatch is not cancelled
-  # by a merge landing while it runs. Do not copy this key to bundle-diff or
-  # codspeed: their push-to-main runs produce per-commit baseline artifacts and
-  # must not coalesce.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || format('{0}-{1}', github.event_name, github.ref) }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Restore the pre-#1615 concurrency strategy so each main push uses its commit SHA as the concurrency group and is not cancelled by later merges. Pull request runs continue to cancel superseded runs for the same PR.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1615
- https://github.com/web-infra-dev/rstest/actions/runs/30063132948/job/89389431294

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).