### PR TITLE
refactor(core): remove redundant worker count clamp

### DIFF
--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -10,7 +10,6 @@ import type {
 import type { CoverageMap, CoverageProvider } from '../../types/coverage';
 import { color, logger, type TraceRun } from '../../utils';
 import { ensureTestEnvironmentDependencies } from '../envDependencies';
-import { isNodeProject } from '../isBrowserProject';
 import {
   claimGlobalSetupOnce,
   runGlobalSetup,
@@ -331,21 +330,7 @@ export function createNodeExecutor(
       [],
     );
 
-    const getRecommendWorkerCount = (): number => {
-      const nodeEntries = Array.from(entriesCache.entries()).filter(([key]) => {
-        const project = projects.find((p) => p.environmentName === key);
-        return !project || isNodeProject(project);
-      });
-      return nodeEntries.flatMap(
-        ([_key, entry]) => Object.values(entry.entries) || [],
-      ).length;
-    };
-
-    const recommendWorkerCount = isWatchMode
-      ? Number.POSITIVE_INFINITY
-      : getRecommendWorkerCount();
-
-    const pool = await createPool({ context, recommendWorkerCount });
+    const pool = await createPool({ context });
 
     runResources = { getRsbuildStats, closeServer, pool };
     return runResources;

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -24,7 +24,7 @@ import {
 } from '../utils';
 import { type TraceEvent, type TraceSpan, noopTraceSpan } from '../utils/trace';
 import { isMemorySufficient } from '../utils/memory';
-import { getNumCpus, parseWorkers, resolveWorkerCount } from '../utils/workers';
+import { getNumCpus, parseWorkers } from '../utils/workers';
 import { selectMemoryGate } from './memoryGate';
 import { getEnvironmentKey } from '../core/environmentGroups';
 import { projectRuntimeConfig } from '../core/runtimeConfigProjection';
@@ -273,10 +273,8 @@ const workerErrorToResult = (
 
 export const createPool = async ({
   context,
-  recommendWorkerCount = Number.POSITIVE_INFINITY,
 }: {
   context: RstestContext;
-  recommendWorkerCount?: number;
 }): Promise<{
   runTests: (params: {
     entries: EntryInfo[];
@@ -334,17 +332,10 @@ export const createPool = async ({
 
   const workerKind: PoolWorkerKind = poolOptions.type ?? 'forks';
 
-  // CPU-derived worker recommendation via the shared override/clamp policy.
-  // The node pool's own formulas: `numCpus - 1` outside watch, half the raw CPU
-  // count in watch; watch passes `recommendWorkerCount` as `Infinity` to keep
-  // warm workers across reruns.
-  const recommendCount = resolveWorkerCount({
-    command: context.command,
-    totalTasks: recommendWorkerCount,
-    recommended: Math.max(numCpus - 1, 1),
-    watchRecommended: Math.max(Math.floor(numCpus / 2), 1),
-    numCpus,
-  });
+  const recommendCount =
+    context.command === 'watch'
+      ? Math.max(Math.floor(numCpus / 2), 1)
+      : Math.max(numCpus - 1, 1);
 
   const maxWorkers = poolOptions.maxWorkers
     ? parseWorkers(poolOptions.maxWorkers, numCpus)

--- a/packages/core/src/utils/workers.ts
+++ b/packages/core/src/utils/workers.ts
@@ -12,8 +12,8 @@ export interface ResolveWorkerCountOptions {
   maxWorkers?: string | number;
   /**
    * Workload upper bound (test file count). The result never exceeds it, so we
-   * never spin more workers than there are files. Pass `Infinity` to opt out
-   * (the node pool does this in watch to keep warm workers across reruns).
+   * never schedule more workers than there are files. Pass `Infinity` to opt
+   * out.
    */
   totalTasks: number;
   /** The caller's CPU-derived recommendation outside watch. */
@@ -25,11 +25,8 @@ export interface ResolveWorkerCountOptions {
 }
 
 /**
- * Shared worker-count policy for both executors — the node pool (`pool/index.ts`)
- * and the browser headless scheduler (`@rstest/browser` `concurrency.ts`).
- * Each caller supplies its own CPU-derived recommendations (the node pool halves
- * the raw CPU count in watch; the browser headless path halves its capped base);
- * what is centralized here is the shared override/clamp policy: an explicit
+ * Worker-count policy for schedulers that eagerly start a fixed number of
+ * workers. The caller supplies its CPU-derived recommendations; an explicit
  * `maxWorkers` always wins, and the result stays within `[1, totalTasks]`.
  */
 export const resolveWorkerCount = ({


### PR DESCRIPTION
## Summary

Rstest's self-owned Node pool starts workers lazily when tasks are dispatched, so pre-counting Node test entries no longer prevents unused workers from being created. This removes `getRecommendWorkerCount` and the corresponding `createPool` parameter while preserving the CPU-based run/watch limits and explicit `pool.maxWorkers` behavior. Browser mode is unaffected because its fixed-concurrency queue still clamps against the queued file count.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).