### PR TITLE
fix(core): scope test environment to the worker under isolate: false

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -98,7 +98,8 @@ CI runs unit tests (the `ut` job) on ubuntu only; OS-specific coverage lives in 
 Before adding a fixture, list existing ones in the same area (`ls e2e/<area>/fixtures`) and name the closest match. Prefer extending it:
 
 - Adding a project, config flag, or test file is additive reuse — "different config" alone does not justify a new fixture. **After extending, re-run every test using that fixture** to confirm none broke.
-- A new fixture is right when reuse would force an **incompatible** change to config other tests depend on, or contort the fixture's intent.
+- A new fixture is right when reuse would force an **incompatible** change to config other tests depend on, or contort the fixture's intent. Name the mechanism that blocks reuse; config expressible per file (environment docblocks, per-file options) does not make a difference incompatible.
+- The same rule applies **inside** a fixture: before adding a test file or helper module, look for one whose structure already matches — same shared module, same peer-file pairing — and extend it instead. Adding exports to an existing helper, or cases to an existing test file, is additive reuse.
 - Prefer **one consolidated regression fixture** that exercises the whole surface over many near-duplicate per-feature files. When several cases share a structural root cause, assert them together.
 
 ## E2E rstest spawns with persistent `dist/.rstest-temp/`

--- a/e2e/no-isolate/fixtures/sharing/a.test.ts
+++ b/e2e/no-isolate/fixtures/sharing/a.test.ts
@@ -1,8 +1,19 @@
 import { expect, test } from '@rstest/core';
