### PR TITLE
perf(vscode): replace SWC with Yuku

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -267,7 +267,6 @@
     "@rsbuild/core": "~2.1.8",
     "@rslib/core": "1.0.0-beta.1",
     "@rstest/core": "workspace:*",
-    "@swc/core": "^1.15.46",
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.16.5",
@@ -284,7 +283,8 @@
     "semver": "^7.8.5",
     "tinyglobby": "^0.2.17",
     "typescript": "^6.0.3",
-    "valibot": "^1.4.2"
+    "valibot": "^1.4.2",
+    "yuku-parser": "^0.8.0"
   },
   "engines": {
     "vscode": "^1.97.0"

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -1,5 +1,19 @@
-import { defineConfig } from '@rslib/core';
+import { createRequire } from 'node:module';
+import { defineConfig, rspack } from '@rslib/core';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
+
+const require = createRequire(import.meta.url);
+const vsceTarget =
+  process.env.VSCE_TARGET ?? `${process.platform}-${process.arch}`;
+// Rstest's Linux VSIX targets use glibc, whose Yuku bindings have a `-gnu` suffix.
+const yukuBindingSuffix = vsceTarget.startsWith('linux-')
+  ? `${vsceTarget}-gnu`
+  : vsceTarget;
+const yukuRequire = createRequire(require.resolve('yuku-parser'));
+// Yuku computes this package name at runtime, so Rspack cannot discover it.
+const yukuBindingPath = yukuRequire.resolve(
+  `@yuku-parser/binding-${yukuBindingSuffix}`,
+);
 
 export default defineConfig({
   lib: [
@@ -14,7 +28,6 @@ export default defineConfig({
       output: {
         externals: {
           vscode: 'commonjs vscode',
-          '@swc/wasm': 'commonjs @swc/wasm',
         },
         sourceMap: process.env.SOURCEMAP === 'true',
       },
@@ -24,6 +37,14 @@ export default defineConfig({
             devtoolModuleFilenameTemplate: '[absolute-resource-path]',
           },
           plugins: [
+            new rspack.CopyRspackPlugin({
+              patterns: [
+                {
+                  from: yukuBindingPath,
+                  to: `@yuku-parser/binding-${yukuBindingSuffix}/yuku-parser.node`,
+                },
+              ],
+            }),
             rsdoctorCIPlugin({ reportDir: '.rsdoctor/extension' }),
           ].filter(Boolean),
         },
@@ -55,9 +76,4 @@ export default defineConfig({
       },
     },
   ],
-  tools: {
-    rspack: {
-      ignoreWarnings: [/Module not found/],
-    },
-  },
 });

--- a/packages/vscode/src/parserTest.ts
+++ b/packages/vscode/src/parserTest.ts
@@ -1,4 +1,4 @@
-import { Compiler } from '@swc/core';
+import { type Node, parse } from 'yuku-parser';
 
 export class Range {
   constructor(
@@ -9,70 +9,11 @@ export class Range {
   ) {}
 }
 
-// Minimal AST typings and type guards to avoid using `any`.
-type Span = { start: number; end: number };
-type NodeBase = { type: string; span?: Span };
-
-type Identifier = NodeBase & { type: 'Identifier'; value: string };
-type MemberExpression = NodeBase & {
-  type: 'MemberExpression';
-  object: unknown;
-};
-type Argument = { expression: unknown };
-type CallExpression = NodeBase & {
-  type: 'CallExpression';
-  callee: unknown;
-  arguments: Argument[];
-  span: Span;
-};
-
-type StringLiteral = NodeBase & { type: 'StringLiteral'; value: string };
-type TemplateElement = { cooked?: string; raw?: string };
-type TemplateLiteral = NodeBase & {
-  type: 'TemplateLiteral';
-  quasis: TemplateElement[];
-  expressions: unknown[];
-};
-
-type Program = { span: Span } & { [key: string]: unknown };
-
-const isObject = (v: unknown): v is Record<string, unknown> =>
-  typeof v === 'object' && v !== null;
-
-const isSpan = (x: unknown): x is Span =>
-  isObject(x) &&
-  typeof (x as Record<string, unknown>).start === 'number' &&
-  typeof (x as Record<string, unknown>).end === 'number';
-
-const hasSpan = (v: unknown): v is { span: Span } =>
-  isObject(v) && isSpan((v as Record<string, unknown>).span);
-
-const isNode = (v: unknown): v is NodeBase =>
-  isObject(v) && typeof (v as Record<string, unknown>).type === 'string';
-const isIdentifier = (v: unknown): v is Identifier =>
-  isNode(v) &&
-  (v as Record<string, unknown>).type === 'Identifier' &&
-  typeof (v as Record<string, unknown>).value === 'string';
-const isMemberExpression = (v: unknown): v is MemberExpression =>
-  isNode(v) &&
-  (v as Record<string, unknown>).type === 'MemberExpression' &&
-  'object' in (v as Record<string, unknown>);
-const isCallExpression = (v: unknown): v is CallExpression =>
-  isNode(v) &&
-  (v as Record<string, unknown>).type === 'CallExpression' &&
-  Array.isArray((v as Record<string, unknown>).arguments as unknown[]) &&
-  hasSpan(v);
-const isArgument = (v: unknown): v is Argument =>
-  isObject(v) && 'expression' in v;
-const isStringLiteral = (v: unknown): v is StringLiteral =>
-  isNode(v) &&
-  (v as Record<string, unknown>).type === 'StringLiteral' &&
-  typeof (v as Record<string, unknown>).value === 'string';
-const isTemplateLiteral = (v: unknown): v is TemplateLiteral =>
-  isNode(v) &&
-  (v as Record<string, unknown>).type === 'TemplateLiteral' &&
-  Array.isArray((v as Record<string, unknown>).quasis as unknown[]) &&
-  Array.isArray((v as Record<string, unknown>).expressions as unknown[]);
+const isNode = (value: unknown): value is Node =>
+  typeof value === 'object' &&
+  value !== null &&
+  'type' in value &&
+  typeof value.type === 'string';
 
 export const parseTestFile = (
   code: string,
@@ -84,126 +25,81 @@ export const parseTestFile = (
     ): (() => void) | void;
   },
 ) => {
-  const compiler = new Compiler();
-
-  // Parse the code using SWC
-  const astUnknown = compiler.parseSync(code, {
-    syntax: 'typescript',
-    tsx: true,
+  const result = parse(code, {
+    lang: 'tsx',
+    preserveParens: false,
+    sourceType: 'module',
   });
-
-  if (!hasSpan(astUnknown)) {
-    // If for some reason the parser returns a program without span, abort early.
-    return;
+  const error = result.diagnostics.find(
+    (diagnostic) => diagnostic.severity === 'error',
+  );
+  if (error) {
+    throw new SyntaxError(error.message);
   }
 
-  const ast: Program = astUnknown as unknown as Program;
-  const offset = ast.span.start - 1;
-  const codeBuffer = Buffer.from(code, 'utf8');
-
-  // Helper function to convert SWC span to VS Code range
-  const spanToRange = (span: { start: number; end: number }): Range => {
-    // Convert byte offset to character index (SWC uses UTF-8 byte offsets)
-    const startSlice = codeBuffer.subarray(0, span.start - offset);
-    const startCharIndex = startSlice.toString('utf8').length;
-
-    const endSlice = codeBuffer.subarray(0, span.end - offset);
-    const endCharIndex = endSlice.toString('utf8').length;
-
-    const lines = code.substring(0, startCharIndex).split('\n');
+  const offsetToRange = (start: number, end: number): Range => {
+    const lines = code.substring(0, start).split('\n');
     const startLine = Math.max(0, lines.length - 1);
     const startChar = lines[startLine]?.length || 0;
 
-    const endLines = code.substring(0, endCharIndex).split('\n');
+    const endLines = code.substring(0, end).split('\n');
     const endLine = Math.max(0, endLines.length - 1);
     const endChar = endLines[endLine]?.length || 0;
 
     return new Range(startLine, endLine, startChar, endChar);
   };
 
-  // Common test function names to detect
-  const testFunctions = new Set(['test', 'it', 'describe', 'suite']);
-
-  // Helper function to extract string literal value
-  const getStringLiteralValue = (node: unknown): string | null => {
-    if (!node) return null;
-
-    if (isStringLiteral(node)) {
+  const getStringLiteralValue = (node: Node | undefined): string | null => {
+    if (node?.type === 'Literal' && typeof node.value === 'string') {
       return node.value;
     }
-    if (isTemplateLiteral(node)) {
-      // For simple template literals without expressions
-      if (node.quasis?.length === 1 && node.expressions.length === 0) {
-        return node.quasis[0].cooked || node.quasis[0].raw || '';
-      }
-      // For template literals with expressions, construct the string
-      let result = '';
-      for (let i = 0; i < node.quasis.length; i++) {
-        result += node.quasis[i].cooked || node.quasis[i].raw || '';
-        if (i < node.expressions.length) {
-          result += '$' + '{...}'; // Placeholder for expressions
-        }
-      }
-      return result;
+    if (node?.type !== 'TemplateLiteral') {
+      return null;
     }
 
-    return null;
+    return node.quasis
+      .map((quasi, index) => {
+        const expression = index < node.expressions.length ? '${...}' : '';
+        return `${quasi.value.cooked ?? quasi.value.raw}${expression}`;
+      })
+      .join('');
   };
 
-  // Recursive function to walk the AST
-  const walkNode = (node: unknown): void => {
-    if (!isObject(node)) {
-      return;
-    }
-
+  const walkNode = (node: Node): void => {
     let exit: (() => void) | void | undefined;
 
-    // Check for call expressions that might be test functions
-    if (isCallExpression(node)) {
-      let functionName: string | null = null;
+    if (node.type === 'CallExpression') {
+      let functionName: string | undefined;
 
-      // Handle direct function calls: test(), it(), describe()
-      const callee = (node as CallExpression).callee;
-      if (isIdentifier(callee)) {
-        functionName = callee.value;
-      }
-      // Handle member expressions: test.only(), describe.skip()
-      else if (isMemberExpression(callee)) {
-        const obj = callee.object;
-        if (isIdentifier(obj)) {
-          functionName = obj.value;
-        }
+      if (node.callee.type === 'Identifier') {
+        functionName = node.callee.name;
+      } else if (
+        node.callee.type === 'MemberExpression' &&
+        node.callee.object.type === 'Identifier'
+      ) {
+        functionName = node.callee.object.name;
       }
 
-      if (functionName && testFunctions.has(functionName)) {
-        // Extract test name from first argument
-        const firstArg = node.arguments?.[0] || undefined;
-        const expr =
-          firstArg && isArgument(firstArg) ? firstArg.expression : undefined;
-        const testName = getStringLiteralValue(expr);
-        const range = spanToRange(node.span);
-
-        type TestFn = 'test' | 'it' | 'describe' | 'suite';
+      if (
+        functionName === 'test' ||
+        functionName === 'it' ||
+        functionName === 'describe' ||
+        functionName === 'suite'
+      ) {
         exit = events.onTest(
-          range,
-          testName || 'unnamed test',
-          functionName as TestFn,
+          offsetToRange(node.start, node.end),
+          getStringLiteralValue(node.arguments[0]) || 'unnamed test',
+          functionName,
         );
       }
     }
 
-    // Walk through all properties of the node to find nested structures
-    for (const key in node) {
-      if (key === 'span') {
-        continue;
-      }
-
-      const value = (node as Record<string, unknown>)[key];
+    for (const value of Object.values(node)) {
       if (Array.isArray(value)) {
         for (const child of value) {
-          // Recurse into array elements to discover nested structures,
-          // even if they are wrapper objects (e.g., CallExpression arguments).
-          walkNode(child as unknown);
+          if (isNode(child)) {
+            walkNode(child);
+          }
         }
       } else if (isNode(value)) {
         walkNode(value);
@@ -213,6 +109,5 @@ export const parseTestFile = (
     exit?.();
   };
 
-  // Start walking from the root
-  walkNode(ast);
+  walkNode(result.program);
 };

--- a/packages/vscode/tests/unit/parse.test.ts
+++ b/packages/vscode/tests/unit/parse.test.ts
@@ -259,6 +259,21 @@ describe('parseTestFile', () => {
     expect(byName.inner.range.startLine).toBe(6);
   });
 
+  it('should compute UTF-16 columns after astral characters', () => {
+    const code = `const emoji = '😀'; test('unicode', () => {});`;
+
+    const results: { name: string; range: Range }[] = [];
+    parseTestFile(code, {
+      onTest: (range: Range, name: string) => {
+        results.push({ name, range });
+      },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe('unicode');
+    expect(results[0].range.startChar).toBe(code.indexOf('test'));
+  });
+
   it('should handle quotes and escaped characters', () => {
     const code = `
       describe('he said "hi"', () => {
@@ -345,5 +360,13 @@ describe('parseTestFile', () => {
     });
 
     expect(tests).toEqual([{ name: 'skipped suite', type: 'suite' }]);
+  });
+
+  it('should reject invalid syntax', () => {
+    expect(() =>
+      parseTestFile('test(', {
+        onTest: () => undefined,
+      }),
+    ).toThrow(SyntaxError);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,7 +597,7 @@ importers:
         version: 2.1.8(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
         version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.40)(vue@3.5.40(typescript@6.0.3))
@@ -670,10 +670,10 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@module-federation/rstest':
         specifier: https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/core':
         specifier: ~2.1.8
         version: 2.1.8(@module-federation/runtime-tools@2.8.0)
@@ -701,10 +701,10 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@module-federation/rstest':
         specifier: https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/core':
         specifier: ~2.1.8
         version: 2.1.8(@module-federation/runtime-tools@2.8.0)
@@ -734,7 +734,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/core':
         specifier: ~2.1.8
         version: 2.1.8(@module-federation/runtime-tools@2.8.0)
@@ -991,7 +991,7 @@ importers:
         version: 2.1.8(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
         version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.40)(vue@3.5.40(typescript@6.0.3))
@@ -1219,7 +1219,7 @@ importers:
         version: 7.58.12(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
         version: 1.4.6(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))
@@ -1330,10 +1330,10 @@ importers:
         version: 0.1.0
       webpack:
         specifier: ^5.109.0
-        version: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+        version: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
       webpack-license-plugin:
         specifier: ^4.5.1
-        version: 4.5.1(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 4.5.1(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
 
   packages/core/tests/runner/fixtures/bare-parent: {}
 
@@ -1470,9 +1470,6 @@ importers:
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
-      '@swc/core':
-        specifier: ^1.15.46
-        version: 1.15.46(@swc/helpers@0.5.23)
       '@types/istanbul-lib-report':
         specifier: ^3.0.3
         version: 3.0.3
@@ -1524,12 +1521,15 @@ importers:
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)
+      yuku-parser:
+        specifier: ^0.8.0
+        version: 0.8.0
 
   scripts:
     dependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.6.1
-        version: 1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rstest/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -3839,101 +3839,8 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
-  '@swc/core-darwin-arm64@1.15.46':
-    resolution: {integrity: sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@swc/core-darwin-x64@1.15.46':
-    resolution: {integrity: sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@swc/core-linux-arm-gnueabihf@1.15.46':
-    resolution: {integrity: sha512-i8tUGnNjyOgMmfmgFSg4aeJLQoFyfpIHK5FjpQAwpRyQIqEUB2w1e8zIDQzY1WhOxx8NoS1S5iUL813Un4Sf5A==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@swc/core-linux-arm64-gnu@1.15.46':
-    resolution: {integrity: sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@swc/core-linux-arm64-musl@1.15.46':
-    resolution: {integrity: sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@swc/core-linux-ppc64-gnu@1.15.46':
-    resolution: {integrity: sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==}
-    engines: {node: '>=10'}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@swc/core-linux-s390x-gnu@1.15.46':
-    resolution: {integrity: sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==}
-    engines: {node: '>=10'}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@swc/core-linux-x64-gnu@1.15.46':
-    resolution: {integrity: sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@swc/core-linux-x64-musl@1.15.46':
-    resolution: {integrity: sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@swc/core-win32-arm64-msvc@1.15.46':
-    resolution: {integrity: sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@swc/core-win32-ia32-msvc@1.15.46':
-    resolution: {integrity: sha512-tUEnfr3Bn9u6FOjUb3PN9p+09qZC2j+wNDLKHzXXZn22rqGcUqR/ohCRSS+nG9B9+X+U+3FewNEHJkTmdIvMjQ==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@swc/core-win32-x64-msvc@1.15.46':
-    resolution: {integrity: sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@swc/core@1.15.46':
-    resolution: {integrity: sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.17'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
-
-  '@swc/types@0.1.27':
-    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
@@ -9688,7 +9595,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@module-federation/enhanced@https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@115230134ddcaad07e2299514f005186d931a39b
       '@module-federation/cli': https://pkg.pr.new/module-federation/core/@module-federation/cli@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
@@ -9705,7 +9612,7 @@ snapshots:
       tapable: 2.3.0
     optionalDependencies:
       typescript: 6.0.3
-      webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+      webpack: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9734,16 +9641,16 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@module-federation/node@https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@module-federation/runtime': https://pkg.pr.new/module-federation/core/@module-federation/runtime@115230134ddcaad07e2299514f005186d931a39b
       '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+      webpack: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9751,10 +9658,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@module-federation/rsbuild-plugin@https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/node': https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/node': https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
     optionalDependencies:
       '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
@@ -9782,10 +9689,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rstest@https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@module-federation/rstest@https://pkg.pr.new/module-federation/core/@module-federation/rstest@1152301(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/node': https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/node': https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
     optionalDependencies:
       '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
@@ -10546,14 +10453,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      babel-loader: 10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
@@ -10572,11 +10479,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      less-loader: 12.3.3(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       reduce-configs: 2.0.1
     optionalDependencies:
       '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
@@ -10688,13 +10595,13 @@ snapshots:
 
   '@rsdoctor/client@1.6.1': {}
 
-  '@rsdoctor/core@1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/core@1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))
-      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/sdk': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/sdk': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rspack/resolver': 0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.49.0
@@ -10712,10 +10619,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/graph@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       es-toolkit: 1.49.0
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -10723,13 +10630,13 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@rsdoctor/core': 1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/sdk': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/core': 1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.8(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/sdk': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
     optionalDependencies:
       '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
@@ -10741,12 +10648,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/sdk@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@rsdoctor/client': 1.6.1
-      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1(supports-color@8.1.1)
@@ -10758,7 +10665,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/types@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
@@ -10766,12 +10673,12 @@ snapshots:
       source-map: 0.7.6
     optionalDependencies:
       '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
-      webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+      webpack: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
 
-  '@rsdoctor/utils@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/utils@1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@types/estree': 1.0.5
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -11324,70 +11231,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@swc/core-darwin-arm64@1.15.46':
-    optional: true
-
-  '@swc/core-darwin-x64@1.15.46':
-    optional: true
-
-  '@swc/core-linux-arm-gnueabihf@1.15.46':
-    optional: true
-
-  '@swc/core-linux-arm64-gnu@1.15.46':
-    optional: true
-
-  '@swc/core-linux-arm64-musl@1.15.46':
-    optional: true
-
-  '@swc/core-linux-ppc64-gnu@1.15.46':
-    optional: true
-
-  '@swc/core-linux-s390x-gnu@1.15.46':
-    optional: true
-
-  '@swc/core-linux-x64-gnu@1.15.46':
-    optional: true
-
-  '@swc/core-linux-x64-musl@1.15.46':
-    optional: true
-
-  '@swc/core-win32-arm64-msvc@1.15.46':
-    optional: true
-
-  '@swc/core-win32-ia32-msvc@1.15.46':
-    optional: true
-
-  '@swc/core-win32-x64-msvc@1.15.46':
-    optional: true
-
-  '@swc/core@1.15.46(@swc/helpers@0.5.23)':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.27
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.15.46
-      '@swc/core-darwin-x64': 1.15.46
-      '@swc/core-linux-arm-gnueabihf': 1.15.46
-      '@swc/core-linux-arm64-gnu': 1.15.46
-      '@swc/core-linux-arm64-musl': 1.15.46
-      '@swc/core-linux-ppc64-gnu': 1.15.46
-      '@swc/core-linux-s390x-gnu': 1.15.46
-      '@swc/core-linux-x64-gnu': 1.15.46
-      '@swc/core-linux-x64-musl': 1.15.46
-      '@swc/core-win32-arm64-msvc': 1.15.46
-      '@swc/core-win32-ia32-msvc': 1.15.46
-      '@swc/core-win32-x64-msvc': 1.15.46
-      '@swc/helpers': 0.5.23
-
-  '@swc/counter@0.1.3': {}
-
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
-
-  '@swc/types@0.1.27':
-    dependencies:
-      '@swc/counter': 0.1.3
 
   '@tailwindcss/node@4.3.3':
     dependencies:
@@ -12287,13 +12133,13 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
-  babel-loader@10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
+  babel-loader@10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       find-up: 5.0.0
     optionalDependencies:
       '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
-      webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+      webpack: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
 
   babel-plugin-vue-jsx-hmr@1.0.0(supports-color@8.1.1):
     dependencies:
@@ -14101,12 +13947,12 @@ snapshots:
       lefthook-windows-arm64: 2.1.10
       lefthook-windows-x64: 2.1.10
 
-  less-loader@12.3.3(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
+  less-loader@12.3.3(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
     dependencies:
       less: 4.6.7
     optionalDependencies:
       '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
-      webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+      webpack: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
 
   less@4.6.7:
     dependencies:
@@ -14874,15 +14720,14 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
+  minimizer-webpack-plugin@5.6.1(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+      webpack: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
     optionalDependencies:
-      '@swc/core': 1.15.46(@swc/helpers@0.5.23)
       csso: 5.0.5
       lightningcss: 1.32.0
       postcss: 8.5.19
@@ -16711,18 +16556,18 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-license-plugin@4.5.1(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
+  webpack-license-plugin@4.5.1(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
     dependencies:
       chalk: 5.4.1
       lodash: 4.18.1
       needle: 3.5.0
       spdx-expression-validate: 2.0.0
-      webpack: 5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
+      webpack: 5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
       webpack-sources: 3.5.1
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19):
+  webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -16738,7 +16583,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)(webpack@5.109.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      minimizer-webpack-plugin: 5.6.1(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)(webpack@5.109.0(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3


### PR DESCRIPTION
## Summary

- Replace `@swc/core` with `yuku-parser` for VS Code test discovery while preserving TSX parsing, syntax-error behavior, template-literal names, and UTF-16 ranges.
- Copy the target-specific Yuku Node-API binding into the VSIX for all six published Windows, macOS, and Linux x64/arm64 targets.
- Reduce the darwin-arm64 VSIX from 10.15 MB to 394.97 KB. The packaged extension contains the expected binding and passes all 58 unit tests and 8 VS Code Extension Host E2E tests.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1632
- https://github.com/yuku-toolchain/yuku/releases/tag/v0.8.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).