### PR TITLE
perf(browser): preserve minified UI assets

### DIFF
--- a/e2e/browser-mode/buildOutput.test.ts
+++ b/e2e/browser-mode/buildOutput.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, it } from '@rstest/core';
+
+const browserUiJsDir = join(
+  __dirname,
+  '../../packages/browser-ui/dist/container-static/js',
+);
+const embeddedBrowserUiJsDir = join(
+  __dirname,
+  '../../packages/browser/dist/browser-container/container-static/js',
+);
+
+it('should preserve pre-minified browser UI assets', () => {
+  const sourceFiles = readdirSync(browserUiJsDir)
+    .filter((file) => file.endsWith('.js'))
+    .sort();
+  const embeddedFiles = readdirSync(embeddedBrowserUiJsDir)
+    .filter((file) => file.endsWith('.js'))
+    .sort();
+
+  expect(embeddedFiles).toEqual(sourceFiles);
+  for (const file of sourceFiles) {
+    expect(
+      readFileSync(join(embeddedBrowserUiJsDir, file)).equals(
+        readFileSync(join(browserUiJsDir, file)),
+      ),
+    ).toBe(true);
+  }
+});

--- a/packages/browser/rslib.config.ts
+++ b/packages/browser/rslib.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
                   globOptions: {
                     ignore: ['**/*.LICENSE.txt', '**/rsdoctor-data.json'],
                   },
+                  info: { minimized: true },
                 },
               ],
             }),


### PR DESCRIPTION
## Summary

- preserve pre-minified browser UI assets when copying them into `@rstest/browser`
- reduce the embedded browser container from 1.88 MB to 814 KB and the total browser package build from 2.13 MB to 1.07 MB
- add a regression test that compares the copied JavaScript assets byte-for-byte

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).