### PR TITLE
feat(playwright): support retry trace modes

### DIFF
--- a/e2e/browser-mode/basic.test.ts
+++ b/e2e/browser-mode/basic.test.ts
@@ -13,6 +13,7 @@ describe('browser mode - basic', () => {
     expect(cli.stdout).toContain('fakeTimers.test.ts');
     expect(cli.stdout).toContain('spy.test.ts');
     expect(cli.stdout).toContain('fixtures.test.ts');
+    expect(cli.stdout).toContain('retryContext.test.ts');
     expect(cli.stdout).not.toContain('/scheduler.html');
   });
 

--- a/e2e/browser-mode/fixtures/basic/tests/retryContext.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/retryContext.test.ts
@@ -1,0 +1,23 @@
+import { afterAll, expect, test as base } from '@rstest/core';
+
+const retryCounts: number[] = [];
+
+const test = base.extend<{ attempt: number }>({
+  attempt: async ({ task }, use) => {
+    retryCounts.push(task.retryCount);
+    await use(task.retryCount);
+  },
+});
+
+test(
+  'exposes the current retry count to fixtures',
+  { retry: 1 },
+  ({ attempt, task }) => {
+    expect(task.retryCount).toBe(attempt);
+    expect(attempt).toBe(1);
+  },
+);
+
+afterAll(() => {
+  expect(retryCounts).toEqual([0, 1]);
+});

--- a/e2e/playwright/fixtures/trace-env.test.ts
+++ b/e2e/playwright/fixtures/trace-env.test.ts
@@ -16,21 +16,32 @@ afterAll(async () => {
   await rm(outputDir, { recursive: true, force: true });
 });
 
