### PR TITLE
chore: include examples in unused checks

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rsbuild build",
     "test": "rstest",
     "test:coverage": "rstest --coverage",
     "test:watch": "rstest --watch"

--- a/examples/react-rsbuild/package.json
+++ b/examples/react-rsbuild/package.json
@@ -17,6 +17,7 @@
     "@rsbuild/core": "~2.1.9",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/adapter-rsbuild": "workspace:*",
+    "@rstest/core": "workspace:*",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/examples/react-rspack-browser/package.json
+++ b/examples/react-rspack-browser/package.json
@@ -17,7 +17,6 @@
     "@rspack/cli": "~2.1.7",
     "@rspack/core": "~2.1.7",
     "@rspack/dev-server": "~2.1.0",
-    "@rspack/plugin-react-refresh": "~2.0.2",
     "@rstest/adapter-rspack": "workspace:*",
     "@rstest/browser": "workspace:*",
     "@rstest/browser-react": "workspace:*",

--- a/examples/react-rspack-browser/rspack.config.ts
+++ b/examples/react-rspack-browser/rspack.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@rspack/cli';
 import { rspack, type SwcLoaderOptions } from '@rspack/core';
 
 export default defineConfig({
+  entry: './src/main.tsx',
   target: 'web',
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],

--- a/examples/react-rspack/package.json
+++ b/examples/react-rspack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/react-rspack",
-  "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
@@ -14,7 +14,6 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^2.1.0",
     "@rspack/cli": "~2.1.7",
     "@rspack/core": "~2.1.7",
     "@rspack/dev-server": "~2.1.0",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "rsbuild dev",
-    "test": "pnpm run test:clinet && pnpm run test:ssr",
-    "test:clinet": "rstest",
+    "test": "pnpm run test:client && pnpm run test:ssr",
+    "test:client": "rstest",
     "test:ssr": "rstest -c rstest.config.ssr.ts",
     "test:watch": "rstest --watch"
   },

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -47,6 +47,40 @@
         "three",
       ],
     },
+    "examples/federation/component-app": {
+      "entry": [
+        "rstest*.{js,mjs,ts,mts}",
+        "scripts/**/*.{js,mjs,ts,mts}",
+        "test/**/*.{js,jsx,ts,tsx}",
+      ],
+      // Module Federation remotes are resolved by its runtime.
+      "ignoreDependencies": ["node-local-remote"],
+    },
+    "examples/federation/main-app": {
+      "entry": [
+        "rstest*.{js,mjs,ts,mts}",
+        "scripts/**/*.{js,mjs,ts,mts}",
+        "test/**/*.{js,jsx,ts,tsx}",
+      ],
+      // Module Federation remotes are resolved by its runtime.
+      "ignoreDependencies": ["component-app", "node-local-remote"],
+    },
+    "examples/federation/node-local-remote": {
+      // Exposed as a Module Federation remote from the Rsbuild config.
+      "entry": ["src/test.js"],
+    },
+    "examples/node": {
+      "ignoreDependencies": [
+        // Loaded dynamically when `rstest --coverage` selects the default provider.
+        "@rstest/coverage-istanbul",
+      ],
+    },
+    "examples/react": {
+      "entry": ["rstest*.config.ts", "src/index.tsx", "test/**/*.{ts,tsx}"],
+    },
+    "examples/vue": {
+      "entry": ["rstest*.ts", "src/index.js", "test/**/*.{js,jsx,ts,tsx}"],
+    },
     "packages/core": {
       "entry": [
         // Runtime files copied to dist via CopyRspackPlugin (dynamically loaded)
@@ -121,5 +155,5 @@
       ],
     },
   },
-  "ignoreWorkspaces": ["e2e/**", "examples/**", "website"],
+  "ignoreWorkspaces": ["e2e/**", "website"],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,9 @@ importers:
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
+      '@rstest/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -876,9 +879,6 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
     devDependencies:
-      '@rsbuild/plugin-react':
-        specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.9(@module-federation/runtime-tools@2.8.0))(@rspack/core@2.1.7(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))
       '@rspack/cli':
         specifier: ~2.1.7
         version: 2.1.7(@rspack/core@2.1.7(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.7(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)))
