### PR TITLE
test(vscode): cover ranges after leading comments

### DIFF
--- a/packages/vscode/tests/unit/parse.test.ts
+++ b/packages/vscode/tests/unit/parse.test.ts
@@ -243,6 +243,47 @@ describe('parseTestFile', () => {
     expect(byName.child.range.startLine).toBe(1);
   });
 
+  it('should compute ranges correctly after leading comments', () => {
+    const code = `/* eslint-disable max-lines */
+/* eslint-disable max-lines-per-function */
+describe('outer', () => {
+  it('inner', () => {});
+  it('inner-1', () => {});
+});`;
+
+    const results: { name: string; range: Range }[] = [];
+    parseTestFile(code, {
+      onTest: (range: Range, name: string) => {
+        results.push({ name, range });
+      },
+    });
+
+    expect(
+      Object.fromEntries(
+        results.map(({ name, range }) => [
+          name,
+          {
+            start: { line: range.startLine, character: range.startChar },
+            end: { line: range.endLine, character: range.endChar },
+          },
+        ]),
+      ),
+    ).toEqual({
+      outer: {
+        start: { line: 2, character: 0 },
+        end: { line: 5, character: 2 },
+      },
+      inner: {
+        start: { line: 3, character: 2 },
+        end: { line: 3, character: 23 },
+      },
+      'inner-1': {
+        start: { line: 4, character: 2 },
+        end: { line: 4, character: 25 },
+      },
+    });
+  });
+
   it('should compute range correctly with chinese characters', () => {
     const code = fs.readFileSync(join(__dirname, './test.txt'), 'utf-8');
 


### PR DESCRIPTION
## Summary

- Add a regression test for VS Code test discovery when a file starts with comments.
- Assert the exact start and end positions of nested `describe` and `it` calls, covering the offset bug fixed by the Yuku parser migration.

## Related Links

- Closes #749

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).