### PR TITLE
fix(core): keep the federation dynamic import hook across projects

### DIFF
--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -148,12 +148,11 @@ const preparePool = async (
   // flag, so it must be set before any bundle code is evaluated.
   const federation = context.runtimeConfig.federation === true;
   (globalThis as Record<string, unknown>).__rstest_federation__ = federation;
-  // With `isolate: false` a previous file in this worker may have installed
-  // the global dynamic-import fallback (`mockRuntimeCode.js`). Always drop it:
-  // it keeps federation strictly opt-in for non-federation files, and for
-  // federation files the runtime module reinstalls a fresh hook whose
-  // `import()` is bound to the current bundle's vm dynamic-import context
-  // rather than the previous file's.
+  // With `isolate: false` a previous file in this worker may have installed the
+  // global dynamic-import fallback (`mockRuntimeCode.js`). Hide it from
+  // non-federation files so federation stays strictly opt-in, and hand it back
+  // on federation re-entry — the installing runtime chunk is kept across files
+  // and never re-executes, so dropping it outright would be permanent.
   setFederationDynamicImportOrigin(federation, testPath);
 
   const cleanupFns: (() => MaybePromise<void>)[] = [];

--- a/packages/core/src/runtime/worker/runtimeHooks.ts
+++ b/packages/core/src/runtime/worker/runtimeHooks.ts
@@ -16,21 +16,30 @@ export const RSTEST_REQUIRE_RESOLVE_HOOK =
   '__rstest_require_resolve__' as const;
 
 /**
+ * The federation fallback, parked while a non-federation file runs. Worker-wide,
+ * matching the lifetime of the global it is taken from, and single-slot because
+ * `mockRuntimeCode.js` installs under `hook = hook || fallback` — once one
+ * project's runtime chunk has installed the fallback, every later project sees a
+ * truthy global and skips its own.
+ */
+let retainedDynamicImportHook: unknown;
+
+/**
  * Point the federation dynamic-import fallback at the source file currently
- * being loaded, so relative specifiers reaching `globalThis` resolve against it.
+ * being loaded, so relative specifiers reaching `globalThis` resolve against it,
+ * and keep the fallback itself visible only to federation files.
  *
- * Only the origin is per-file — never delete `RSTEST_DYNAMIC_IMPORT_HOOK` here.
- * A project's runtime chunk installs it as `hook = hook || fallback`, and
- * `clearModuleCache` keeps evaluated runtime chunks alive, so re-entering that
- * project never re-runs the install. Under `isolate: false` a non-federation
- * file that dropped the hook on its way past would strand the federation
- * project's remaining files on an unresolved free identifier. (Only a project
- * whose runtime chunk has not run yet reinstalls it, so the hazard is an
- * interleaving rather than every mixed run.)
+ * Hiding it is a strict opt-in contract: a non-federation file must not be able
+ * to observe or invoke another project's shim. But hiding cannot mean discarding
+ * — `clearModuleCache` keeps evaluated runtime chunks alive, so a project that
+ * has already run never re-executes its install, and a discarded hook would
+ * strand that project's remaining files on an unresolved free identifier.
+ * Retaining and restoring satisfies both.
  *
- * Leaving it installed is inert: normally-loaded modules get the hook as a VM
- * argument that shadows the global, and a cleared origin makes the fallback
- * defer to Node's native `import()`.
+ * The origin needs no such treatment: it is re-established before every
+ * federation file. Clearing it is still worthwhile, since a stale origin from
+ * another project would silently resolve relative specifiers against the wrong
+ * directory instead of deferring to Node's native `import()`.
  */
 export const setFederationDynamicImportOrigin = (
   federation: boolean,
@@ -38,9 +47,19 @@ export const setFederationDynamicImportOrigin = (
 ): void => {
   const runtimeGlobal = globalThis as Record<string, unknown>;
   if (federation) {
+    if (
+      runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK] === undefined &&
+      retainedDynamicImportHook !== undefined
+    ) {
+      runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK] = retainedDynamicImportHook;
+    }
     runtimeGlobal[RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK] = origin;
   } else {
     delete runtimeGlobal[RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK];
+    if (runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK] !== undefined) {
+      retainedDynamicImportHook = runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK];
+      delete runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK];
+    }
   }
 };
 

--- a/packages/core/src/runtime/worker/runtimeHooks.ts
+++ b/packages/core/src/runtime/worker/runtimeHooks.ts
@@ -15,6 +15,23 @@ export const RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK =
 export const RSTEST_REQUIRE_RESOLVE_HOOK =
   '__rstest_require_resolve__' as const;
 
