### PR TITLE
docs: hide the federation config page from production builds

### DIFF
--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -320,7 +320,6 @@ Rstest CLI options are registered per command instead of being shared by every c
 | `--detectAsyncLeaks`                | Detect async resources that leak after tests finish, see [detectAsyncLeaks](/config/test/detect-async-leaks)                                                          |
 | `--disableConsoleIntercept`         | Disable console intercept, see [disableConsoleIntercept](/config/test/disable-console-intercept)                                                                      |
 | `--exclude <exclude>`               | Exclude files from test, see [exclude](/config/test/exclude)                                                                                                          |
-| `--federation`                      | Enable Module Federation compatibility mode, see [federation](/config/test/federation)                                                                                |
 | `--findRelatedTests`                | Alias for `--related` for Jest compatibility                                                                                                                          |
 | `--globals`                         | Provide global APIs, see [globals](/config/test/globals)                                                                                                              |
 | `-h, --help`                        | Display help for command                                                                                                                                              |

--- a/website/docs/en/shared/agent-migrate.md
+++ b/website/docs/en/shared/agent-migrate.md
@@ -2,96 +2,31 @@
 
 ## Goal
 
-Migrate Jest- or Vitest-based tests and configuration to Rstest with minimal behavior changes.
-
-## Migration principles (must follow)
-
-1. **Smallest-change-first**: prefer the smallest viable change that restores test pass.
-2. **Config before code**: prefer fixing in config/tooling/mocks before touching test logic.
-3. **Do not change user source behavior**: avoid modifying production/business source files unless user explicitly requests it.
-4. **Avoid bulk test rewrites**: do not refactor entire test suites when a local compatibility patch can solve it.
-5. **Preserve test intent**: keep assertions and scenario coverage unchanged unless clearly broken by framework differences.
-6. **Two-phase legacy-runner lifecycle (per migrated scope)**: (a) While the scope being migrated is not green on Rstest, keep every Jest/Vitest dep + config/setup/workspace file untouched — they are your rollback path. (b) Once that scope is green, delete its scope-local legacy config/setup files in the same commit. Drop the shared legacy devDeps (`jest`, `vitest`, adapters, environments) only when no other scope still relies on them — in a partial / mixed-mode monorepo migration that means the final scope, not the first. Leaving files behind "for reference" creates two source-of-truth configs. Framework-specific file enumeration: see the deltas reference.
-7. **Literal API substitution, no shims**: rewrite every `vi.` / `jest.` / `vitest.` call site — no global aliasing, no local rebinding, no aliased imports. Full forbidden-form list and reasoning in `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`.
-8. **Replace on call sites, not strings**: match only identifiers preceding `(`; after every batch edit, grep `describe\(|it\(|test\(` to confirm no test name string was mutated. Regex template and rationale in `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`.
-9. **Coverage thresholds are not negotiable**: never lower `coverage.thresholds` (lines/functions/branches/statements) to make a migrated suite pass. If thresholds fail under Rstest, investigate `coverage.include` / `exclude` / provider wiring before touching the numbers.
+Migrate Jest/Vitest tests and config to Rstest with minimal behavior changes. Use the current Rstest migration docs for exact mappings; this skill adds scope, dependency, and cleanup guardrails.
 
 ## Workflow
 
-1. Detect current test framework (`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md`)
-2. Dependency install gate (blocker check, see `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`)
-3. Open the framework-specific deltas file and the official migration guide it points to. Prefer the `.md` URL form when fetching — Rstest pages provide Markdown variants that are more AI-friendly.
-   - Jest: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/jest-migration-deltas.md`
-   - Vitest: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/vitest-migration-deltas.md`
-   - Global API replacement rules: `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`
-4. Apply the mapping from the official guide + the skill-side enforcement rules from the deltas file
-5. Check type errors
-6. Run tests and fix deltas
-7. Apply cleanup phase of principle 6 once the migrated scope is green (delete scope-local legacy config/setup in the same commit; drop shared legacy devDeps only when no other scope still relies on them; framework-specific file list is in the deltas file)
-8. Summarize changes
+1. Detect runner and scope (`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md`).
+2. Run dependency/version gates (`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`).
+3. Read only the needed deltas: Jest, Vitest, and/or global API replacement.
+4. Migrate scripts/config/setup before tests; prefer adapters or Rsbuild/Rspack config fixes before editing test bodies.
+5. Validate discovery/types/run, fixing failures in this order: dependency skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies.
+6. After the scope is green, remove only scope-local legacy files and devDeps no remaining scope uses.
+7. Summarize changes, kept legacy files, unsupported fields, and TODOs.
 
