### PR TITLE
perf(coverage-v8): replace Acorn with Yuku

### DIFF
--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -34,13 +34,13 @@
   },
   "dependencies": {
     "@jridgewell/trace-mapping": "0.3.31",
-    "acorn": "^8.17.0",
     "estree-walker": "^3.0.3",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.2.0",
     "js-tokens": "^10.0.0",
-    "picomatch": "^4.0.5"
+    "picomatch": "^4.0.5",
+    "yuku-parser": "^0.8.0"
   },
   "devDependencies": {
     "@rsbuild/core": "~2.1.8",

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -7,12 +7,12 @@ import type {
   CoverageProvider as RstestCoverageProvider,
   RawCoverageResolveOptions,
 } from '@rstest/core';
-import { Parser } from 'acorn';
 import { type CoverageMap, type FileCoverageData } from 'istanbul-lib-coverage';
 import type { ReportBase } from 'istanbul-lib-report';
 import { createContext } from 'istanbul-lib-report';
 import reports from 'istanbul-reports';
 import picomatch from 'picomatch';
+import { parse } from 'yuku-parser';
 import { createFastCoverageMap, mapWithConcurrency } from './utils';
 import {
   applyV8CoverageWithAst,
@@ -524,10 +524,17 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   private parseAst(code: string, outputModule: boolean) {
-    return Parser.parse(code, {
-      ecmaVersion: 'latest',
+    const result = parse(code, {
+      preserveParens: false,
       sourceType: outputModule ? 'module' : 'script',
     });
+    const error = result.diagnostics.find(
+      (diagnostic) => diagnostic.severity === 'error',
+    );
+    if (error) {
+      throw new SyntaxError(error.message);
+    }
+    return result.program;
   }
 
   private async convertWithAst(

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -44,6 +44,7 @@ import {
 import type { Profiler } from 'node:inspector';
 import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage';
 import jsTokens from 'js-tokens';
+import type { Program } from 'yuku-parser';
 import { walk } from 'estree-walker';
 
 type SourceMapLike = Omit<EncodedSourceMap | DecodedSourceMap, 'version'> & {
@@ -109,7 +110,7 @@ type PreparedCoverage = {
 type FileCoverageLike = FileCoverageData | { data: FileCoverageData };
 
 type ConvertOptions = {
-  ast: unknown | (() => unknown);
+  ast: Program | (() => Program);
   cacheKey: string;
   code: string;
   coverage: Pick<Profiler.ScriptCoverage, 'functions' | 'url'>;
@@ -1262,6 +1263,10 @@ function isTernarySeparatorOnly(code: string): boolean {
 
 function getIgnoreHints(code: string): IgnoreHint[] {
   const ignoreHints: IgnoreHint[] = [];
+  if (!code.includes('ignore')) {
+    return ignoreHints;
+  }
+
   const tokens = jsTokens(code);
   let current = 0;
   let previousTokenWasIgnoreHint = false;

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -9,8 +9,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import type { NormalizedCoverageOptions } from '@rstest/core';
-import { Parser } from 'acorn';
 import type { FileCoverageData } from 'istanbul-lib-coverage';
+import { parse } from 'yuku-parser';
 import { CoverageProvider } from '../src/provider';
 import { convertV8CoverageWithAst } from '../src/v8AstConverter';
 
@@ -111,10 +111,17 @@ function getProviderInternals(provider: CoverageProvider): ProviderInternals {
 }
 
 function parseModule(code: string) {
-  return Parser.parse(code, {
-    ecmaVersion: 'latest',
+  const result = parse(code, {
+    preserveParens: false,
     sourceType: 'module',
   });
+  const error = result.diagnostics.find(
+    (diagnostic) => diagnostic.severity === 'error',
+  );
+  if (error) {
+    throw new SyntaxError(error.message);
+  }
+  return result.program;
 }
 
 describe('coverage-v8 provider', () => {
@@ -269,6 +276,59 @@ describe('coverage-v8 provider', () => {
     const fileCoverage = coverage[file]!;
     expect(fileCoverage.fnMap[0]?.name).toBe('a');
     expect(fileCoverage.f).toEqual({ 0: 0 });
+  });
+
+  it('uses Yuku UTF-16 spans with V8 offsets', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-yuku-unicode.js');
+    const code = 'const label = "😀";\nconst value = () => 1;';
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:yuku-unicode`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.fnMap[0]?.decl.start).toEqual({
+      line: 2,
+      column: 14,
+    });
+  });
+
+  it('converts Yuku ESTree destructuring defaults and logical branches', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-yuku-branches.js');
+    const code = 'const { value = 1 } = input;\nconst result = (a && b) || c;';
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:yuku-branches`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.branchMap[0]?.type).toBe('default-arg');
+    expect(coverage[file]?.branchMap[1]?.type).toBe('binary-expr');
+    expect(coverage[file]?.branchMap[1]?.locations).toHaveLength(3);
   });
 
   it('preserves non-file source map URLs as coverage filenames', async () => {
@@ -516,6 +576,29 @@ describe('coverage-v8 provider', () => {
 
     expect(coverage[file]?.branchMap[0]?.locations).toHaveLength(1);
     expect(coverage[file]?.b[0]).toEqual([1]);
+  });
+
+  it('honors ignore-file comments before reporting parser errors', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-ignore-file.js');
+    const code = '/* c8 ignore file */ const =;';
+
+    const coverage = await convertV8CoverageWithAst({
+      ast: () => parseModule(code),
+      cacheKey: `${file}:ignore-file`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage).toEqual({});
   });
 
   it('invalidates prepared AST coverage when an external source map changes', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1388,9 +1388,6 @@ importers:
       '@jridgewell/trace-mapping':
         specifier: 0.3.31
         version: 0.3.31
-      acorn:
-        specifier: ^8.17.0
-        version: 8.17.0
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1409,6 +1406,9 @@ importers:
       picomatch:
         specifier: ^4.0.5
         version: 4.0.5
+      yuku-parser:
+        specifier: ^0.8.0
+        version: 0.8.0
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.1.8
@@ -4447,6 +4447,70 @@ packages:
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  '@yuku-parser/binding-darwin-arm64@0.8.0':
+    resolution: {integrity: sha512-04AakSJhI4mPrqhZzXdFyaEDh0YkfeqbnyYY3aCrmxeWfR/Xr8+kFn5sh+wZYN/5HatPniELKHixJuUCUyfBvg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-parser/binding-darwin-x64@0.8.0':
+    resolution: {integrity: sha512-BQJGI9bDeyb/X2rwhtXoBTQ9EtbkJtteX6C7cZ9jow0pqqmoOufgHPP2+m65GLk2eVNCBcfl3xlTGpJ7RFcviw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-parser/binding-freebsd-x64@0.8.0':
+    resolution: {integrity: sha512-04hmgnU152wya88raI+RQhxZPgwXcHbfdNZLu3x5ggKnJVHLD8xZZLcWIKSs59CiEXL6PKVX1/cx8GoTYlaCaQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-parser/binding-linux-arm-gnu@0.8.0':
+    resolution: {integrity: sha512-+cuJWUK13lwce721XGRjz7izSr2Q1U0RlHkDzdkohWpRWlttTqRdxNnaW13nDc47GBDrNsXMHx+KLcebeOeeGg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm-musl@0.8.0':
+    resolution: {integrity: sha512-rOVPRqt9cm1YP/wPV+yyZh0FYr6UR/wm/BXslvLuge0LDewVvDrm/AxcDrwWuPAu61Nzdg2rMVfcNnrplCbC1w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.0':
+    resolution: {integrity: sha512-pAoIozKr6E+ptpaQz4CZv1O7cay2f4m7kbd+DSQug5MKdUBTZZ18GdWSPvq0fwQYraH9hZlyLqrMaeP5W/ncrA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm64-musl@0.8.0':
+    resolution: {integrity: sha512-JCAg50ahXuYlrsIi1jmymX9X/9B0JYBRroAHnYttN44tAvCo1PFqukHrw1up6HvEOoLA0OjlM0Zwh60u3Gc/Zg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-x64-gnu@0.8.0':
+    resolution: {integrity: sha512-tEeVQ14etp7lpUqXzq+X5AlQzFH+m3TVDiCKIq17zxnxJ117DOVvoveWSkSMt/lj68z48SvZUMHe7xLvqtO1lg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-x64-musl@0.8.0':
+    resolution: {integrity: sha512-+UGRYnF37nnbZNMsMjSGDXKUTIxYUmbbk3Lzib88sLK7kg2y80vjchYYoYsDUK9kAgqPWyA9hKGURHy/Kk9Few==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-win32-arm64@0.8.0':
+    resolution: {integrity: sha512-l+7Va9/sX1ccRjzjJj6MR0arKsvHB5b419+pKbwzn+/18A/xfccWqmxXrn0C0NyVLlbEb3AV9Is+AbF72O85yA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-parser/binding-win32-x64@0.8.0':
+    resolution: {integrity: sha512-dolKDTJv2xrWowDBEkvSaDvCsVFZOA7DCUuD+7DatglS68WbuxS4LudU5bzSeAOL5vgPpyGm82469cMLnL+6vQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-toolchain/types@0.8.0':
+    resolution: {integrity: sha512-hL/raFM5V9UT2lVE/lIWDTWvANqSB8TvMVp+PgICehBa96KhTl/UpGm370JXaacukR+QnaHM2Yv6O/UcrzAFGg==}
 
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
@@ -8776,6 +8840,12 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  yuku-ast@0.8.0:
+    resolution: {integrity: sha512-trBzFsSa6k32vzNUCH6pFhAoTzWD/NifSYOIQ/6v14vXKh7TRhd2vDNIwRguGdXvcyfBNEEGcsfxFHrnJbS+FQ==}
+
+  yuku-parser@0.8.0:
+    resolution: {integrity: sha512-obrazyE8Cyh79xTQS9wv44khnhvkXG1CDSSy0bg+Pjjla+iXkKXK2b6+LTYXSN3qvVfQxc0MN5qhNKYr9sl3Zw==}
+
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
@@ -11976,6 +12046,41 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
+
+  '@yuku-parser/binding-darwin-arm64@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-darwin-x64@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-freebsd-x64@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-gnu@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-musl@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-musl@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-gnu@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-musl@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-win32-arm64@0.8.0':
+    optional: true
+
+  '@yuku-parser/binding-win32-x64@0.8.0':
+    optional: true
+
+  '@yuku-toolchain/types@0.8.0': {}
 
   '@zeit/schemas@2.36.0': {}
 
@@ -16788,6 +16893,27 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   yoga-layout@3.2.1: {}
+
+  yuku-ast@0.8.0:
+    dependencies:
+      '@yuku-toolchain/types': 0.8.0
+
+  yuku-parser@0.8.0:
+    dependencies:
+      '@yuku-toolchain/types': 0.8.0
+      yuku-ast: 0.8.0
+    optionalDependencies:
+      '@yuku-parser/binding-darwin-arm64': 0.8.0
+      '@yuku-parser/binding-darwin-x64': 0.8.0
+      '@yuku-parser/binding-freebsd-x64': 0.8.0
+      '@yuku-parser/binding-linux-arm-gnu': 0.8.0
+      '@yuku-parser/binding-linux-arm-musl': 0.8.0
+      '@yuku-parser/binding-linux-arm64-gnu': 0.8.0
+      '@yuku-parser/binding-linux-arm64-musl': 0.8.0
+      '@yuku-parser/binding-linux-x64-gnu': 0.8.0
+      '@yuku-parser/binding-linux-x64-musl': 0.8.0
+      '@yuku-parser/binding-win32-arm64': 0.8.0
+      '@yuku-parser/binding-win32-x64': 0.8.0
 
   zimmerframe@1.1.4: {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -213,4 +213,5 @@ webm
 webp
 worktree
 worktrees
+yuku
 Zenbook


### PR DESCRIPTION
## Summary

- Replace Acorn with `yuku-parser` in the V8 coverage provider while preserving script/module parsing and syntax-error behavior.
- Keep the existing ESTree coverage conversion path and add coverage for UTF-16 offsets, logical/default branches, and ignore-file parse failures.
- Improve the real Rsbuild V8 coverage run by 61.7% at the median. Measurements used Node 24.11.1 on darwin-arm64 with Rstest 0.11.4; one warmup was excluded and each variant was measured three times with `pnpm test --coverage --coverage.provider v8`.

| Parser | Runs | Median | Mean |
| --- | --- | ---: | ---: |
| Acorn | 8.74s / 9.12s / 8.03s | 8.74s | 8.63s |
| Yuku | 3.42s / 3.35s / 3.25s | 3.35s | 3.34s |

The Rsbuild run still passes all 378 tests across 56 test files, with unchanged coverage totals: 4,844/15,153 statements, 1,080/3,398 functions, and 2,367/10,941 branches.

## Related Links

- https://github.com/yuku-toolchain/yuku/releases/tag/v0.8.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).