### PR TITLE
fix(core): force webpack runtime mode

### DIFF
--- a/e2e/browser-mode/fixtures/basic/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/basic/rstest.config.mts
@@ -2,6 +2,13 @@ import { defineConfig } from '@rstest/core';
 import { BROWSER_PORTS, BROWSER_TEST_TIMEOUT } from '../ports';
 
 export default defineConfig({
+  tools: {
+    rspack: {
+      experiments: {
+        runtimeMode: 'rspack',
+      },
+    },
+  },
   browser: {
     enabled: true,
     provider: 'playwright',

--- a/e2e/build/fixtures/tools/rspack/rstest.config.mts
+++ b/e2e/build/fixtures/tools/rspack/rstest.config.mts
@@ -5,6 +5,9 @@ export default defineConfig({
   name: 'node',
   tools: {
     rspack: {
+      experiments: {
+        runtimeMode: 'rspack',
+      },
       resolve: {
         alias: {
           './a': path.join(__dirname, './src/b'),

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -11,6 +11,7 @@ import { getTempRstestOutputDir, resolveProjectBuildCache } from '../../utils';
 import { runtimeChunkNameForEnvironment } from '../runtimeChunk';
 import {
   applyMockExportsPresence,
+  forceWebpackRuntimeMode,
   getMockRstestPluginOptions,
   importMetaRstestDefine,
 } from './mockBuild';
@@ -171,16 +172,13 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 type: 'javascript/esm',
               });
 
-              config.experiments ??= {};
-              // TODO: Remove this override once RstestPlugin's custom runtime
-              // module is compatible with Rspack's experimental runtime.
-              config.experiments.runtimeMode = 'webpack';
+              const experiments = forceWebpackRuntimeMode(config);
               // Disable rspack's built-in `webassembly/async` handling and turn
               // every `.wasm` into a self-contained JS module via wasmLoader.mjs
               // that reads its on-disk SOURCE bytes and instantiates them, so
               // there is no `async_wasm_loading` runtime and no `readFile(`
               // string-replace. All wasm reads resolve source-relative (#1455).
-              config.experiments.asyncWebAssembly = false;
+              experiments.asyncWebAssembly = false;
               config.module.rules.push({
                 test: /\.wasm$/,
                 type: 'javascript/auto',

--- a/packages/core/src/core/plugins/basic.ts
+++ b/packages/core/src/core/plugins/basic.ts
@@ -171,12 +171,15 @@ export const pluginBasic: (context: RstestContext) => RsbuildPlugin = (
                 type: 'javascript/esm',
               });
 
+              config.experiments ??= {};
+              // TODO: Remove this override once RstestPlugin's custom runtime
+              // module is compatible with Rspack's experimental runtime.
+              config.experiments.runtimeMode = 'webpack';
               // Disable rspack's built-in `webassembly/async` handling and turn
               // every `.wasm` into a self-contained JS module via wasmLoader.mjs
               // that reads its on-disk SOURCE bytes and instantiates them, so
               // there is no `async_wasm_loading` runtime and no `readFile(`
               // string-replace. All wasm reads resolve source-relative (#1455).
-              config.experiments ??= {};
               config.experiments.asyncWebAssembly = false;
               config.module.rules.push({
                 test: /\.wasm$/,

--- a/packages/core/src/core/plugins/mockBuild.ts
+++ b/packages/core/src/core/plugins/mockBuild.ts
@@ -7,6 +7,16 @@ export type RstestBuildTarget = 'node' | 'web';
 
 type RspackInstance = ModifyRspackConfigUtils['rspack'];
 
+export const forceWebpackRuntimeMode = (
+  config: Rspack.Configuration,
+): NonNullable<Rspack.Configuration['experiments']> => {
+  const experiments = (config.experiments ??= {});
+  // TODO: Remove this override once Rstest's custom runtime modules are
+  // compatible with Rspack's experimental runtime.
+  experiments.runtimeMode = 'webpack';
+  return experiments;
+};
+
 /**
  * The `import.meta.rstest` define text for each executor. The node form is
  * byte-identical to the historical inline literal in `pluginBasic`; the web
@@ -141,6 +151,7 @@ export const applyWebMockRspackConfig = (
   config: Rspack.Configuration,
   options: { rspack: RspackInstance; rootPath: string },
 ): void => {
+  forceWebpackRuntimeMode(config);
   config.plugins ??= [];
   config.plugins.push(
     new options.rspack.experiments.RstestPlugin(

--- a/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
+++ b/packages/core/tests/core/__snapshots__/rsbuild.test.ts.snap
@@ -7,6 +7,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (esm output) 1
   "entry": {},
   "experiments": {
     "asyncWebAssembly": false,
+    "runtimeMode": "webpack",
     "sourceImport": true,
   },
   "externals": [
@@ -704,6 +705,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (jsdom) 1`] = 
   "entry": {},
   "experiments": {
     "asyncWebAssembly": false,
+    "runtimeMode": "webpack",
     "sourceImport": true,
   },
   "externals": [
@@ -1386,6 +1388,7 @@ exports[`prepareRsbuild > should generate rspack config correctly (node) 1`] = `
   "entry": {},
   "experiments": {
     "asyncWebAssembly": false,
+    "runtimeMode": "webpack",
     "sourceImport": true,
   },
   "externals": [
@@ -2055,6 +2058,7 @@ exports[`prepareRsbuild > should generate rspack config correctly in watch mode 
   "entry": [Function],
   "experiments": {
     "asyncWebAssembly": false,
+    "runtimeMode": "webpack",
     "sourceImport": true,
   },
   "externals": [
@@ -3071,6 +3075,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
   "entry": {},
   "experiments": {
     "asyncWebAssembly": false,
+    "runtimeMode": "webpack",
     "sourceImport": true,
   },
   "externals": [
@@ -3753,6 +3758,7 @@ exports[`prepareRsbuild > should generate rspack config correctly with projects 
   "entry": {},
   "experiments": {
     "asyncWebAssembly": false,
+    "runtimeMode": "webpack",
     "sourceImport": true,
   },
   "externals": [

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -1566,7 +1566,13 @@ describe('prepareRsbuild', () => {
               resolve: {},
               source: {},
               output: {},
-              tools: {},
+              tools: {
+                rspack: {
+                  experiments: {
+                    runtimeMode: 'rspack',
+                  },
+                },
+              },
               testEnvironment: {
                 name: 'node',
               },
@@ -1584,6 +1590,7 @@ describe('prepareRsbuild', () => {
       origin: { bundlerConfigs },
     } = await rsbuildInstance.inspectConfig();
 
+    expect(bundlerConfigs[0]?.experiments?.runtimeMode).toBe('webpack');
     expect(bundlerConfigs[0]).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary

Rspack's experimental runtime mode rejects the custom runtime module injected by `RstestPlugin`, causing test runs to fail when `tools.rspack.experiments.runtimeMode` is set to `rspack`. This PR forces `webpack` runtime mode in `@rstest/core` until the custom runtime is compatible, and adds unit and end-to-end regression coverage for the override.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).