### PR TITLE
refactor(adapter-rslib): replace tsconfck with get-tsconfig

### DIFF
--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -39,7 +39,7 @@
     "@rslib/core": "1.0.0-beta.1",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
-    "tsconfck": "3.1.6",
+    "get-tsconfig": "5.0.0-beta.5",
     "typescript": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/adapter-rslib/src/tsconfig.ts
+++ b/packages/adapter-rslib/src/tsconfig.ts
@@ -1,5 +1,13 @@
-import { basename, join } from 'node:path';
-import { find, parse } from 'tsconfck';
+import { statSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+
+const isFileSync = (filePath: string): boolean | undefined => {
+  try {
+    return statSync(filePath, { throwIfNoEntry: false })?.isFile();
+  } catch {
+    return false;
+  }
+};
 
 export async function loadTsconfig(
   root: string,
@@ -7,14 +15,16 @@ export async function loadTsconfig(
 ): Promise<{
   compilerOptions?: Record<string, any>;
 }> {
-  const tsconfigFileName = await find(join(root, tsconfigPath), {
-    root,
-    configName: basename(tsconfigPath),
-  });
+  const resolvedTsconfigPath = isAbsolute(tsconfigPath)
+    ? tsconfigPath
+    : join(root, tsconfigPath);
 
-  if (tsconfigFileName) {
-    const { tsconfig } = await parse(tsconfigFileName);
-    return tsconfig;
+  if (isFileSync(resolvedTsconfigPath)) {
+    const { readTsconfig } = await import('get-tsconfig');
+
+    return readTsconfig(resolvedTsconfigPath, {
+      typescriptVersion: false,
+    }).config;
   }
 
   return {};

--- a/packages/adapter-rslib/tests/fixtures/tsconfig/tsconfig.custom.json
+++ b/packages/adapter-rslib/tests/fixtures/tsconfig/tsconfig.custom.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "rootDir": "./custom"
+  }
+}

--- a/packages/adapter-rslib/tests/fixtures/tsconfig/tsconfig.json
+++ b/packages/adapter-rslib/tests/fixtures/tsconfig/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "rootDir": "./"
+  }
+}

--- a/packages/adapter-rslib/tests/tsconfig.test.ts
+++ b/packages/adapter-rslib/tests/tsconfig.test.ts
@@ -1,0 +1,38 @@
+import { join } from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import { loadTsconfig } from '../src/tsconfig';
+
+const fixtureDir = join(__dirname, 'fixtures/tsconfig');
+
+describe('loadTsconfig', () => {
+  it('should load tsconfig files', async () => {
+    const defaultTsconfig = await loadTsconfig(fixtureDir);
+    const customTsconfig = await loadTsconfig(
+      fixtureDir,
+      './tsconfig.custom.json',
+    );
+    const absoluteTsconfig = await loadTsconfig(
+      fixtureDir,
+      join(fixtureDir, 'tsconfig.custom.json'),
+    );
+
+    expect(defaultTsconfig).toEqual({
+      compilerOptions: {
+        rootDir: './',
+      },
+    });
+    expect(customTsconfig).toEqual({
+      compilerOptions: {
+        rootDir: './custom',
+      },
+    });
+    expect(absoluteTsconfig).toEqual(customTsconfig);
+  });
+
+  it('should return an empty object when the path is not a file', async () => {
+    await expect(
+      loadTsconfig(fixtureDir, 'non-existent.json'),
+    ).resolves.toEqual({});
+    await expect(loadTsconfig(fixtureDir, '.')).resolves.toEqual({});
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,9 +1043,9 @@ importers:
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
-      tsconfck:
-        specifier: 3.1.6
-        version: 3.1.6(typescript@6.0.3)
+      get-tsconfig:
+        specifier: 5.0.0-beta.5
+        version: 5.0.0-beta.5
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5710,6 +5710,10 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
   git-hooks-list@4.1.1:
     resolution: {integrity: sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==}
 
@@ -8408,17 +8412,6 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
-
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -13363,6 +13356,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   git-hooks-list@4.1.1: {}
 
   github-from-package@0.0.0:
@@ -16480,10 +16477,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
 
   tslib@2.8.1: {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -189,7 +189,6 @@ tinyspy
 transpiling
 treeshaking
 tsbuildinfo
-tsconfck
 tsdoc
 tsup
 unawaited


### PR DESCRIPTION
## Summary

Replace the unmaintained `tsconfck` dependency in `@rstest/adapter-rslib` with `get-tsconfig`, matching Rslib's tsconfig loading behavior while preserving existing compiler option semantics. The loader now resolves explicit relative and absolute paths, skips non-file paths, and dynamically loads the parser only when a tsconfig file exists.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1757
- https://github.com/dominikg/tsconfck/issues/240

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).