### PR TITLE
perf(coverage-v8): use Yuku AST utilities

### DIFF
--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -34,12 +34,11 @@
   },
   "dependencies": {
     "@jridgewell/trace-mapping": "0.3.31",
-    "estree-walker": "^3.0.3",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.2.0",
-    "js-tokens": "^10.0.0",
     "picomatch": "^4.0.5",
+    "yuku-ast": "^0.8.0",
     "yuku-parser": "^0.8.0"
   },
   "devDependencies": {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -524,17 +524,10 @@ export class CoverageProvider implements RstestCoverageProvider {
   }
 
   private parseAst(code: string, outputModule: boolean) {
-    const result = parse(code, {
+    return parse(code, {
       preserveParens: false,
       sourceType: outputModule ? 'module' : 'script',
     });
-    const error = result.diagnostics.find(
-      (diagnostic) => diagnostic.severity === 'error',
-    );
-    if (error) {
-      throw new SyntaxError(error.message);
-    }
-    return result.program;
   }
 
   private async convertWithAst(

--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -43,9 +43,8 @@ import {
 } from '@jridgewell/trace-mapping';
 import type { Profiler } from 'node:inspector';
 import type { CoverageMap, FileCoverageData } from 'istanbul-lib-coverage';
-import jsTokens from 'js-tokens';
-import type { Program } from 'yuku-parser';
-import { walk } from 'estree-walker';
+import { walk } from 'yuku-ast';
+import type { Comment, ParseResult } from 'yuku-parser';
 
 type SourceMapLike = Omit<EncodedSourceMap | DecodedSourceMap, 'version'> & {
   version: number;
@@ -110,7 +109,7 @@ type PreparedCoverage = {
 type FileCoverageLike = FileCoverageData | { data: FileCoverageData };
 
 type ConvertOptions = {
-  ast: Program | (() => Program);
+  ast: ParseResult | (() => ParseResult);
   cacheKey: string;
   code: string;
   coverage: Pick<Profiler.ScriptCoverage, 'functions' | 'url'>;
@@ -132,7 +131,7 @@ const IGNORE_LINES_PATTERN =
 const EOL_PATTERN = /\r?\n/g;
 const MAX_PREPARED_CACHE_SIZE = 50;
 
-const preparedCache = new Map<string, Promise<PreparedCoverage>>();
+const preparedCache = new Map<string, Promise<PreparedCoverage | null>>();
 
 const createTraceMap = (sourceMap: SourceMapLike, sourceMapUrl?: string) =>
   new TraceMap(
@@ -182,15 +181,9 @@ export async function applyV8CoverageWithAst(
 async function getPreparedCoverage(
   options: ConvertOptions,
 ): Promise<PreparedCoverage | null> {
-  const ignoreHints = getIgnoreHints(options.code);
-
-  if (ignoreHints.length === 1 && ignoreHints[0]?.type === 'file') {
-    return null;
-  }
-
   let prepared = preparedCache.get(options.cacheKey);
   if (!prepared) {
-    prepared = prepareCoverage(options, ignoreHints);
+    prepared = prepareCoverage(options);
     preparedCache.set(options.cacheKey, prepared);
 
     if (preparedCache.size > MAX_PREPARED_CACHE_SIZE) {
@@ -206,8 +199,24 @@ async function getPreparedCoverage(
 
 async function prepareCoverage(
   options: ConvertOptions,
-  ignoreHints: IgnoreHint[],
-): Promise<PreparedCoverage> {
+): Promise<PreparedCoverage | null> {
+  const parseResult =
+    typeof options.ast === 'function' ? options.ast() : options.ast;
+  const ignoreHints = options.code.includes('ignore')
+    ? getIgnoreHints(options.code, parseResult.comments)
+    : [];
+
+  if (ignoreHints.length === 1 && ignoreHints[0]?.type === 'file') {
+    return null;
+  }
+
+  const error = parseResult.diagnostics.find(
+    (diagnostic) => diagnostic.severity === 'error',
+  );
+  if (error) {
+    throw new SyntaxError(error.message);
+  }
+
   const filename = fileURLToPath(options.coverage.url);
   const directory = dirname(filename);
   const sourceMapResult = options.sourceMap
@@ -256,9 +265,7 @@ async function prepareCoverage(
   const isSkipped = (node: AstNode | null | undefined) =>
     Boolean(node && skippedNodes.has(node));
 
-  const ast = typeof options.ast === 'function' ? options.ast() : options.ast;
-
-  walk(ast as Parameters<typeof walk>[0], {
+  walk(parseResult.program, {
     enter(node) {
       const current = node as AstNode;
       if (nextIgnore !== false) {
@@ -1261,54 +1268,28 @@ function isTernarySeparatorOnly(code: string): boolean {
   return /^[?:\s]*$/.test(code);
 }
 
-function getIgnoreHints(code: string): IgnoreHint[] {
+function getIgnoreHints(code: string, comments: Comment[]): IgnoreHint[] {
   const ignoreHints: IgnoreHint[] = [];
-  if (!code.includes('ignore')) {
-    return ignoreHints;
-  }
 
-  const tokens = jsTokens(code);
-  let current = 0;
-  let previousTokenWasIgnoreHint = false;
+  for (const comment of comments) {
+    const value =
+      comment.type === 'Block'
+        ? comment.value.replace(/^\*/, '')
+        : comment.value;
+    const type = value.match(IGNORE_PATTERN)?.[1];
 
-  for (const token of tokens) {
-    if (
-      previousTokenWasIgnoreHint &&
-      token.type !== 'WhiteSpace' &&
-      token.type !== 'LineTerminatorSequence'
-    ) {
-      const previous = ignoreHints.at(-1);
-      if (previous) {
-        previous.loc.end = current;
-      }
-      previousTokenWasIgnoreHint = false;
+    if (type === 'file') {
+      return [{ type, loc: { start: 0, end: 0 } }];
     }
 
-    if (
-      token.type === 'SingleLineComment' ||
-      token.type === 'MultiLineComment'
-    ) {
-      const loc = { start: current, end: current + token.value.length };
-      const comment = token.value
-        .replace(/^\/\*\*/, '')
-        .replace(/^\/\*/, '')
-        .replace(/\*\*\/$/, '')
-        .replace(/\*\/$/, '')
-        .replace(/^\/\//, '');
-      const groups = comment.match(IGNORE_PATTERN);
-      const type = groups?.[1];
-
-      if (type === 'file') {
-        return [{ type, loc: { start: 0, end: 0 } }];
+    if (type === 'if' || type === 'else' || type === 'next') {
+      const loc = { start: comment.start, end: comment.end };
+      const nextTokenOffset = code.slice(comment.end).search(/\S/);
+      if (nextTokenOffset !== -1) {
+        loc.end += nextTokenOffset;
       }
-
-      if (type === 'if' || type === 'else' || type === 'next') {
-        ignoreHints.push({ type, loc });
-        previousTokenWasIgnoreHint = true;
-      }
+      ignoreHints.push({ type, loc });
     }
-
-    current += token.value.length;
   }
 
   return ignoreHints;

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -111,17 +111,10 @@ function getProviderInternals(provider: CoverageProvider): ProviderInternals {
 }
 
 function parseModule(code: string) {
-  const result = parse(code, {
+  return parse(code, {
     preserveParens: false,
     sourceType: 'module',
   });
-  const error = result.diagnostics.find(
-    (diagnostic) => diagnostic.severity === 'error',
-  );
-  if (error) {
-    throw new SyntaxError(error.message);
-  }
-  return result.program;
 }
 
 describe('coverage-v8 provider', () => {
@@ -489,6 +482,34 @@ describe('coverage-v8 provider', () => {
 
     expect(coverage[file]?.branchMap[0]?.locations).toHaveLength(1);
     expect(coverage[file]?.b[0]).toEqual([1]);
+  });
+
+  it('uses Yuku comments for ignore hints', async () => {
+    const file = join(tmpdir(), 'rstest-coverage-v8-yuku-comments.js');
+    const code = `const marker = "/* v8 ignore if */";
+if (first) { foo(); } else { bar(); }
+const label = "😀";
+/** v8 ignore if */ if (second) { foo(); } else { bar(); }`;
+    const ast = parseModule(code);
+
+    const coverage = await convertV8CoverageWithAst({
+      ast,
+      cacheKey: `${file}:yuku-comments`,
+      code,
+      coverage: {
+        url: pathToFileURL(file).href,
+        functions: [
+          {
+            functionName: '',
+            isBlockCoverage: true,
+            ranges: [{ startOffset: 0, endOffset: code.length, count: 1 }],
+          },
+        ],
+      },
+    });
+
+    expect(coverage[file]?.branchMap[0]?.locations).toHaveLength(2);
+    expect(coverage[file]?.branchMap[1]?.locations).toHaveLength(1);
   });
 
   it('gives implicit else branches numeric locations', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1388,9 +1388,6 @@ importers:
       '@jridgewell/trace-mapping':
         specifier: 0.3.31
         version: 0.3.31
-      estree-walker:
-        specifier: ^3.0.3
-        version: 3.0.3
       istanbul-lib-coverage:
         specifier: ^3.2.2
         version: 3.2.2
@@ -1400,12 +1397,12 @@ importers:
       istanbul-reports:
         specifier: ^3.2.0
         version: 3.2.0
-      js-tokens:
-        specifier: ^10.0.0
-        version: 10.0.0
       picomatch:
         specifier: ^4.0.5
         version: 4.0.5
+      yuku-ast:
+        specifier: ^0.8.0
+        version: 0.8.0
       yuku-parser:
         specifier: ^0.8.0
         version: 0.8.0
@@ -6113,9 +6110,6 @@ packages:
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
-
-  js-tokens@10.0.0:
-    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -13779,8 +13773,6 @@ snapshots:
       nopt: 7.2.1
 
   js-cookie@3.0.7: {}
-
-  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## Summary

- Replace `estree-walker` with `yuku-ast` and reuse `yuku-parser` comments for coverage ignore hints, removing the extra `js-tokens` pass while preserving ignore-file syntax-error behavior.
- Improve the real Rsbuild V8 coverage run by 16.6% at the median. Measurements used Node 24.11.1 on darwin-arm64 with Rstest 0.11.4; one warmup was excluded and each variant was measured three times with `pnpm test --coverage --coverage.provider v8`.

| Implementation | Runs | Median | Mean |
| --- | --- | --- | --- |
| Yuku + `estree-walker` + `js-tokens` | 3.40s / 3.61s / 3.49s | 3.49s | 3.50s |
| Yuku + `yuku-ast` + parser comments | 2.91s / 2.78s / 3.10s | 2.91s | 2.93s |

All 378 tests across 56 files pass with an unchanged coverage report.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1632
- https://github.com/yuku-toolchain/yuku/releases/tag/v0.8.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; internal implementation only).