-test.sequential('writes Playwright trace from env', async ({ page }) => {
-  await rm(outputDir, { recursive: true, force: true });
-  await mkdir(outputDir, { recursive: true });
+let attempts = 0;
 
-  await page.setContent('<h1>Env trace target</h1>');
-  await expect(page.locator('h1')).toHaveText('Env trace target');
-});
+test.sequential(
+  'writes Playwright trace from env',
+  { retry: 1 },
+  async ({ page, task }) => {
+    if (attempts === 0) {
+      await rm(outputDir, { recursive: true, force: true });
+      await mkdir(outputDir, { recursive: true });
+    }
+
+    expect(task.retryCount).toBe(attempts);
+    attempts++;
+    await page.setContent('<h1>Env trace target</h1>');
+    await expect(page.locator('h1')).toHaveText('Env trace target');
+    expect(attempts).toBe(2);
+  },
+);
 
 test.sequential('verifies Playwright trace from env', async () => {
-  const [traceEntry] = (await readdir(outputDir)).filter((entry) =>
+  const traceEntries = (await readdir(outputDir)).filter((entry) =>
     entry.startsWith('writes-Playwright-trace-from-env-'),
   );
-  expect(traceEntry).toBeTruthy();
+  expect(traceEntries).toHaveLength(1);
 
-  const traceDir = join(outputDir, traceEntry!);
+  const traceDir = join(outputDir, traceEntries[0]!);
   expect((await stat(join(traceDir, 'trace.zip'))).size).toBeGreaterThan(0);
 
   const summary = JSON.parse(

--- a/e2e/playwright/fixtures/trace.test.ts
+++ b/e2e/playwright/fixtures/trace.test.ts
@@ -1,20 +1,34 @@
 import { mkdir, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterAll, expect, test as base } from '@rstest/playwright';
-import type { PlaywrightOptions } from '@rstest/playwright';
+import type {
+  PlaywrightOptions,
+  PlaywrightTraceMode,
+} from '@rstest/playwright';
 
 const outputDir = join(import.meta.dirname, '.rstest test traces');
 
-const test = base.extend({
-  playwright: {
+const getPlaywrightOptions = (mode: PlaywrightTraceMode) =>
+  ({
     browserName: 'chromium',
     launchOptions: process.env.CI ? { channel: 'chrome' } : undefined,
     trace: {
-      mode: 'on',
+      mode,
       outputDir,
       print: false,
     },
-  } satisfies PlaywrightOptions,
+  }) satisfies PlaywrightOptions;
+
+const test = base.extend({
+  playwright: getPlaywrightOptions('on'),
+});
+
+const firstRetryTraceTest = base.extend({
+  playwright: getPlaywrightOptions('on-first-retry'),
+});
+
+const allRetriesTraceTest = base.extend({
+  playwright: getPlaywrightOptions('on-all-retries'),
 });
 
 afterAll(async () => {
@@ -100,4 +114,75 @@ test.sequential('verifies retry traces are not overwritten', async () => {
   }
 
   console.log('RSTEST_PLAYWRIGHT_TRACE_RETRY_OK');
+});
+
+firstRetryTraceTest.sequential(
+  'does not trace a passing initial attempt',
+  async ({ page, task }) => {
+    expect(task.retryCount).toBe(0);
+    await page.setContent('<h1>Initial attempt</h1>');
+  },
+);
+
+test.sequential(
+  'verifies a passing initial attempt was not traced',
+  async () => {
+    const traceEntries = (await readdir(outputDir)).filter((entry) =>
+      entry.startsWith('does-not-trace-a-passing-initial-attempt-'),
+    );
+
+    expect(traceEntries).toEqual([]);
+  },
+);
+
+let firstRetryTraceAttempts = 0;
+
+firstRetryTraceTest.sequential(
+  'traces only the first retry',
+  { retry: 2 },
+  async ({ page, task }) => {
+    expect(task.retryCount).toBe(firstRetryTraceAttempts);
+    firstRetryTraceAttempts++;
+    await page.setContent('<h1>First retry trace</h1>');
+    expect(firstRetryTraceAttempts).toBe(3);
+  },
+);
+
+test.sequential('verifies only the first retry was traced', async () => {
+  const traceEntries = (await readdir(outputDir)).filter((entry) =>
+    entry.startsWith('traces-only-the-first-retry-'),
+  );
+
+  expect(traceEntries).toHaveLength(1);
+  expect(
+    (await stat(join(outputDir, traceEntries[0]!, 'trace.zip'))).size,
+  ).toBeGreaterThan(0);
+  console.log('RSTEST_PLAYWRIGHT_TRACE_FIRST_RETRY_OK');
+});
+
+let allRetriesTraceAttempts = 0;
+
+allRetriesTraceTest.sequential(
+  'traces all retries',
+  { retry: 2 },
+  async ({ page, task }) => {
+    expect(task.retryCount).toBe(allRetriesTraceAttempts);
+    allRetriesTraceAttempts++;
+    await page.setContent('<h1>All retries trace</h1>');
+    expect(allRetriesTraceAttempts).toBe(3);
+  },
+);
+
+test.sequential('verifies all retries were traced', async () => {
+  const traceEntries = (await readdir(outputDir)).filter((entry) =>
+    entry.startsWith('traces-all-retries-'),
+  );
+
+  expect(traceEntries).toHaveLength(2);
+  for (const traceEntry of traceEntries) {
+    expect(
+      (await stat(join(outputDir, traceEntry, 'trace.zip'))).size,
+    ).toBeGreaterThan(0);
+  }
+  console.log('RSTEST_PLAYWRIGHT_TRACE_ALL_RETRIES_OK');
 });

--- a/e2e/playwright/index.test.ts
+++ b/e2e/playwright/index.test.ts
@@ -66,6 +66,8 @@ describe('@rstest/playwright', () => {
     await expectExecSuccess();
     expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_TRACE_OK');
     expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_TRACE_RETRY_OK');
+    expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_TRACE_FIRST_RETRY_OK');
+    expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_TRACE_ALL_RETRIES_OK');
     expect(cli.stdout).toContain('[rstest-playwright] Trace saved:');
   });
 
@@ -77,7 +79,7 @@ describe('@rstest/playwright', () => {
         nodeOptions: {
           cwd: join(__dirname, 'fixtures'),
           env: {
-            RSTEST_PLAYWRIGHT_TRACE: 'on',
+            RSTEST_PLAYWRIGHT_TRACE: 'on-first-retry',
             RSTEST_PLAYWRIGHT_TRACE_OUTPUT_DIR: '.rstest-env-traces',
           },
         },

--- a/e2e/test-api/fixtures/testOptionsRetryRepeats.test.ts
+++ b/e2e/test-api/fixtures/testOptionsRetryRepeats.test.ts
@@ -1,12 +1,38 @@
-import { expect, it } from '@rstest/core';
+import { afterAll, beforeEach, expect, test as base } from '@rstest/core';
 
 // retry × repeats: each repeat gets an independent retry budget. With
 // retry: 1 and repeats: 2, the first repeat passes on attempt 2 (retry used),
 // the second repeat passes on attempt 2 (retry used again), the third repeat
 // passes on attempt 2 (retry used a third time). Total executions = 6.
+const expectedRetryCounts = [0, 1, 0, 1, 0, 1];
+const fixtureRetryCounts: number[] = [];
+const hookRetryCounts: number[] = [];
+
+const test = base.extend<{ attempt: number }>({
+  attempt: async ({ task }, use) => {
+    fixtureRetryCounts.push(task.retryCount);
+    await use(task.retryCount);
+  },
+});
+
+beforeEach(({ task }) => {
+  hookRetryCounts.push(task.retryCount);
+});
+
 let runs = 0;
-it('retry budget is per-repeat', { retry: 1, repeats: 2 }, () => {
-  runs++;
-  // Fail on odd attempts (1, 3, 5) and pass on even attempts (2, 4, 6).
-  expect(runs % 2).toBe(0);
+test(
+  'retry budget is per-repeat',
+  { retry: 1, repeats: 2 },
+  ({ attempt, task }) => {
+    expect(attempt).toBe(task.retryCount);
+    expect(task.retryCount).toBe(runs % 2);
+    runs++;
+    // Fail on odd attempts (1, 3, 5) and pass on even attempts (2, 4, 6).
+    expect(runs % 2).toBe(0);
+  },
+);
+
+afterAll(() => {
+  expect(fixtureRetryCounts).toEqual(expectedRetryCounts);
+  expect(hookRetryCounts).toEqual(expectedRetryCounts);
 });

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -100,6 +100,7 @@ export class TestRunner {
         beforeEachListeners: BeforeEachListener[];
         afterEachListeners: AfterEachListener[];
       },
+      retryCount: number,
     ): Promise<TestResult> => {
       if (test.runMode === 'skip') {
         snapshotClient.skipTest(testPath, getTaskNameWithPrefix(test));
@@ -157,6 +158,7 @@ export class TestRunner {
         test,
         snapshotClient.getSnapshotState(testPath),
         fixtureCleanups,
+        retryCount,
       );
 
       try {
@@ -665,7 +667,11 @@ export class TestRunner {
               // attributed errors from earlier repeats that already passed.
               const repeatRetryErrors: FormattedError[] = [];
               do {
-                const currentResult = await runTestsCase(test, parentHooks);
+                const currentResult = await runTestsCase(
+                  test,
+                  parentHooks,
+                  retryCount,
+                );
 
                 if (currentResult.status === 'fail') {
                   repeatRetryErrors.push(
@@ -823,7 +829,7 @@ export class TestRunner {
     }
   }
 
-  private createTestContext(test: TestCase): TestContext {
+  private createTestContext(test: TestCase, retryCount: number): TestContext {
     const context = (() => {
       throw new Error('done() callback is deprecated, use promise instead');
     }) as unknown as TestContext;
@@ -837,6 +843,7 @@ export class TestRunner {
       name: test.name,
       filepath: toNativePath(test.testPath),
       projectRoot: toNativePath(this.workerState!.projectRoot),
+      retryCount,
       get meta() {
         return (test.meta ??= {});
       },
@@ -928,6 +935,7 @@ export class TestRunner {
     test: TestCase,
     snapshotState: SnapshotState,
     fixtureCleanups: (() => Promise<void>)[],
+    retryCount: number,
   ): FixtureResolver {
     setState<MatcherState>(
       {
@@ -946,7 +954,7 @@ export class TestRunner {
       (globalThis as any)[GLOBAL_EXPECT],
     );
 
-    const context = this.createTestContext(test);
+    const context = this.createTestContext(test, retryCount);
 
     // create test context
     Object.defineProperty(test, 'context', {

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -24,6 +24,8 @@ export interface TestContext {
     filepath?: string;
     /** Absolute path of the current project's root directory. */
     projectRoot?: string;
+    /** Current retry index, starting at 0 for the initial attempt. */
+    retryCount: number;
     /** Result of the current test, undefined if the test is not run yet */
     result?: TestResult;
     /** Mutable metadata copied to the current test result. */

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -257,7 +257,7 @@ import type { PlaywrightOptions } from '@rstest/playwright';
 
 const e2e = test.extend({
   playwright: {
-    trace: process.env.CI ? 'retain-on-failure' : 'off',
+    trace: process.env.CI ? 'on-first-retry' : 'off',
   } satisfies PlaywrightOptions,
 });
 
@@ -279,7 +279,7 @@ Use `RSTEST_PLAYWRIGHT_TRACE_OUTPUT_DIR` to override the default output director
 RSTEST_PLAYWRIGHT_TRACE=on RSTEST_PLAYWRIGHT_TRACE_OUTPUT_DIR=.rstest/playwright-traces rstest
 ```
 
-`trace` accepts `'off'`, `'on'`, `'retain-on-failure'`, or an options object:
+`trace` accepts `'off'`, `'on'`, `'retain-on-failure'`, `'on-first-retry'`, `'on-all-retries'`, or an options object. `on-first-retry` records and keeps only the first retry, while `on-all-retries` records and keeps every retry. Neither mode starts tracing during the initial attempt.
 
 ```ts
 const e2e = test.extend({

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -83,7 +83,8 @@ export type PlaywrightDebugOptions = {
   pauseOnFailure?: boolean;
 };
 
-export type PlaywrightTraceMode = 'off' | 'on' | 'retain-on-failure';
+export type PlaywrightTraceMode =
+  'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries';
 
 export type PlaywrightTraceOptions = {
   /**
@@ -289,7 +290,11 @@ const normalizeTraceOptions = (
 const normalizeTraceMode = (
   mode: string | undefined,
 ): PlaywrightTraceMode | undefined => {
-  return mode === 'on' || mode === 'off' || mode === 'retain-on-failure'
+  return mode === 'on' ||
+    mode === 'off' ||
+    mode === 'retain-on-failure' ||
+    mode === 'on-first-retry' ||
+    mode === 'on-all-retries'
     ? mode
     : undefined;
 };
@@ -313,7 +318,7 @@ const getTraceArtifacts = (
 ) => {
   const options = normalizeTraceOptions(playwright.trace);
 
-  if (options.mode === 'off') {
+  if (!shouldCaptureTrace(options.mode, task.retryCount)) {
     return;
   }
 
@@ -333,6 +338,15 @@ const getTraceArtifacts = (
     debugPath: join(dir, 'debug.md'),
   };
 };
+
+export const shouldCaptureTrace = (
+  mode: PlaywrightTraceMode,
+  retryCount: number,
+): boolean =>
+  mode === 'on' ||
+  mode === 'retain-on-failure' ||
+  (mode === 'on-first-retry' && retryCount === 1) ||
+  (mode === 'on-all-retries' && retryCount > 0);
 
 type TraceArtifacts = NonNullable<ReturnType<typeof getTraceArtifacts>>;
 
@@ -917,7 +931,10 @@ const playwrightFixtures = {
         try {
           if (artifacts && traceStarted) {
             const shouldSaveTrace =
-              artifacts.options.mode === 'on' || task.result?.status === 'fail';
+              artifacts.options.mode === 'on' ||
+              artifacts.options.mode === 'on-first-retry' ||
+              artifacts.options.mode === 'on-all-retries' ||
+              task.result?.status === 'fail';
             const shouldStageTrace =
               artifacts.options.mode === 'retain-on-failure' &&
               task.result?.status !== 'fail';

--- a/packages/playwright/tests/fixture.test.ts
+++ b/packages/playwright/tests/fixture.test.ts
@@ -7,7 +7,11 @@ import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { expect as coreExpect } from '@rstest/core';
 import { afterEach, beforeEach, expect, test } from '../src';
-import { getDebugOptions, resolveLaunchOptions } from '../src/fixture';
+import {
+  getDebugOptions,
+  resolveLaunchOptions,
+  shouldCaptureTrace,
+} from '../src/fixture';
 import type { Browser, BrowserContext, Page } from 'playwright';
 import type {
   PlaywrightFixture,
@@ -295,6 +299,30 @@ test('enables headed debug mode from PWDEBUG', () => {
       process.env.PWDEBUG = original;
     }
   }
+});
+
+test('selects Playwright trace attempts by mode', () => {
+  const retryCounts = [0, 1, 2];
+
+  expect(retryCounts.map((count) => shouldCaptureTrace('off', count))).toEqual([
+    false,
+    false,
+    false,
+  ]);
+  expect(retryCounts.map((count) => shouldCaptureTrace('on', count))).toEqual([
+    true,
+    true,
+    true,
+  ]);
+  expect(
+    retryCounts.map((count) => shouldCaptureTrace('retain-on-failure', count)),
+  ).toEqual([true, true, true]);
+  expect(
+    retryCounts.map((count) => shouldCaptureTrace('on-first-retry', count)),
+  ).toEqual([false, true, false]);
+  expect(
+    retryCounts.map((count) => shouldCaptureTrace('on-all-retries', count)),
+  ).toEqual([false, true, true]);
 });
 
 test.extend({}).describe('extended test API', () => {

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -567,6 +567,8 @@ export interface TestContext {
     filepath?: string;
     /** Absolute path of the current project's root directory when provided by the runner. Added in 0.11.1. */
     projectRoot?: string;
+    /** Current retry index, starting at 0 for the initial attempt. Added in 0.11.6. */
+    retryCount: number;
     /** Result of the current test, undefined if the test is not run yet */
     result?: TestResult;
     /** Mutable metadata copied to the current test result. Added in 0.11.1. */
@@ -582,6 +584,10 @@ export interface TestContext {
   onTestFailed: OnTestFailed;
 }
 ```
+
+<ApiMeta addedVersion="0.11.6" />
+
+Use `context.task.retryCount` to read the current retry index from tests, hooks, and fixtures. It is `0` for the initial attempt, `1` for the first retry, and resets to `0` for each run configured through `repeats`.
 
 Use `context.task.meta` to attach JSON-serializable metadata to the current test result. You can mutate the metadata object or replace it with a new metadata object. Custom reporters and the programmatic API can read this metadata from `TestResult.meta`:
 

--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -312,7 +312,7 @@ import type { PlaywrightOptions } from '@rstest/playwright';
 
 const e2e = test.extend({
   playwright: {
-    trace: process.env.CI ? 'retain-on-failure' : 'off',
+    trace: process.env.CI ? 'on-first-retry' : 'off',
   } satisfies PlaywrightOptions,
 });
 
@@ -334,7 +334,11 @@ Use `RSTEST_PLAYWRIGHT_TRACE_OUTPUT_DIR` to override the default output director
 RSTEST_PLAYWRIGHT_TRACE=on RSTEST_PLAYWRIGHT_TRACE_OUTPUT_DIR=.rstest/playwright-traces rstest
 ```
 
-`trace` accepts `'off'`, `'on'`, `'retain-on-failure'`, or an options object:
+`trace` accepts `'off'`, `'on'`, `'retain-on-failure'`, `'on-first-retry'`, `'on-all-retries'`, or an options object:
+
+<ApiMeta addedVersion="0.11.6" />
+
+`on-first-retry` records and keeps a trace only for the first retry. `on-all-retries` records and keeps a trace for every retry. Neither mode starts tracing during the initial attempt, so passing tests avoid trace startup and temporary artifact work.
 
 ```ts
 const e2e = test.extend({

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -556,6 +556,8 @@ export interface TestContext {
     filepath?: string;
     /** Absolute path of the current project's root directory when provided by the runner. Added in 0.11.1. */
     projectRoot?: string;
+    /** Current retry index, starting at 0 for the initial attempt. Added in 0.11.6. */
+    retryCount: number;
     /** Result of the current test, undefined if the test is not run yet */
     result?: TestResult;
     /** Mutable metadata copied to the current test result. Added in 0.11.1. */
@@ -571,6 +573,10 @@ export interface TestContext {
   onTestFailed: OnTestFailed;
 }
 ```
+
+<ApiMeta addedVersion="0.11.6" />
+
+你可以通过 `context.task.retryCount` 在测试、Hook 和 fixture 中读取当前的 retry index。初次尝试时该值为 `0`，第一次 retry 时为 `1`；配置 `repeats` 后，每次 repeat 都会从 `0` 重新计数。
 
 你可以使用 `context.task.meta` 给当前测试结果附加可 JSON 序列化的元数据。既可以修改该对象，也可以整体替换为一个新的 metadata 对象。自定义 Reporter 和 programmatic API 可以从 `TestResult.meta` 读取这些数据：
 

--- a/website/docs/zh/guide/advanced/playwright.mdx
+++ b/website/docs/zh/guide/advanced/playwright.mdx
@@ -312,7 +312,7 @@ import type { PlaywrightOptions } from '@rstest/playwright';
 
 const e2e = test.extend({
   playwright: {
-    trace: process.env.CI ? 'retain-on-failure' : 'off',
+    trace: process.env.CI ? 'on-first-retry' : 'off',
   } satisfies PlaywrightOptions,
 });
 
@@ -334,7 +334,11 @@ RSTEST_PLAYWRIGHT_TRACE=retain-on-failure rstest
 RSTEST_PLAYWRIGHT_TRACE=on RSTEST_PLAYWRIGHT_TRACE_OUTPUT_DIR=.rstest/playwright-traces rstest
 ```
 
-`trace` 支持 `'off'`、`'on'`、`'retain-on-failure'`，也支持传入 options 对象：
+`trace` 支持 `'off'`、`'on'`、`'retain-on-failure'`、`'on-first-retry'`、`'on-all-retries'`，也支持传入 options 对象：
+
+<ApiMeta addedVersion="0.11.6" />
+
+`on-first-retry` 只记录并保留第一次 retry 的 trace。`on-all-retries` 会记录并保留每次 retry 的 trace。两种模式在初次尝试时都不会启动 tracing，因此通过的测试不会产生 trace 启动和临时产物开销。
 
 ```ts
 const e2e = test.extend({


### PR DESCRIPTION
## Summary

- Expose `context.task.retryCount` to tests, hooks, and fixtures before fixture resolution, resetting it for each repeat.
- Add Playwright-compatible `on-first-retry` and `on-all-retries` trace modes without starting tracing on successful initial attempts.
- Cover Node, browser-mode, fixture config, and environment-variable behavior, and document the public API in English and Chinese.

## Related Links

- Closes https://github.com/web-infra-dev/rstest/issues/1654
- https://github.com/web-infra-dev/rspress/pull/3569

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).