### PR TITLE
release: 0.11.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,8 @@ _Note_: `rslint --type-check` is the repo's type check and exists at the root on
 - Public API or config changes usually require docs updates.
 - Behavioral changes require corresponding e2e coverage unless there is a clear reason existing coverage is sufficient.
 - If a config option is shared with Rsbuild/Rslib/Rspack, check whether the adapters need to transform or pass it through consistently.
-- Keep release-train versions separate from `@rstest/core` compatibility: stable peer ranges must start at the oldest supported core version. When a package starts consuming an unreleased core capability, use `workspace:^` only as a temporary marker for the next release.
-- In every `release:` PR, replace temporary `workspace:^` peer markers with the actual release range, confirm every `@rstest/core` peer range accepts the new core version, and review ranges at each potentially breaking core boundary (each minor while core is `0.x`, then each major from `1.x` onward). Do not raise a package's lower bound when its core compatibility did not change.
+- Keep release-train versions separate from `@rstest/core` compatibility: packages compatible across releases must declare an explicit peer range starting at the oldest supported core version. Use a ranged workspace marker such as `workspace:^` only temporarily when a package starts consuming an unreleased core capability. Packages that require an identical core version must use `workspace:*` so the published peer is exact.
+- In every `release:` PR, replace temporary ranged workspace peer markers with the actual release range, confirm every `@rstest/core` peer accepts the new core version, and review ranges at each potentially breaking core boundary (each minor while core is `0.x`, then each major from `1.x` onward). Do not raise a package's lower bound when its core compatibility did not change, and do not widen an exact lockstep peer.
 - Do not make repo-wide rewrites unless explicitly asked.
 - Do not revert unrelated local changes.
 

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -54,7 +54,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "workspace:^",
+    "@rstest/core": "^0.11.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -66,7 +66,7 @@
     "playwright": "^1.62.1"
   },
   "peerDependencies": {
-    "@rstest/core": "workspace:^",
+    "@rstest/core": "workspace:*",
     "playwright": "^1.49.1"
   },
   "peerDependenciesMeta": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -52,6 +52,6 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "workspace:^"
+    "@rstest/core": "^0.11.0"
   }
 }

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -54,7 +54,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "workspace:~"
+    "@rstest/core": "^0.11.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/playwright",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Playwright fixture integration for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -46,7 +46,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "workspace:^",
+    "@rstest/core": "^0.11.6",
     "playwright": "^1.49.1"
   },
   "engines": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
## What's Changed
* fix(core): skip environment resource tracking for worker-scoped environments by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1645
* fix(core): improve GitHub Actions summaries by @9aoy in https://github.com/web-infra-dev/rstest/pull/1648
* refactor(adapter-rslib): replace tsconfck with get-tsconfig by @9aoy in https://github.com/web-infra-dev/rstest/pull/1649
* fix(browser): run globalSetup in watch mode by @9aoy in https://github.com/web-infra-dev/rstest/pull/1643
* docs: document virtual module mocks by @9aoy in https://github.com/web-infra-dev/rstest/pull/1646
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1650
* fix(core): support modern jsdom versions by @9aoy in https://github.com/web-infra-dev/rstest/pull/1652
* docs: optimize browser setup in CI by @9aoy in https://github.com/web-infra-dev/rstest/pull/1653
* feat(playwright): support retry trace modes by @9aoy in https://github.com/web-infra-dev/rstest/pull/1657
* fix(core): remove full stack fallback message by @9aoy in https://github.com/web-infra-dev/rstest/pull/1658
* fix(browser): run globalSetup when listing tests by @9aoy in https://github.com/web-infra-dev/rstest/pull/1659
* feat(core): add expect poll config by @9aoy in https://github.com/web-infra-dev/rstest/pull/1660
* fix(deps): relax core peer dependency ranges by @9aoy in https://github.com/web-infra-dev/rstest/pull/1662
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1664
* fix(core): force webpack runtime mode by @9aoy in https://github.com/web-infra-dev/rstest/pull/1665
* refactor(core): remove redundant worker count clamp by @9aoy in https://github.com/web-infra-dev/rstest/pull/1666
* refactor(core, browser): drive watch mode through the TestExecutor seam by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1668
* refactor(browser): split hostController into scheduler modules by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1669
* feat(core): support prebundle test environments by @9aoy in https://github.com/web-infra-dev/rstest/pull/1663
* ci: avoid duplicate VS Code unit tests by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1671


**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.11.5...v0.11.6