### PR TITLE
perf(core): split browser runtime vendor chunk

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -51,7 +51,12 @@ const readableMinifyConfig = {
 const fullyMinifiedNodeChunks =
   /(?:^|\/)(?:@babel\/code-frame|@clack\/prompts|@vitest\/pretty-format|chokidar|diff|fake-timers|magic-string\.es)~0\.js$/;
 const fullyMinifiedBrowserChunks =
-  /(?:^|\/)(?:fake-timers|magic-string\.es)~1\.js$/;
+  /(?:^|\/)(?:browser-runtime-vendor|fake-timers|magic-string\.es)~1\.js$/;
+
+// An allowlist preserves the existing lazy snapshot, fake-timers, and
+// magic-string chunk boundaries.
+const browserRuntimeVendorModules =
+  /[\\/]node_modules[\\/](?:@vitest[\\/](?:expect|pretty-format|spy|utils)|base64-js|buffer|chai|ieee754|pathe|path-browserify|process|stacktrace-parser|tinyrainbow|tinyspy|url-extras)(?:[\\/]|$)/;
 
 // API Extractor keeps this reference from bundled @vitest/expect but omits
 // the matching global augmentation that makes the declaration self-contained.
@@ -192,6 +197,23 @@ export default defineConfig({
       plugins: [pluginNodePolyfill()],
       tools: {
         rspack: {
+          optimization: {
+            // Split chunks register through the Rspack runtime. Leaving it in
+            // the entry chunk creates a circular ESM initialization dependency.
+            runtimeChunk: {
+              name: 'browser-runtime-runtime',
+            },
+            splitChunks: {
+              cacheGroups: {
+                browserRuntimeVendor: {
+                  chunks: 'initial',
+                  enforce: true,
+                  name: 'browser-runtime-vendor',
+                  test: browserRuntimeVendorModules,
+                },
+              },
+            },
+          },
           plugins: [
             rsdoctorCIPlugin({ reportDir: '.rsdoctor/browser' }),
           ].filter(Boolean),


### PR DESCRIPTION
## Summary

- Extract stable assertion and browser-polyfill dependencies from the eager browser runtime into a fully minified vendor chunk while preserving the existing lazy snapshot, fake-timers, and magic-string boundaries.
- Emit the Rspack runtime separately to avoid a circular ESM initialization dependency between the runtime and vendor chunks.
- In same-environment builds, eager browser runtime JS decreases from 553.0 kB to 317.3 kB (-42.6%) and from 103.6 kB to 82.3 kB gzip (-20.6%); total browser runtime gzip decreases from 143.9 kB to 117.9 kB (-18.1%).

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1624

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).