### PR TITLE
fix(core): skip environment resource tracking for worker-scoped environments

### DIFF
--- a/packages/core/src/runtime/worker/env/happyDom.ts
+++ b/packages/core/src/runtime/worker/env/happyDom.ts
@@ -14,7 +14,7 @@ type HappyDOMOptions = ConstructorParameters<typeof HappyDOMWindow>[0];
 export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
   {
     name: 'happy-dom',
-    setup: async (global, options = {}) => {
+    setup: async (global, options = {}, context) => {
       checkPkgInstalled('happy-dom');
 
       const { Window, GlobalWindow } = await import('happy-dom');
@@ -35,13 +35,14 @@ export const environment: TestEnvironment<typeof globalThis, HappyDOMOptions> =
       });
       const cleanupObjectURLs = installObjectURLTracker(
         win.URL as unknown as typeof URL,
+        context,
       );
 
       const cleanupGlobal = installGlobal(global, win, {
         // jsdom doesn't support Request and Response, but happy-dom does
         additionalKeys: ['Request', 'Response', 'MessagePort', 'fetch', 'URL'],
       });
-      const cleanupTimers = installTimerTracking(global, nodeTimers);
+      const cleanupTimers = installTimerTracking(global, nodeTimers, context);
 
       const cleanupHandler = addDefaultErrorHandler(
         global as unknown as Window,

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -1,7 +1,7 @@
 import { Blob as NodeBlob } from 'node:buffer';
 import { URL as NodeURL } from 'node:url';
 import type { ConstructorOptions, DOMWindow } from 'jsdom';
-import type { TestEnvironment } from '../../../types';
+import type { TestEnvironment, TestEnvironmentContext } from '../../../types';
 import { checkPkgInstalled } from '../../util';
 import {
   addDefaultErrorHandler,
@@ -21,7 +21,10 @@ type JSDOMBlobImpl = {
   _bytes?: Uint8Array;
 };
 
-function installJSDOMObjectURL(window: DOMWindow): () => void {
+function installJSDOMObjectURL(
+  window: DOMWindow,
+  context: TestEnvironmentContext,
+): () => void {
   const implSymbol = Object.getOwnPropertySymbols(new window.Blob())[0]!;
   const URLConstructor = window.URL as typeof URL;
   const createDescriptor = Object.getOwnPropertyDescriptor(
@@ -63,7 +66,9 @@ function installJSDOMObjectURL(window: DOMWindow): () => void {
     });
   }
 
-  const cleanupObjectURLs = installObjectURLTracker(URLConstructor);
+  // The polyfill above is behavior and always installs, unlike the tracker
+  // below, which only feeds environment teardown.
+  const cleanupObjectURLs = installObjectURLTracker(URLConstructor, context);
   return () => {
     cleanupObjectURLs();
     if (createDescriptor) {
@@ -89,7 +94,7 @@ function installJSDOMObjectURL(window: DOMWindow): () => void {
 
 export const environment: TestEnvironment<typeof globalThis> = {
   name: 'jsdom',
-  setup: async (global, options) => {
+  setup: async (global, options, context) => {
     checkPkgInstalled('jsdom');
     const { CookieJar, JSDOM, ResourceLoader, VirtualConsole } =
       await import('jsdom');
@@ -133,14 +138,14 @@ export const environment: TestEnvironment<typeof globalThis> = {
       ...restOptions,
       beforeParse(window) {
         beforeParse?.(window);
-        cleanupObjectURLs = installJSDOMObjectURL(window);
+        cleanupObjectURLs = installJSDOMObjectURL(window, context);
       },
     });
 
     const cleanupGlobal = installGlobal(global, dom.window, {
       additionalKeys: ['URL', 'URLSearchParams'],
     });
-    const cleanupTimers = installTimerTracking(global, nodeTimers);
+    const cleanupTimers = installTimerTracking(global, nodeTimers, context);
 
     const cleanupHandler = addDefaultErrorHandler(global as unknown as Window);
 

--- a/packages/core/src/runtime/worker/env/utils.ts
+++ b/packages/core/src/runtime/worker/env/utils.ts
@@ -1,4 +1,5 @@
 import { promisify } from 'node:util';
+import type { TestEnvironmentContext } from '../../../types';
 import { KEYS } from './jsdomKeys';
 
 export type NodeTimerPrimitives = Pick<
@@ -35,9 +36,20 @@ function isClassLike(name: string) {
   return name[0] && name.startsWith(name[0].toUpperCase());
 }
 
+/**
+ * Record the object URLs created through `URLConstructor` so the returned
+ * cleanup can revoke the ones the test never revoked itself. Tracking only
+ * feeds environment teardown, so a worker-scoped environment gets a no-op:
+ * see `TestEnvironmentReturn.teardown`.
+ */
 export function installObjectURLTracker(
   URLConstructor: typeof URL,
+  context: TestEnvironmentContext,
 ): () => void {
+  if (context.scope === 'worker') {
+    return () => {};
+  }
+
   const objectURLs = new Set<string>();
   const createDescriptor = Object.getOwnPropertyDescriptor(
     URLConstructor,
@@ -186,37 +198,75 @@ export function installGlobal(
 }
 
 /**
- * Keep Node timer handles scoped to one DOM environment so pending timers do
- * not keep a worker alive after that environment has been torn down.
+ * Shadow the DOM timers `installGlobal` just exposed with Node's, so tests get
+ * real `NodeJS.Timeout` handles. A file-scoped environment gets wrappers that
+ * record every timer created, so the returned cleanup can clear the stragglers;
+ * a worker-scoped one gets the Node primitives unwrapped — its teardown never
+ * runs, so recording would retain every timer and its callback closure for the
+ * worker's whole life (see `TestEnvironmentReturn.teardown`).
  */
 export function installTimerTracking(
   global: typeof globalThis,
   nodeTimers: NodeTimerPrimitives,
+  context: TestEnvironmentContext,
 ): () => void {
-  const timers = new Map<NodeJS.Timeout, (timer: NodeJS.Timeout) => void>();
   const descriptors = new Map<
     (typeof TIMER_KEYS)[number],
     PropertyDescriptor
   >();
+
+  const install = (
+    timers: Pick<NodeTimerPrimitives, (typeof TIMER_KEYS)[number]>,
+  ): void => {
+    for (const key of TIMER_KEYS) {
+      const descriptor = Object.getOwnPropertyDescriptor(global, key);
+      if (descriptor) {
+        descriptors.set(key, descriptor);
+      }
+      Object.defineProperty(global, key, {
+        configurable: true,
+        value: timers[key],
+        writable: true,
+      });
+    }
+  };
+
+  const restore = (): void => {
+    for (const key of TIMER_KEYS) {
+      const descriptor = descriptors.get(key);
+      if (descriptor) {
+        Object.defineProperty(global, key, descriptor);
+      } else {
+        Reflect.deleteProperty(global, key);
+      }
+    }
+  };
+
+  if (context.scope === 'worker') {
+    install(nodeTimers);
+    return restore;
+  }
+
+  const pending = new Map<NodeJS.Timeout, (timer: NodeJS.Timeout) => void>();
   let active = true;
 
-  const track = (
+  const record = (
     timer: NodeJS.Timeout,
     clearTimer: (timer: NodeJS.Timeout) => void,
   ): NodeJS.Timeout => {
     if (active) {
-      timers.set(timer, clearTimer);
+      pending.set(timer, clearTimer);
     }
     return timer;
   };
 
   const setTimeout = ((...args: unknown[]) =>
-    track(
+    record(
       Reflect.apply(nodeTimers.setTimeout, global, args) as NodeJS.Timeout,
       nodeTimers.clearTimeout,
     )) as NodeTimerPrimitives['setTimeout'];
   const setInterval = ((...args: unknown[]) =>
-    track(
+    record(
       Reflect.apply(nodeTimers.setInterval, global, args) as NodeJS.Timeout,
       nodeTimers.clearInterval,
     )) as NodeTimerPrimitives['setInterval'];
@@ -233,37 +283,15 @@ export function installTimerTracking(
     );
   }
 
-  const trackedTimers = {
-    setInterval,
-    setTimeout,
-  };
-  for (const key of TIMER_KEYS) {
-    const descriptor = Object.getOwnPropertyDescriptor(global, key);
-    if (descriptor) {
-      descriptors.set(key, descriptor);
-    }
-    Object.defineProperty(global, key, {
-      configurable: true,
-      value: trackedTimers[key],
-      writable: true,
-    });
-  }
+  install({ setInterval, setTimeout });
 
   return () => {
     active = false;
-    for (const [timer, clearTimer] of timers) {
+    for (const [timer, clearTimer] of pending) {
       clearTimer(timer);
     }
-    timers.clear();
-
-    for (const key of TIMER_KEYS) {
-      const descriptor = descriptors.get(key);
-      if (descriptor) {
-        Object.defineProperty(global, key, descriptor);
-      } else {
-        Reflect.deleteProperty(global, key);
-      }
-    }
+    pending.clear();
+    restore();
   };
 }
 

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -324,11 +324,13 @@ const preparePool = async (
       throw new Error(`Unknown test environment: ${testEnvironment.name}`);
     }
     const { environment } = await loadEnvironment();
+    const scope = isolate ? 'file' : 'worker';
     const { teardown } = await environment.setup(
       global,
       testEnvironment.options || {},
+      { scope },
     );
-    if (isolate) {
+    if (scope === 'file') {
       cleanupFns.push(() => teardown(global));
     }
   }

--- a/packages/core/src/types/environment.ts
+++ b/packages/core/src/types/environment.ts
@@ -1,12 +1,26 @@
 import type { MaybePromise } from './utils';
 
 export interface TestEnvironmentReturn {
+  /**
+   * Only called for a `file`-scoped environment. A `worker`-scoped one lives
+   * as long as the worker, so anything this would have drained must not be
+   * accumulated in the first place (rstest#1644).
+   */
   teardown: (global: any) => MaybePromise<void>;
+}
+export interface TestEnvironmentContext {
+  /**
+   * How long this environment instance lives: `file` is torn down when the
+   * file finishes, `worker` is kept for the worker's whole life
+   * (`isolate: false`).
+   */
+  scope: 'file' | 'worker';
 }
 export interface TestEnvironment<Global = any, Options = Record<string, any>> {
   name: string;
   setup: (
     global: Global,
     options: Options,
+    context: TestEnvironmentContext,
   ) => MaybePromise<TestEnvironmentReturn>;
 }

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -33,7 +33,11 @@ test('clears pending Node timers during jsdom teardown', async () => {
     clearedIntervals.push(timer);
     nativeTimers.clearInterval(timer);
   }) as typeof clearInterval;
-  const { teardown } = await environment.setup(testGlobal, {});
+  const { teardown } = await environment.setup(
+    testGlobal,
+    {},
+    { scope: 'file' },
+  );
   const timeout = testGlobal.setTimeout(() => {}, 60_000);
   const interval = testGlobal.setInterval(() => {}, 60_000);
   let tornDown = false;
@@ -65,14 +69,18 @@ test('clears pending Node timers during jsdom teardown', async () => {
 test('should preserve URL customizations from beforeParse', async () => {
   const testGlobal = { console, URL, URLSearchParams } as typeof globalThis;
   const originalURL = testGlobal.URL;
-  const { teardown } = await environment.setup(testGlobal, {
-    beforeParse(window: DOMWindow) {
-      const OriginalURL = window.URL as typeof URL;
-      class CustomURL extends OriginalURL {}
-      Object.defineProperty(CustomURL, 'beforeParseMarker', { value: true });
-      window.URL = CustomURL;
+  const { teardown } = await environment.setup(
+    testGlobal,
+    {
+      beforeParse(window: DOMWindow) {
+        const OriginalURL = window.URL as typeof URL;
+        class CustomURL extends OriginalURL {}
+        Object.defineProperty(CustomURL, 'beforeParseMarker', { value: true });
+        window.URL = CustomURL;
+      },
     },
-  });
+    { scope: 'file' },
+  );
 
   try {
     expect(

--- a/packages/core/tests/runtime/worker/env/utils.test.ts
+++ b/packages/core/tests/runtime/worker/env/utils.test.ts
@@ -27,7 +27,7 @@ test('should not record timers for a worker-scoped environment', () => {
   expect(cleared).toEqual([]);
 });
 
-test('should revoke remaining object URLs and restore methods', () => {
+const createTestURL = () => {
   const revoked: string[] = [];
   let nextId = 0;
   class TestURL extends URL {
@@ -39,7 +39,11 @@ test('should revoke remaining object URLs and restore methods', () => {
       revoked.push(url);
     }
   }
+  return { TestURL, revoked };
+};
 
+test('should revoke remaining object URLs and restore methods', () => {
+  const { TestURL, revoked } = createTestURL();
   const originalCreateObjectURL = TestURL.createObjectURL;
   const originalRevokeObjectURL = TestURL.revokeObjectURL;
   const cleanup = installObjectURLTracker(TestURL, { scope: 'file' });
@@ -52,4 +56,19 @@ test('should revoke remaining object URLs and restore methods', () => {
   expect(revoked).toEqual([revokedByUser, revokedByCleanup]);
   expect(TestURL.createObjectURL).toBe(originalCreateObjectURL);
   expect(TestURL.revokeObjectURL).toBe(originalRevokeObjectURL);
+});
+
+test('should not track object URLs for a worker-scoped environment', () => {
+  const { TestURL, revoked } = createTestURL();
+  const originalCreateObjectURL = TestURL.createObjectURL;
+
+  const cleanup = installObjectURLTracker(TestURL, { scope: 'worker' });
+  TestURL.createObjectURL(new Blob());
+  cleanup();
+
+  // The methods are left unwrapped, so there is nothing to revoke — the
+  // worker-scoped environment must not retain what it never tears down
+  // (#1644).
+  expect(TestURL.createObjectURL).toBe(originalCreateObjectURL);
+  expect(revoked).toEqual([]);
 });

--- a/packages/core/tests/runtime/worker/env/utils.test.ts
+++ b/packages/core/tests/runtime/worker/env/utils.test.ts
@@ -1,5 +1,31 @@
 import { expect, test } from '@rstest/core';
-import { installObjectURLTracker } from '../../../../src/runtime/worker/env/utils';
+import {
+  installObjectURLTracker,
+  installTimerTracking,
+  type NodeTimerPrimitives,
+} from '../../../../src/runtime/worker/env/utils';
+
+test('should not record timers for a worker-scoped environment', () => {
+  const cleared: unknown[] = [];
+  const nodeTimers = {
+    setTimeout: () => ({}) as NodeJS.Timeout,
+    setInterval: () => ({}) as NodeJS.Timeout,
+    clearTimeout: (timer: unknown) => cleared.push(timer),
+    clearInterval: (timer: unknown) => cleared.push(timer),
+  } as unknown as NodeTimerPrimitives;
+  const testGlobal = {} as typeof globalThis;
+
+  const cleanup = installTimerTracking(testGlobal, nodeTimers, {
+    scope: 'worker',
+  });
+  testGlobal.setTimeout(() => {}, 1000);
+  testGlobal.setInterval(() => {}, 1000);
+  cleanup();
+
+  // Nothing to clear proves nothing was recorded — the worker-scoped
+  // environment must not retain timers it will never tear down (#1644).
+  expect(cleared).toEqual([]);
+});
 
 test('should revoke remaining object URLs and restore methods', () => {
   const revoked: string[] = [];
@@ -16,7 +42,7 @@ test('should revoke remaining object URLs and restore methods', () => {
 
   const originalCreateObjectURL = TestURL.createObjectURL;
   const originalRevokeObjectURL = TestURL.revokeObjectURL;
-  const cleanup = installObjectURLTracker(TestURL);
+  const cleanup = installObjectURLTracker(TestURL, { scope: 'file' });
   const revokedByUser = TestURL.createObjectURL(new Blob());
   const revokedByCleanup = TestURL.createObjectURL(new Blob());
 

--- a/website/docs/en/config/test/isolate.mdx
+++ b/website/docs/en/config/test/isolate.mdx
@@ -15,7 +15,7 @@ By default, Rstest runs each test in an isolated environment, which avoids the i
 If your code has no side effects, turning off this option will help improve performance because module caches can be reused between different test files.
 
 :::warning Module top-level code runs once per worker
-When `isolate` is `false`, a module imported by multiple test files is evaluated **once per worker**, not once per file. Any code at that shared module's top level — including hooks registered there (e.g. a helper that calls `beforeEach` at module scope) — therefore runs only for the first file that loads it, not for every file. For setup that must run per file, use [`setupFiles`](/config/test/setup-files), which Rstest re-runs for each test file even without isolation. The [test environment](/config/test/test-environment) follows the same rule — it is created once per worker, so its state (e.g. the DOM) persists across files and can be reset per file in `setupFiles`.
+When `isolate` is `false`, a module imported by multiple test files is evaluated **once per worker**, not once per file. Any code at that shared module's top level — including hooks registered there (e.g. a helper that calls `beforeEach` at module scope) — therefore runs only for the first file that loads it, not for every file. For setup that must run per file, use [`setupFiles`](/config/test/setup-files), which Rstest re-runs for each test file even without isolation. The [test environment](/config/test/test-environment) follows the same rule — it is created once per worker, so its state (the DOM, timers you did not clear, installed fake timers) persists across files and can be reset per file in `setupFiles`.
 :::
 
 import { Tab, Tabs } from '@theme';

--- a/website/docs/zh/config/test/isolate.mdx
+++ b/website/docs/zh/config/test/isolate.mdx
@@ -15,7 +15,7 @@ description: 默认情况下，Rstest 会运行每个测试在一个独立的环
 如果你的代码没有副作用影响，关闭这个选项将有助于提升性能因为可以在不同的测试文件间复用模块缓存。
 
 :::warning 模块顶层代码每个 worker 只执行一次
-当 `isolate` 为 `false` 时，被多个测试文件引入的模块在每个 worker 中**只会被求值一次**，而非每个文件求值一次。因此该共享模块顶层的所有代码——包括在其模块作用域注册的 hooks（例如某个 helper 在模块作用域调用 `beforeEach`）——只会对第一个加载它的文件生效，而不会对每个文件生效。如果某段 setup 逻辑需要按文件执行，请使用 [`setupFiles`](/config/test/setup-files)，即使关闭隔离，Rstest 也会为每个测试文件重新执行它。[测试环境](/config/test/test-environment)遵循同样的规则——它在每个 worker 中只创建一次，其状态（例如 DOM）会跨文件保留，可在 `setupFiles` 中按文件重置。
+当 `isolate` 为 `false` 时，被多个测试文件引入的模块在每个 worker 中**只会被求值一次**，而非每个文件求值一次。因此该共享模块顶层的所有代码——包括在其模块作用域注册的 hooks（例如某个 helper 在模块作用域调用 `beforeEach`）——只会对第一个加载它的文件生效，而不会对每个文件生效。如果某段 setup 逻辑需要按文件执行，请使用 [`setupFiles`](/config/test/setup-files)，即使关闭隔离，Rstest 也会为每个测试文件重新执行它。[测试环境](/config/test/test-environment)遵循同样的规则——它在每个 worker 中只创建一次，其状态（DOM、未清理的 timer、已安装的 fake timers）会跨文件保留，可在 `setupFiles` 中按文件重置。
 :::
 
 import { Tab, Tabs } from '@theme';


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/web-infra-dev/rstest/pull/1642, which made the test environment worker-scoped under `isolate: false`. A consequence of that change is that the environment's `teardown` is never called in this mode. The jsdom and happy-dom environments still installed their leaked-resource trackers anyway: every `setTimeout` / `setInterval` a test creates is recorded into a `Map`, and every `URL.createObjectURL` result into a `Set`. `teardown` is the only consumer of either. Neither is pruned when a timer fires or is cleared, so both grow for the worker's entire life — write-only bookkeeping that keeps each timer's callback closure (and everything it captures) alive.

Concretely, a run of 200 jsdom test files on one worker, where each file renders a component that schedules a `300ms` debounce internally:

| | file 1 finishes | file 200 finishes |
| --- | --- | --- |
| before | the debounce timer has already fired, but its handle + callback closure sit in the environment's timer `Map` | ~200 fired-and-forgotten timers still retained; worker memory grows monotonically with the file count |
| after | nothing was recorded — Node drops the handle once the timer fires | flat |

A worker-scoped environment now installs Node's timer primitives unwrapped instead of the recording wrappers. Timer semantics are unchanged in both isolate modes: the environment still shadows the DOM timers with Node's, so tests keep getting real `NodeJS.Timeout` handles (`.refresh()`, `promisify.custom`). With the default `isolate: true` nothing changes at all — teardown still runs per file and still drains the trackers.

The signal is threaded as a third `context: { scope: 'file' | 'worker' }` argument on `TestEnvironment.setup`. This is an internal type: `testEnvironment` only accepts `'node' | 'jsdom' | 'happy-dom'`, the interface is absent from every published `.d.ts` entry, and there are exactly two implementors. Both trackers take the context and derive the policy themselves, so the rule has one owner rather than one copy per environment.

Docs are updated to say that under `isolate: false` the environment's state — the DOM, timers you did not clear, installed fake timers — persists across files, and can be reset per file in `setupFiles`.

## Related Links

- Closes https://github.com/web-infra-dev/rstest/issues/1644
- Follow-up to https://github.com/web-infra-dev/rstest/pull/1642

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
