### PR TITLE
fix(core): target the real __webpack_require__ in the mock runtime proxy

### DIFF
--- a/e2e/browser-mode/fixtures/ports.ts
+++ b/e2e/browser-mode/fixtures/ports.ts
@@ -22,6 +22,7 @@ export const BROWSER_PORTS = {
   snapshot: 5196,
   watch: 5186,
   'watch-stale': 5218,
+  'watch-headed': 5270,
   webkit: 5198,
   viewport: 5214,
   'viewport-preset': 5216,

--- a/e2e/browser-mode/watchHeaded.test.ts
+++ b/e2e/browser-mode/watchHeaded.test.ts
@@ -39,11 +39,15 @@ describe('browser mode - headed watch', () => {
         ],
       });
 
-      await cli.waitForStdout('Duration');
-      expect(cli.stdout).toMatch('Test Files 2 passed');
-
-      await killCliProcessTree(cli);
-      await deleteFixtureTarget(fs, fixturesTargetPath);
+      try {
+        await cli.waitForStdout('Duration');
+        expect(cli.stdout).toMatch('Test Files 2 passed');
+      } finally {
+        // A leaked headed browser is costlier than the headless leaks other
+        // watch tests tolerate — always tear down, even on assertion failure.
+        await killCliProcessTree(cli);
+        await deleteFixtureTarget(fs, fixturesTargetPath);
+      }
     },
   );
 });

--- a/e2e/browser-mode/watchHeaded.test.ts
+++ b/e2e/browser-mode/watchHeaded.test.ts
@@ -1,0 +1,49 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@rstest/core';
+import { prepareFixtures } from '../scripts';
+import { BROWSER_PORTS } from './fixtures/ports';
+import {
+  deleteFixtureTarget,
+  killCliProcessTree,
+  runBrowserWatchCliWithCwd,
+  shouldRunHeadedBrowserTests,
+} from './utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('browser mode - headed watch', () => {
+  // Headed watch is the only mode that builds the HMR runtime (see
+  // `shouldEnableBrowserHmr`); every other fixture in the matrix runs
+  // headless or one-shot, so this smoke is the sole coverage between an
+  // HMR-runtime-only regression and users' default local `--watch`.
+  // Deliberately boot + first run only, no file-change rerun: headed browser
+  // sessions are expensive on CI, and the initial run already covers the
+  // HMR-runtime bundle shape.
+  it.runIf(shouldRunHeadedBrowserTests)(
+    'should run tests in headed watch mode',
+    async () => {
+      const fixturesTargetPath = `${__dirname}/fixtures/fixtures-test-browser-watch-headed`;
+
+      const { fs } = await prepareFixtures({
+        fixturesPath: `${__dirname}/fixtures/watch`,
+        fixturesTargetPath,
+      });
+
+      const { cli } = await runBrowserWatchCliWithCwd(fixturesTargetPath, {
+        args: [
+          '--browser.headless',
+          'false',
+          `--browser.port=${BROWSER_PORTS['watch-headed']}`,
+        ],
+      });
+
+      await cli.waitForStdout('Duration');
+      expect(cli.stdout).toMatch('Test Files 2 passed');
+
+      await killCliProcessTree(cli);
+      await deleteFixtureTarget(fs, fixturesTargetPath);
+    },
+  );
+});

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -60,13 +60,19 @@ if (globalThis.__rstest_federation__) {
 }
 //#endregion
 
-const originalWebpackRequire = __webpack_require__;
-
 //#region proxy __webpack_require__
