### PR TITLE
fix(browser): run globalSetup when listing tests

### DIFF
--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/tests/node.test.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/tests/node.test.ts
@@ -1,5 +1,7 @@
-import { expect, it } from '@rstest/core';
+import { describe, expect, it } from '@rstest/core';
 
-it('reads the node project globalSetup env change', () => {
-  expect(process.env.RSTEST_E2E_GS_NODE).toBe('from-node-setup');
+describe(`node collection sees browser setup (${process.env.RSTEST_E2E_GS_BROWSER})`, () => {
+  it('reads the node project globalSetup env change', () => {
+    expect(process.env.RSTEST_E2E_GS_NODE).toBe('from-node-setup');
+  });
 });

--- a/e2e/browser-mode/fixtures/browser-global-setup/tests/globalSetup.test.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/tests/globalSetup.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 
-describe('browser globalSetup env propagation', () => {
+describe(`browser globalSetup env propagation (${import.meta.env.RSTEST_E2E_GS})`, () => {
   it('reads env changes made by globalSetup on the host', () => {
     console.log('[browser-global-setup-test] running');
 

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -140,6 +140,27 @@ describe('browser mode - globalSetup', () => {
     expect(teardownIndex).toBeGreaterThan(testIndex);
   });
 
+  it('runs globalSetup and teardown around browser test collection', async () => {
+    const { cli, expectExecSuccess } = await runBrowserCli(
+      'browser-global-setup',
+      { command: 'list' },
+    );
+
+    await expectExecSuccess();
+
+    const setupIndex = cli.stdout.indexOf('[browser-global-setup] executed');
+    const testIndex = cli.stdout.indexOf(
+      'tests/globalSetup.test.ts > browser globalSetup env propagation (from-global-setup) > reads env changes made by globalSetup on the host',
+    );
+    const teardownIndex = cli.stdout.indexOf(
+      '[browser-global-teardown] executed',
+    );
+
+    expect(setupIndex).toBeGreaterThanOrEqual(0);
+    expect(testIndex).toBeGreaterThan(setupIndex);
+    expect(teardownIndex).toBeGreaterThan(testIndex);
+  });
+
   it('skips globalSetup when the shard slice has no files for the project', async () => {
     // The fixture has a single test file: shard 2/2 is deterministically
     // empty, so the stage must not run setup (or queue teardown) for it —

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -203,6 +203,30 @@ describe('browser mode - globalSetup', () => {
     expect(cli.stdout).toMatch(/Tests.*2 passed/);
   });
 
+  for (const [name, args] of [
+    ['without sharding', []],
+    ['with sharding', ['--shard=1/1']],
+  ] as const) {
+    it(`runs browser globalSetup before mixed node test collection ${name}`, async () => {
+      const { cli, expectExecSuccess } = await runBrowserCli(
+        'browser-global-setup-mixed',
+        { command: 'list', args: [...args] },
+      );
+
+      await expectExecSuccess();
+
+      const setupIndex = cli.stdout.indexOf(
+        '[mixed-browser-global-setup] executed',
+      );
+      const nodeTestIndex = cli.stdout.indexOf(
+        'project-node/tests/node.test.ts > node collection sees browser setup (from-browser-setup) > reads the node project globalSetup env change',
+      );
+
+      expect(setupIndex).toBeGreaterThanOrEqual(0);
+      expect(nodeTestIndex).toBeGreaterThan(setupIndex);
+    });
+  }
+
   it('drains global teardown on the mixed path when a file filter selects only the browser project', async () => {
     // With no node tests to run, the node executor is never constructed, so the
     // teardown drain must live in core — otherwise the setup's IPC child leaks

--- a/packages/browser/src/browserExecutor.ts
+++ b/packages/browser/src/browserExecutor.ts
@@ -110,13 +110,14 @@ export async function createBrowserExecutor(
         inFlightCycle = undefined;
       }
     },
-    async collect(): Promise<{ list: ListCommandResult[] }> {
+    async collect(opts): Promise<{ list: ListCommandResult[] }> {
       const pending = listBrowserTests(context, {
         projects,
         shardedEntries,
         freezeShardedEntries,
         filesOnly,
         appliedModifyRstestConfigEnvironments,
+        env: opts.env,
       });
       inFlightCycle = pending;
       try {

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -4463,7 +4463,10 @@ export const listBrowserTests = async (
       environmentName: project.environmentName,
       projectRoot: normalize(project.rootPath),
       runtimeConfig: serializableConfig(
-        projectRuntimeConfig(project, { envMode: 'static' }),
+        projectRuntimeConfig(project, {
+          envMode: 'static',
+          envOverlay: options?.env,
+        }),
       ),
       viewport: project.normalizedConfig.browser.viewport,
     }),

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -26,7 +26,11 @@ import {
   runGlobalSetup,
   runGlobalTeardown,
 } from './globalSetup';
-import { runBrowserGlobalSetupStage } from './browser/globalSetupStage';
+import {
+  type BrowserGlobalSetupStageResult,
+  runBrowserGlobalSetupStage,
+} from './browser/globalSetupStage';
+import type { BrowserTestExecutor } from './browser/loader';
 import { createSetupFileState } from './setupFileState';
 import { createRsbuildServer, prepareRsbuild } from './rsbuild';
 import { isBrowserProject, isNodeProject } from './isBrowserProject';
@@ -39,6 +43,12 @@ type ListedTest = {
   project?: string;
   location?: Location;
   type: 'file' | 'suite' | 'case';
+};
+
+type PreparedBrowserCollection = {
+  executor: BrowserTestExecutor;
+  stage: BrowserGlobalSetupStageResult;
+  shardedEntries?: Map<string, { entries: Record<string, string> }>;
 };
 
 const SummaryProjectLabel = color.gray('Projects'.padStart(11));
@@ -152,12 +162,14 @@ const collectNodeTests = async ({
   context,
   nodeProjects,
   globTestSourceEntries,
+  beforeCollect,
   onRsbuildConfigResolved,
   onModifyRstestConfigApplied,
 }: {
   context: RstestContext;
   nodeProjects: ProjectContext[];
   globTestSourceEntries: (name: string) => Promise<Record<string, string>>;
+  beforeCollect?: () => Promise<void>;
   onRsbuildConfigResolved?: () => Promise<void>;
   onModifyRstestConfigApplied?: () => Promise<void>;
 }) => {
@@ -202,6 +214,13 @@ const collectNodeTests = async ({
     rsbuildInstance,
     rootPath: context.rootPath,
   });
+
+  try {
+    await beforeCollect?.();
+  } catch (error) {
+    await closeServer();
+    throw error;
+  }
 
   const pool = await createPool({
     context,
@@ -292,6 +311,7 @@ const collectBrowserTests = async ({
   freezeShardedEntries,
   filesOnly,
   appliedModifyRstestConfigEnvironments,
+  prepared,
 }: {
   context: RstestContext;
   browserProjects: ProjectContext[];
@@ -299,6 +319,7 @@ const collectBrowserTests = async ({
   freezeShardedEntries?: boolean;
   filesOnly?: boolean;
   appliedModifyRstestConfigEnvironments?: Set<string>;
+  prepared?: PreparedBrowserCollection;
 }): Promise<{
   errors?: FormattedError[];
   list: ListCommandResult[];
@@ -315,12 +336,14 @@ const collectBrowserTests = async ({
   // one browser entry point (import stays dynamic: no browser module load for
   // node-only lists).
   const { loadBrowserExecutor } = await import('./browser/loader');
-  const executor = await loadBrowserExecutor(context, browserProjects, null, {
-    shardedEntries,
-    freezeShardedEntries,
-    filesOnly,
-    appliedModifyRstestConfigEnvironments,
-  });
+  const executor =
+    prepared?.executor ??
+    (await loadBrowserExecutor(context, browserProjects, null, {
+      shardedEntries,
+      freezeShardedEntries,
+      filesOnly,
+      appliedModifyRstestConfigEnvironments,
+    }));
 
   const close = async () => {
     try {
@@ -333,9 +356,10 @@ const collectBrowserTests = async ({
   try {
     const stage = filesOnly
       ? undefined
-      : await runBrowserGlobalSetupStage(context, browserProjects, {
+      : (prepared?.stage ??
+        (await runBrowserGlobalSetupStage(context, browserProjects, {
           entriesCache: shardedEntries,
-        });
+        })));
     if (stage?.errors.length) {
       return { list: [], errors: stage.errors, close };
     }
@@ -406,35 +430,72 @@ const collectAllTests = async ({
   // Separate browser and node mode projects
   const browserProjects = context.projects.filter(isBrowserProject);
   const nodeProjects = context.projects.filter(isNodeProject);
+  const freezeShardedEntries = Boolean(
+    context.normalizedConfig.shard && nodeProjects.length,
+  );
+  let preparedBrowserCollection: PreparedBrowserCollection | undefined;
+
+  const prepareBrowserCollection = async () => {
+    if (!browserProjects.length) {
+      return;
+    }
+
+    const shardedEntries = getShardedEntries?.();
+    const { loadBrowserExecutor } = await import('./browser/loader');
+    const executor = await loadBrowserExecutor(context, browserProjects, null, {
+      shardedEntries,
+      freezeShardedEntries,
+      appliedModifyRstestConfigEnvironments,
+    });
+
+    try {
+      const stage = await runBrowserGlobalSetupStage(context, browserProjects, {
+        entriesCache: shardedEntries,
+      });
+      preparedBrowserCollection = { executor, stage, shardedEntries };
+    } catch (error) {
+      await executor.close().catch(() => undefined);
+      throw error;
+    }
+  };
 
   const collectBrowser = () =>
     collectBrowserTests({
       context,
       browserProjects,
-      shardedEntries: getShardedEntries?.(),
-      freezeShardedEntries: Boolean(
-        context.normalizedConfig.shard && nodeProjects.length,
-      ),
+      shardedEntries:
+        preparedBrowserCollection?.shardedEntries ?? getShardedEntries?.(),
+      freezeShardedEntries,
       appliedModifyRstestConfigEnvironments,
+      prepared: preparedBrowserCollection,
     });
 
   if (collectBrowserAfterConfigHooks && nodeProjects.length) {
     let refreshedAfterConfigHooks = false;
-    const nodeResult = await collectNodeTests({
-      context,
-      nodeProjects,
-      globTestSourceEntries,
-      onRsbuildConfigResolved,
-      onModifyRstestConfigApplied: async () => {
-        refreshedAfterConfigHooks = true;
-        await onModifyRstestConfigApplied?.();
-      },
-    });
-    if (
-      !refreshedAfterConfigHooks &&
-      !context.projects.some((project) => project._environmentGroup)
-    ) {
-      await onModifyRstestConfigApplied?.();
+    let nodeResult: Awaited<ReturnType<typeof collectNodeTests>>;
+    try {
+      nodeResult = await collectNodeTests({
+        context,
+        nodeProjects,
+        globTestSourceEntries,
+        beforeCollect: async () => {
+          if (
+            !refreshedAfterConfigHooks &&
+            !context.projects.some((project) => project._environmentGroup)
+          ) {
+            await onModifyRstestConfigApplied?.();
+          }
+          await prepareBrowserCollection();
+        },
+        onRsbuildConfigResolved,
+        onModifyRstestConfigApplied: async () => {
+          refreshedAfterConfigHooks = true;
+          await onModifyRstestConfigApplied?.();
+        },
+      });
+    } catch (error) {
+      await preparedBrowserCollection?.executor.close().catch(() => undefined);
+      throw error;
     }
     let browserResult: Awaited<ReturnType<typeof collectBrowser>>;
     try {
@@ -453,6 +514,8 @@ const collectAllTests = async ({
       },
     };
   }
+
+  await prepareBrowserCollection();
 
   // Settle both sides before unwrapping: a fail-fast `Promise.all` would leak
   // the surviving side's resources (node rsbuild server + pool, or browser

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -26,6 +26,7 @@ import {
   runGlobalSetup,
   runGlobalTeardown,
 } from './globalSetup';
+import { runBrowserGlobalSetupStage } from './browser/globalSetupStage';
 import { createSetupFileState } from './setupFileState';
 import { createRsbuildServer, prepareRsbuild } from './rsbuild';
 import { isBrowserProject, isNodeProject } from './isBrowserProject';
@@ -299,6 +300,7 @@ const collectBrowserTests = async ({
   filesOnly?: boolean;
   appliedModifyRstestConfigEnvironments?: Set<string>;
 }): Promise<{
+  errors?: FormattedError[];
   list: ListCommandResult[];
   close: () => Promise<void>;
 }> => {
@@ -319,12 +321,29 @@ const collectBrowserTests = async ({
     filesOnly,
     appliedModifyRstestConfigEnvironments,
   });
+
+  const close = async () => {
+    try {
+      await runGlobalTeardown();
+    } finally {
+      await executor.close();
+    }
+  };
+
   try {
-    const { list } = await executor.collect({});
-    return { list, close: () => executor.close() };
+    const stage = filesOnly
+      ? undefined
+      : await runBrowserGlobalSetupStage(context, browserProjects, {
+          entriesCache: shardedEntries,
+        });
+    if (stage?.errors.length) {
+      return { list: [], errors: stage.errors, close };
+    }
+
+    const { list } = await executor.collect({ env: stage?.env });
+    return { list, close };
   } catch (error) {
-    // A rejected collect cleans up host-side resources, but the executor must
-    // still be closed so an in-flight launch cannot outlive the failure.
+    // A rejected setup or collect must still close an in-flight browser launch.
     await executor.close().catch(() => undefined);
     throw error;
   }
@@ -426,7 +445,7 @@ const collectAllTests = async ({
     }
 
     return {
-      errors: nodeResult.errors,
+      errors: [...(nodeResult.errors ?? []), ...(browserResult.errors ?? [])],
       list: [...nodeResult.list, ...browserResult.list],
       getSourceMap: nodeResult.getSourceMap,
       close: async () => {
@@ -468,7 +487,7 @@ const collectAllTests = async ({
   ]);
 
   return {
-    errors: nodeResult.errors,
+    errors: [...(nodeResult.errors ?? []), ...(browserResult.errors ?? [])],
     list: [...nodeResult.list, ...browserResult.list],
     getSourceMap: nodeResult.getSourceMap,
     close: async () => {
@@ -652,17 +671,12 @@ export async function listTests(
     }
   }
 
-  const {
-    list,
-    close,
-    getSourceMap,
-    errors = [],
-  } = filesOnly
-    ? await collectTestFiles({
+  const collection = filesOnly
+    ? collectTestFiles({
         context,
         globTestSourceEntries,
       })
-    : await collectAllTests({
+    : collectAllTests({
         context,
         globTestSourceEntries,
         getShardedEntries: shard
@@ -678,6 +692,14 @@ export async function listTests(
         appliedModifyRstestConfigEnvironments:
           appliedBrowserModifyRstestConfigEnvironments,
       });
+  let collected: Awaited<typeof collection>;
+  try {
+    collected = await collection;
+  } catch (error) {
+    await runGlobalTeardown();
+    throw error;
+  }
+  const { list, close, getSourceMap, errors = [] } = collected;
 
   const tests: ListedTest[] = [];
 

--- a/packages/core/src/types/browser.ts
+++ b/packages/core/src/types/browser.ts
@@ -86,6 +86,7 @@ export type ListBrowserTestsOptions = Pick<
   | 'filesOnly'
   | 'projects'
   | 'appliedModifyRstestConfigEnvironments'
+  | 'env'
 >;
 
 /**

--- a/packages/core/src/types/executor.ts
+++ b/packages/core/src/types/executor.ts
@@ -116,7 +116,7 @@ export interface TestExecutor {
    * later phase converges it onto the seam.
    */
   collect?(
-    options: Pick<ExecutorRunCycleOptions, 'fileFilters'>,
+    options: Pick<ExecutorRunCycleOptions, 'env' | 'fileFilters'>,
   ): Promise<{ list: ListCommandResult[] }>;
   close(): Promise<void>;
   /**


### PR DESCRIPTION
## Summary

Browser Mode previously entered test collection directly for `rstest list`, so project `globalSetup` hooks did not run and collection-time dependencies were unavailable. This PR runs the existing browser global-setup stage before collection, forwards its environment changes into the browser runtime, and drains teardown after listing completes.

A browser e2e regression now verifies setup, collection-time environment propagation, and teardown ordering.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1639

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).