+/**
+ * Point the federation dynamic-import fallback at the source file currently
+ * being loaded, so relative specifiers reaching `globalThis` resolve against it.
+ *
+ * Only the origin is per-file — never delete `RSTEST_DYNAMIC_IMPORT_HOOK` here.
+ * A project's runtime chunk installs it as `hook = hook || fallback`, and
+ * `clearModuleCache` keeps evaluated runtime chunks alive, so re-entering that
+ * project never re-runs the install. Under `isolate: false` a non-federation
+ * file that dropped the hook on its way past would strand the federation
+ * project's remaining files on an unresolved free identifier. (Only a project
+ * whose runtime chunk has not run yet reinstalls it, so the hazard is an
+ * interleaving rather than every mixed run.)
+ *
+ * Leaving it installed is inert: normally-loaded modules get the hook as a VM
+ * argument that shadows the global, and a cleared origin makes the fallback
+ * defer to Node's native `import()`.
+ */
 export const setFederationDynamicImportOrigin = (
   federation: boolean,
   origin: string,
@@ -24,7 +41,6 @@ export const setFederationDynamicImportOrigin = (
     runtimeGlobal[RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK] = origin;
   } else {
     delete runtimeGlobal[RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK];
-    delete runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK];
   }
 };
 

--- a/packages/core/tests/runtime/worker/runtimeHooks.test.ts
+++ b/packages/core/tests/runtime/worker/runtimeHooks.test.ts
@@ -28,7 +28,7 @@ describe('runtime hook identifier contract', () => {
     );
   });
 
-  it('preserves the federation dynamic import hook while updating its origin', () => {
+  it('hides the federation dynamic import hook from non-federation files and hands it back', () => {
     const runtimeGlobal = globalThis as Record<string, unknown>;
     const dynamicImportHook = () => undefined;
     runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK] = dynamicImportHook;
@@ -42,9 +42,17 @@ describe('runtime hook identifier contract', () => {
 
     setFederationDynamicImportOrigin(false, '/project/other.test.ts');
 
-    // Nothing reinstalls the hook for an already-evaluated project, so passing
-    // through a non-federation file may clear the origin but not the hook.
+    // Federation stays strictly opt-in: a non-federation file sees neither.
     expect(runtimeGlobal[RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK]).toBeUndefined();
+    expect(runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK]).toBeUndefined();
+
+    setFederationDynamicImportOrigin(true, '/project/later.test.ts');
+
+    // ...but hiding is not discarding. Nothing reinstalls the hook for a project
+    // whose runtime chunk already ran, so re-entry must get the same one back.
     expect(runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK]).toBe(dynamicImportHook);
+    expect(runtimeGlobal[RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK]).toBe(
+      '/project/later.test.ts',
+    );
   });
 });

--- a/packages/core/tests/runtime/worker/runtimeHooks.test.ts
+++ b/packages/core/tests/runtime/worker/runtimeHooks.test.ts
@@ -42,7 +42,9 @@ describe('runtime hook identifier contract', () => {
 
     setFederationDynamicImportOrigin(false, '/project/other.test.ts');
 
+    // Nothing reinstalls the hook for an already-evaluated project, so passing
+    // through a non-federation file may clear the origin but not the hook.
     expect(runtimeGlobal[RSTEST_DYNAMIC_IMPORT_ORIGIN_HOOK]).toBeUndefined();
-    expect(runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK]).toBeUndefined();
+    expect(runtimeGlobal[RSTEST_DYNAMIC_IMPORT_HOOK]).toBe(dynamicImportHook);
   });
 });


### PR DESCRIPTION
## Summary

`federation: true` bundles reach the dynamic import fallback through `globalThis.__rstest_dynamic_import__`, installed once per project by that project's injected runtime chunk under `hook = hook || fallback`. `clearModuleCache` deliberately keeps evaluated runtime chunks alive across files, so re-entering a project never re-runs that install.

`setFederationDynamicImportOrigin` nevertheless deleted the hook every time it passed a non-federation file, which made the delete permanent for any project already evaluated. Under `isolate: false` a single worker serves several projects, so a non-federation file landing between two files of the same federation project left the later ones with an unresolved free identifier.

Only the origin is per-file, and it is re-established before every federation file, so clearing that alone is enough — and it is still worth clearing, since a stale origin from another project would silently resolve relative specifiers against the wrong directory. Keeping the hook installed is inert: normally-loaded modules receive it as a VM argument that shadows the global, and a cleared origin makes the fallback defer to Node's native `import()`.

Covered by a unit test asserting the hook survives a non-federation pass. No e2e case is added: which project the scheduler reaches first is a perf decision, so the required interleaving cannot be pinned deterministically from a fixture.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).