### PR TITLE
fix(core): remove full stack fallback message

### DIFF
--- a/e2e/test-api/edgeCase.test.ts
+++ b/e2e/test-api/edgeCase.test.ts
@@ -52,9 +52,7 @@ describe('Test Edge Cases', () => {
     });
     await expectExecFailed();
 
-    expectStderrLog(
-      "No user error stack found, showing fullStack. Set 'DEBUG=rstest' to always show fullStack.",
-    );
+    expect(cli.stderr).not.toContain('No user error stack found');
     expect(cli.stderr).not.toContain('nativeFrame');
     expectStderrLog('at fallbackFrame (node:internal/rstest_fallback:10:5)');
     expectStderrLog('at hiddenFrame (node:internal/rstest_hidden:20:6)');

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -90,11 +90,6 @@ export async function printError(
       );
 
       if (printableFullStackFrames[0]) {
-        logger.stderr(
-          color.gray(
-            "No user error stack found, showing fullStack. Set 'DEBUG=rstest' to always show fullStack.",
-          ),
-        );
         stackFrames = printableFullStackFrames;
       } else {
         logger.stderr(


### PR DESCRIPTION
## Summary

- Remove the redundant notice emitted when Rstest successfully falls back to an unfiltered stack.
- Preserve the fallback stack frames and update the existing end-to-end coverage for the quieter output.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).