### PR TITLE
fix(deps): relax core peer dependency ranges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ _Note_: `rslint --type-check` is the repo's type check and exists at the root on
 - Public API or config changes usually require docs updates.
 - Behavioral changes require corresponding e2e coverage unless there is a clear reason existing coverage is sufficient.
 - If a config option is shared with Rsbuild/Rslib/Rspack, check whether the adapters need to transform or pass it through consistently.
+- Keep release-train versions separate from `@rstest/core` compatibility: peer ranges must start at the oldest supported core version instead of using `workspace:^`. Update the range when a package consumes a newer core capability, and review it at every potentially breaking core boundary (each minor while core is `0.x`, then each major from `1.x` onward).
 - Do not make repo-wide rewrites unless explicitly asked.
 - Do not revert unrelated local changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,8 @@ _Note_: `rslint --type-check` is the repo's type check and exists at the root on
 - Public API or config changes usually require docs updates.
 - Behavioral changes require corresponding e2e coverage unless there is a clear reason existing coverage is sufficient.
 - If a config option is shared with Rsbuild/Rslib/Rspack, check whether the adapters need to transform or pass it through consistently.
-- Keep release-train versions separate from `@rstest/core` compatibility: peer ranges must start at the oldest supported core version instead of using `workspace:^`. Update the range when a package consumes a newer core capability, and review it at every potentially breaking core boundary (each minor while core is `0.x`, then each major from `1.x` onward).
+- Keep release-train versions separate from `@rstest/core` compatibility: stable peer ranges must start at the oldest supported core version. When a package starts consuming an unreleased core capability, use `workspace:^` only as a temporary marker for the next release.
+- In every `release:` PR, replace temporary `workspace:^` peer markers with the actual release range, confirm every `@rstest/core` peer range accepts the new core version, and review ranges at each potentially breaking core boundary (each minor while core is `0.x`, then each major from `1.x` onward). Do not raise a package's lower bound when its core compatibility did not change.
 - Do not make repo-wide rewrites unless explicitly asked.
 - Do not revert unrelated local changes.
 

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.0 || ^2.0.0",
-    "@rstest/core": "workspace:^"
+    "@rstest/core": "^0.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@rslib/core": ">=0.18.6 || ^1.0.0-0",
-    "@rstest/core": "workspace:^",
+    "@rstest/core": "^0.11.0",
     "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@rspack/cli": "^2.0.0",
     "@rspack/core": "^2.0.0",
-    "@rstest/core": "workspace:^"
+    "@rstest/core": "^0.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -46,7 +46,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "^0.11.4",
+    "@rstest/core": "^0.11.6",
     "playwright": "^1.49.1"
   },
   "engines": {

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -46,7 +46,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "workspace:^",
+    "@rstest/core": "^0.11.4",
     "playwright": "^1.49.1"
   },
   "engines": {

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -46,7 +46,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "^0.11.6",
+    "@rstest/core": "workspace:^",
     "playwright": "^1.49.1"
   },
   "engines": {


### PR DESCRIPTION
## Summary

This PR prevents patch releases from unnecessarily forcing consumers to upgrade every Rstest package together.

- Support `@rstest/core` from `0.11.0` in the three adapters.
- Keep `workspace:^` as a temporary marker when a package consumes an unreleased core capability.
- Require each `release:` PR to replace temporary markers with the actual release range and preserve older compatible lower bounds elsewhere.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).