-__webpack_require__ = new Proxy(
-  function (...args) {
+// The proxy target is the original `__webpack_require__` itself, so all
+// property operations — get/set/`in`/`for...in`/`hasOwnProperty` — hit the
+// one real object through the default traps, regardless of whether a runtime
+// property was assigned before or after this proxy was installed. (A
+// wrapper-function target splits properties across two objects and needs
+// hand-written merge traps for every read path; rspack's HMR runtime, which
+// clones `__webpack_require__` per module via `for...in` + `hasOwnProperty`,
+// silently drops `.m`/`.c`/`.i` under that split and crashes headed watch.)
+__webpack_require__ = new Proxy(__webpack_require__, {
+  apply(target, thisArg, args) {
     try {
-      return originalWebpackRequire(...args);
+      return Reflect.apply(target, thisArg, args);
     } catch (e) {
       const errMsg = e.message ?? e.toString();
       if (errMsg.includes('__webpack_modules__[moduleId] is not a function')) {
@@ -75,52 +81,41 @@ __webpack_require__ = new Proxy(
       throw e;
     }
   },
-  {
-    set(target, property, value) {
-      if (
-        globalThis.__rstest_federation__ &&
-        property === 'f' &&
-        value &&
-        typeof value === 'object'
-      ) {
-        // The bundler assigns `__webpack_require__.f = {}` early, and later
-        // runtime modules install throwing placeholders via
-        // `f.consumes = f.consumes || thrower`. Pre-seeding no-ops keeps the
-        // placeholders from ever being installed, so eager chunk loading
-        // cannot fail before the federation runtime initializes.
-        value.consumes ??= function () {};
-        value.remotes ??= function () {};
+  set(target, property, value) {
+    if (
+      globalThis.__rstest_federation__ &&
+      property === 'f' &&
+      value &&
+      typeof value === 'object'
+    ) {
+      // The bundler assigns `__webpack_require__.f = {}` early, and later
+      // runtime modules install throwing placeholders via
+      // `f.consumes = f.consumes || thrower`. Pre-seeding no-ops keeps the
+      // placeholders from ever being installed, so eager chunk loading
+      // cannot fail before the federation runtime initializes.
+      value.consumes ??= function () {};
+      value.remotes ??= function () {};
 
-        // Module Federation's Node runtime plugin patches chunk-loading
-        // handlers (`readFileVm` / `require`) to load chunks via native
-        // require, which would evaluate them outside this runtime instance
-        // and lose Rstest's mocks and shims. Freeze those handlers once
-        // Rspack installs them.
-        const proxied = new Proxy(value, {
-          set(obj, key, val) {
-            if ((key === 'readFileVm' || key === 'require') && obj[key]) {
-              return true;
-            }
-            obj[key] = val;
+      // Module Federation's Node runtime plugin patches chunk-loading
+      // handlers (`readFileVm` / `require`) to load chunks via native
+      // require, which would evaluate them outside this runtime instance
+      // and lose Rstest's mocks and shims. Freeze those handlers once
+      // Rspack installs them.
+      target[property] = new Proxy(value, {
+        set(obj, key, val) {
+          if ((key === 'readFileVm' || key === 'require') && obj[key]) {
             return true;
-          },
-        });
-        target[property] = proxied;
-        originalWebpackRequire[property] = proxied;
-        return true;
-      }
-      target[property] = value;
-      originalWebpackRequire[property] = value;
+          }
+          obj[key] = val;
+          return true;
+        },
+      });
       return true;
-    },
-    get(target, property) {
-      if (property in target) {
-        return target[property];
-      }
-      return originalWebpackRequire[property];
-    },
+    }
+    target[property] = value;
+    return true;
   },
-);
+});
 //#endregion
 
 __webpack_require__.rstest_original_modules = {};

--- a/packages/core/src/core/plugins/mockRuntimeCode.js
+++ b/packages/core/src/core/plugins/mockRuntimeCode.js
@@ -101,19 +101,20 @@ __webpack_require__ = new Proxy(__webpack_require__, {
       // require, which would evaluate them outside this runtime instance
       // and lose Rstest's mocks and shims. Freeze those handlers once
       // Rspack installs them.
-      target[property] = new Proxy(value, {
+      const frozenHandlers = new Proxy(value, {
         set(obj, key, val) {
           if ((key === 'readFileVm' || key === 'require') && obj[key]) {
+            // Deliberately claim success: the federation runtime assigns in
+            // strict mode, and returning false would turn the intended
+            // silent drop into a TypeError at its call site.
             return true;
           }
-          obj[key] = val;
-          return true;
+          return Reflect.set(obj, key, val);
         },
       });
-      return true;
+      return Reflect.set(target, property, frozenHandlers);
     }
-    target[property] = value;
-    return true;
+    return Reflect.set(target, property, value);
   },
 });
 //#endregion

--- a/packages/core/tests/core/plugins/mockRuntimeCode.test.ts
+++ b/packages/core/tests/core/plugins/mockRuntimeCode.test.ts
@@ -49,6 +49,38 @@ const evaluateRuntimeCode = ({
   return { fakeGlobal, webpackRequire, proxiedRequire };
 };
 
+describe('mockRuntimeCode webpack require proxy', () => {
+  it('keeps pre-existing and later-assigned properties on one enumeration surface', () => {
+    const webpackRequire = createWebpackRequireStub();
+    // Runtime properties rspack assigns before the mock runtime module
+    // installs its proxy (`.m`, `.c`, `.i` in a real bundle).
+    webpackRequire.m = {};
+    webpackRequire.i = [];
+
+    const { proxiedRequire } = evaluateRuntimeCode({
+      federation: false,
+      webpackRequire,
+    });
+
+    // rspack's HMR runtime clones `__webpack_require__` per module via
+    // `for...in` + `hasOwnProperty`. Properties assigned before and after the
+    // proxy install must both survive that clone — headed watch crashes on a
+    // missing `.i` otherwise.
+    const clone: Record<string, unknown> = {};
+    for (const key in proxiedRequire) {
+      if (Object.prototype.hasOwnProperty.call(proxiedRequire, key)) {
+        clone[key] = proxiedRequire[key];
+      }
+    }
+
+    expect(clone.m).toBe(webpackRequire.m);
+    expect(clone.i).toBe(webpackRequire.i);
+    expect(clone.rstest_original_modules).toBe(
+      proxiedRequire.rstest_original_modules,
+    );
+  });
+});
+
 describe('mockRuntimeCode federation shims', () => {
   it('does not install federation shims when federation is disabled', () => {
     const { fakeGlobal, proxiedRequire } = evaluateRuntimeCode({


### PR DESCRIPTION
## Summary

Running browser mode in headed watch (`pnpm test --watch` locally, e.g. `examples/browser-react`) crashed before any test ran, with a fatal "Browser UI WebSocket disconnected before reload completed" error.

The mock runtime replaces `__webpack_require__` with a Proxy over a fresh wrapper function, which splits runtime properties across two objects: properties assigned before the proxy installed (`.m`, `.c`, `.i`, ...) lived only on the original function and were invisible to own-property enumeration on the proxy. Rspack's HMR runtime clones `__webpack_require__` per module via `for...in` + `hasOwnProperty`, so the clone silently dropped `.i` and the runner iframe crashed on boot — headed watch is the only mode that builds the HMR runtime (`shouldEnableBrowserHmr`), so no other mode was affected.

Fix: the Proxy now targets the original `__webpack_require__` itself, keeping only an `apply` trap (module-not-found error rewrite) and the federation `f` `set` trap. All property operations hit one real object through the default traps, so the hand-written `get` merge trap and dual writes are gone.

Headed watch was structurally unreachable in the e2e matrix (`headless` defaults to `isCI`; every watch fixture pins `headless: true`), which is why CI never caught this. Added a minimal headed watch e2e smoke (boot + first run only, gated by `shouldRunHeadedBrowserTests`) and a unit test that replays the HMR clone pattern against the proxy.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

https://claude.ai/code/session_01FXu6x2vkLNn2miBjfxRtXG