### PR TITLE
ci: avoid duplicate VS Code unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,7 +249,7 @@ jobs:
         # the pre-collapse behavior where it ran after the `test` row's e2e
         # step.
         if: ${{ !cancelled() && steps.e2e_test.outcome == 'success' && matrix.node_version == '24' && (needs.prepare.outputs.is_full_run == 'true' || matrix.os == 'windows-latest') }}
-        run: pnpm run test:vscode
+        run: cd packages/vscode && pnpm test:e2e
 
   # ======== codspeed ========
   # Temporarily disabled: CodSpeed runner quota exhausted.


### PR DESCRIPTION
## Summary

The root unit-test job already runs the VS Code extension's unit tests through the workspace project configuration. Update the dedicated VS Code CI step to run only `test:e2e`, avoiding a second unit-test run while preserving Extension Host coverage.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