-import { getSharedEvalId } from './shared';
+import { screen } from '@testing-library/dom';
+import { capturedBody, capturedDocument, getSharedEvalId } from './shared';
 
 test('a: statically imported module is shared across files', () => {
   expect(getSharedEvalId()).toBe(1);
+});
+
+// Peer of the same test in b.test.ts — no execution-order assumption; whichever
+// file runs second reads captures taken while the other file was loading, and
+// so exercises the environment persisted from it.
+test('a: module-eval-time DOM captures stay live', () => {
+  expect(capturedBody).toBe(document.body);
+  expect(capturedDocument).toBe(document);
+  document.body.innerHTML = '<p>a-marker</p>';
+  expect(screen.getByText('a-marker')).toBeTruthy();
 });
 
 test('a: dynamically imported module is shared across files', async () => {

--- a/e2e/no-isolate/fixtures/sharing/b.test.ts
+++ b/e2e/no-isolate/fixtures/sharing/b.test.ts
@@ -1,8 +1,17 @@
 import { expect, test } from '@rstest/core';
-import { getSharedEvalId } from './shared';
+import { screen } from '@testing-library/dom';
+import { capturedBody, capturedDocument, getSharedEvalId } from './shared';
 
 test('b: statically imported module is shared across files', () => {
   expect(getSharedEvalId()).toBe(1);
+});
+
+// Peer of the same test in a.test.ts (see the rationale there).
+test('b: module-eval-time DOM captures stay live', () => {
+  expect(capturedBody).toBe(document.body);
+  expect(capturedDocument).toBe(document);
+  document.body.innerHTML = '<p>b-marker</p>';
+  expect(screen.getByText('b-marker')).toBeTruthy();
 });
 
 test('b: dynamically imported module is shared across files', async () => {

--- a/e2e/no-isolate/fixtures/sharing/nodeEnvironment.test.ts
+++ b/e2e/no-isolate/fixtures/sharing/nodeEnvironment.test.ts
@@ -1,0 +1,11 @@
+// @rstest-environment node
+import { expect, it } from '@rstest/core';
+
+// Splits this jsdom project into two environment groups. A worker holds its
+// environment for life under `isolate: false`, so the pool must give this file
+// its own worker rather than reusing a jsdom one — otherwise DOM globals leak
+// in here, and the jsdom files lose the captures they took at module-eval time.
+it('a node-environment file sees no DOM globals', () => {
+  expect(typeof window).toBe('undefined');
+  expect(typeof document).toBe('undefined');
+});

--- a/e2e/no-isolate/fixtures/sharing/rstest.config.ts
+++ b/e2e/no-isolate/fixtures/sharing/rstest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   isolate: false,
+  // jsdom so the capture guards (domCapture.ts + capture*.test.ts) can lock
+  // the environment lifetime to the module lifetime; every other fixture file
+  // is environment-agnostic.
+  testEnvironment: 'jsdom',
   setupFiles: ['./setup.ts'],
   // Lets the surface guard assert a mock from a persisted `rstest` reference is
   // reset per test (surfaceHelper.ts), and drives the shared-module mock reset

--- a/e2e/no-isolate/fixtures/sharing/shared.ts
+++ b/e2e/no-isolate/fixtures/sharing/shared.ts
@@ -6,3 +6,11 @@ g.__rstestSharedEvalCount = (g.__rstestSharedEvalCount ?? 0) + 1;
 const evalIdAtLoad: number = g.__rstestSharedEvalCount;
 
 export const getSharedEvalId = (): number => evalIdAtLoad;
+
+// The same once-per-worker evaluation, applied to the DOM: these bind at import
+// exactly like `@testing-library/dom`'s `screen` binds `document.body`. The
+// test environment must therefore outlive the file that evaluated this module,
+// or the captures dangle on a closed window from the second file on.
+// See https://github.com/web-infra-dev/rstest/issues/767.
+export const capturedBody: HTMLElement = document.body;
+export const capturedDocument: Document = document;

--- a/e2e/no-isolate/moduleSharing.test.ts
+++ b/e2e/no-isolate/moduleSharing.test.ts
@@ -10,7 +10,7 @@ describe('module state sharing under isolate: false', () => {
   // Runs the whole `sharing` fixture dir (one worker, isolate: false) and
   // asserts every file passes. The fixtures never assume a file execution order
   // (the runner does not guarantee one); each guard holds whichever way the
-  // files are scheduled. Covers three regressions:
+  // files are scheduled. Covers four regressions:
   // - https://github.com/web-infra-dev/rstest/issues/1373: a module imported by
   //   multiple files is evaluated once per worker (state shared) while setup
   //   still re-runs per file (a/b.test.ts + shared.ts).
@@ -27,6 +27,17 @@ describe('module state sharing under isolate: false', () => {
   //   must keep resetting it across the file boundary even though the per-file
   //   reset no longer clears the (weakly-held) registry (mockShareA/mockShareB +
   //   sharedMock.ts).
+  // - https://github.com/web-infra-dev/rstest/issues/767: the test environment
+  //   shares the module registry's per-worker lifetime. A persisted module may
+  //   capture the DOM at evaluation time (`@testing-library/dom`'s `screen`
+  //   binds `document.body` at import); with a per-file environment teardown
+  //   those captures dangled on a closed jsdom window, failing every file after
+  //   the first on a reused worker — so `shared.ts` captures the DOM alongside
+  //   its eval counter, and its a/b.test.ts peers assert both. The flip side is
+  //   that a worker must never serve two environment configs: an environment
+  //   docblock splits this jsdom project in two, and the pool has to shed its
+  //   jsdom worker for the node group (nodeEnvironment.test.ts) while the jsdom
+  //   group keeps sharing modules.
   it('shares imported module state across files while re-running setup', async ({
     onTestFinished,
   }) => {

--- a/packages/core/src/pool/AGENTS.md
+++ b/packages/core/src/pool/AGENTS.md
@@ -18,6 +18,7 @@
 - Worker ids are bounded `[1, maxWorkers]` and reused; consumers depend on `RSTEST_WORKER_ID` for resource partitioning. A slot and its id free only after the child actually exits.
 - birpc's timeout is disabled: a host rpc method that never resolves hangs the worker task indefinitely.
 - `buildId` threaded into the task context drives the worker-side rebuild-boundary cache flush; changing its scoping breaks `isolate: false` cross-project cache sharing (rstest#1376).
+- Runner reuse is environment-matched: a worker keeps its test environment alive for its whole life under `isolate: false`, so it may only take tasks whose `environmentKey` matches. Dropping the affinity would leave persisted modules holding evaluation-time captures of a torn-down environment (rstest#767); the worker rejects a mismatched task as a file-level failure rather than swapping. The `minWorkers` idle floor is likewise counted per environment. `environmentKey` is derived host-side and threaded on the task — never re-derived in the worker.
 
 ## Coupling points (change both sides)
 

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -26,6 +26,7 @@ import { type TraceEvent, type TraceSpan, noopTraceSpan } from '../utils/trace';
 import { isMemorySufficient } from '../utils/memory';
 import { getNumCpus, parseWorkers, resolveWorkerCount } from '../utils/workers';
 import { selectMemoryGate } from './memoryGate';
+import { getEnvironmentKey } from '../core/environmentGroups';
 import { projectRuntimeConfig } from '../core/runtimeConfigProjection';
 import {
   createRunnerEventSink,
@@ -148,6 +149,7 @@ const buildTask = async ({
     type,
     options: {
       entryInfo,
+      environmentKey: getEnvironmentKey(runtimeConfig.testEnvironment),
       context: {
         outputModule: project.outputModule,
         taskId: index + 1,

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -149,6 +149,14 @@ const buildTask = async ({
     type,
     options: {
       entryInfo,
+      // Known limit: the key is `stableJson`, so environment option values
+      // JSON cannot express (an `html` ArrayBuffer, a `beforeParse` function,
+      // a `virtualConsole` instance) collapse to identical bytes — two
+      // projects differing only in such values share a key and, under
+      // `isolate: false`, may share a worker's environment. Accepted as too
+      // narrow to guard; if it ever matters, fall back to a project-scoped
+      // key when the config is not JSON-representable instead of trying to
+      // serialize those values.
       environmentKey: getEnvironmentKey(runtimeConfig.testEnvironment),
       context: {
         outputModule: project.outputModule,

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -9,7 +9,7 @@ import { createPoolWorker } from './workers';
  *   - one task per worker at a time (concurrentTasksPerWorker=1)
  *   - parallel dispatch up to maxWorkers, slot-waiter blocks excess callers
  *   - isolate=true: fresh runner per task, stopped in the background
- *   - isolate=false: idle runners reused, lazy-spawned on demand
+ *   - isolate=false: idle runners reused (environment-matched), lazy-spawned
  */
 export class Pool {
   private readonly options: PoolOptions;
@@ -78,12 +78,19 @@ export class Pool {
    * claimed (idle-runner reuse or `slotWaiters` push) without revisiting it.
    */
   private async acquireRunner(task: PoolTask): Promise<PoolRunner> {
+    const { environmentKey } = task.options;
+
     while (true) {
       // Prefer reuse of an idle runner (only meaningful when isolate=false,
       // since isolate=true never returns runners to the idle pool). Most
-      // recently returned first (LIFO) — hottest kept module cache.
-      const reuse = this.idleRunners.pop();
-      if (reuse) {
+      // recently returned first (LIFO) — hottest kept module cache — and
+      // restricted to runners already holding this task's environment, so a
+      // reused worker never has to swap environments mid-life.
+      const reuseIndex = this.idleRunners.findLastIndex(
+        (idle) => idle.environmentKey === environmentKey,
+      );
+      if (reuseIndex !== -1) {
+        const reuse = this.idleRunners.splice(reuseIndex, 1)[0]!;
         if (reuse.isUsable()) {
           this.activeRunners.add(reuse);
           return reuse;
@@ -96,6 +103,13 @@ export class Pool {
 
       const inFlight = this.inFlightCount;
       if (inFlight >= this.options.maxWorkers) {
+        // No idle runner holds this environment. Idle runners still occupy
+        // slots, so shed the coldest one rather than parking behind workers
+        // that can never serve this task; its slot — and this waiter — is
+        // released once the child exits.
+        if (this.idleRunners.length > 0) {
+          this.disposeRunnerInBackground(this.idleRunners.shift()!);
+        }
         await new Promise<void>((resolve) => {
           this.slotWaiters.push(resolve);
         });
@@ -122,7 +136,7 @@ export class Pool {
       const workerId = this.acquireWorkerId();
       const worker = createPoolWorker(task, this.options, workerId);
       gate?.attachWorker(worker);
-      const runner = new PoolRunner(worker, { workerId });
+      const runner = new PoolRunner(worker, { workerId, environmentKey });
       this.activeRunners.add(runner);
       try {
         await runner.start();
@@ -208,10 +222,18 @@ export class Pool {
     //   2) There is no waiter, but the idle pool has not yet reached
     //      `minWorkers` — keep the runner around as steady-state capacity.
     // Otherwise the idle pool is already at the floor, so shed this runner.
+    //
+    // The floor is counted per environment, because reuse is environment-
+    // matched: idle runners holding a different environment can never serve
+    // this one, so counting them would let a cold environment's leftovers
+    // squat the floor and force this environment to respawn every task.
     const minWorkers = Math.max(this.options.minWorkers, 0);
     const hasWaiter = this.slotWaiters.length > 0;
+    const idleForEnvironment = this.idleRunners.filter(
+      (idle) => idle.environmentKey === runner.environmentKey,
+    ).length;
 
-    if (hasWaiter || this.idleRunners.length < minWorkers) {
+    if (hasWaiter || idleForEnvironment < minWorkers) {
       this.idleRunners.push(runner);
       if (hasWaiter) {
         // Idle slot is immediately consumable — wake one waiter now.

--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -59,6 +59,7 @@ let nextTaskSeq = 0;
 
 type PoolRunnerOptions = {
   workerId: number;
+  environmentKey: string;
 };
 
 /**
@@ -73,6 +74,8 @@ type PoolRunnerOptions = {
  */
 export class PoolRunner {
   readonly workerId: number;
+  /** Environment identity this worker holds for life — see `Pool.acquireRunner`. */
+  readonly environmentKey: string;
   readonly worker: PoolWorker;
   private state: RunnerState = 'IDLE';
   private operationChain: Promise<unknown> = Promise.resolve();
@@ -95,6 +98,7 @@ export class PoolRunner {
 
   constructor(worker: PoolWorker, options: PoolRunnerOptions) {
     this.workerId = options.workerId;
+    this.environmentKey = options.environmentKey;
     this.worker = worker;
 
     this.handleMessage = this.handleMessage.bind(this);

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -312,9 +312,6 @@ const preparePool = async (
       `Test environment changed on a reused worker: ${activeEnvironmentKey} -> ${environmentKey}`,
     );
   }
-  if (!isolate) {
-    activeEnvironmentKey = environmentKey;
-  }
   // `node` is the no-op fast path; every other environment is resolved through
   // the registry so adding one is a single entry instead of a new switch arm.
   // teardown is `MaybePromise<void>` and is awaited via `Promise.all` in
@@ -333,6 +330,13 @@ const preparePool = async (
     if (isolate) {
       cleanupFns.push(() => teardown(global));
     }
+  }
+  // Pin only after setup succeeded. A setup failure (e.g. an invalid jsdom
+  // option) surfaces as a file-level failure and leaves the worker reusable;
+  // pinning eagerly would make every later same-key task skip setup and run
+  // bare-Node against a config the user asked to be a DOM.
+  if (!isolate) {
+    activeEnvironmentKey = environmentKey;
   }
   tracker?.transition('prepare');
 

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -61,6 +61,26 @@ const registerGlobalApi = (api: Rstest) => {
 const globalCleanups: (() => void)[] = [];
 let isTeardown = false;
 /**
+ * Test environment kept alive across files on a reused worker
+ * (`isolate: false`).
+ *
+ * User modules persist per worker under `isolate: false` (#1373), and a
+ * persisted module may capture environment values at evaluation time —
+ * testing-library's `screen` binds `document.body` once, at import. The
+ * environment must therefore live exactly as long as the module registry, or
+ * such captures dangle on a torn-down window from the second file on. This is
+ * the same staleness class #1376 solved for context-bound core APIs via live
+ * bindings — an option third-party modules do not have, so here the
+ * environment's lifetime moves instead.
+ *
+ * A worker only ever holds one environment: the scheduler restricts reuse to
+ * tasks whose `environmentKey` matches (`Pool.acquireRunner`). No
+ * teardown runs at worker exit — the host owns termination (see
+ * `pool/AGENTS.md`) and process death reclaims the environment, same as the
+ * kept module cache.
+ */
+let activeEnvironmentKey: string | undefined;
+/**
  * Last per-compile `buildId` this (possibly reused) worker loaded; a change
  * means a watch rebuild and triggers a full cache flush below (#1373).
  *
@@ -132,6 +152,7 @@ const preparePool = async (
     entryInfo: { distPath, testPath },
     updateSnapshot,
     context,
+    environmentKey,
   }: RunWorkerOptions['options'],
   tracker?: PhaseTracker,
 ) => {
@@ -178,6 +199,7 @@ const preparePool = async (
       testEnvironment,
       snapshotFormat,
       env,
+      isolate,
     },
   } = context;
 
@@ -280,12 +302,25 @@ const preparePool = async (
   });
 
   tracker?.transition('envSetup');
+  const hasPinnedEnvironment = activeEnvironmentKey !== undefined;
+  if (hasPinnedEnvironment && activeEnvironmentKey !== environmentKey) {
+    // Unreachable: the scheduler only reuses a worker for tasks matching its
+    // pinned environment (`Pool.acquireRunner`). The throw guards against a
+    // future regression in that affinity — swapping environments here would
+    // leave persisted modules holding captures of the previous one.
+    throw new Error(
+      `Test environment changed on a reused worker: ${activeEnvironmentKey} -> ${environmentKey}`,
+    );
+  }
+  if (!isolate) {
+    activeEnvironmentKey = environmentKey;
+  }
   // `node` is the no-op fast path; every other environment is resolved through
   // the registry so adding one is a single entry instead of a new switch arm.
   // teardown is `MaybePromise<void>` and is awaited via `Promise.all` in
   // `cleanup`, so a single uniform wrapper preserves both the sync (jsdom) and
   // async (happy-dom) teardown shapes.
-  if (testEnvironment.name !== 'node') {
+  if (testEnvironment.name !== 'node' && !hasPinnedEnvironment) {
     const loadEnvironment = environmentLoaders[testEnvironment.name];
     if (!loadEnvironment) {
       throw new Error(`Unknown test environment: ${testEnvironment.name}`);
@@ -295,7 +330,9 @@ const preparePool = async (
       global,
       testEnvironment.options || {},
     );
-    cleanupFns.push(() => teardown(global));
+    if (isolate) {
+      cleanupFns.push(() => teardown(global));
+    }
   }
   tracker?.transition('prepare');
 

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -121,6 +121,14 @@ export type RunWorkerOptions = {
     entryInfo: EntryInfo;
     setupEntries: EntryInfo[];
     context: WorkerContext;
+    /**
+     * Identity of this task's test environment, derived host-side by
+     * `getEnvironmentKey`. The pool reuses a worker only for matching keys
+     * (see `pool/AGENTS.md`), and the worker compares it to detect a violation
+     * of that guarantee — neither side re-derives it. Node-pool only: it sits
+     * outside `context` because it is dispatch metadata, not worker state.
+     */
+    environmentKey: string;
     updateSnapshot: SnapshotUpdateState;
     type: 'run' | 'collect';
     /** assets is only defined when memory is sufficient, otherwise we should get them via rpc getAssetsByEntry method */

--- a/packages/core/tests/core/environmentGroups.test.ts
+++ b/packages/core/tests/core/environmentGroups.test.ts
@@ -1,0 +1,26 @@
+import { getEnvironmentKey } from '../../src/core/environmentGroups';
+
+describe('getEnvironmentKey', () => {
+  it('should ignore property order', () => {
+    // The key decides both entry grouping and worker reuse affinity, so two
+    // configs that differ only in property order must not split a project or
+    // shed each other's worker.
+    expect(
+      getEnvironmentKey({
+        name: 'jsdom',
+        options: { url: 'http://localhost', pretendToBeVisual: true },
+      }),
+    ).toBe(
+      getEnvironmentKey({
+        name: 'jsdom',
+        options: { pretendToBeVisual: true, url: 'http://localhost' },
+      }),
+    );
+  });
+
+  it('should distinguish different options', () => {
+    expect(getEnvironmentKey({ name: 'jsdom' })).not.toBe(
+      getEnvironmentKey({ name: 'jsdom', options: { url: 'http://a.dev' } }),
+    );
+  });
+});

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -38,10 +38,13 @@ const stubRpcMethods = () =>
 const createTask = (
   type: PoolTask['type'] = 'run',
   optionOverrides?: Record<string, unknown>,
+  // A worker is only reused for tasks carrying the same key.
+  environmentKey = 'node',
 ): PoolTask => ({
   worker: 'forks',
   type,
   options: {
+    environmentKey,
     ...optionOverrides,
   } as any,
   rpcMethods: stubRpcMethods(),
@@ -172,6 +175,29 @@ describe('Pool - isolate', () => {
       // Incrementing run count proves the same process instance handled
       // both tasks — not just a recycled PID.
       expect((r1 as any)._runCount).toBe((r2 as any)._runCount - 1);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('should not reuse a worker for a different test environment', async () => {
+    const pool = new Pool(createPoolOptions({ isolate: false, minWorkers: 1 }));
+    try {
+      // A worker keeps its environment alive across files under
+      // `isolate: false`, so reuse must be environment-matched — otherwise a
+      // persisted module's evaluation-time DOM captures would dangle on the
+      // previous environment (rstest#767).
+      const jsdom = await pool.runTest(createTask('run', undefined, 'jsdom'));
+      const node = await pool.runTest(createTask());
+      expect((jsdom as any)._workerIdentity).not.toBe(
+        (node as any)._workerIdentity,
+      );
+
+      // Same environment still reuses — affinity must not disable sharing.
+      const nodeAgain = await pool.runTest(createTask());
+      expect((nodeAgain as any)._workerIdentity).toBe(
+        (node as any)._workerIdentity,
+      );
     } finally {
       await pool.close();
     }

--- a/packages/core/tests/pool/threadsPool.test.ts
+++ b/packages/core/tests/pool/threadsPool.test.ts
@@ -38,6 +38,8 @@ const createTask = (
   worker: 'threads',
   type,
   options: {
+    // A worker is only reused for tasks carrying the same key.
+    environmentKey: 'node',
     ...optionOverrides,
   } as any,
   rpcMethods: stubRpcMethods(),

--- a/website/docs/en/config/test/isolate.mdx
+++ b/website/docs/en/config/test/isolate.mdx
@@ -15,7 +15,7 @@ By default, Rstest runs each test in an isolated environment, which avoids the i
 If your code has no side effects, turning off this option will help improve performance because module caches can be reused between different test files.
 
 :::warning Module top-level code runs once per worker
-When `isolate` is `false`, a module imported by multiple test files is evaluated **once per worker**, not once per file. Any code at that shared module's top level — including hooks registered there (e.g. a helper that calls `beforeEach` at module scope) — therefore runs only for the first file that loads it, not for every file. For setup that must run per file, use [`setupFiles`](/config/test/setup-files), which Rstest re-runs for each test file even without isolation.
+When `isolate` is `false`, a module imported by multiple test files is evaluated **once per worker**, not once per file. Any code at that shared module's top level — including hooks registered there (e.g. a helper that calls `beforeEach` at module scope) — therefore runs only for the first file that loads it, not for every file. For setup that must run per file, use [`setupFiles`](/config/test/setup-files), which Rstest re-runs for each test file even without isolation. The [test environment](/config/test/test-environment) follows the same rule — it is created once per worker, so its state (e.g. the DOM) persists across files and can be reset per file in `setupFiles`.
 :::
 
 import { Tab, Tabs } from '@theme';

--- a/website/docs/zh/config/test/isolate.mdx
+++ b/website/docs/zh/config/test/isolate.mdx
@@ -15,7 +15,7 @@ description: 默认情况下，Rstest 会运行每个测试在一个独立的环
 如果你的代码没有副作用影响，关闭这个选项将有助于提升性能因为可以在不同的测试文件间复用模块缓存。
 
 :::warning 模块顶层代码每个 worker 只执行一次
-当 `isolate` 为 `false` 时，被多个测试文件引入的模块在每个 worker 中**只会被求值一次**，而非每个文件求值一次。因此该共享模块顶层的所有代码——包括在其模块作用域注册的 hooks（例如某个 helper 在模块作用域调用 `beforeEach`）——只会对第一个加载它的文件生效，而不会对每个文件生效。如果某段 setup 逻辑需要按文件执行，请使用 [`setupFiles`](/config/test/setup-files)，即使关闭隔离，Rstest 也会为每个测试文件重新执行它。
+当 `isolate` 为 `false` 时，被多个测试文件引入的模块在每个 worker 中**只会被求值一次**，而非每个文件求值一次。因此该共享模块顶层的所有代码——包括在其模块作用域注册的 hooks（例如某个 helper 在模块作用域调用 `beforeEach`）——只会对第一个加载它的文件生效，而不会对每个文件生效。如果某段 setup 逻辑需要按文件执行，请使用 [`setupFiles`](/config/test/setup-files)，即使关闭隔离，Rstest 也会为每个测试文件重新执行它。[测试环境](/config/test/test-environment)遵循同样的规则——它在每个 worker 中只创建一次，其状态（例如 DOM）会跨文件保留，可在 `setupFiles` 中按文件重置。
 :::
 
 import { Tab, Tabs } from '@theme';


### PR DESCRIPTION
## Summary

Under `isolate: false` a worker keeps its module registry across test files, but the test environment (jsdom / happy-dom) was still created and torn down **per file**. Any module that reads the environment at evaluation time is evaluated once, so from the second file on it holds references into a window that has already been closed — the most common case being `@testing-library/dom`'s `screen`, which binds `document.body` at import.

Concretely, with `isolate: false` and `testEnvironment: 'jsdom'`:

```ts
// shared.ts — evaluated ONCE per worker
export const capturedBody = document.body;
```

```ts
// a.test.ts and b.test.ts — same worker, both import shared.ts
import { capturedBody } from './shared';
test('captures stay live', () => {
  expect(capturedBody).toBe(document.body);
});
```

**Before** — the environment was file-scoped while modules were worker-scoped, so the two lifetimes disagreed:

| | worker (`isolate: false`) |
|---|---|
| `a.test.ts` | create jsdom **instance 1** → evaluate `shared.ts` (`capturedBody` = instance 1's body) → run → **tear down instance 1** |
| `b.test.ts` | create jsdom **instance 2** → `shared.ts` is already in the kept registry, **not re-evaluated** → `capturedBody` still points into the torn-down instance 1 → fails |

In a real suite this surfaces as every `screen.getByText(...)` after the first file failing to find elements that are visibly in the DOM.

**After** — the environment is created once per worker and never torn down between files, the same lifetime the module registry already has:

| | worker (`isolate: false`) |
|---|---|
| `a.test.ts` | create a fresh jsdom, pin its identity → evaluate `shared.ts` → run |
| `b.test.ts` | same worker, same instance — setup and teardown both skipped → `capturedBody === document.body` holds |

That one-lifetime rule raises the question the rest of the diff answers: what if the next file wants a **different** environment (a sibling project, an `@rstest-environment` docblock)? The worker can no longer swap — so the scheduler must never hand it that file:

- `runInPool` installs the environment once per worker under `isolate: false` and pins its identity (only after setup succeeds, so a broken config fails loudly on every file instead of silently degrading later files to bare Node); `isolate: true` keeps the existing per-file setup/teardown.
- `environmentKey` is derived host-side (`getEnvironmentKey`) and threaded on the task, next to the existing `buildId` plumbing. `Pool.acquireRunner` only reuses an idle worker whose key matches and sheds a mismatched one instead of swapping, and the `minWorkers` idle floor is counted per environment so one cold environment's leftovers cannot squat the floor.
- A worker that is nevertheless handed a mismatched task fails that file loudly rather than silently swapping.

No config or public API change; `isolate: true` behavior is untouched. The docs for `isolate` now state that the test environment follows the same per-worker rule and can be reset per file in `setupFiles`.

## Related Links

- https://github.com/web-infra-dev/rstest/issues/767
- Follows the per-worker module registry introduced in https://github.com/web-infra-dev/rstest/pull/1376

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
