### PR TITLE
fix(core): support modern jsdom versions

### DIFF
--- a/e2e/dom/fixtures/rstest.envOptions.config.mts
+++ b/e2e/dom/fixtures/rstest.envOptions.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
   testEnvironment: {
     name: 'jsdom',
     options: {
+      console: true,
       url: 'http://localhost:8081/test-options',
     },
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -121,7 +121,7 @@
   },
   "peerDependencies": {
     "happy-dom": "^20.8.3",
-    "jsdom": "*"
+    "jsdom": ">=15.0.0"
   },
   "peerDependenciesMeta": {
     "happy-dom": {

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -21,6 +21,25 @@ type JSDOMBlobImpl = {
   _bytes?: Uint8Array;
 };
 
+type VirtualConsoleForwarder =
+  | {
+      forwardTo(console: Console): unknown;
+    }
+  | {
+      sendTo(console: Console): unknown;
+    };
+
+export const forwardVirtualConsole = (
+  virtualConsole: VirtualConsoleForwarder,
+  console: Console,
+): void => {
+  if ('forwardTo' in virtualConsole) {
+    virtualConsole.forwardTo(console);
+  } else {
+    virtualConsole.sendTo(console);
+  }
+};
+
 function installJSDOMObjectURL(
   window: DOMWindow,
   context: TestEnvironmentContext,
@@ -120,6 +139,11 @@ export const environment: TestEnvironment<typeof globalThis> = {
       ...restOptions
     } = options as JSDOMOptions;
     let cleanupObjectURLs = () => {};
+    const virtualConsole =
+      console && global.console ? new VirtualConsole() : undefined;
+    if (virtualConsole && global.console) {
+      forwardVirtualConsole(virtualConsole, global.console);
+    }
     const dom = new JSDOM(html, {
       pretendToBeVisual,
       resources:
@@ -127,10 +151,7 @@ export const environment: TestEnvironment<typeof globalThis> = {
         (userAgent ? new ResourceLoader({ userAgent }) : undefined),
       runScripts,
       url,
-      virtualConsole:
-        console && global.console
-          ? new VirtualConsole().sendTo(global.console)
-          : undefined,
+      virtualConsole,
       cookieJar: cookieJar ? new CookieJar() : undefined,
       includeNodeLocations,
       contentType,

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -1,7 +1,10 @@
 import { promisify } from 'node:util';
 import { expect, test } from '@rstest/core';
 import type { DOMWindow } from 'jsdom';
-import { environment } from '../../../../src/runtime/worker/env/jsdom';
+import {
+  environment,
+  forwardVirtualConsole,
+} from '../../../../src/runtime/worker/env/jsdom';
 
 const createTestGlobal = (): typeof globalThis =>
   ({
@@ -14,6 +17,36 @@ const createTestGlobal = (): typeof globalThis =>
     URL: globalThis.URL,
     URLSearchParams: globalThis.URLSearchParams,
   }) as typeof globalThis;
+
+test('forwards the console with the pre-v27 jsdom API', () => {
+  const forwarded: Console[] = [];
+
+  forwardVirtualConsole(
+    {
+      sendTo(console) {
+        forwarded.push(console);
+      },
+    },
+    console,
+  );
+
+  expect(forwarded).toEqual([console]);
+});
+
+test('forwards the console with the jsdom v27+ API', () => {
+  const forwarded: Console[] = [];
+
+  forwardVirtualConsole(
+    {
+      forwardTo(console) {
+        forwarded.push(console);
+      },
+    },
+    console,
+  );
+
+  expect(forwarded).toEqual([console]);
+});
 
 test('clears pending Node timers during jsdom teardown', async () => {
   const testGlobal = createTestGlobal();


### PR DESCRIPTION
## Summary

- Require jsdom 15 or newer instead of accepting every version.
- Support both `VirtualConsole.sendTo()` and `VirtualConsole.forwardTo()` so `testEnvironment.options.console` works across jsdom versions.

## Related Links

- https://github.com/jsdom/jsdom/releases/tag/27.0.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).