### PR TITLE
fix(core): route federation chunks through require instead of a virtual fs

### DIFF
--- a/e2e/federation/fixtures/basic/index.test.ts
+++ b/e2e/federation/fixtures/basic/index.test.ts
@@ -29,14 +29,39 @@ it('should set the federation flag during global setup', () => {
   expect(process.env.RSTEST_E2E_FEDERATION_IN_SETUP).toBe('true');
 });
 
-it('should preserve emitted binary assets in the virtual file system', () => {
+declare const __webpack_require__: any;
+
+it('should load async chunks through the require chunk handler from memory', async () => {
+  // Federation forces `output.chunkLoading: 'require'`; a dynamic import of a
+  // local module produces a real js async chunk that only the generated
+  // `f.require` handler can install (`f.readFileVm` is not generated, and the
+  // federation `remotes`/`consumes` handlers ignore plain js chunks). Wrapping
+  // `__webpack_require__.e` proves the import went through the chunk-ensure
+  // machinery instead of being inlined, so a silent fallback to fs-based
+  // loading fails this test on every platform.
+  expect(__webpack_require__.f.readFileVm).toBeUndefined();
+  expect(typeof __webpack_require__.f.require).toBe('function');
+
+  const ensuredChunks: unknown[] = [];
+  const originalEnsure = __webpack_require__.e;
+  __webpack_require__.e = function (chunkId: unknown) {
+    ensuredChunks.push(chunkId);
+    return originalEnsure.call(this, chunkId);
+  };
+  try {
+    const mod = await import('./lazy-target');
+    expect(mod.answer).toBe(42);
+  } finally {
+    __webpack_require__.e = originalEnsure;
+  }
+  expect(ensuredChunks.length).toBeGreaterThan(0);
+});
+
+it('should preserve emitted binary assets on disk with writeToDisk', () => {
   const fs = require('node:fs');
   const emittedImagePath = resolve(__dirname, 'dist/.rstest-temp', imagePath);
   expect(fs.existsSync(emittedImagePath)).toBe(true);
 
-  fs.readFileSync(emittedImagePath, 'utf8');
-  const mutatedContent = fs.readFileSync(emittedImagePath);
-  mutatedContent[0] = 0;
   const content = fs.readFileSync(emittedImagePath);
   const sourceContent = fs.readFileSync(
     resolve(

--- a/e2e/federation/fixtures/basic/lazy-target.ts
+++ b/e2e/federation/fixtures/basic/lazy-target.ts
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/e2e/federation/fixtures/basic/rstest.config.ts
+++ b/e2e/federation/fixtures/basic/rstest.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   federation: true,
   globalSetup: ['./setup.ts'],
+  // Emitted assets are only reachable through the real filesystem: federation
+  // no longer installs a virtual `fs` view over the in-memory build output
+  // (chunks load through `require`), so tests that read emitted files opt
+  // into writing the build output to disk.
+  dev: {
+    writeToDisk: true,
+  },
   output: {
     emitAssets: true,
   },

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import {
   importMetaHook,
   RSTEST_DYNAMIC_IMPORT_HOOK,
@@ -55,6 +55,7 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
           tools,
           dev,
           testEnvironment,
+          federation,
         },
         outputModule,
         rootPath,
@@ -123,6 +124,33 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
               config.mode = isProd ? 'production' : 'development';
               config.output ??= {};
               config.output.iife = false;
+              if (federation) {
+                // Module Federation's Node preset makes chunk loading fs-based
+                // (`readFileVm`), but the bundle's assets only exist in the
+                // in-memory `assetFiles` map, never on disk. `require`-based
+                // loading routes chunks through the vm-injected `require`,
+                // which resolves them from that map.
+                config.output.chunkLoading = 'require';
+                // The config-level value above states the intent, but
+                // `@module-federation/rstest` >= 2.9.0 explicitly writes
+                // `output.chunkLoading = 'async-node'` from its own config
+                // hook (earlier versions only set `target`), and hook order
+                // puts it after this one. Enforce at compiler level instead:
+                // plugin `apply` runs after every config-level hook and
+                // before rspack derives target defaults, so this write wins
+                // regardless of what federation plugins do to the config
+                // object. A federation plugin that writes the field in its
+                // own `apply` (e.g. a hand-wired `StreamingTargetPlugin`)
+                // still wins — documented limitation. `chunkFormat` stays on
+                // the target-derived `'commonjs'`.
+                config.plugins ??= [];
+                config.plugins.push({
+                  name: 'RstestFederationRequireChunkLoading',
+                  apply(compiler: Rspack.Compiler) {
+                    compiler.options.output.chunkLoading = 'require';
+                  },
+                });
+              }
               // polyfill interop
               // TODO: if we ever expose `output.importFunctionName` as a user
               // option, rspack#13849's rewrite still reads it directly to pick

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -60,6 +60,32 @@ if (globalThis.__rstest_federation__) {
 }
 //#endregion
 
+//#region suppress the federation runtime's chunk-handler caution
+// `@module-federation/node`'s runtime plugin warns whenever it sees a
+// `require` chunk handler, assuming a build it may fail to patch. rstest
+// picks `chunkLoading: 'require'` deliberately (chunks must resolve from the
+// in-memory assets, not fs) and the handler freeze below turns the patch
+// attempt into a guarded no-op, so the warning is pure noise for every
+// federation test file. Filter exactly that message; if its wording ever
+// changes this fails open and the warning simply shows again.
+if (
+  globalThis.__rstest_federation__ &&
+  !globalThis.__rstest_mf_caution_filtered__
+) {
+  globalThis.__rstest_mf_caution_filtered__ = true;
+  const rstestOriginalConsoleWarn = console.warn;
+  console.warn = function (...args) {
+    if (
+      typeof args[1] === 'string' &&
+      args[1].includes('build target is not set to "async-node"')
+    ) {
+      return;
+    }
+    rstestOriginalConsoleWarn.apply(this, args);
+  };
+}
+//#endregion
+
 //#region proxy __webpack_require__
 // The proxy target is the original `__webpack_require__` itself, so all
 // property operations — get/set/`in`/`for...in`/`hasOwnProperty` — hit the

--- a/packages/core/src/runtime/worker/globalSetupWorker.ts
+++ b/packages/core/src/runtime/worker/globalSetupWorker.ts
@@ -90,8 +90,6 @@ const runGlobalSetup = async (data: {
         ? await import('./loadEsModule')
         : await import('./loadModule');
 
-      const virtualFsAssetFiles = data.federation ? data.assetFiles : undefined;
-
       const module = await loadModule({
         codeContent: getAssetText(data.assetFiles, distPath),
         distPath,
@@ -104,7 +102,6 @@ const runGlobalSetup = async (data: {
         },
         assetFiles: data.assetFiles,
         interopDefault: data.interopDefault,
-        virtualFsAssetFiles,
       });
 
       let teardownCallback: (() => Promise<void> | void) | undefined;

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
 import path from 'pathe';
 import type { AssetFiles } from '../../types/worker';
-import { getAssetBuffer, getAssetText } from '../../utils/assetFiles';
+import { getAssetText } from '../../utils/assetFiles';
 import { logger } from '../../utils/logger';
 import { clearCacheCleaners, clearSyntheticModuleCache } from './interop';
 import {
@@ -33,111 +33,6 @@ const getAssetName = (
   }
   return undefined;
 };
-
-const formatAssetContent = (
-  assetFiles: AssetFiles,
-  name: string,
-  options?: unknown,
-) => {
-  const buffer = getAssetBuffer(assetFiles, name);
-  const encoding =
-    typeof options === 'string'
-      ? options
-      : options && typeof options === 'object' && 'encoding' in options
-        ? options.encoding
-        : undefined;
-  return typeof encoding === 'string'
-    ? buffer.toString(encoding as BufferEncoding)
-    : buffer;
-};
-
-const createVirtualFsAssetProxy = (
-  fsModule: typeof import('node:fs'),
-  assetFiles: AssetFiles,
-): typeof import('node:fs') =>
-  new Proxy(fsModule, {
-    get(target, property, receiver) {
-      if (property === 'existsSync') {
-        return (filePath: unknown) =>
-          getAssetName(assetFiles, filePath) !== undefined ||
-          target.existsSync(
-            filePath as Parameters<typeof target.existsSync>[0],
-          );
-      }
-
-      if (property === 'readFile') {
-        return (
-          filePath: unknown,
-          optionsOrCallback: unknown,
-          maybeCallback?: unknown,
-        ) => {
-          const callback =
-            typeof optionsOrCallback === 'function'
-              ? optionsOrCallback
-              : maybeCallback;
-          const name = getAssetName(assetFiles, filePath);
-
-          if (name !== undefined && typeof callback === 'function') {
-            queueMicrotask(() =>
-              callback(
-                null,
-                formatAssetContent(assetFiles, name, optionsOrCallback),
-              ),
-            );
-            return;
-          }
-
-          return Reflect.apply(
-            target.readFile,
-            target,
-            [filePath, optionsOrCallback, maybeCallback].filter(
-              (value) => value !== undefined,
-            ),
-          );
-        };
-      }
-
-      if (property === 'readFileSync') {
-        return (filePath: unknown, options?: unknown) => {
-          const name = getAssetName(assetFiles, filePath);
-          if (name !== undefined) {
-            return formatAssetContent(assetFiles, name, options);
-          }
-          return target.readFileSync(
-            filePath as Parameters<typeof target.readFileSync>[0],
-            options as Parameters<typeof target.readFileSync>[1],
-          );
-        };
-      }
-
-      if (property === 'promises') {
-        return new Proxy(target.promises, {
-          get(promisesTarget, promisesProperty, promisesReceiver) {
-            if (promisesProperty === 'readFile') {
-              return (filePath: unknown, options?: unknown) => {
-                const name = getAssetName(assetFiles, filePath);
-                return name === undefined
-                  ? Reflect.apply(promisesTarget.readFile, promisesTarget, [
-                      filePath,
-                      options,
-                    ])
-                  : Promise.resolve(
-                      formatAssetContent(assetFiles, name, options),
-                    );
-              };
-            }
-            return Reflect.get(
-              promisesTarget,
-              promisesProperty,
-              promisesReceiver,
-            );
-          },
-        });
-      }
-
-      return Reflect.get(target, property, receiver);
-    },
-  });
 
 const defineRstestRequireResolve =
   ({
@@ -183,7 +78,6 @@ const createRequire = (
   rstestContext: Record<string, any>,
   assetFiles: AssetFiles,
   interopDefault: boolean,
-  virtualFsAssetFiles?: AssetFiles,
 ): NodeJS.Require => {
   const _require = (() => {
     try {
@@ -195,13 +89,6 @@ const createRequire = (
   })();
 
   const require = ((id: string) => {
-    if (id === 'fs' || id === 'node:fs') {
-      const fsModule = _require(id);
-      return virtualFsAssetFiles
-        ? createVirtualFsAssetProxy(fsModule, virtualFsAssetFiles)
-        : fsModule;
-    }
-
     const currentDirectory = path.dirname(distPath);
 
     const joinedPath = isRelativePath(id)
@@ -219,7 +106,6 @@ const createRequire = (
           rstestContext,
           assetFiles,
           interopDefault,
-          virtualFsAssetFiles,
         });
       } catch (err) {
         logger.error(
@@ -302,7 +188,6 @@ export const loadModule = ({
   rstestContext,
   assetFiles: assetFilesArg,
   interopDefault,
-  virtualFsAssetFiles: virtualFsAssetFilesArg,
 }: {
   interopDefault: boolean;
   codeContent: string;
@@ -310,7 +195,6 @@ export const loadModule = ({
   testPath: string;
   rstestContext: Record<string, any>;
   assetFiles: AssetFiles;
-  virtualFsAssetFiles?: AssetFiles;
 }): any => {
   // Fold this file's assets into the persistent map. Recursive loads (require /
   // dynamic imports) re-pass that same map, so skip the no-op self-merge.
@@ -318,7 +202,6 @@ export const loadModule = ({
     Object.assign(accumulatedAssetFiles, assetFilesArg);
   }
   const assetFiles = accumulatedAssetFiles;
-  const virtualFsAssetFiles = virtualFsAssetFilesArg ? assetFiles : undefined;
   const fileDir = path.dirname(testPath);
 
   const localModule = {
@@ -340,7 +223,6 @@ export const loadModule = ({
       rstestContext,
       assetFiles,
       interopDefault,
-      virtualFsAssetFiles,
     ),
     [RSTEST_DYNAMIC_IMPORT_HOOK]: defineRstestDynamicImport({
       testPath,
@@ -385,7 +267,6 @@ export const cacheableLoadModule = ({
   rstestContext,
   assetFiles,
   interopDefault,
-  virtualFsAssetFiles,
 }: {
   interopDefault: boolean;
   codeContent: string;
@@ -393,7 +274,6 @@ export const cacheableLoadModule = ({
   testPath: string;
   rstestContext: Record<string, any>;
   assetFiles: AssetFiles;
-  virtualFsAssetFiles?: AssetFiles;
 }): any => {
   if (moduleCache.has(testPath)) {
     return moduleCache.get(testPath);
@@ -405,7 +285,6 @@ export const cacheableLoadModule = ({
     rstestContext,
     assetFiles,
     interopDefault,
-    virtualFsAssetFiles,
   });
   moduleCache.set(testPath, mod);
   return mod;

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -433,7 +433,6 @@ const loadFiles = async ({
   const { loadModule } = outputModule
     ? await import('./loadEsModule')
     : await import('./loadModule');
-  const virtualFsAssetFiles = federation ? assetFiles : undefined;
 
   // A reused worker can hold several projects' runtime chunks at once, so pass
   // the current entry path to every self-scoped cleaner. Only its
@@ -448,7 +447,6 @@ const loadFiles = async ({
       rstestContext,
       assetFiles,
       interopDefault,
-      virtualFsAssetFiles,
     });
   }
 
@@ -468,7 +466,6 @@ const loadFiles = async ({
       rstestContext,
       assetFiles,
       interopDefault,
-      virtualFsAssetFiles,
     });
   }
 
@@ -482,7 +479,6 @@ const loadFiles = async ({
     rstestContext,
     assetFiles,
     interopDefault,
-    virtualFsAssetFiles,
   });
 };
 

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -1005,6 +1005,98 @@ describe('prepareRsbuild', () => {
     expect(project.outputModule).toBe(false);
   });
 
+  it('should force require-based chunk loading for federation projects', async () => {
+    // Stand-in for @module-federation/rstest >= 2.9.0's node preset: it
+    // appends a `tools.rspack` patcher via a post-ordered
+    // `modifyEnvironmentConfig` merge — running after rstest's own
+    // `tools.rspack` — that sets `target: 'async-node'` AND explicitly
+    // writes `output.chunkLoading = 'async-node'` (earlier versions only
+    // set the target). rstest cannot win that battle at config level, so
+    // it enforces `require` through a compiler-level plugin whose `apply`
+    // runs after every config hook.
+    const asyncNodeTargetPlugin: RsbuildPlugin = {
+      name: 'federation-like-async-node-target',
+      setup(api) {
+        api.modifyEnvironmentConfig({
+          order: 'post',
+          handler: (config, { mergeEnvironmentConfig }) =>
+            mergeEnvironmentConfig(config, {
+              tools: {
+                rspack: (rspackConfig) => {
+                  rspackConfig.target = 'async-node';
+                  rspackConfig.output ??= {};
+                  rspackConfig.output.chunkLoading = 'async-node';
+                },
+              },
+            }),
+        });
+      },
+    };
+
+    const project = {
+      name: 'test',
+      rootPath,
+      environmentName: 'test',
+      outputModule: false,
+      normalizedConfig: {
+        federation: true,
+        plugins: [asyncNodeTargetPlugin],
+        resolve: {},
+        source: {},
+        output: {},
+        tools: {},
+        testEnvironment: {
+          name: 'node',
+        },
+        browser: { enabled: false },
+      },
+    };
+
+    const rsbuildInstance = await prepareRsbuild({
+      context: {
+        rootPath,
+        command: 'run',
+        normalizedConfig: {
+          root: rootPath,
+          name: 'test',
+          output: {
+            distPath: {
+              root: TEMP_RSTEST_OUTPUT_DIR,
+            },
+          },
+          pool: { type: 'forks' },
+        },
+        projects: [project],
+      } as unknown as RstestContext,
+      globTestSourceEntries: async () => ({}),
+      setupFileState: createSetupFileState(),
+    });
+
+    const configs = await rsbuildInstance.initConfigs();
+
+    expect(configs[0]!.target).toBe('async-node');
+    // The adversarial post hook won the config-level battle, as the real
+    // federation plugin does...
+    expect(configs[0]!.output?.chunkLoading).toBe('async-node');
+    // ...so the enforcement lives in a compiler-level plugin: its `apply`
+    // runs after every config hook and re-asserts `require`.
+    const enforcementPlugin = configs[0]!.plugins?.find(
+      (plugin) =>
+        plugin &&
+        typeof plugin === 'object' &&
+        'name' in plugin &&
+        plugin.name === 'RstestFederationRequireChunkLoading',
+    );
+    expect(enforcementPlugin).toBeDefined();
+    const compiler = { options: { output: { chunkLoading: 'async-node' } } };
+    (enforcementPlugin as { apply: (c: unknown) => void }).apply(compiler);
+    expect(compiler.options.output.chunkLoading).toBe('require');
+    // `chunkFormat` is deliberately left to rspack's target derivation
+    // (`'commonjs'` for node targets); the federation e2e suite is the
+    // behavioral pin for the emitted chunk format.
+    expect(configs[0]!.output?.chunkFormat).toBeUndefined();
+  });
+
   it('should not allow modifyRstestConfig to switch browser mode', async () => {
     const modifyBrowserModePlugin: RsbuildPlugin = {
       name: 'modify-rstest-browser-mode',

--- a/packages/core/tests/runner/requireResolveOrigin.test.ts
+++ b/packages/core/tests/runner/requireResolveOrigin.test.ts
@@ -4,7 +4,6 @@ import os from 'node:os';
 import vm from 'node:vm';
 import { onTestFinished, rs } from '@rstest/core';
 import path from 'pathe';
-import type { AssetFiles } from '../../src/types';
 import {
   clearModuleCache as clearEsModuleCache,
   loadModule as loadEsModule,
@@ -89,96 +88,6 @@ describe('require.resolve origin runtime helper', () => {
     });
 
     expect(exports).toEqual(createRequire(testPath).resolve.paths('foo'));
-  });
-
-  it('preserves fs read contracts for opted-in virtual assets', async () => {
-    const virtualFile = path.join(
-      os.tmpdir(),
-      `rstest-virtual-fs-${Date.now()}`,
-      'dist',
-      'chunk.js',
-    );
-    const assetFiles: AssetFiles = {
-      [virtualFile]: 'virtual chunk',
-    };
-    const binaryFile = path.join(path.dirname(virtualFile), 'asset.bin');
-    const binaryContent = Buffer.from([0, 0xff, 0x80, 0x41]);
-    assetFiles[binaryFile] = binaryContent;
-    const loadOptions = {
-      codeContent: `
-        const fs = require('node:fs');
-        module.exports = {
-          exists: fs.existsSync(${JSON.stringify(virtualFile)}),
-          syncBuffer: fs.existsSync(${JSON.stringify(virtualFile)})
-            ? fs.readFileSync(${JSON.stringify(virtualFile)})
-            : undefined,
-          syncText: fs.existsSync(${JSON.stringify(virtualFile)})
-            ? fs.readFileSync(${JSON.stringify(virtualFile)}, 'utf-8')
-            : undefined,
-          callback: fs.existsSync(${JSON.stringify(virtualFile)})
-            ? new Promise((resolve, reject) => {
-                fs.readFile(${JSON.stringify(virtualFile)}, (error, content) =>
-                  error ? reject(error) : resolve(content),
-                );
-              })
-            : undefined,
-          promise: fs.existsSync(${JSON.stringify(virtualFile)})
-            ? fs.promises.readFile(${JSON.stringify(virtualFile)}, 'utf-8')
-            : undefined,
-          binary: fs.existsSync(${JSON.stringify(binaryFile)})
-            ? fs.readFileSync(${JSON.stringify(binaryFile)})
-            : undefined,
-          binaryText: fs.existsSync(${JSON.stringify(binaryFile)})
-            ? fs.readFileSync(${JSON.stringify(binaryFile)}, 'utf8')
-            : undefined,
-          mutatedBinary: fs.existsSync(${JSON.stringify(binaryFile)})
-            ? (() => {
-                const content = fs.readFileSync(${JSON.stringify(binaryFile)});
-                content[0] = 42;
-                return content;
-              })()
-            : undefined,
-          binaryAfterMutation: fs.existsSync(${JSON.stringify(binaryFile)})
-            ? fs.readFileSync(${JSON.stringify(binaryFile)})
-            : undefined,
-        };
-      `,
-      distPath: path.join(os.tmpdir(), `rstest-virtual-fs-${Date.now()}.js`),
-      testPath: path.join(
-        os.tmpdir(),
-        `rstest-virtual-fs-${Date.now()}.test.ts`,
-      ),
-      rstestContext: {},
-      assetFiles,
-      interopDefault: true,
-    };
-
-    expect(loadModule(loadOptions)).toEqual({
-      exists: false,
-      syncBuffer: undefined,
-      syncText: undefined,
-      callback: undefined,
-      promise: undefined,
-      binary: undefined,
-      binaryText: undefined,
-      mutatedBinary: undefined,
-      binaryAfterMutation: undefined,
-    });
-    const virtual = loadModule({
-      ...loadOptions,
-      virtualFsAssetFiles: assetFiles,
-    });
-    expect(virtual.exists).toBe(true);
-    expect(Buffer.isBuffer(virtual.syncBuffer)).toBe(true);
-    expect(virtual.syncBuffer.toString()).toBe('virtual chunk');
-    expect(virtual.syncText).toBe('virtual chunk');
-    expect(Buffer.isBuffer(await virtual.callback)).toBe(true);
-    expect(await virtual.promise).toBe('virtual chunk');
-    expect(Buffer.isBuffer(virtual.binary)).toBe(true);
-    expect(virtual.binary).toEqual(binaryContent);
-    expect(virtual.binaryText).toBe('\0\ufffd\ufffdA');
-    expect(virtual.mutatedBinary).toEqual(Buffer.from([42, 0xff, 0x80, 0x41]));
-    expect(virtual.binaryAfterMutation).toEqual(binaryContent);
   });
 
   it('binds top-level this to exports in CommonJS modules', () => {

--- a/website/docs/en/config/test/federation.mdx
+++ b/website/docs/en/config/test/federation.mdx
@@ -21,7 +21,7 @@ Rstest evaluates test bundles inside a single worker runtime so that module mock
 - Externalized dynamic imports get a `globalThis` fallback, so federation runtime chunks evaluated via `vm`/`eval` can still load modules with Node's native dynamic import.
 - Module Federation's placeholder chunk handlers (`consumes` / `remotes`) are kept from throwing before the federation runtime initializes.
 - Federation runtime plugins cannot replace Rstest's chunk-loading handlers, which would otherwise evaluate chunks outside the test runtime and lose mocks.
-- Node-targeted federation runs use Rstest's CommonJS worker loader and can serve virtual async-node chunks from the in-memory build output.
+- Node-targeted federation runs use Rstest's CommonJS worker loader; Rstest forces `output.chunkLoading: 'require'` so async chunks load through Rstest's module loader from the in-memory build output instead of the filesystem.
 
 import { Tab, Tabs } from '@theme';
 

--- a/website/docs/zh/config/test/federation.mdx
+++ b/website/docs/zh/config/test/federation.mdx
@@ -21,7 +21,7 @@ Rstest 在单个 worker 运行时中执行测试产物，以保证模块 mock �
 - 为外部化的动态导入提供 `globalThis` 兜底实现，使通过 `vm`/`eval` 执行的 federation 运行时 chunk 仍能使用 Node 原生动态导入加载模块。
 - 防止 Module Federation 的占位 chunk 处理器（`consumes` / `remotes`）在 federation 运行时初始化前抛出异常。
 - 阻止 federation 运行时插件替换 Rstest 的 chunk 加载处理器，否则 chunk 会在测试运行时之外执行并丢失 mock。
-- 面向 Node 的 federation 运行会使用 Rstest 的 CommonJS worker loader，并可从内存构建产物中提供虚拟 async-node chunks。
+- 面向 Node 的 federation 运行会使用 Rstest 的 CommonJS worker loader；Rstest 会将 `output.chunkLoading` 强制为 `'require'`，使 async chunks 通过 Rstest 的模块加载器从内存构建产物中加载，而不经过文件系统。
 
 import { Tab, Tabs } from '@theme';
 


### PR DESCRIPTION
## Summary

Module Federation's Node preset makes rspack emit fs-based chunk loading (`readFileVm`), but Rstest's build outputs only exist in the in-memory asset map, never on disk. The previous answer was a partial fs proxy covering only four read methods, which gave federation runtimes a self-contradictory fs view (`existsSync` true, `statSync` ENOENT) and missed `node:fs/promises` entirely.

This PR removes the fs dependency at codegen level instead: federation projects force `output.chunkLoading: 'require'`, so the generated chunk handler resolves chunks through the vm-injected `require` from the in-memory assets — and the whole virtual fs proxy becomes dead code and is deleted. `@module-federation/rstest` >= 2.9.0 explicitly writes `output.chunkLoading: 'async-node'` from its own post-ordered `tools.rspack` patcher (earlier versions only set the target), so a config-level value cannot win by hook order; Rstest enforces `'require'` through a compiler-level plugin instead — plugin `apply` runs after every config hook and before rspack derives target defaults. The rsbuild config test pins this against a federation-like patcher that mirrors 2.9.0's merge exactly, and a federation e2e case dynamically imports a local module so the require handler's load-from-memory branch stays exercised on the full e2e matrix. `@module-federation/node`'s per-file CAUTION warning about the require chunk handler is filtered in the injected runtime, since the patch attempt it warns about is already a guarded no-op under Rstest's frozen chunk handlers.

Verified against the real Module Federation example suite on MF 2.9.0 (shared react/react-dom negotiation, HTTP + on-disk remotes, isolate on/off, browser mode, and mock/spy/fake-timers/snapshot combined with federated imports in the same files): all green with zero virtual-path fs traffic.

Known limitation: a federation plugin that writes `output.chunkLoading` in its own compiler-level `apply` (e.g. wiring `StreamingTargetPlugin` manually) still wins over this enforcement; the removed proxy did not fully support those setups either. Upstream, `@module-federation/rstest`'s `applyNodeRspackDefaults` already treats `'require'` as compatible in its warning logic but still overrides it — preserving an explicit `'require'` there would make this enforcement unnecessary.

### Behavior change vs #1695

Deleting the proxy also deletes the user-visible fs reads of emitted assets at virtual dist paths under federation, which #1695 pinned in the federation e2e. The supported route for reading emitted files is `dev.writeToDisk`; the e2e fixture now opts into it and asserts binary integrity against the real emitted file. The cross-worker IPC preservation that #1695 fixed stays covered by its `assetFiles`/pool unit tests, which are untouched.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1407
- https://github.com/web-infra-dev/rstest/pull/1695

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