-## Detect current test framework
+## Guardrails
 
-See `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/detect-test-framework.md` for detection signals and the mixed-mode scope policy.
+- Keep the smallest viable scope; do not broaden a monorepo migration or bulk-rewrite tests when config/setup fixes are plausible.
+- Do not change production behavior, assertions, test names, scenarios, or coverage thresholds to make migration pass.
+- No `jest`/`vi` shims or aliases; rewrite call sites to Rstest APIs (`https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/global-api-migration.md`).
+- Do not silently drop unknown config fields; verify or report them as unsupported.
 
-## Dependency install gate (blocker check)
+## High-risk Rstest deltas
 
-Before large-scale edits, verify dependencies can be installed and test runner binaries are available. Detailed checks, blocked-mode output format, and `ni` policy are in `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md`.
+- `rstest` / `rstest run` is single-run; watch mode is `rstest --watch` or `rstest watch`.
+- `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
+- Rstest runs on Rsbuild/Rspack. Use `https://raw.githubusercontent.com/rstackjs/agent-skills/main/skills/migrate-to-rstest/references/dependency-install-gate.md` for latest-only APIs, coverage providers, adapters, plugins, and toolchain-version fallbacks.
 
-## Patch scope policy (strict)
+## Escalate before large edits
 
-### Preferred change order
-
-1. CLI/script/config migration (`package.json`, `rstest.config.ts`, include/exclude, test environment).
-2. Test setup adapter migration (for example `@testing-library/jest-dom/vitest` to matcher-based setup in Rstest).
-3. Mock compatibility adjustments (target module path, `{ mock: true }`, `importActual`).
-4. Narrow per-test setup fixes (single-file, single-suite level).
-5. Path resolution compatibility fixes (`import.meta.url` vs `__dirname`) in test/setup helpers.
-6. As a last resort, test body changes.
-7. Never modify runtime source logic by default.
-
-### Red lines
-
-Principles 6–9 above are themselves red lines — the bullets below cover the scope / intent red lines not captured there:
-
-- Do not rewrite many tests in one sweep without first proving config-level fixes are insufficient.
-- Do not alter business/runtime behavior to satisfy tests.
-- Do not change assertion semantics just to make tests pass.
-- Do not broaden migration to unrelated packages in a monorepo.
-
-### Escalation rule for large edits
-
-If a fix would require either:
-
-- editing many test files, or
-- changing user source files,
-
-stop and provide:
-
-1. why minimal fixes failed,
-2. proposed large-change options,
-3. expected impact/risk per option,
-4. recommended option.
-
-## Run tests and fix deltas
-
-- Run the test suite and fix failures iteratively.
-- Fix configuration and resolver errors first, then address mocks/timers/snapshots, and touch test logic last.
-- If a third-party package fails because of ESM/CJS interop differences, prefer a config-level fix first by overriding its external module type in the test/build config, for example:
-
-```ts
-output: {
-   externals: {
-      'fs-extra': 'commonjs fs-extra',
-   },
-},
-```
-
-Use this when a dependency is being interpreted as the wrong module format under Rstest/Rspack.
-
-- If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3` (fixed in 0.9.3 — upgrade before debugging mock behavior further).
-
-## Summarize changes
-
-- Provide a concise change summary and list files touched.
-- Call out any remaining manual steps or TODOs.
+If the next fix requires many test edits or production source changes, stop and report: why smaller fixes failed, options, risks, and the recommended path.

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -320,7 +320,6 @@ Rstest CLI 参数是按命令注册的，并不是所有命令共享同一套参
 | `--detectAsyncLeaks`                | 检测测试结束后仍然存活的异步资源，详见 [detectAsyncLeaks](/config/test/detect-async-leaks)                                                           |
 | `--disableConsoleIntercept`         | 禁用 console 拦截，详见 [disableConsoleIntercept](/config/test/disable-console-intercept)                                                            |
 | `--exclude <exclude>`               | 排除指定文件，详见 [exclude](/config/test/exclude)                                                                                                   |
-| `--federation`                      | 启用 Module Federation 兼容模式，详见 [federation](/config/test/federation)                                                                          |
 | `--findRelatedTests`                | `--related` 的 Jest 兼容别名                                                                                                                         |
 | `--globals`                         | 提供全局 API，详见 [globals](/config/test/globals)                                                                                                   |
 | `-h, --help`                        | 显示帮助信息                                                                                                                                         |

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -12,6 +12,16 @@ const siteUrl = 'https://rstest.rs';
 const description =
   'Rstest is a JavaScript testing framework powered by Rspack';
 
+/**
+ * Pages that are still being stabilized: authored and served by `rspress dev`,
+ * but dropped from the production route table so they are never emitted,
+ * linked, or listed in the sitemap. `ConfigOverview` gates its own entries on
+ * the same `NODE_ENV` check — keep the two lists in sync.
+ */
+const unreleasedRoutes = ['**/config/test/federation.mdx'];
+
+const isProduction = process.env.NODE_ENV === 'production';
+
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
   title: 'Rstest',
@@ -33,7 +43,12 @@ export default defineConfig({
   route: {
     cleanUrls: true,
     // exclude document fragments from routes
-    exclude: ['**/zh/shared/**', '**/en/shared/**', './theme'],
+    exclude: [
+      '**/zh/shared/**',
+      '**/en/shared/**',
+      './theme',
+      ...(isProduction ? unreleasedRoutes : []),
+    ],
   },
   themeConfig: {
     socialLinks: [

--- a/website/theme/components/ConfigOverview.tsx
+++ b/website/theme/components/ConfigOverview.tsx
@@ -53,7 +53,15 @@ const OVERVIEW_GROUPS: BasicGroup[] = [
   },
   {
     name: 'environment',
-    items: ['pool', 'isolate', 'testEnvironment', 'federation'],
+    items: [
+      'pool',
+      'isolate',
+      'testEnvironment',
+      // Unreleased: its page is excluded from the production route table by
+      // `unreleasedRoutes` in rspress.config.ts, so linking it in a production
+      // build would be a dead link.
+      ...(process.env.NODE_ENV === 'production' ? [] : ['federation']),
+    ],
   },
   {
     name: 'browser',


### PR DESCRIPTION
## Summary

`federation` was added in #1407 but is not ready to be surfaced to users yet, while its reference page is still worth keeping authored and browsable as the feature stabilizes.

- Production builds exclude `config/test/federation` from the route table via `unreleasedRoutes` in `rspress.config.ts`, so the page is never emitted, linked, or listed in the sitemap. `rspress dev` still serves it.
- `ConfigOverview` gates its `federation` entry on the same `NODE_ENV` check. The `_meta.json` entries stay as-is — Rspress drops a sidebar entry whose route does not exist, so no dead link is produced.
- The `--federation` rows in the CLI tables are removed outright rather than gated. `checkDeadLinks` runs before any config-supplied remark plugin, so a markdown link pointing at the excluded route fails the production build; there is no ordering that lets a plugin strip the row first.

Both `federation.mdx` pages are kept unchanged, so re-listing the option later is a matter of dropping it from `unreleasedRoutes`.

The second commit is unrelated housekeeping: `build:agent-install` inlines the migrate-to-rstest skill from upstream at build time, and the committed copy had drifted, so every local `pnpm build` left the file dirty.

## Related Links

- #1407

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
