### PR TITLE
fix(browser): preserve Browser UI routes with generated HTML

### DIFF
--- a/e2e/browser-mode/basic.test.ts
+++ b/e2e/browser-mode/basic.test.ts
@@ -27,4 +27,16 @@ describe('browser mode - basic', () => {
       expect(cli.exec.exitCode).toBe(0);
     },
   );
+
+  it.runIf(shouldRunHeadedBrowserTests)(
+    'should serve the Browser UI when user plugins generate an index HTML',
+    async () => {
+      const { cli } = await runBrowserCli('basic', {
+        args: ['-c', 'rstest.userHtml.config.mts'],
+      });
+
+      await cli.exec;
+      expect(cli.exec.exitCode).toBe(0);
+    },
+  );
 });

--- a/e2e/browser-mode/fixtures/basic/rstest.userHtml.config.mts
+++ b/e2e/browser-mode/fixtures/basic/rstest.userHtml.config.mts
@@ -1,0 +1,30 @@
+import { rspack, type RsbuildPlugin } from '@rsbuild/core';
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS, BROWSER_TEST_TIMEOUT } from '../ports';
+
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: false,
+    port: BROWSER_PORTS.basic,
+  },
+  include: ['tests/dom.test.ts'],
+  plugins: [
+    {
+      name: 'test:user-html',
+      setup(api) {
+        api.modifyRspackConfig((config) => {
+          config.plugins ??= [];
+          config.plugins.push(
+            new rspack.HtmlRspackPlugin({
+              filename: 'index.html',
+              template: './user.html',
+            }),
+          );
+        });
+      },
+    } satisfies RsbuildPlugin,
+  ],
+  testTimeout: BROWSER_TEST_TIMEOUT,
+});

--- a/e2e/browser-mode/fixtures/basic/user.html
+++ b/e2e/browser-mode/fixtures/basic/user.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>User HTML</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -1789,6 +1789,55 @@ const createBrowserRuntime = async ({
     }
   };
 
+  const serveContainerRoute = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: () => void,
+  ): Promise<void> => {
+    if (!req.url) {
+      next();
+      return;
+    }
+
+    const url = new URL(req.url, 'http://localhost');
+    if (url.pathname === '/') {
+      if (await respondWithDevServerHtml(url, res)) {
+        return;
+      }
+
+      const html =
+        injectedContainerHtml ||
+        containerHtmlTemplate?.replace(OPTIONS_PLACEHOLDER, 'null');
+
+      if (html) {
+        res.setHeader('Content-Type', 'text/html');
+        res.end(html);
+        return;
+      }
+
+      res.statusCode = 502;
+      res.end('Container UI is not available.');
+      return;
+    }
+
+    if (url.pathname.startsWith('/container-static/')) {
+      if (await proxyDevServerAsset(req, res)) {
+        return;
+      }
+
+      if (serveContainer) {
+        serveContainer(req, res, next);
+        return;
+      }
+
+      res.statusCode = 502;
+      res.end('Container assets are not available.');
+      return;
+    }
+
+    next();
+  };
+
   // ---- Build one isolated rsbuild instance + dev server per project ----
   const buildProjectServer = async (
     project: ProjectContext,
@@ -1846,6 +1895,13 @@ const createBrowserRuntime = async ({
             project.normalizedConfig.browser.port ??
             (isContainerServer ? 4000 : 0),
           strictPort: project.normalizedConfig.browser.strictPort,
+          // User plugins may emit index.html; register before Rsbuild's HTML
+          // completion middleware so `/` remains owned by the Browser UI.
+          setup: isContainerServer
+            ? ({ server }) => {
+                server.middlewares.use(serveContainerRoute);
+              }
+            : undefined,
         },
         dev: createBrowserRsbuildDevConfig(enableHmr),
         environments: {
@@ -2195,43 +2251,6 @@ const createBrowserRuntime = async ({
             res.end('Failed to open editor');
           }
           return;
-        }
-        // Container UI HTML + static assets are served by the container origin
-        // only. Per-project runner servers expose just /runner.html + assets.
-        if (isContainerServer) {
-          if (url.pathname === '/') {
-            if (await respondWithDevServerHtml(url, res)) {
-              return;
-            }
-
-            const html =
-              injectedContainerHtml ||
-              containerHtmlTemplate?.replace(OPTIONS_PLACEHOLDER, 'null');
-
-            if (html) {
-              res.setHeader('Content-Type', 'text/html');
-              res.end(html);
-              return;
-            }
-
-            res.statusCode = 502;
-            res.end('Container UI is not available.');
-            return;
-          }
-          if (url.pathname.startsWith('/container-static/')) {
-            if (await proxyDevServerAsset(req, res)) {
-              return;
-            }
-
-            if (serveContainer) {
-              serveContainer(req, res, next);
-              return;
-            }
-
-            res.statusCode = 502;
-            res.end('Container assets are not available.');
-            return;
-          }
         }
         if (url.pathname === '/runner.html') {
           res.setHeader('Content-Type', 'text/html');


### PR DESCRIPTION
## Summary

User plugins that emit `index.html` can intercept `/` before Rstest serves the Browser UI, leaving headed Browser Mode unable to start. This PR registers the container HTML and static asset routes during server setup so they keep precedence over Rsbuild's generated HTML middleware, with headed browser regression coverage using `HtmlRspackPlugin`.

## Related Links

- Extracted from https://github.com/web-infra-dev/rstest/pull/1639

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).