### PR TITLE
chore(lint): type-check unit tests and enable no-unused-vars

### DIFF
--- a/e2e/mock/tests/mockObject.test.ts
+++ b/e2e/mock/tests/mockObject.test.ts
@@ -287,8 +287,8 @@ describe('rs.mocked', () => {
   // whether or not the call signature carries a `this` parameter — the latter
   // is the shape a `function` + `class` declaration merge produces.
   test('Mocked<T> stays assignable to T for construct+call members', () => {
-    class Handle {
-      _tag!: number;
+    interface Handle {
+      _tag: number;
     }
     interface Api {
       op: (new () => Handle) & (() => Promise<number>);
@@ -329,8 +329,8 @@ describe('rs.mocked', () => {
   // Type-level regression: mocking a function typed with an explicit `this`
   // must not force a receiver — `rs.mocked(fn)(arg)` should still type-check.
   test('mocked function stays callable without a receiver for this-typed functions', () => {
-    class Ctx {
-      _brand!: 'ctx';
+    interface Ctx {
+      _brand: 'ctx';
     }
     type Run = (this: Ctx, arg: number) => string;
     const callsWithoutReceiver = (mocked: Mocked<Run>): string => mocked(1);
@@ -365,6 +365,9 @@ describe('rs.mocked', () => {
       mocked.api.getValue.mockReturnValue(200);
     };
 
+    // `Service` must stay a class — `Mocked<typeof Service>` is what this
+    // regression covers — so it is asserted as a value, not only queried.
+    expect(Service.getValue()).toBe(42);
     expect(asRealClass).toBeTypeOf('function');
     expect(readsStaticProperty).toBeTypeOf('function');
     expect(configuresStaticMethod).toBeTypeOf('function');

--- a/packages/adapter-rsbuild/tests/tsconfig.json
+++ b/packages/adapter-rsbuild/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@rstest/tsconfig/base",
   "compilerOptions": {
-    "types": ["node", "@rstest/core/globals"]
+    "types": ["node"]
   },
   "include": ["./**/*.ts"]
 }

--- a/packages/adapter-rslib/tests/tsconfig.json
+++ b/packages/adapter-rslib/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@rstest/tsconfig/base",
   "compilerOptions": {
-    "types": ["node", "@rstest/core/globals"]
+    "types": ["node"]
   },
   "include": ["./**/*.ts"]
 }

--- a/packages/adapter-rspack/tests/tsconfig.json
+++ b/packages/adapter-rspack/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@rstest/tsconfig/base",
   "compilerOptions": {
-    "types": ["node", "@rstest/core/globals"]
+    "types": ["node"]
   },
   "include": ["./**/*.ts"]
 }

--- a/packages/browser/tests/playwrightRuntime.test.ts
+++ b/packages/browser/tests/playwrightRuntime.test.ts
@@ -184,7 +184,7 @@ describe('launchPlaywrightBrowser', () => {
     });
     const page = await context.newPage();
 
-    expect((page as FakePage).getByRole()).toBe('locator');
+    expect((page as unknown as FakePage).getByRole()).toBe('locator');
 
     await page[Symbol.asyncDispose]();
     await context[Symbol.asyncDispose]();

--- a/packages/browser/tests/protocol.test.ts
+++ b/packages/browser/tests/protocol.test.ts
@@ -101,6 +101,7 @@ describe('browser protocol types', () => {
           level: 'log',
           content: 'test log',
           testPath: '/test.ts',
+          projectName: 'default',
           type: 'stdout',
         },
       };

--- a/packages/browser/tests/tsconfig.json
+++ b/packages/browser/tests/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts", "../src/env.d.ts"]
 }

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@rstest/core';
 import { join } from 'pathe';
 import { mergeWithCLIOptions, resolveProjects } from '../../src/cli/init';
-import type { RstestConfig } from '../../src/types';
+import type { InlineProjectConfig, RstestConfig } from '../../src/types';
 
 const rootPath = join(__dirname, '../..');
 
@@ -598,7 +598,7 @@ describe('resolveProjects', () => {
         },
       });
 
-      expect(projects[0]!.config.browser.providerOptions).toEqual({
+      expect(projects[0]!.config.browser!.providerOptions).toEqual({
         launch: {
           channel: 'chrome',
         },
@@ -643,7 +643,7 @@ describe('resolveProjects', () => {
 
       // CLI overrides only `launch.channel`; sibling leaves (`launch.args`) and
       // the unrelated `context` object from config are preserved.
-      expect(projects[0]!.config.browser.providerOptions).toEqual({
+      expect(projects[0]!.config.browser!.providerOptions).toEqual({
         launch: {
           channel: 'chrome',
           args: ['--no-sandbox'],
@@ -655,17 +655,22 @@ describe('resolveProjects', () => {
     });
   });
 
+  // `resolveProjects` spreads an inline project into a full config, so the CLI
+  // coverage merge still reaches project-level `coverage` even though the public
+  // project config type omits the key.
+  const projectWithCoverage = (
+    coverage: RstestConfig['coverage'],
+  ): InlineProjectConfig =>
+    ({ name: 'test-project', coverage }) as InlineProjectConfig;
+
   describe('coverage CLI options', () => {
     it('should apply coverage.changed from CLI', async () => {
       const projects = await resolveProjects({
         config: {
           projects: [
-            {
-              name: 'test-project',
-              coverage: {
-                enabled: true,
-              },
-            },
+            projectWithCoverage({
+              enabled: true,
+            }),
           ],
         },
         root: rootPath,
@@ -749,7 +754,7 @@ describe('resolveProjects', () => {
       expect(projects[0]!.config.coverage).toMatchObject({
         changed: false,
       });
-      expect(projects[0]!.config.coverage.enabled).toBeUndefined();
+      expect(projects[0]!.config.coverage!.enabled).toBeUndefined();
     });
 
     it('should enable coverage when coverage provider is set from CLI', async () => {
@@ -825,13 +830,10 @@ describe('resolveProjects', () => {
       const projects = await resolveProjects({
         config: {
           projects: [
-            {
-              name: 'test-project',
-              coverage: {
-                enabled: true,
-                reporters: ['text', ['json', { file: 'coverage.json' }]],
-              },
-            },
+            projectWithCoverage({
+              enabled: true,
+              reporters: ['text', ['json', { file: 'coverage.json' }]],
+            }),
           ],
         },
         root: rootPath,
@@ -852,16 +854,13 @@ describe('resolveProjects', () => {
       const projects = await resolveProjects({
         config: {
           projects: [
-            {
-              name: 'test-project',
-              coverage: {
-                include: ['old-include/**'],
-                exclude: ['old-exclude/**'],
-                reporters: ['html'],
-                reportsDirectory: 'old-coverage',
-                clean: true,
-              },
-            },
+            projectWithCoverage({
+              include: ['old-include/**'],
+              exclude: ['old-exclude/**'],
+              reporters: ['html'],
+              reportsDirectory: 'old-coverage',
+              clean: true,
+            }),
           ],
         },
         root: rootPath,

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -274,9 +274,10 @@ describe('mergeRstestConfig', () => {
     );
 
     expect(
-      rstest.projects[0]?.normalizedConfig.performance?.buildCache
-        ?.buildDependencies,
-    ).toEqual(['/repo/configs/cache-flags.ts']);
+      rstest.projects[0]?.normalizedConfig.performance?.buildCache,
+    ).toMatchObject({
+      buildDependencies: ['/repo/configs/cache-flags.ts'],
+    });
   });
 
   it('should preserve explicit default buildCache directory for projects', () => {
@@ -303,9 +304,10 @@ describe('mergeRstestConfig', () => {
     );
 
     expect(
-      rstest.projects[0]?.normalizedConfig.performance?.buildCache
-        ?.cacheDirectory,
-    ).toBe('/repo/projects/node/node_modules/.cache/rstest');
+      rstest.projects[0]?.normalizedConfig.performance?.buildCache,
+    ).toMatchObject({
+      cacheDirectory: '/repo/projects/node/node_modules/.cache/rstest',
+    });
     expect(
       resolveProjectBuildCache({
         context: rstest,
@@ -464,6 +466,7 @@ describe('mergeRstestConfig', () => {
         },
         {
           browser: {
+            provider: 'playwright',
             providerOptions: {
               launch: { channel: 'chrome' },
               context: { locale: 'en-US' },
@@ -500,6 +503,7 @@ describe('mergeRstestConfig', () => {
       },
       {
         browser: {
+          provider: 'playwright',
           providerOptions: {
             launch: {
               args: ['--headless=new'],
@@ -534,6 +538,7 @@ describe('mergeRstestConfig', () => {
       },
       {
         browser: {
+          provider: 'playwright',
           providerOptions: { launch: { channel: 'chrome' } },
         },
       },

--- a/packages/core/tests/core/globalSetup.test.ts
+++ b/packages/core/tests/core/globalSetup.test.ts
@@ -126,6 +126,7 @@ describe('runGlobalSetup', () => {
       globalSetupEntries: [],
       assetFiles: {},
       sourceMaps: {},
+      federation: false,
       interopDefault: true,
       outputModule: false,
     });

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -7,10 +7,14 @@ import {
   syncCoverageSetupExcludes,
 } from '../../src/core/rsbuild';
 import { createSetupFileState } from '../../src/core/setupFileState';
-import type { RstestContext, RstestExposeAPI } from '../../src/types';
+import type {
+  ResolvedRstestConfig,
+  RstestContext,
+  RstestExposeAPI,
+} from '../../src/types';
 import { listTests } from '../../src/core/listTests';
 import { Rstest } from '../../src/core/rstest';
-import { TEMP_RSTEST_OUTPUT_DIR } from '../../src/utils';
+import { castArray, TEMP_RSTEST_OUTPUT_DIR } from '../../src/utils';
 
 process.env.DEBUG = 'false';
 
@@ -172,6 +176,10 @@ describe('prepareRsbuild', () => {
         },
       };
 
+      const shardedConfig: ResolvedRstestConfig = {
+        root: tempRoot,
+        shard: { index: 1, count: 2 },
+      };
       const context = new Rstest(
         {
           cwd: tempRoot,
@@ -196,10 +204,7 @@ describe('prepareRsbuild', () => {
             },
           ],
         },
-        {
-          root: tempRoot,
-          shard: { index: 1, count: 2 },
-        },
+        shardedConfig,
       );
 
       const list = await listTests(context, { json: false });
@@ -434,6 +439,8 @@ describe('prepareRsbuild', () => {
       name: 'browser-project',
       rootPath,
       environmentName: 'browser-project',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         forceRerunTriggers: [],
         include: ['original.test.ts'],
@@ -520,6 +527,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         include: ['original.test.ts'],
         plugins: [modifyRstestConfigPlugin],
@@ -635,6 +644,7 @@ describe('prepareRsbuild', () => {
         rstestApi?.modifyRstestConfig((config) => {
           config.browser = {
             ...config.browser,
+            provider: 'playwright',
             enabled: true,
           };
         });
@@ -713,6 +723,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         include: ['original.test.ts'],
         exclude: {
@@ -879,6 +891,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         root: rootPath,
         include: ['original.test.ts'],
@@ -972,9 +986,15 @@ describe('prepareRsbuild', () => {
         const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
         rstestApi?.modifyRstestConfig((config) => {
-          config.setupFiles = [...config.setupFiles, 'extra-setup.ts'];
-          config.globalSetup = [...config.globalSetup, 'extra-global.ts'];
-          config.include = [...config.include, 'extra.test.ts'];
+          config.setupFiles = [
+            ...castArray(config.setupFiles),
+            'extra-setup.ts',
+          ];
+          config.globalSetup = [
+            ...castArray(config.globalSetup),
+            'extra-global.ts',
+          ];
+          config.include = [...castArray(config.include), 'extra.test.ts'];
         });
       },
     };
@@ -983,6 +1003,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath: tempRoot,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         root: tempRoot,
         include: ['base.test.ts'],
@@ -1024,7 +1046,7 @@ describe('prepareRsbuild', () => {
             pool: { type: 'forks' },
           },
           projects: [project],
-        },
+        } as unknown as RstestContext,
         globTestSourceEntries: async () => ({}),
         setupFileState: createSetupFileState(),
       });
@@ -1073,6 +1095,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath: tempRoot,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         root: tempRoot,
         include: ['base.test.ts'],
@@ -1173,6 +1197,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath: tempRoot,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         root: tempRoot,
         include: ['base.test.ts'],
@@ -1280,6 +1306,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath: tempRoot,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         root: tempRoot,
         include: ['base.test.ts'],
@@ -1379,6 +1407,8 @@ describe('prepareRsbuild', () => {
       name: 'test',
       rootPath: tempRoot,
       environmentName: 'test',
+      outputModule: false,
+      _globalSetups: false,
       normalizedConfig: {
         root: tempRoot,
         include: ['base.test.ts'],

--- a/packages/core/tests/core/runnerEventSink.test.ts
+++ b/packages/core/tests/core/runnerEventSink.test.ts
@@ -18,11 +18,11 @@ const makeContext = (
     failedCount?: number;
   } = {},
 ) => {
-  const calls: Record<string, unknown[]> = {
-    stateFileResult: [],
-    snapshotAdd: [],
-    reporterFileResult: [],
-    reporterConsole: [],
+  const calls = {
+    stateFileResult: [] as unknown[],
+    snapshotAdd: [] as unknown[],
+    reporterFileResult: [] as unknown[],
+    reporterConsole: [] as unknown[],
   };
   const reporter = {
     onTestFileResult: (r: unknown) => {

--- a/packages/core/tests/coverage/generate.test.ts
+++ b/packages/core/tests/coverage/generate.test.ts
@@ -19,9 +19,6 @@ const createFileCoverage = (file: string): FileCoverageData => ({
   s: {},
   f: {},
   b: {},
-  all: false,
-  _coverageSchema: 'test',
-  hash: file,
 });
 
 const createCoverageMap = (
@@ -123,6 +120,7 @@ describe('generateCoverage', () => {
       async generateReports(coverageMap) {
         reportedFiles.push(coverageMap.files());
       },
+      generateCoverageForUntestedFiles: async () => [],
     } satisfies CoverageProvider;
 
     const coverageMap = createCoverageMap();
@@ -183,6 +181,7 @@ describe('generateCoverage', () => {
       async generateReports(coverageMap) {
         reportedFiles.push(coverageMap.files());
       },
+      generateCoverageForUntestedFiles: async () => [],
     } satisfies CoverageProvider;
 
     const coverageMap = createCoverageMap();
@@ -238,6 +237,7 @@ describe('generateCoverage', () => {
       async generateReports(coverageMap) {
         reportedFiles.push(coverageMap.files());
       },
+      generateCoverageForUntestedFiles: async () => [],
     } satisfies CoverageProvider;
 
     const coverageMap = createCoverageMap();
@@ -289,6 +289,7 @@ describe('generateCoverage', () => {
       async generateReports(coverageMap) {
         reportedFiles.push(coverageMap.files());
       },
+      generateCoverageForUntestedFiles: async () => [],
     } satisfies CoverageProvider;
 
     const coverageMap = createCoverageMap();
@@ -390,63 +391,16 @@ describe('generateCoverage', () => {
     const coveredFile = path.join(srcDir, 'covered.ts');
     const defaultCoverage = withDefaultConfig({}).coverage;
     const coveredFiles = new Map<string, FileCoverageData>([
-      [
-        coveredFile,
-        {
-          path: coveredFile,
-          statementMap: {},
-          fnMap: {},
-          branchMap: {},
-          s: {},
-          f: {},
-          b: {},
-          all: false,
-          _coverageSchema: 'test',
-          hash: coveredFile,
-        },
-      ],
+      [coveredFile, createFileCoverage(coveredFile)],
     ]);
-
-    const createCoverageMap = (): CoverageMap =>
-      ({
-        addFileCoverage(coverage: { path: string }) {
-          coveredFiles.set(coverage.path, coverage);
-        },
-        files() {
-          return Array.from(coveredFiles.keys());
-        },
-        filter(predicate: (filePath: string) => boolean) {
-          for (const filePath of Array.from(coveredFiles.keys())) {
-            if (!predicate(filePath)) {
-              coveredFiles.delete(filePath);
-            }
-          }
-        },
-        merge(coverage: Record<string, FileCoverageData>) {
-          Object.entries(coverage).forEach(([filePath, fileCoverage]) => {
-            coveredFiles.set(filePath, fileCoverage);
-          });
-        },
-      }) as CoverageMap;
 
     const provider = {
       init: () => {},
       collect: () => null,
       cleanup: () => {},
-      createCoverageMap: () => createCoverageMap(),
+      createCoverageMap: () => createCoverageMap(coveredFiles),
       async generateCoverageForUntestedFiles({ files }) {
-        return files.map((file) => ({
-          path: file,
-          statementMap: {},
-          fnMap: {},
-          branchMap: {},
-          s: {},
-          f: {},
-          b: {},
-          all: false,
-          _coverageSchema: 'test',
-          hash: file,
-        }));
+        return files.map(createFileCoverage);
       },
       async generateReports() {},
     } satisfies CoverageProvider;

--- a/packages/core/tests/pool/helpers.ts
+++ b/packages/core/tests/pool/helpers.ts
@@ -1,0 +1,15 @@
+/**
+ * Awaits a pool run that is expected to reject and hands back the rejection so
+ * the test can assert on the enriched message. A run that resolves fails here
+ * rather than further down on an `undefined` message.
+ */
+export const expectRejection = async (
+  promise: Promise<unknown>,
+): Promise<Error> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error('Expected the pool run to reject, but it resolved.');
+};

--- a/packages/core/tests/pool/helpers.ts
+++ b/packages/core/tests/pool/helpers.ts
@@ -1,7 +1,8 @@
 /**
  * Awaits a pool run that is expected to reject and hands back the rejection so
- * the test can assert on the enriched message. A run that resolves fails here
- * rather than further down on an `undefined` message.
+ * the test can assert on the enriched message. A run that resolves — or rejects
+ * with something that carries no message — fails here rather than further down
+ * on an `undefined` message.
  */
 export const expectRejection = async (
   promise: Promise<unknown>,
@@ -9,7 +10,12 @@ export const expectRejection = async (
   try {
     await promise;
   } catch (error) {
-    return error as Error;
+    if (error instanceof Error) {
+      return error;
+    }
+    throw new Error(
+      `Expected the pool run to reject with an Error, got: ${String(error)}`,
+    );
   }
   throw new Error('Expected the pool run to reject, but it resolved.');
 };

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'pathe';
 import { MemoryGate } from '../../src/pool/memoryGate';
 import { Pool } from '../../src/pool/pool';
+import { expectRejection } from './helpers';
 import type { PoolOptions, PoolTask } from '../../src/pool/types';
 
 const WORKER_ENTRY = resolve(__dirname, './fixtures/testWorker.mjs');
@@ -100,9 +101,9 @@ describe('Pool - fatal error', () => {
   it('should enrich error with captured stderr when worker crashes', async () => {
     const pool = new Pool(createPoolOptions());
     try {
-      const err: Error = await pool
-        .runTest(createTask('run', { __testMode: 'stderr-crash' }))
-        .catch((e: Error) => e);
+      const err = await expectRejection(
+        pool.runTest(createTask('run', { __testMode: 'stderr-crash' })),
+      );
       expect(err.message).toContain('segfault at 0x0');
     } finally {
       await pool.close();
@@ -116,9 +117,9 @@ describe('Pool - stderr handling', () => {
   it('should truncate large stderr in error messages', async () => {
     const pool = new Pool(createPoolOptions());
     try {
-      const err: Error = await pool
-        .runTest(createTask('run', { __testMode: 'stderr-large' }))
-        .catch((e: Error) => e);
+      const err = await expectRejection(
+        pool.runTest(createTask('run', { __testMode: 'stderr-large' })),
+      );
       expect(err.message).toContain('[truncated');
       expect(err.message).toContain('bytes of stderr]');
       // Tail is preserved
@@ -133,9 +134,9 @@ describe('Pool - stderr handling', () => {
   it('should capture stderr written immediately before exit', async () => {
     const pool = new Pool(createPoolOptions());
     try {
-      const err: Error = await pool
-        .runTest(createTask('run', { __testMode: 'stderr-late' }))
-        .catch((e: Error) => e);
+      const err = await expectRejection(
+        pool.runTest(createTask('run', { __testMode: 'stderr-late' })),
+      );
       expect(err.message).toContain('late-stderr-marker');
     } finally {
       await pool.close();
@@ -387,7 +388,7 @@ describe('Pool - capacity', () => {
       ...sorted.slice(0, maxWorkers).map((iv) => iv.end),
     );
     for (let i = maxWorkers; i < sorted.length; i++) {
-      expect(sorted[i].start).toBeGreaterThanOrEqual(firstBatchEarliestEnd);
+      expect(sorted[i]!.start).toBeGreaterThanOrEqual(firstBatchEarliestEnd);
     }
 
     await pool.close();

--- a/packages/core/tests/pool/threadsPool.test.ts
+++ b/packages/core/tests/pool/threadsPool.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'pathe';
 import { Pool } from '../../src/pool/pool';
+import { expectRejection } from './helpers';
 import type { PoolOptions, PoolTask } from '../../src/pool/types';
 
 const WORKER_ENTRY = resolve(__dirname, './fixtures/testWorker.mjs');
@@ -96,9 +97,9 @@ describe('ThreadsPool - fatal error', () => {
   it('should enrich error with captured stderr when worker crashes', async () => {
     const pool = new Pool(createPoolOptions());
     try {
-      const err: Error = await pool
-        .runTest(createTask('run', { __testMode: 'stderr-crash' }))
-        .catch((e: Error) => e);
+      const err = await expectRejection(
+        pool.runTest(createTask('run', { __testMode: 'stderr-crash' })),
+      );
       expect(err.message).toContain('segfault at 0x0');
     } finally {
       await pool.close();
@@ -112,9 +113,9 @@ describe('ThreadsPool - stderr handling', () => {
   it('should truncate large stderr in error messages', async () => {
     const pool = new Pool(createPoolOptions());
     try {
-      const err: Error = await pool
-        .runTest(createTask('run', { __testMode: 'stderr-large' }))
-        .catch((e: Error) => e);
+      const err = await expectRejection(
+        pool.runTest(createTask('run', { __testMode: 'stderr-large' })),
+      );
       expect(err.message).toContain('[truncated');
       expect(err.message).toContain('bytes of stderr]');
       expect(err.message).toContain('STDERR_TAIL_MARKER');

--- a/packages/core/tests/reporter/githubActions.test.ts
+++ b/packages/core/tests/reporter/githubActions.test.ts
@@ -104,7 +104,7 @@ describe('GithubActionsReporter step summary', () => {
         testResults: [],
         duration: emptyDuration,
         snapshotSummary: emptySnapshotSummary,
-        getSourcemap: () => null,
+        getSourcemap: async () => null,
       });
 
       const summary = await fs.readFile(summaryPath, 'utf-8');
@@ -151,7 +151,7 @@ describe('GithubActionsReporter step summary', () => {
         testResults: [],
         duration: emptyDuration,
         snapshotSummary: emptySnapshotSummary,
-        getSourcemap: () => null,
+        getSourcemap: async () => null,
       });
 
       const summary = await fs.readFile(summaryPath, 'utf-8');
@@ -196,7 +196,7 @@ describe('GithubActionsReporter step summary', () => {
         testResults: [],
         duration: emptyDuration,
         snapshotSummary: emptySnapshotSummary,
-        getSourcemap: () => null,
+        getSourcemap: async () => null,
         unhandledErrors: [new Error('global setup failed')],
       });
 
@@ -270,7 +270,7 @@ describe('GithubActionsReporter step summary', () => {
         ],
         duration: emptyDuration,
         snapshotSummary: emptySnapshotSummary,
-        getSourcemap: () => null,
+        getSourcemap: async () => null,
       });
 
       const summary = await fs.readFile(summaryPath, 'utf-8');
@@ -356,7 +356,7 @@ describe('GithubActionsReporter step summary', () => {
         ],
         duration: emptyDuration,
         snapshotSummary: emptySnapshotSummary,
-        getSourcemap: () => null,
+        getSourcemap: async () => null,
       });
 
       const summary = await fs.readFile(summaryPath, 'utf-8');

--- a/packages/core/tests/reporter/junit.test.ts
+++ b/packages/core/tests/reporter/junit.test.ts
@@ -11,6 +11,7 @@ describe('JUnitReporter', () => {
 
     const mockTestResults: TestResult[] = [
       {
+        testId: 'test-1',
         status: 'pass',
         name: 'should pass',
         testPath: '/test/root/test1.test.ts',
@@ -18,6 +19,7 @@ describe('JUnitReporter', () => {
         project: 'default',
       },
       {
+        testId: 'test-2',
         status: 'fail',
         name: 'should fail',
         testPath: '/test/root/test1.test.ts',
@@ -33,6 +35,7 @@ describe('JUnitReporter', () => {
         project: 'default',
       },
       {
+        testId: 'test-3',
         status: 'skip',
         name: 'should skip',
         testPath: '/test/root/test1.test.ts',
@@ -43,6 +46,7 @@ describe('JUnitReporter', () => {
 
     const mockFileResults: TestFileResult[] = [
       {
+        testId: 'test-4',
         status: 'fail',
         name: 'test1.test.ts',
         testPath: '/test/root/test1.test.ts',
@@ -73,7 +77,7 @@ describe('JUnitReporter', () => {
       results: mockFileResults,
       testResults: mockTestResults,
       duration: mockDuration,
-      getSourcemap: () => null,
+      getSourcemap: async () => null,
     });
 
     // Verify that XML was generated
@@ -119,7 +123,7 @@ describe('JUnitReporter', () => {
       results: [],
       testResults: [],
       duration: mockDuration,
-      getSourcemap: () => null,
+      getSourcemap: async () => null,
     });
 
     expect(logs.some((log) => log.includes('tests="0"'))).toBe(true);
@@ -140,6 +144,7 @@ describe('JUnitReporter', () => {
 
     const mockTestResults: TestResult[] = [
       {
+        testId: 'test-5',
         status: 'fail',
         name: 'test with <xml> & "quotes" & \'apos\'',
         testPath: '/test/root/test.test.ts',
@@ -157,6 +162,7 @@ describe('JUnitReporter', () => {
 
     const mockFileResults: TestFileResult[] = [
       {
+        testId: 'test-6',
         status: 'fail',
         name: 'test.test.ts',
         testPath: '/test/root/test.test.ts',
@@ -176,7 +182,7 @@ describe('JUnitReporter', () => {
       results: mockFileResults,
       testResults: mockTestResults,
       duration: mockDuration,
-      getSourcemap: () => null,
+      getSourcemap: async () => null,
     });
 
     // Verify XML is properly escaped

--- a/packages/core/tests/reporter/summary.test.ts
+++ b/packages/core/tests/reporter/summary.test.ts
@@ -84,27 +84,29 @@ describe('DefaultReporter summary streams', () => {
     const { stdout, stderr } = spyOnConsole();
     const writes: string[] = [];
 
-    rs.spyOn(process.stderr, 'write').mockImplementation(
-      (_chunk, _encoding, callback) => {
-        writes.push('flush stderr');
-        if (typeof _encoding === 'function') {
-          _encoding();
-        } else {
-          callback?.();
-        }
+    // `write` is overloaded and the mock signature only reflects the encoding
+    // form, so the 2-arg callback has to be recovered by hand.
+    const recordWrite =
+      (label: string) =>
+      (
+        _chunk: unknown,
+        encodingOrCallback?: unknown,
+        callback?: unknown,
+      ): boolean => {
+        writes.push(label);
+        const done = (
+          typeof encodingOrCallback === 'function'
+            ? encodingOrCallback
+            : callback
+        ) as (() => void) | undefined;
+        done?.();
         return true;
-      },
+      };
+    rs.spyOn(process.stderr, 'write').mockImplementation(
+      recordWrite('flush stderr'),
     );
     rs.spyOn(process.stdout, 'write').mockImplementation(
-      (_chunk, _encoding, callback) => {
-        writes.push('flush stdout');
-        if (typeof _encoding === 'function') {
-          _encoding();
-        } else {
-          callback?.();
-        }
-        return true;
-      },
+      recordWrite('flush stdout'),
     );
 
     const reporter = new DefaultReporter({

--- a/packages/core/tests/runner/loadEsModule.test.ts
+++ b/packages/core/tests/runner/loadEsModule.test.ts
@@ -86,8 +86,9 @@ describe('loadEsModule', () => {
     const sm = await asModule(namespace, '/fake/id/default-and-named');
 
     expect(Object.keys(sm.namespace).sort()).toEqual(['default', 'foo']);
-    expect(sm.namespace.default).toBe(defaultVal);
-    expect(sm.namespace.foo).toBe('foo-val');
+    const namespaceExports = sm.namespace as Record<string, unknown>;
+    expect(namespaceExports.default).toBe(defaultVal);
+    expect(namespaceExports.foo).toBe('foo-val');
   });
 
   it('should reuse the cached SyntheticModule for the same resolved id', async () => {

--- a/packages/core/tests/runner/util.test.ts
+++ b/packages/core/tests/runner/util.test.ts
@@ -18,9 +18,11 @@ it('test formatName', () => {
 
 describe('formatTestError', () => {
   it('adds a hint for missing Istanbul coverage helpers', async () => {
-    const [error] = await formatTestError(
-      new ReferenceError('cov_15453043885016330810 is not defined'),
-    );
+    const error = (
+      await formatTestError(
+        new ReferenceError('cov_15453043885016330810 is not defined'),
+      )
+    )[0]!;
 
     expect(error.message).toContain('cov_15453043885016330810 is not defined');
     expect(error.message).toContain('Istanbul coverage counter');
@@ -40,9 +42,11 @@ describe('formatTestError', () => {
     };
 
     try {
-      const [error] = await formatTestError(
-        new ReferenceError('cov_15453043885016330810 is not defined'),
-      );
+      const error = (
+        await formatTestError(
+          new ReferenceError('cov_15453043885016330810 is not defined'),
+        )
+      )[0]!;
 
       expect(error.message).toContain('coverage.exclude');
       expect(error.message).toContain('Istanbul ignore hint');
@@ -60,9 +64,9 @@ describe('formatTestError', () => {
   });
 
   it('does not add the Istanbul hint for normal reference errors', async () => {
-    const [error] = await formatTestError(
-      new ReferenceError('foo is not defined'),
-    );
+    const error = (
+      await formatTestError(new ReferenceError('foo is not defined'))
+    )[0]!;
 
     expect(error.message).toBe('foo is not defined');
   });

--- a/packages/core/tests/runtime/api/mockObject.test.ts
+++ b/packages/core/tests/runtime/api/mockObject.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@rstest/core';
 import { mockObject } from '../../../src/runtime/api/mockObject';
 import { initSpy } from '../../../src/runtime/api/spy';
+import type { Mocked } from '../../../src/types';
 
 type Key = string | symbol;
 
@@ -10,8 +11,14 @@ const make = (type: 'automock' | 'autospy') => {
   const { createMockInstance, isMockFunction } = initSpy();
   return {
     isMockFunction,
-    run: <T extends Record<Key, any>>(object: T): T =>
-      mockObject({ createMockInstance, globalConstructors, type }, object, {}),
+    // `mockObject` is declared as `T -> T`, but every function on the result is
+    // a mock at runtime, which is what these tests assert against.
+    run: <T extends Record<Key, any>>(object: T): Mocked<T> =>
+      mockObject(
+        { createMockInstance, globalConstructors, type },
+        object,
+        {},
+      ) as Mocked<T>,
   };
 };
 
@@ -207,7 +214,7 @@ describe('mockObject autospy', () => {
     const result = run({ Foo });
     expect(isMockFunction(result.Foo)).toBe(true);
 
-    const instance = new result.Foo();
+    const instance = new result.Foo() as Mocked<InstanceType<typeof Foo>>;
     expect(isMockFunction(instance.greet)).toBe(true);
     expect(instance.greet()).toBe('hi');
     expect(instance.greet.mock.calls).toHaveLength(1);

--- a/packages/core/tests/runtime/api/spy.test.ts
+++ b/packages/core/tests/runtime/api/spy.test.ts
@@ -231,7 +231,7 @@ describe('initSpy spyOn', () => {
   it('spies on a getter accessor', () => {
     const { spyOn } = initSpy();
     let backing = 1;
-    const obj = {};
+    const obj = {} as { val: number };
     Object.defineProperty(obj, 'val', {
       configurable: true,
       get() {
@@ -243,7 +243,7 @@ describe('initSpy spyOn', () => {
     });
 
     const getSpy = spyOn(obj, 'val', 'get');
-    void (obj as { val: number }).val;
+    void obj.val;
     expect(getSpy.mock.calls).toHaveLength(1);
   });
 

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -28,7 +28,7 @@ describe('normalizeFixtures', () => {
   it('computes deps only for fixtures that exist in the set', () => {
     const aFn = ({ b }: any) => b;
     const result = normalizeFixtures({ a: [aFn], b: 1, c: 2 } as any);
-    expect(result.a.deps).toEqual(['b']);
+    expect(result.a!.deps).toEqual(['b']);
   });
 
   it('merges extendFixtures with local fixtures taking precedence', () => {
@@ -43,7 +43,7 @@ describe('normalizeFixtures param parsing (getFixtureUsedProps)', () => {
   it('skips dependency detection for an _-prefixed first param', () => {
     const fixtureFn = (_ctx: any) => {};
     const result = normalizeFixtures({ a: [fixtureFn] } as any);
-    expect(result.a.deps).toEqual([]);
+    expect(result.a!.deps).toEqual([]);
   });
 
   it('throws when the first param is not destructured', () => {
@@ -88,7 +88,7 @@ describe('normalizeFixtures param parsing (getFixtureUsedProps)', () => {
       foo: 1,
       bar: 2,
     } as any);
-    expect([...(result.used.deps ?? [])].sort()).toEqual(['bar', 'foo']);
+    expect([...(result.used!.deps ?? [])].sort()).toEqual(['bar', 'foo']);
   });
 });
 

--- a/packages/core/tests/runtime/worker/env/utils.test.ts
+++ b/packages/core/tests/runtime/worker/env/utils.test.ts
@@ -5,7 +5,7 @@ test('should revoke remaining object URLs and restore methods', () => {
   const revoked: string[] = [];
   let nextId = 0;
   class TestURL extends URL {
-    static override createObjectURL(): string {
+    static override createObjectURL(_object: Blob | MediaSource): string {
       return `blob:test:${nextId++}`;
     }
 

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["./**/*.ts", "./rstestEnv.d.ts"]
+  "include": ["./**/*.ts", "./rstestEnv.d.ts", "../src/env.d.ts"]
 }

--- a/packages/core/tests/utils/environmentComments.test.ts
+++ b/packages/core/tests/utils/environmentComments.test.ts
@@ -32,8 +32,13 @@ const createProject = (): ProjectContext => ({
     },
     browser: {
       enabled: false,
+      provider: 'playwright',
+      browser: 'chromium',
+      headless: true,
+      strictPort: false,
+      providerOptions: {},
     },
-  } as ProjectContext['normalizedConfig'],
+  } as unknown as ProjectContext['normalizedConfig'],
 });
 
 describe('environment comments', () => {
@@ -699,6 +704,7 @@ const jsdom = '// @rstest-environment jsdom';
           },
           includeSource: [],
           browser: {
+            ...createProject().normalizedConfig.browser,
             enabled: true,
           },
         },
@@ -1239,6 +1245,7 @@ const jsdom = '// @rstest-environment jsdom';
           },
           includeSource: [],
           browser: {
+            ...createProject().normalizedConfig.browser,
             enabled: true,
           },
         },

--- a/packages/core/tests/utils/testFiles.test.ts
+++ b/packages/core/tests/utils/testFiles.test.ts
@@ -67,7 +67,7 @@ describe('getTestEntries literal/glob handling', () => {
     });
     const values = Object.values(entries);
     expect(values).toHaveLength(1);
-    expect(pathe.normalize(values[0])).toBe(
+    expect(pathe.normalize(values[0]!)).toBe(
       pathe.join(pathe.normalize(rootPath), virtualName),
     );
   });

--- a/packages/core/tests/utils/traceSummary.test.ts
+++ b/packages/core/tests/utils/traceSummary.test.ts
@@ -40,7 +40,7 @@ it('aggregates phases by name across files and ranks them', () => {
   expect(phases.map((p) => p.name)).toEqual(['tests', 'load']);
   expect(phases[0]).toMatchObject({ totalUs: 400_000, count: 2 });
   // 400 / 600 total phase time.
-  expect(phases[0].pct).toBeCloseTo(66.6667, 2);
+  expect(phases[0]!.pct).toBeCloseTo(66.6667, 2);
   expect(phases[1]).toMatchObject({ name: 'load', totalUs: 200_000 });
 });
 

--- a/packages/coverage-istanbul/src/utils.ts
+++ b/packages/coverage-istanbul/src/utils.ts
@@ -13,7 +13,12 @@ const SOURCE_MAP_SCAN_CONCURRENCY = 8;
 const { createCoverageMap } = istanbulLibCoverage;
 
 type BranchHits = Record<string, number[]>;
-type IstanbulFileCoverageData = FileCoverageData & {
+/**
+ * What the instrumenter actually writes onto file coverage: `all`, `bT` and
+ * `hash` exist at runtime and the merge paths below read them, but the
+ * published istanbul types declare none of the three.
+ */
+export type IstanbulFileCoverageData = FileCoverageData & {
   all?: boolean;
   bT?: BranchHits;
   hash?: string;

--- a/packages/coverage-istanbul/tests/utils.test.ts
+++ b/packages/coverage-istanbul/tests/utils.test.ts
@@ -5,10 +5,11 @@ import istanbulCoverage from 'istanbul-lib-coverage';
 import {
   createFastCoverageMap,
   getSourceMappingURL,
+  type IstanbulFileCoverageData,
   transformCoverage,
 } from '../src/utils';
 
-const createFileCoverage = (file: string) => ({
+const createFileCoverage = (file: string): IstanbulFileCoverageData => ({
   path: file,
   statementMap: {
     0: { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
@@ -116,16 +117,15 @@ describe('coverage istanbul utils', () => {
     coverageMap.merge({
       [file]: createFileCoverage(file),
     });
-    coverageMap.merge({
-      [file]: {
-        ...createFileCoverage(file),
-        statementMap: {
-          0: { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
-        },
-        s: { 0: 5 },
-        hash: 'different',
+    const rehashed: IstanbulFileCoverageData = {
+      ...createFileCoverage(file),
+      statementMap: {
+        0: { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
       },
-    });
+      s: { 0: 5 },
+      hash: 'different',
+    };
+    coverageMap.merge({ [file]: rehashed });
 
     expect(coverageMap.fileCoverageFor(file).toJSON()).toMatchObject({
       statementMap: {
@@ -145,15 +145,14 @@ describe('coverage istanbul utils', () => {
     });
     const getNativeMergeCalls = trackNativeMerge(coverageMap, file);
 
-    coverageMap.merge({
-      [file]: {
-        ...createUnhashedFileCoverage(file),
-        bT: { 0: [17, 19] },
-        s: { 0: 5 },
-        f: { 0: 7 },
-        b: { 0: [11, 13] },
-      },
-    });
+    const incoming: IstanbulFileCoverageData = {
+      ...createUnhashedFileCoverage(file),
+      bT: { 0: [17, 19] },
+      s: { 0: 5 },
+      f: { 0: 7 },
+      b: { 0: [11, 13] },
+    };
+    coverageMap.merge({ [file]: incoming });
 
     expect(getNativeMergeCalls()).toBe(1);
     const fileCoverage = coverageMap.fileCoverageFor(file).toJSON();
@@ -179,7 +178,7 @@ describe('coverage istanbul utils', () => {
         ...createUnhashedFileCoverage(file),
         fnMap: {
           0: {
-            ...createFileCoverage(file).fnMap[0],
+            ...createFileCoverage(file).fnMap[0]!,
             name: 'renamed',
           },
         },
@@ -216,7 +215,7 @@ describe('coverage istanbul utils', () => {
         ...createUnhashedFileCoverage(file),
         branchMap: {
           0: {
-            ...createFileCoverage(file).branchMap[0],
+            ...createFileCoverage(file).branchMap[0]!,
             loc: {
               start: { line: 1, column: 0 },
               end: { line: 1, column: 11 },
@@ -247,7 +246,11 @@ describe('coverage istanbul utils', () => {
     const file = '/project/src/index.ts';
     const coverageMap = createFastCoverageMap();
 
-    coverageMap.addFileCoverage({ ...createFileCoverage(file), all: true });
+    const allFileCoverage: IstanbulFileCoverageData = {
+      ...createFileCoverage(file),
+      all: true,
+    };
+    coverageMap.addFileCoverage(allFileCoverage);
     coverageMap.addFileCoverage(createFileCoverage(file));
 
     const fileCoverage = coverageMap.fileCoverageFor(file).toJSON();

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -1089,7 +1089,7 @@ export class CoverageProvider implements RstestCoverageProvider {
     try {
       await this.session.post('Profiler.stopPreciseCoverage');
       await this.session.post('Profiler.disable');
-    } catch (_err) {
+    } catch {
       // Ignore teardown errors to prevent masking original errors
     }
   }

--- a/packages/coverage-v8/src/utils.ts
+++ b/packages/coverage-v8/src/utils.ts
@@ -10,7 +10,12 @@ import istanbulLibCoverage from 'istanbul-lib-coverage';
 const { createCoverageMap } = istanbulLibCoverage;
 
 type BranchHits = Record<string, number[]>;
-type IstanbulFileCoverageData = FileCoverageData & {
+/**
+ * What the instrumenter actually writes onto file coverage: `all`, `bT` and
+ * `hash` exist at runtime and the merge paths below read them, but the
+ * published istanbul types declare none of the three.
+ */
+export type IstanbulFileCoverageData = FileCoverageData & {
   all?: boolean;
   bT?: BranchHits;
   hash?: string;

--- a/packages/coverage-v8/tests/provider.test.ts
+++ b/packages/coverage-v8/tests/provider.test.ts
@@ -12,6 +12,7 @@ import type { NormalizedCoverageOptions } from '@rstest/core';
 import type { FileCoverageData } from 'istanbul-lib-coverage';
 import { parse } from 'yuku-parser';
 import { CoverageProvider } from '../src/provider';
+import type { IstanbulFileCoverageData } from '../src/utils';
 import { convertV8CoverageWithAst } from '../src/v8AstConverter';
 
 const createOptions = (
@@ -82,7 +83,13 @@ const trackNativeMerge = (
   return () => mergeCalls;
 };
 
-type ProviderInternals = CoverageProvider & {
+// `Omit`, not a plain intersection: the class declares these as private
+// members, and intersecting a private member with a public one collapses the
+// whole type to `never`.
+type ProviderInternals = Omit<
+  CoverageProvider,
+  'findInDict' | 'convertWithAst' | 'takeRawCoverage'
+> & {
   findInDict: (
     dict: Record<string, string> | undefined,
     filePath: string,
@@ -92,7 +99,11 @@ type ProviderInternals = CoverageProvider & {
     entry: {
       url: string;
       scriptId: string;
-      functions: [];
+      functions: {
+        functionName: string;
+        isBlockCoverage: boolean;
+        ranges: { startOffset: number; endOffset: number; count: number }[];
+      }[];
     },
     options?: {
       assetFiles?: Record<string, string>;
@@ -995,15 +1006,14 @@ export default class CustomCoverageReporter {
     });
     const getNativeMergeCalls = trackNativeMerge(coverageMap, file);
 
-    coverageMap.merge({
-      [file]: {
-        ...createUnhashedFileCoverage(file),
-        bT: { 0: [17, 19] },
-        s: { 0: 5 },
-        f: { 0: 7 },
-        b: { 0: [11, 13] },
-      },
-    });
+    const incoming: IstanbulFileCoverageData = {
+      ...createUnhashedFileCoverage(file),
+      bT: { 0: [17, 19] },
+      s: { 0: 5 },
+      f: { 0: 7 },
+      b: { 0: [11, 13] },
+    };
+    coverageMap.merge({ [file]: incoming });
 
     expect(getNativeMergeCalls()).toBe(1);
     const fileCoverage = coverageMap.fileCoverageFor(file).toJSON();

--- a/packages/coverage-v8/tests/tsconfig.json
+++ b/packages/coverage-v8/tests/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rstest/tsconfig/base",
   "compilerOptions": {
-    "rootDir": ".",
     "types": ["node", "@rstest/core/globals"]
   },
-  "include": ["**/*.test.ts"]
+  "include": ["./**/*.ts"]
 }

--- a/packages/playwright/tests/expect.test.ts
+++ b/packages/playwright/tests/expect.test.ts
@@ -292,9 +292,11 @@ describe('@rstest/playwright expect', () => {
     const setTimeout = rs.fn(realTimers.setTimeout);
     const getRealTimers = rs.spyOn(rstest, 'getRealTimers').mockReturnValue({
       ...realTimers,
+      // `rs.fn` cannot reproduce `setTimeout.__promisify__`, which nothing here
+      // calls.
       setTimeout,
       clearTimeout,
-    });
+    } as unknown as ReturnType<typeof rstest.getRealTimers>);
 
     try {
       await expect(createPage('Example Domain')).toHaveTitle('Example Domain');

--- a/packages/playwright/tests/fixture.test.ts
+++ b/packages/playwright/tests/fixture.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, expect, test } from '../src';
 import { getDebugOptions, resolveLaunchOptions } from '../src/fixture';
 import type { Browser, BrowserContext, Page } from 'playwright';
 import type {
+  PlaywrightFixture,
   PlaywrightFixtures,
   PlaywrightOptions,
   PlaywrightTest,
@@ -210,7 +211,7 @@ agentTest('supports third-party fixture wrappers', async ({ agent, page }) => {
 });
 
 test.extend({
-  playwright: async (_, use) => {
+  playwright: async (_, use: PlaywrightUse<PlaywrightOptions>) => {
     await use({
       browserName: 'chromium',
       launchOptions: {
@@ -222,7 +223,9 @@ test.extend({
   expect(playwright.launchOptions).toEqual({ headless: true });
 });
 
-browserTest.extend<{ url: string }>({
+// Overriding a base fixture while adding a new one has to name the overridden
+// fixture in the added set, or `page` is not assignable here.
+browserTest.extend<{ url: string } & Pick<PlaywrightFixture, 'page'>>({
   url: 'about:blank',
   page: async ({ context, url }, use) => {
     const page = await context.newPage();
@@ -250,7 +253,7 @@ const thirdPartyFixtures = {
   },
 } satisfies PlaywrightFixtures<
   { customContext: BrowserContext },
-  { playwright: PlaywrightOptions }
+  PlaywrightFixture
 >;
 
 browserTest.extend(thirdPartyFixtures)(

--- a/rslint.config.mts
+++ b/rslint.config.mts
@@ -233,11 +233,18 @@ export default defineConfig([
   {
     languageOptions: {
       parserOptions: {
-        project: ['./e2e/tsconfig.json', './packages/*/tsconfig.json'],
+        // Unit tests need their own entry: a package tsconfig is `composite`
+        // with `rootDir: src` and cannot include a sibling directory, so
+        // without `tests/tsconfig.json` every test escapes both type-aware
+        // lint rules and tsc itself.
+        project: [
+          './e2e/tsconfig.json',
+          './packages/*/tsconfig.json',
+          './packages/*/tests/tsconfig.json',
+        ],
       },
     },
     rules: {
-      '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-require-imports': 'off',

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -72,6 +72,7 @@ idents
 iife
 imagex
 importee
+instrumenter
 jfif
 jiti
 jridgewell


### PR DESCRIPTION
## Summary

`packages/*/tests` sat outside every tsconfig program, so unit tests escaped both `tsc` and every type-aware lint rule — even a plainly unused import in a test could not be caught. On top of that, `@typescript-eslint/no-unused-vars` had been off since rules were bulk-silenced when linting was first adopted, never for a stated reason.

- rslint's `project` now lists `./packages/*/tests/tsconfig.json` alongside the package and e2e configs, and the three adapter packages get the test tsconfig they were missing. Type-checked files go from 1380 to 1484.
- `@typescript-eslint/no-unused-vars` is back on.
- Two test tsconfigs were unusable as type-check programs: the coverage packages extended their `composite` package config with `rootDir: tests`, so every `../src` import raised TS6059/TS6307. Both now extend the shared base like their siblings.

Clearing the resulting backlog surfaced real drift in the fixtures, which is where most of the diff lands: coverage provider mocks missing `generateCoverageForUntestedFiles`, a `ProviderInternals` test helper that silently collapsed to `never` against the class's private members, fixtures carrying fields absent from `FileCoverageData`, reporter fixtures missing `testId`, sync `getSourcemap` stubs, and a wrong `PlaywrightFixtures` generic.

The only `src` changes are non-behavioral: the coverage packages export the `IstanbulFileCoverageData` type their tests already relied on, and one unused `catch` binding is dropped.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