@@ -940,9 +940,6 @@ importers:
       '@rspack/dev-server':
         specifier: ~2.1.0
         version: 2.1.0(@rspack/core@2.1.7(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))
-      '@rspack/plugin-react-refresh':
-        specifier: ~2.0.2
-        version: 2.0.2(@rspack/core@2.1.7(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack

--- a/website/docs/en/guide/framework/more.mdx
+++ b/website/docs/en/guide/framework/more.mdx
@@ -41,4 +41,10 @@ An Rsbuild plugin solves compilation and build integration. The full testing exp
 
 If your project already uses Rsbuild, Rslib, or one of their adapters, prefer reusing that existing configuration first. That usually lets you inherit plugins, aliases, and other build settings automatically.
 
+## Example projects
+
+- [Preact](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rsbuild-preact)
+- [Solid](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rsbuild-solid)
+- [Svelte](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rsbuild-svelte)
+
 If you run into issues while integrating more frameworks, please contact us through [GitHub Issues](https://github.com/web-infra-dev/rstest/issues).

--- a/website/docs/en/guide/integration/rspack.mdx
+++ b/website/docs/en/guide/integration/rspack.mdx
@@ -43,6 +43,10 @@ By default, the adapter uses `process.cwd()` to resolve the Rspack config. If yo
 Since Rstest uses Rsbuild internally as its bundler, some Rstest built-in behaviors may differ from Rspack's defaults. For example, Rstest has its own CSS processing pipeline. To avoid conflicts, this adapter automatically disables Rstest (Rsbuild) built-in CSS plugins so that Rspack's CSS configuration takes effect. This means that some Rsbuild-specific CSS features and configurations (e.g., `output.cssModules` configuration) will not be available when using this adapter.
 :::
 
+## Example project
+
+See the [Rspack adapter example](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rspack-adapter) for a complete React project that inherits its Rspack configuration in Rstest.
+
 ## API
 
 ### `withRspackConfig(options)`

--- a/website/docs/zh/guide/framework/more.mdx
+++ b/website/docs/zh/guide/framework/more.mdx
@@ -41,4 +41,10 @@ Rsbuild 插件解决的是框架文件的编译与构建接入，测试体验通
 
 如果你的项目本身已经在使用 Rsbuild、Rslib 或它们的适配器，也可以优先复用现有配置，这样通常能自动继承插件、别名和其他构建设置。
 
+## 示例项目
+
+- [Preact](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rsbuild-preact)
+- [Solid](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rsbuild-solid)
+- [Svelte](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rsbuild-svelte)
+
 如果你在接入更多框架时遇到问题，欢迎通过 [GitHub Issues](https://github.com/web-infra-dev/rstest/issues) 与我们联系。

--- a/website/docs/zh/guide/integration/rspack.mdx
+++ b/website/docs/zh/guide/integration/rspack.mdx
@@ -43,6 +43,10 @@ export default defineConfig({
 由于 Rstest 内部使用 Rsbuild 作为打包工具，一些 Rstest 的内置行为可能与 Rspack 的默认行为不同。例如，Rstest 有自己的 CSS 处理流程。为了避免冲突，此适配器会自动禁用 Rstest（Rsbuild） 内置的 CSS 插件，使 Rspack 的 CSS 配置生效。这意味着使用此适配器时，一些 Rsbuild 特有的 CSS 功能和配置（如 `output.cssModules` 配置）将不可用。
 :::
 
+## 示例项目
+
+你可以参考 [Rspack adapter 示例](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rspack-adapter)，了解如何在完整的 React 项目中让 Rstest 继承 Rspack 配置。
+
 ## API
 
 ### `withRspackConfig(options)`


### PR DESCRIPTION
## Summary

- Include example workspaces in Knip analysis while declaring their runtime-loaded entries and Module Federation exceptions.
- Fix the dependency, script, module-format, and Rspack entry drift surfaced by those checks.
- Link the framework and Rspack guides to maintained examples in `rstackjs/rstack-examples`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).