### PR TITLE
test(core): centralize test temp directory cleanup

### DIFF
--- a/packages/core/tests/core/envDependencies.test.ts
+++ b/packages/core/tests/core/envDependencies.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import { stripVTControlCharacters } from 'node:util';
 import path from 'node:path';
 import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { withTempDir } from '../helpers/tempDir';
 import { ensureTestEnvironmentDependencies } from '../../src/core/envDependencies';
 
 const originalStdinIsTTY = process.stdin.isTTY;
@@ -44,11 +44,10 @@ describe('ensureTestEnvironmentDependencies', () => {
   });
 
   it('asks whether to install jsdom for jsdom test environment', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-jsdom-'));
-    const projectRoot = path.join(root, 'project');
-    fs.mkdirSync(projectRoot);
+    await withTempDir('rstest-jsdom-', async (root) => {
+      const projectRoot = path.join(root, 'project');
+      fs.mkdirSync(projectRoot);
 
-    try {
       const installer = rs.fn(async (packageName: string, cwd: string) => {
         mockPackage(cwd, packageName);
         return true;
@@ -63,17 +62,14 @@ describe('ensureTestEnvironmentDependencies', () => {
       );
 
       expect(installer).toHaveBeenCalledWith('jsdom', root, 'jsdom', {});
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('skips install when the test environment dependency resolves from core', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-core-env-'));
-    const projectRoot = path.join(root, 'project');
-    fs.mkdirSync(projectRoot);
+    await withTempDir('rstest-core-env-', async (root) => {
+      const projectRoot = path.join(root, 'project');
+      fs.mkdirSync(projectRoot);
 
-    try {
       const installer = rs.fn(async () => false);
 
       await ensureTestEnvironmentDependencies(
@@ -86,17 +82,14 @@ describe('ensureTestEnvironmentDependencies', () => {
       );
 
       expect(installer).not.toHaveBeenCalled();
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('throws early when installer does not install the test environment dependency', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-missing-env-'));
-    const projectRoot = path.join(root, 'project');
-    fs.mkdirSync(projectRoot);
+    await withTempDir('rstest-missing-env-', async (root) => {
+      const projectRoot = path.join(root, 'project');
+      fs.mkdirSync(projectRoot);
 
-    try {
       const installer = rs.fn(async () => false);
 
       let error: unknown;
@@ -118,17 +111,14 @@ describe('ensureTestEnvironmentDependencies', () => {
         `Failed to load testEnvironment "jsdom" dependency: jsdom in ${root}, please make sure it is installed.`,
       );
       expect(installer).toHaveBeenCalledWith('jsdom', root, 'jsdom', {});
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('asks whether to install happy-dom for happy-dom test environment', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-happy-dom-'));
-    const projectRoot = path.join(root, 'project');
-    fs.mkdirSync(projectRoot);
+    await withTempDir('rstest-happy-dom-', async (root) => {
+      const projectRoot = path.join(root, 'project');
+      fs.mkdirSync(projectRoot);
 
-    try {
       const installer = rs.fn(async (packageName: string, cwd: string) => {
         mockPackage(cwd, packageName);
         return true;
@@ -148,8 +138,6 @@ describe('ensureTestEnvironmentDependencies', () => {
         'happy-dom',
         {},
       );
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -1,17 +1,11 @@
-import {
-  mkdirSync,
-  mkdtempSync,
-  realpathSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, realpathSync, writeFileSync } from 'node:fs';
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { join, normalize } from 'pathe';
 import {
   prepareRsbuild,
   syncCoverageSetupExcludes,
 } from '../../src/core/rsbuild';
+import { withTempDir } from '../helpers/tempDir';
 import { createSetupFileState } from '../../src/core/setupFileState';
 import type {
   ResolvedRstestConfig,
@@ -177,9 +171,7 @@ describe('prepareRsbuild', () => {
   });
 
   it('should list browser shard entries after node modifyRstestConfig hooks', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-list-shard-'));
-
-    try {
+    await withTempDir('rstest-list-shard-', async (tempRoot) => {
       for (const file of [
         'aa-node.test.ts',
         'ab-node.test.ts',
@@ -245,16 +237,13 @@ describe('prepareRsbuild', () => {
         'ab-node.test.ts',
         'c-node.test.ts',
       ]);
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should resolve list environment dependencies after modifyRstestConfig', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-list-environment-'));
-    const packageRoot = join(tempRoot, 'node_modules/jsdom');
+    await withTempDir('rstest-list-environment-', async (tempRoot) => {
+      const packageRoot = join(tempRoot, 'node_modules/jsdom');
 
-    try {
       mkdirSync(packageRoot, { recursive: true });
       writeFileSync(
         join(packageRoot, 'package.json'),
@@ -308,15 +297,11 @@ describe('prepareRsbuild', () => {
         resolvedPath: realpathSync(join(packageRoot, 'index.js')),
       });
       expect(dependency?.bundlePath).toBeUndefined();
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should skip list environment preparation for projects without test entries', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-list-empty-env-'));
-
-    try {
+    await withTempDir('rstest-list-empty-env-', async (tempRoot) => {
       const context = new Rstest(
         {
           cwd: tempRoot,
@@ -338,40 +323,37 @@ describe('prepareRsbuild', () => {
       await expect(listTests(context, { json: false })).resolves.toEqual([]);
 
       expect(poolTestEnvironmentModules.at(-1)?.size).toBe(0);
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should close the list pool when collecting tests fails', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-list-cleanup-'));
+    await withTempDir('rstest-list-cleanup-', async (tempRoot) => {
+      try {
+        writeFileSync(join(tempRoot, 'example.test.ts'), 'export {};\n');
+        const context = new Rstest(
+          {
+            cwd: tempRoot,
+            command: 'list',
+            embedded: true,
+            projects: [],
+          },
+          {
+            root: tempRoot,
+            include: ['example.test.ts'],
+          },
+        );
 
-    try {
-      writeFileSync(join(tempRoot, 'example.test.ts'), 'export {};\n');
-      const context = new Rstest(
-        {
-          cwd: tempRoot,
-          command: 'list',
-          embedded: true,
-          projects: [],
-        },
-        {
-          root: tempRoot,
-          include: ['example.test.ts'],
-        },
-      );
+        poolCloseCount = 0;
+        poolCollectError = new Error('collect failed');
 
-      poolCloseCount = 0;
-      poolCollectError = new Error('collect failed');
-
-      await expect(listTests(context, { json: false })).rejects.toThrow(
-        'collect failed',
-      );
-      expect(poolCloseCount).toBe(1);
-    } finally {
-      poolCollectError = undefined;
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+        await expect(listTests(context, { json: false })).rejects.toThrow(
+          'collect failed',
+        );
+        expect(poolCloseCount).toBe(1);
+      } finally {
+        poolCollectError = undefined;
+      }
+    });
   });
 
   it('should expose merged global and project config snapshots', async () => {
@@ -847,58 +829,57 @@ describe('prepareRsbuild', () => {
   });
 
   it('should keep normalized rstest config after modifyRstestConfig returns partial config', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-partial-config-'));
-    writeFileSync(join(tempRoot, 'setup.ts'), 'export {};\n');
-    writeFileSync(join(tempRoot, 'globalSetup.ts'), 'export {};\n');
+    await withTempDir('rstest-partial-config-', async (tempRoot) => {
+      writeFileSync(join(tempRoot, 'setup.ts'), 'export {};\n');
+      writeFileSync(join(tempRoot, 'globalSetup.ts'), 'export {};\n');
 
-    const modifyRstestConfigPlugin: RsbuildPlugin = {
-      name: 'modify-rstest-config-partial-return',
-      setup(api) {
-        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+      const modifyRstestConfigPlugin: RsbuildPlugin = {
+        name: 'modify-rstest-config-partial-return',
+        setup(api) {
+          const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
-        rstestApi?.modifyRstestConfig(() => ({
-          include: ['**/*.partial.test.ts'],
-          exclude: ['**/ignored.test.ts'],
-          setupFiles: ['./setup.ts'],
-          globalSetup: ['./globalSetup.ts'],
-          includeSource: ['./new-src.ts'],
-          testEnvironment: 'jsdom',
-          root: tempRoot,
-          output: {
-            module: false,
+          rstestApi?.modifyRstestConfig(() => ({
+            include: ['**/*.partial.test.ts'],
+            exclude: ['**/ignored.test.ts'],
+            setupFiles: ['./setup.ts'],
+            globalSetup: ['./globalSetup.ts'],
+            includeSource: ['./new-src.ts'],
+            testEnvironment: 'jsdom',
+            root: tempRoot,
+            output: {
+              module: false,
+            },
+          }));
+        },
+      };
+
+      const project = {
+        name: 'test',
+        rootPath,
+        environmentName: 'test',
+        outputModule: false,
+        _globalSetups: false,
+        normalizedConfig: {
+          include: ['original.test.ts'],
+          exclude: {
+            patterns: ['**/original-ignored.test.ts'],
+            override: false,
           },
-        }));
-      },
-    };
-
-    const project = {
-      name: 'test',
-      rootPath,
-      environmentName: 'test',
-      outputModule: false,
-      _globalSetups: false,
-      normalizedConfig: {
-        include: ['original.test.ts'],
-        exclude: {
-          patterns: ['**/original-ignored.test.ts'],
-          override: false,
+          includeSource: ['original-src.ts'],
+          setupFiles: ['original-setup.ts'],
+          globalSetup: ['original-globalSetup.ts'],
+          plugins: [modifyRstestConfigPlugin],
+          resolve: {},
+          source: {},
+          output: {},
+          tools: {},
+          testEnvironment: {
+            name: 'node',
+          },
+          browser: { enabled: false },
         },
-        includeSource: ['original-src.ts'],
-        setupFiles: ['original-setup.ts'],
-        globalSetup: ['original-globalSetup.ts'],
-        plugins: [modifyRstestConfigPlugin],
-        resolve: {},
-        source: {},
-        output: {},
-        tools: {},
-        testEnvironment: {
-          name: 'node',
-        },
-        browser: { enabled: false },
-      },
-    };
+      };
 
-    try {
       const rsbuildInstance = await prepareRsbuild({
         context: {
           rootPath,
@@ -943,32 +924,29 @@ describe('prepareRsbuild', () => {
       expect(project.normalizedConfig.testEnvironment).toEqual({
         name: 'jsdom',
       });
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should derive setup file maps after modifyRstestConfig is applied', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-setup-maps-'));
-    writeFileSync(join(tempRoot, 'setup.ts'), 'export {};\n');
-    writeFileSync(join(tempRoot, 'globalSetup.ts'), 'export {};\n');
+    await withTempDir('rstest-setup-maps-', async (tempRoot) => {
+      writeFileSync(join(tempRoot, 'setup.ts'), 'export {};\n');
+      writeFileSync(join(tempRoot, 'globalSetup.ts'), 'export {};\n');
 
-    const modifySetupPlugin: RsbuildPlugin = {
-      name: 'modify-rstest-setup-files',
-      setup(api) {
-        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+      const modifySetupPlugin: RsbuildPlugin = {
+        name: 'modify-rstest-setup-files',
+        setup(api) {
+          const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
-        rstestApi?.modifyRstestConfig((config) => {
-          config.root = tempRoot;
-          config.setupFiles = ['./setup.ts'];
-          config.globalSetup = ['./globalSetup.ts'];
-        });
-      },
-    };
+          rstestApi?.modifyRstestConfig((config) => {
+            config.root = tempRoot;
+            config.setupFiles = ['./setup.ts'];
+            config.globalSetup = ['./globalSetup.ts'];
+          });
+        },
+      };
 
-    const setupFileState = createSetupFileState();
+      const setupFileState = createSetupFileState();
 
-    try {
       const rsbuildInstance = await prepareRsbuild({
         context: {
           rootPath,
@@ -1020,9 +998,7 @@ describe('prepareRsbuild', () => {
       expect(setupFileState.globalSetupFiles.test).toEqual({
         'globalSetup~ts': join(tempRoot, 'globalSetup.ts'),
       });
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should preserve normalized defaults after modifyRstestConfig mutates public config shape', async () => {
@@ -1122,67 +1098,66 @@ describe('prepareRsbuild', () => {
   });
 
   it('should replace arrays when modifyRstestConfig mutates public config arrays', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-array-mutation-'));
-    for (const file of [
-      'base-setup.ts',
-      'extra-setup.ts',
-      'base-global.ts',
-      'extra-global.ts',
-    ]) {
-      writeFileSync(join(tempRoot, file), 'export {};\n');
-    }
+    await withTempDir('rstest-array-mutation-', async (tempRoot) => {
+      for (const file of [
+        'base-setup.ts',
+        'extra-setup.ts',
+        'base-global.ts',
+        'extra-global.ts',
+      ]) {
+        writeFileSync(join(tempRoot, file), 'export {};\n');
+      }
 
-    const modifyRstestConfigPlugin: RsbuildPlugin = {
-      name: 'modify-rstest-config-array-mutation',
-      setup(api) {
-        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+      const modifyRstestConfigPlugin: RsbuildPlugin = {
+        name: 'modify-rstest-config-array-mutation',
+        setup(api) {
+          const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
-        rstestApi?.modifyRstestConfig((config) => {
-          config.setupFiles = [
-            ...castArray(config.setupFiles),
-            'extra-setup.ts',
-          ];
-          config.globalSetup = [
-            ...castArray(config.globalSetup),
-            'extra-global.ts',
-          ];
-          config.include = [...castArray(config.include), 'extra.test.ts'];
-        });
-      },
-    };
-
-    const project = {
-      name: 'test',
-      rootPath: tempRoot,
-      environmentName: 'test',
-      outputModule: false,
-      _globalSetups: false,
-      normalizedConfig: {
-        root: tempRoot,
-        include: ['base.test.ts'],
-        exclude: {
-          patterns: ['**/node_modules/**'],
-          override: false,
+          rstestApi?.modifyRstestConfig((config) => {
+            config.setupFiles = [
+              ...castArray(config.setupFiles),
+              'extra-setup.ts',
+            ];
+            config.globalSetup = [
+              ...castArray(config.globalSetup),
+              'extra-global.ts',
+            ];
+            config.include = [...castArray(config.include), 'extra.test.ts'];
+          });
         },
-        setupFiles: ['base-setup.ts'],
-        globalSetup: ['base-global.ts'],
-        plugins: [modifyRstestConfigPlugin],
-        resolve: {},
-        source: {},
-        output: {
-          distPath: {
-            root: TEMP_RSTEST_OUTPUT_DIR,
+      };
+
+      const project = {
+        name: 'test',
+        rootPath: tempRoot,
+        environmentName: 'test',
+        outputModule: false,
+        _globalSetups: false,
+        normalizedConfig: {
+          root: tempRoot,
+          include: ['base.test.ts'],
+          exclude: {
+            patterns: ['**/node_modules/**'],
+            override: false,
           },
+          setupFiles: ['base-setup.ts'],
+          globalSetup: ['base-global.ts'],
+          plugins: [modifyRstestConfigPlugin],
+          resolve: {},
+          source: {},
+          output: {
+            distPath: {
+              root: TEMP_RSTEST_OUTPUT_DIR,
+            },
+          },
+          tools: {},
+          testEnvironment: {
+            name: 'node',
+          },
+          browser: { enabled: false },
         },
-        tools: {},
-        testEnvironment: {
-          name: 'node',
-        },
-        browser: { enabled: false },
-      },
-    };
+      };
 
-    try {
       const rsbuildInstance = await prepareRsbuild({
         context: {
           rootPath: tempRoot,
@@ -1217,65 +1192,62 @@ describe('prepareRsbuild', () => {
         'base.test.ts',
         'extra.test.ts',
       ]);
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should expand root placeholders after modifyRstestConfig changes path fields', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-root-placeholder-'));
-    for (const file of ['setup.ts', 'globalSetup.ts']) {
-      writeFileSync(join(tempRoot, file), 'export {}\n');
-    }
+    await withTempDir('rstest-root-placeholder-', async (tempRoot) => {
+      for (const file of ['setup.ts', 'globalSetup.ts']) {
+        writeFileSync(join(tempRoot, file), 'export {}\n');
+      }
 
-    const modifyRstestConfigPlugin: RsbuildPlugin = {
-      name: 'modify-rstest-config-root-placeholders',
-      setup(api) {
-        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+      const modifyRstestConfigPlugin: RsbuildPlugin = {
+        name: 'modify-rstest-config-root-placeholders',
+        setup(api) {
+          const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
-        rstestApi?.modifyRstestConfig(() => ({
-          include: ['<rootDir>/src/**/*.test.ts'],
-          exclude: ['<rootDir>/src/ignored.test.ts'],
-          setupFiles: ['<rootDir>/setup.ts'],
-          globalSetup: ['<rootDir>/globalSetup.ts'],
-          includeSource: ['<rootDir>/src/**/*.ts'],
-        }));
-      },
-    };
-
-    const project = {
-      name: 'test',
-      rootPath: tempRoot,
-      environmentName: 'test',
-      outputModule: false,
-      _globalSetups: false,
-      normalizedConfig: {
-        root: tempRoot,
-        include: ['base.test.ts'],
-        exclude: {
-          patterns: ['**/node_modules/**'],
-          override: false,
+          rstestApi?.modifyRstestConfig(() => ({
+            include: ['<rootDir>/src/**/*.test.ts'],
+            exclude: ['<rootDir>/src/ignored.test.ts'],
+            setupFiles: ['<rootDir>/setup.ts'],
+            globalSetup: ['<rootDir>/globalSetup.ts'],
+            includeSource: ['<rootDir>/src/**/*.ts'],
+          }));
         },
-        setupFiles: [],
-        globalSetup: [],
-        includeSource: [],
-        plugins: [modifyRstestConfigPlugin],
-        resolve: {},
-        source: {},
-        output: {
-          distPath: {
-            root: TEMP_RSTEST_OUTPUT_DIR,
+      };
+
+      const project = {
+        name: 'test',
+        rootPath: tempRoot,
+        environmentName: 'test',
+        outputModule: false,
+        _globalSetups: false,
+        normalizedConfig: {
+          root: tempRoot,
+          include: ['base.test.ts'],
+          exclude: {
+            patterns: ['**/node_modules/**'],
+            override: false,
           },
+          setupFiles: [],
+          globalSetup: [],
+          includeSource: [],
+          plugins: [modifyRstestConfigPlugin],
+          resolve: {},
+          source: {},
+          output: {
+            distPath: {
+              root: TEMP_RSTEST_OUTPUT_DIR,
+            },
+          },
+          tools: {},
+          testEnvironment: {
+            name: 'node',
+          },
+          browser: { enabled: false },
         },
-        tools: {},
-        testEnvironment: {
-          name: 'node',
-        },
-        browser: { enabled: false },
-      },
-    };
+      };
 
-    try {
       const setupFileState = createSetupFileState();
       const rsbuildInstance = await prepareRsbuild({
         context: {
@@ -1322,76 +1294,73 @@ describe('prepareRsbuild', () => {
       expect(setupFileState.globalSetupFiles.test).toEqual({
         'globalSetup~ts': join(tempRoot, 'globalSetup.ts'),
       });
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should refresh root-derived fields after modifyRstestConfig changes root', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-root-derived-'));
-    const newRoot = join(tempRoot, 'fixture');
-    mkdirSync(newRoot, { recursive: true });
-    writeFileSync(join(tempRoot, 'tsconfig.json'), '{}\n');
-    writeFileSync(join(newRoot, 'tsconfig.json'), '{}\n');
+    await withTempDir('rstest-root-derived-', async (tempRoot) => {
+      const newRoot = join(tempRoot, 'fixture');
+      mkdirSync(newRoot, { recursive: true });
+      writeFileSync(join(tempRoot, 'tsconfig.json'), '{}\n');
+      writeFileSync(join(newRoot, 'tsconfig.json'), '{}\n');
 
-    const modifyRstestConfigPlugin: RsbuildPlugin = {
-      name: 'modify-rstest-config-root-derived',
-      setup(api) {
-        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+      const modifyRstestConfigPlugin: RsbuildPlugin = {
+        name: 'modify-rstest-config-root-derived',
+        setup(api) {
+          const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
-        rstestApi?.modifyRstestConfig((config) => {
-          config.root = './fixture';
-        });
-      },
-    };
-
-    const project = {
-      name: 'test',
-      rootPath: tempRoot,
-      environmentName: 'test',
-      outputModule: false,
-      _globalSetups: false,
-      normalizedConfig: {
-        root: tempRoot,
-        include: ['base.test.ts'],
-        exclude: {
-          patterns: ['**/node_modules/**', '**/dist/.rstest-temp'],
-          override: false,
+          rstestApi?.modifyRstestConfig((config) => {
+            config.root = './fixture';
+          });
         },
-        setupFiles: [],
-        globalSetup: [],
-        plugins: [modifyRstestConfigPlugin],
-        resolve: {},
-        source: {
-          tsconfigPath: join(tempRoot, 'tsconfig.json'),
-        },
-        output: {
-          distPath: {
-            root: TEMP_RSTEST_OUTPUT_DIR,
+      };
+
+      const project = {
+        name: 'test',
+        rootPath: tempRoot,
+        environmentName: 'test',
+        outputModule: false,
+        _globalSetups: false,
+        normalizedConfig: {
+          root: tempRoot,
+          include: ['base.test.ts'],
+          exclude: {
+            patterns: ['**/node_modules/**', '**/dist/.rstest-temp'],
+            override: false,
           },
+          setupFiles: [],
+          globalSetup: [],
+          plugins: [modifyRstestConfigPlugin],
+          resolve: {},
+          source: {
+            tsconfigPath: join(tempRoot, 'tsconfig.json'),
+          },
+          output: {
+            distPath: {
+              root: TEMP_RSTEST_OUTPUT_DIR,
+            },
+          },
+          tools: {},
+          testEnvironment: {
+            name: 'node',
+          },
+          performance: {
+            buildCache: true,
+          },
+          coverage: {
+            enabled: false,
+            exclude: [],
+            provider: 'v8',
+            reporters: ['text'],
+            reportsDirectory: join(tempRoot, 'coverage'),
+            clean: true,
+            reportOnFailure: false,
+            allowExternal: false,
+          },
+          browser: { enabled: false },
         },
-        tools: {},
-        testEnvironment: {
-          name: 'node',
-        },
-        performance: {
-          buildCache: true,
-        },
-        coverage: {
-          enabled: false,
-          exclude: [],
-          provider: 'v8',
-          reporters: ['text'],
-          reportsDirectory: join(tempRoot, 'coverage'),
-          clean: true,
-          reportOnFailure: false,
-          allowExternal: false,
-        },
-        browser: { enabled: false },
-      },
-    };
+      };
 
-    try {
       const rsbuildInstance = await prepareRsbuild({
         context: {
           rootPath: tempRoot,
@@ -1426,81 +1395,78 @@ describe('prepareRsbuild', () => {
         '**/node_modules/**',
         expect.stringContaining(TEMP_RSTEST_OUTPUT_DIR),
       ]);
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should preserve explicit tsconfigPath after modifyRstestConfig changes root', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-root-tsconfig-'));
-    const newRoot = join(tempRoot, 'fixture');
-    const customTsconfigPath = join(newRoot, 'tsconfig.custom.json');
-    mkdirSync(newRoot, { recursive: true });
-    writeFileSync(join(tempRoot, 'tsconfig.json'), '{}\n');
-    writeFileSync(join(newRoot, 'tsconfig.json'), '{}\n');
-    writeFileSync(customTsconfigPath, '{}\n');
+    await withTempDir('rstest-root-tsconfig-', async (tempRoot) => {
+      const newRoot = join(tempRoot, 'fixture');
+      const customTsconfigPath = join(newRoot, 'tsconfig.custom.json');
+      mkdirSync(newRoot, { recursive: true });
+      writeFileSync(join(tempRoot, 'tsconfig.json'), '{}\n');
+      writeFileSync(join(newRoot, 'tsconfig.json'), '{}\n');
+      writeFileSync(customTsconfigPath, '{}\n');
 
-    const modifyRstestConfigPlugin: RsbuildPlugin = {
-      name: 'modify-rstest-config-root-custom-tsconfig',
-      setup(api) {
-        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+      const modifyRstestConfigPlugin: RsbuildPlugin = {
+        name: 'modify-rstest-config-root-custom-tsconfig',
+        setup(api) {
+          const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
-        rstestApi?.modifyRstestConfig((config) => {
-          config.root = './fixture';
-          config.source = {
-            tsconfigPath: customTsconfigPath,
-          };
-        });
-      },
-    };
-
-    const project = {
-      name: 'test',
-      rootPath: tempRoot,
-      environmentName: 'test',
-      outputModule: false,
-      _globalSetups: false,
-      normalizedConfig: {
-        root: tempRoot,
-        include: ['base.test.ts'],
-        exclude: {
-          patterns: ['**/node_modules/**'],
-          override: false,
+          rstestApi?.modifyRstestConfig((config) => {
+            config.root = './fixture';
+            config.source = {
+              tsconfigPath: customTsconfigPath,
+            };
+          });
         },
-        setupFiles: [],
-        globalSetup: [],
-        plugins: [modifyRstestConfigPlugin],
-        resolve: {},
-        source: {
-          tsconfigPath: join(tempRoot, 'tsconfig.json'),
-        },
-        output: {
-          distPath: {
-            root: TEMP_RSTEST_OUTPUT_DIR,
+      };
+
+      const project = {
+        name: 'test',
+        rootPath: tempRoot,
+        environmentName: 'test',
+        outputModule: false,
+        _globalSetups: false,
+        normalizedConfig: {
+          root: tempRoot,
+          include: ['base.test.ts'],
+          exclude: {
+            patterns: ['**/node_modules/**'],
+            override: false,
           },
+          setupFiles: [],
+          globalSetup: [],
+          plugins: [modifyRstestConfigPlugin],
+          resolve: {},
+          source: {
+            tsconfigPath: join(tempRoot, 'tsconfig.json'),
+          },
+          output: {
+            distPath: {
+              root: TEMP_RSTEST_OUTPUT_DIR,
+            },
+          },
+          tools: {},
+          testEnvironment: {
+            name: 'node',
+          },
+          performance: {
+            buildCache: true,
+          },
+          coverage: {
+            enabled: false,
+            exclude: [],
+            provider: 'v8',
+            reporters: ['text'],
+            reportsDirectory: join(tempRoot, 'coverage'),
+            clean: true,
+            reportOnFailure: false,
+            allowExternal: false,
+          },
+          browser: { enabled: false },
         },
-        tools: {},
-        testEnvironment: {
-          name: 'node',
-        },
-        performance: {
-          buildCache: true,
-        },
-        coverage: {
-          enabled: false,
-          exclude: [],
-          provider: 'v8',
-          reporters: ['text'],
-          reportsDirectory: join(tempRoot, 'coverage'),
-          clean: true,
-          reportOnFailure: false,
-          allowExternal: false,
-        },
-        browser: { enabled: false },
-      },
-    };
+      };
 
-    try {
       const rsbuildInstance = await prepareRsbuild({
         context: {
           rootPath: tempRoot,
@@ -1531,77 +1497,74 @@ describe('prepareRsbuild', () => {
         cacheDirectory: join(newRoot, 'node_modules/.cache/rstest-test'),
         buildDependencies: [customTsconfigPath],
       });
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should normalize relative tsconfigPath after modifyRstestConfig changes source', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'rstest-relative-tsconfig-'));
-    const customTsconfigPath = join(tempRoot, 'tsconfig.custom.json');
-    writeFileSync(join(tempRoot, 'tsconfig.json'), '{}\n');
-    writeFileSync(customTsconfigPath, '{}\n');
+    await withTempDir('rstest-relative-tsconfig-', async (tempRoot) => {
+      const customTsconfigPath = join(tempRoot, 'tsconfig.custom.json');
+      writeFileSync(join(tempRoot, 'tsconfig.json'), '{}\n');
+      writeFileSync(customTsconfigPath, '{}\n');
 
-    const modifyRstestConfigPlugin: RsbuildPlugin = {
-      name: 'modify-rstest-config-relative-tsconfig',
-      setup(api) {
-        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+      const modifyRstestConfigPlugin: RsbuildPlugin = {
+        name: 'modify-rstest-config-relative-tsconfig',
+        setup(api) {
+          const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
 
-        rstestApi?.modifyRstestConfig((config) => {
-          config.source = {
-            tsconfigPath: './tsconfig.custom.json',
-          };
-        });
-      },
-    };
-
-    const project = {
-      name: 'test',
-      rootPath: tempRoot,
-      environmentName: 'test',
-      outputModule: false,
-      _globalSetups: false,
-      normalizedConfig: {
-        root: tempRoot,
-        include: ['base.test.ts'],
-        exclude: {
-          patterns: ['**/node_modules/**'],
-          override: false,
+          rstestApi?.modifyRstestConfig((config) => {
+            config.source = {
+              tsconfigPath: './tsconfig.custom.json',
+            };
+          });
         },
-        setupFiles: [],
-        globalSetup: [],
-        plugins: [modifyRstestConfigPlugin],
-        resolve: {},
-        source: {
-          tsconfigPath: join(tempRoot, 'tsconfig.json'),
-        },
-        output: {
-          distPath: {
-            root: TEMP_RSTEST_OUTPUT_DIR,
+      };
+
+      const project = {
+        name: 'test',
+        rootPath: tempRoot,
+        environmentName: 'test',
+        outputModule: false,
+        _globalSetups: false,
+        normalizedConfig: {
+          root: tempRoot,
+          include: ['base.test.ts'],
+          exclude: {
+            patterns: ['**/node_modules/**'],
+            override: false,
           },
+          setupFiles: [],
+          globalSetup: [],
+          plugins: [modifyRstestConfigPlugin],
+          resolve: {},
+          source: {
+            tsconfigPath: join(tempRoot, 'tsconfig.json'),
+          },
+          output: {
+            distPath: {
+              root: TEMP_RSTEST_OUTPUT_DIR,
+            },
+          },
+          tools: {},
+          testEnvironment: {
+            name: 'node',
+          },
+          performance: {
+            buildCache: true,
+          },
+          coverage: {
+            enabled: false,
+            exclude: [],
+            provider: 'v8',
+            reporters: ['text'],
+            reportsDirectory: join(tempRoot, 'coverage'),
+            clean: true,
+            reportOnFailure: false,
+            allowExternal: false,
+          },
+          browser: { enabled: false },
         },
-        tools: {},
-        testEnvironment: {
-          name: 'node',
-        },
-        performance: {
-          buildCache: true,
-        },
-        coverage: {
-          enabled: false,
-          exclude: [],
-          provider: 'v8',
-          reporters: ['text'],
-          reportsDirectory: join(tempRoot, 'coverage'),
-          clean: true,
-          reportOnFailure: false,
-          allowExternal: false,
-        },
-        browser: { enabled: false },
-      },
-    };
+      };
 
-    try {
       const rsbuildInstance = await prepareRsbuild({
         context: {
           rootPath: tempRoot,
@@ -1630,9 +1593,7 @@ describe('prepareRsbuild', () => {
       expect(project.normalizedConfig.performance?.buildCache).toMatchObject({
         buildDependencies: [customTsconfigPath],
       });
-    } finally {
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it('should generate rspack config correctly (jsdom)', async () => {

--- a/packages/core/tests/core/testEnvironmentModule.test.ts
+++ b/packages/core/tests/core/testEnvironmentModule.test.ts
@@ -1,5 +1,5 @@
+import { withTempDir } from '../helpers/tempDir';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
@@ -65,248 +65,246 @@ const createPackage = (
 
 describe('prepareTestEnvironmentModules', () => {
   it('automatically creates a bundle for a supported project-resolved environment dependency', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-env-bundle-'));
-    const projectRoot = path.join(root, 'project');
-    fs.mkdirSync(projectRoot);
-    createPackage(root, 'export class JSDOM {}');
-    const canvasPath = createPackage(projectRoot, 'exports.token = "canvas";', {
-      name: 'canvas',
-      type: 'commonjs',
-    });
-    createPackage(
-      projectRoot,
-      `
+    await withTempDir('rstest-env-bundle-', async (root) => {
+      const projectRoot = path.join(root, 'project');
+      fs.mkdirSync(projectRoot);
+      createPackage(root, 'export class JSDOM {}');
+      const canvasPath = createPackage(
+        projectRoot,
+        'exports.token = "canvas";',
+        {
+          name: 'canvas',
+          type: 'commonjs',
+        },
+      );
+      createPackage(
+        projectRoot,
+        `
 const canvas = require('canvas');
 exports.JSDOM = class JSDOM {};
 exports.canvasToken = canvas.token;
 `,
-      { type: 'commonjs' },
-    );
-    const projectJsdomPath = fs.realpathSync(
-      path.join(projectRoot, 'node_modules', 'jsdom', 'index.js'),
-    );
+        { type: 'commonjs' },
+      );
+      const projectJsdomPath = fs.realpathSync(
+        path.join(projectRoot, 'node_modules', 'jsdom', 'index.js'),
+      );
 
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(projectRoot, { prebundle: 'auto' })],
-      rootPath: root,
-    });
-
-    try {
-      const moduleReference = result.modules.get('jsdom');
-      expect(moduleReference).toMatchObject({
-        name: 'jsdom',
-        packageName: 'jsdom',
-        resolvedPath: projectJsdomPath,
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(projectRoot, { prebundle: 'auto' })],
+        rootPath: root,
       });
-      expect(moduleReference?.bundlePath).toBeTruthy();
-      if (!moduleReference?.bundlePath) {
-        throw new Error('Expected jsdom to be bundled.');
-      }
-      expect(fs.existsSync(moduleReference.bundlePath)).toBe(true);
 
-      const bundled = await import(
-        pathToFileURL(moduleReference.bundlePath).href
-      );
-      expect(typeof bundled.JSDOM).toBe('function');
-      expect(bundled.canvasToken).toBe('canvas');
-      expect(fs.readFileSync(moduleReference.bundlePath, 'utf8')).toContain(
-        canvasPath,
-      );
-      expect(moduleReference.bundlePath.split(path.sep)).toContain(
-        'node_modules',
-      );
-    } finally {
-      const bundlePath = result.modules.get('jsdom')?.bundlePath;
-      await result.cleanup();
-      expect(bundlePath && fs.existsSync(bundlePath)).toBe(false);
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+      try {
+        const moduleReference = result.modules.get('jsdom');
+        expect(moduleReference).toMatchObject({
+          name: 'jsdom',
+          packageName: 'jsdom',
+          resolvedPath: projectJsdomPath,
+        });
+        expect(moduleReference?.bundlePath).toBeTruthy();
+        if (!moduleReference?.bundlePath) {
+          throw new Error('Expected jsdom to be bundled.');
+        }
+        expect(fs.existsSync(moduleReference.bundlePath)).toBe(true);
+
+        const bundled = await import(
+          pathToFileURL(moduleReference.bundlePath).href
+        );
+        expect(typeof bundled.JSDOM).toBe('function');
+        expect(bundled.canvasToken).toBe('canvas');
+        expect(fs.readFileSync(moduleReference.bundlePath, 'utf8')).toContain(
+          canvasPath,
+        );
+        expect(moduleReference.bundlePath.split(path.sep)).toContain(
+          'node_modules',
+        );
+      } finally {
+        const bundlePath = result.modules.get('jsdom')?.bundlePath;
+        await result.cleanup();
+        expect(bundlePath && fs.existsSync(bundlePath)).toBe(false);
+      }
+    });
   });
 
   it('preserves the worker NODE_ENV at prebundle runtime', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-env-node-env-'));
-    createPackage(
-      root,
-      `
+    await withTempDir('rstest-env-node-env-', async (root) => {
+      createPackage(
+        root,
+        `
 export class JSDOM {}
 export const readNodeEnv = () => process.env.NODE_ENV;
 `,
-    );
+      );
 
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { prebundle: true })],
-      rootPath: root,
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(root, { prebundle: true })],
+        rootPath: root,
+      });
+      const previousNodeEnv = process.env.NODE_ENV;
+
+      try {
+        const bundlePath = result.modules.get('jsdom')?.bundlePath;
+        expect(bundlePath).toBeTruthy();
+        if (!bundlePath) {
+          throw new Error('Expected jsdom to be bundled.');
+        }
+        const bundled = await import(pathToFileURL(bundlePath).href);
+        process.env.NODE_ENV = 'rstest-runtime-probe';
+        expect(bundled.readNodeEnv()).toBe('rstest-runtime-probe');
+      } finally {
+        if (previousNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = previousNodeEnv;
+        }
+        await result.cleanup();
+      }
     });
-    const previousNodeEnv = process.env.NODE_ENV;
-
-    try {
-      const bundlePath = result.modules.get('jsdom')?.bundlePath;
-      expect(bundlePath).toBeTruthy();
-      if (!bundlePath) {
-        throw new Error('Expected jsdom to be bundled.');
-      }
-      const bundled = await import(pathToFileURL(bundlePath).href);
-      process.env.NODE_ENV = 'rstest-runtime-probe';
-      expect(bundled.readNodeEnv()).toBe('rstest-runtime-probe');
-    } finally {
-      if (previousNodeEnv === undefined) {
-        delete process.env.NODE_ENV;
-      } else {
-        process.env.NODE_ENV = previousNodeEnv;
-      }
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
   });
 
   it('preserves bare Node builtins in non-literal dynamic imports', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-dynamic-builtin-'),
-    );
-    createPackage(
-      root,
-      `
+    await withTempDir('rstest-env-dynamic-builtin-', async (root) => {
+      createPackage(
+        root,
+        `
 export class JSDOM {}
 export const loadModule = (specifier) => import(specifier);
 `,
-    );
+      );
 
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { prebundle: true })],
-      rootPath: root,
-    });
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(root, { prebundle: true })],
+        rootPath: root,
+      });
 
-    try {
-      const bundlePath = result.modules.get('jsdom')?.bundlePath;
-      expect(bundlePath).toBeTruthy();
-      if (!bundlePath) {
-        throw new Error('Expected jsdom to be bundled.');
+      try {
+        const bundlePath = result.modules.get('jsdom')?.bundlePath;
+        expect(bundlePath).toBeTruthy();
+        if (!bundlePath) {
+          throw new Error('Expected jsdom to be bundled.');
+        }
+        const bundled = await import(pathToFileURL(bundlePath).href);
+        const nodeFs = await bundled.loadModule('fs');
+        expect(typeof nodeFs.readFile).toBe('function');
+      } finally {
+        await result.cleanup();
       }
-      const bundled = await import(pathToFileURL(bundlePath).href);
-      const nodeFs = await bundled.loadModule('fs');
-      expect(typeof nodeFs.readFile).toBe('function');
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('reads the version from the resolved environment package', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-resolved-version-'),
-    );
-    const projectRoot = path.join(root, 'project');
-    fs.mkdirSync(projectRoot);
-    createPackage(root, 'export class Window {}', {
-      name: 'happy-dom',
-      version: '20.11.1',
-    });
-    const projectHappyDomPath = createPackage(
-      projectRoot,
-      'export class Window {}',
-      {
+    await withTempDir('rstest-env-resolved-version-', async (root) => {
+      const projectRoot = path.join(root, 'project');
+      fs.mkdirSync(projectRoot);
+      createPackage(root, 'export class Window {}', {
         name: 'happy-dom',
-        packageExports: { '.': './index.js' },
-        version: '21.0.0',
-      },
-    );
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [
-        createProject(projectRoot, {
-          environmentName: 'happy-dom',
-          prebundle: 'auto',
-        }),
-      ],
-      rootPath: root,
-    });
-
-    try {
-      expect(result.modules.get('happy-dom')).toMatchObject({
-        resolvedPath: projectHappyDomPath,
+        version: '20.11.1',
       });
-      expect(result.modules.get('happy-dom')?.bundlePath).toBeUndefined();
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+      const projectHappyDomPath = createPackage(
+        projectRoot,
+        'export class Window {}',
+        {
+          name: 'happy-dom',
+          packageExports: { '.': './index.js' },
+          version: '21.0.0',
+        },
+      );
+
+      const result = await prepareTestEnvironmentModules({
+        projects: [
+          createProject(projectRoot, {
+            environmentName: 'happy-dom',
+            prebundle: 'auto',
+          }),
+        ],
+        rootPath: root,
+      });
+
+      try {
+        expect(result.modules.get('happy-dom')).toMatchObject({
+          resolvedPath: projectHappyDomPath,
+        });
+        expect(result.modules.get('happy-dom')?.bundlePath).toBeUndefined();
+      } finally {
+        await result.cleanup();
+      }
+    });
   });
 
   it('emits ESM native externals as file URLs', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-esm-external-'),
-    );
-    const projectRoot = path.join(root, 'project');
-    fs.mkdirSync(projectRoot);
-    const canvasPath = createPackage(projectRoot, 'exports.token = "canvas";', {
-      name: 'canvas',
-      type: 'commonjs',
-    });
-    createPackage(
-      projectRoot,
-      `
+    await withTempDir('rstest-env-esm-external-', async (root) => {
+      const projectRoot = path.join(root, 'project');
+      fs.mkdirSync(projectRoot);
+      const canvasPath = createPackage(
+        projectRoot,
+        'exports.token = "canvas";',
+        {
+          name: 'canvas',
+          type: 'commonjs',
+        },
+      );
+      createPackage(
+        projectRoot,
+        `
 import canvas from 'canvas';
 export class JSDOM {}
 export const canvasToken = canvas.token;
 `,
-    );
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(projectRoot, { prebundle: true })],
-      rootPath: root,
-    });
-
-    try {
-      const bundlePath = result.modules.get('jsdom')?.bundlePath;
-      expect(bundlePath).toBeTruthy();
-      if (!bundlePath) {
-        throw new Error('Expected jsdom to be bundled.');
-      }
-      const bundled = await import(pathToFileURL(bundlePath).href);
-      expect(bundled.canvasToken).toBe('canvas');
-      expect(fs.readFileSync(bundlePath, 'utf8')).toContain(
-        pathToFileURL(canvasPath).href,
       );
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(projectRoot, { prebundle: true })],
+        rootPath: root,
+      });
+
+      try {
+        const bundlePath = result.modules.get('jsdom')?.bundlePath;
+        expect(bundlePath).toBeTruthy();
+        if (!bundlePath) {
+          throw new Error('Expected jsdom to be bundled.');
+        }
+        const bundled = await import(pathToFileURL(bundlePath).href);
+        expect(bundled.canvasToken).toBe('canvas');
+        expect(fs.readFileSync(bundlePath, 'utf8')).toContain(
+          pathToFileURL(canvasPath).href,
+        );
+      } finally {
+        await result.cleanup();
+      }
+    });
   });
 
   // cspell:word pnpapi
   it('keeps Yarn PnP runtime access external', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-pnpapi-external-'),
-    );
-    createPackage(
-      root,
-      `
+    await withTempDir('rstest-env-pnpapi-external-', async (root) => {
+      createPackage(
+        root,
+        `
 require('pnpapi');
 exports.JSDOM = class JSDOM {};
 `,
-      { type: 'commonjs' },
-    );
+        { type: 'commonjs' },
+      );
 
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { prebundle: true })],
-      rootPath: root,
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(root, { prebundle: true })],
+        rootPath: root,
+      });
+
+      try {
+        expect(result.modules.get('jsdom')?.bundlePath).toBeTruthy();
+      } finally {
+        await result.cleanup();
+      }
     });
-
-    try {
-      expect(result.modules.get('jsdom')?.bundlePath).toBeTruthy();
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
   });
 
   it('keeps a missing optional canvas dependency external', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-optional-canvas-'),
-    );
-    createPackage(
-      root,
-      `
+    await withTempDir('rstest-env-optional-canvas-', async (root) => {
+      createPackage(
+        root,
+        `
 let canvasInstalled = false;
 try {
   require.resolve('canvas');
@@ -318,39 +316,8 @@ if (canvasInstalled) {
 exports.JSDOM = class JSDOM {};
 exports.canvasInstalled = canvasInstalled;
 `,
-      { type: 'commonjs', version: '15.2.0' },
-    );
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { prebundle: 'auto' })],
-      rootPath: root,
-    });
-
-    try {
-      const moduleReference = result.modules.get('jsdom');
-      expect(moduleReference?.bundlePath).toBeTruthy();
-      if (!moduleReference?.bundlePath) {
-        throw new Error('Expected jsdom to be bundled.');
-      }
-
-      const bundled = await import(
-        pathToFileURL(moduleReference.bundlePath).href
+        { type: 'commonjs', version: '15.2.0' },
       );
-      expect(typeof bundled.JSDOM).toBe('function');
-      expect(bundled.canvasInstalled).toBe(false);
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it.each(['14.1.0', '31.0.0'])(
-    'keeps unsupported jsdom %s on the native dependency path',
-    async (version) => {
-      const root = fs.mkdtempSync(
-        path.join(os.tmpdir(), 'rstest-env-unsupported-version-'),
-      );
-      createPackage(root, 'export class JSDOM {}', { version });
 
       const result = await prepareTestEnvironmentModules({
         projects: [createProject(root, { prebundle: 'auto' })],
@@ -359,292 +326,309 @@ exports.canvasInstalled = canvasInstalled;
 
       try {
         const moduleReference = result.modules.get('jsdom');
-        expect(moduleReference?.resolvedPath).toBeTruthy();
-        expect(moduleReference?.bundlePath).toBeUndefined();
+        expect(moduleReference?.bundlePath).toBeTruthy();
+        if (!moduleReference?.bundlePath) {
+          throw new Error('Expected jsdom to be bundled.');
+        }
+
+        const bundled = await import(
+          pathToFileURL(moduleReference.bundlePath).href
+        );
+        expect(typeof bundled.JSDOM).toBe('function');
+        expect(bundled.canvasInstalled).toBe(false);
       } finally {
         await result.cleanup();
-        fs.rmSync(root, { recursive: true, force: true });
       }
+    });
+  });
+
+  it.each(['14.1.0', '31.0.0'])(
+    'keeps unsupported jsdom %s on the native dependency path',
+    async (version) => {
+      await withTempDir('rstest-env-unsupported-version-', async (root) => {
+        createPackage(root, 'export class JSDOM {}', { version });
+
+        const result = await prepareTestEnvironmentModules({
+          projects: [createProject(root, { prebundle: 'auto' })],
+          rootPath: root,
+        });
+
+        try {
+          const moduleReference = result.modules.get('jsdom');
+          expect(moduleReference?.resolvedPath).toBeTruthy();
+          expect(moduleReference?.bundlePath).toBeUndefined();
+        } finally {
+          await result.cleanup();
+        }
+      });
     },
   );
 
   it.each(['27.4.0', '28.1.0'])(
     'keeps jsdom %s on the native path because bundling can change its optional cssstyle resolution',
     async (version) => {
-      const root = fs.mkdtempSync(
-        path.join(os.tmpdir(), 'rstest-env-cssstyle-resolution-'),
-      );
-      createPackage(root, 'export class JSDOM {}', { version });
+      await withTempDir('rstest-env-cssstyle-resolution-', async (root) => {
+        createPackage(root, 'export class JSDOM {}', { version });
 
-      const result = await prepareTestEnvironmentModules({
-        projects: [createProject(root, { prebundle: 'auto' })],
-        rootPath: root,
+        const result = await prepareTestEnvironmentModules({
+          projects: [createProject(root, { prebundle: 'auto' })],
+          rootPath: root,
+        });
+
+        try {
+          expect(result.modules.get('jsdom')?.resolvedPath).toBeTruthy();
+          expect(result.modules.get('jsdom')?.bundlePath).toBeUndefined();
+        } finally {
+          await result.cleanup();
+        }
       });
-
-      try {
-        expect(result.modules.get('jsdom')?.resolvedPath).toBeTruthy();
-        expect(result.modules.get('jsdom')?.bundlePath).toBeUndefined();
-      } finally {
-        await result.cleanup();
-        fs.rmSync(root, { recursive: true, force: true });
-      }
     },
   );
 
   it('keeps unsupported happy-dom versions on the native dependency path', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-unsupported-happy-dom-'),
-    );
-    createPackage(root, 'export class Window {}', {
-      name: 'happy-dom',
-      version: '21.0.0',
-    });
+    await withTempDir('rstest-env-unsupported-happy-dom-', async (root) => {
+      createPackage(root, 'export class Window {}', {
+        name: 'happy-dom',
+        version: '21.0.0',
+      });
 
-    const result = await prepareTestEnvironmentModules({
-      projects: [
-        createProject(root, {
-          environmentName: 'happy-dom',
-          prebundle: 'auto',
-        }),
-      ],
-      rootPath: root,
-    });
+      const result = await prepareTestEnvironmentModules({
+        projects: [
+          createProject(root, {
+            environmentName: 'happy-dom',
+            prebundle: 'auto',
+          }),
+        ],
+        rootPath: root,
+      });
 
-    try {
-      const moduleReference = result.modules.get('happy-dom');
-      expect(moduleReference?.resolvedPath).toBeTruthy();
-      expect(moduleReference?.bundlePath).toBeUndefined();
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+      try {
+        const moduleReference = result.modules.get('happy-dom');
+        expect(moduleReference?.resolvedPath).toBeTruthy();
+        expect(moduleReference?.bundlePath).toBeUndefined();
+      } finally {
+        await result.cleanup();
+      }
+    });
   });
 
   it('automatically creates a bundle for supported happy-dom 20', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-supported-happy-dom-'),
-    );
-    createPackage(root, 'export class Window {}', {
-      name: 'happy-dom',
-      version: '20.11.1',
-    });
+    await withTempDir('rstest-env-supported-happy-dom-', async (root) => {
+      createPackage(root, 'export class Window {}', {
+        name: 'happy-dom',
+        version: '20.11.1',
+      });
 
-    const result = await prepareTestEnvironmentModules({
-      projects: [
-        createProject(root, {
-          environmentName: 'happy-dom',
-          prebundle: 'auto',
-        }),
-      ],
-      rootPath: root,
-    });
+      const result = await prepareTestEnvironmentModules({
+        projects: [
+          createProject(root, {
+            environmentName: 'happy-dom',
+            prebundle: 'auto',
+          }),
+        ],
+        rootPath: root,
+      });
 
-    try {
-      const moduleReference = result.modules.get('happy-dom');
-      expect(moduleReference?.bundlePath).toBeTruthy();
-      if (!moduleReference?.bundlePath) {
-        throw new Error('Expected happy-dom to be bundled.');
+      try {
+        const moduleReference = result.modules.get('happy-dom');
+        expect(moduleReference?.bundlePath).toBeTruthy();
+        if (!moduleReference?.bundlePath) {
+          throw new Error('Expected happy-dom to be bundled.');
+        }
+        const bundled = await import(
+          pathToFileURL(moduleReference.bundlePath).href
+        );
+        expect(typeof bundled.Window).toBe('function');
+      } finally {
+        await result.cleanup();
       }
-      const bundled = await import(
-        pathToFileURL(moduleReference.bundlePath).href
-      );
-      expect(typeof bundled.Window).toBe('function');
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('forces the happy-dom prebundle outside the automatic version matrix', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-force-happy-dom-'),
-    );
-    createPackage(root, 'export class Window {}', {
-      name: 'happy-dom',
-      version: '21.0.0',
-    });
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [
-        createProject(root, {
-          environmentName: 'happy-dom',
-          prebundle: true,
-        }),
-      ],
-      rootPath: root,
-    });
-
-    try {
-      const moduleReference = result.modules.get('happy-dom');
-      expect(moduleReference?.bundlePath).toBeTruthy();
-      if (!moduleReference?.bundlePath) {
-        throw new Error('Expected happy-dom to be bundled.');
-      }
-      const bundled = await import(
-        pathToFileURL(moduleReference.bundlePath).href
-      );
-      expect(typeof bundled.Window).toBe('function');
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('creates the prebundle independently of the test output module format', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-env-cjs-'));
-    createPackage(root, 'export class JSDOM {}');
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { outputModule: false, prebundle: true })],
-      rootPath: root,
-    });
-
-    try {
-      const moduleReference = result.modules.get('jsdom');
-      expect(moduleReference?.resolvedPath).toBeTruthy();
-      expect(moduleReference?.bundlePath).toBeTruthy();
-      if (!moduleReference?.bundlePath) {
-        throw new Error('Expected jsdom to be bundled.');
-      }
-      const bundled = await import(
-        pathToFileURL(moduleReference.bundlePath).href
-      );
-      expect(typeof bundled.JSDOM).toBe('function');
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('does not prebundle when prebundle is false', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-env-native-'));
-    createPackage(root, 'export class JSDOM {}');
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { prebundle: false })],
-      rootPath: root,
-    });
-
-    try {
-      expect(result.modules.get('jsdom')).toMatchObject({
-        name: 'jsdom',
+    await withTempDir('rstest-env-force-happy-dom-', async (root) => {
+      createPackage(root, 'export class Window {}', {
+        name: 'happy-dom',
+        version: '21.0.0',
       });
-      expect(result.modules.get('jsdom')?.bundlePath).toBeUndefined();
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
 
-  it('does not prebundle by default', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-default-native-'),
-    );
-    createPackage(root, 'export class JSDOM {}');
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root)],
-      rootPath: root,
-    });
-
-    try {
-      expect(result.modules.get('jsdom')).toMatchObject({
-        name: 'jsdom',
-      });
-      expect(result.modules.get('jsdom')?.bundlePath).toBeUndefined();
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('falls back to the native entry when the prebundle build fails', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-build-fallback-'),
-    );
-    const resolvedPath = createPackage(
-      root,
-      `import './missing-dependency.js';
-export class JSDOM {}`,
-    );
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { prebundle: true })],
-      rootPath: root,
-    });
-
-    try {
-      expect(result.modules.get('jsdom')).toEqual({
-        name: 'jsdom',
-        packageName: 'jsdom',
-        resolvedPath,
-        bundlePath: undefined,
-      });
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('forces the prebundle outside the automatic version matrix', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-env-force-'));
-    createPackage(root, 'export class JSDOM {}', { version: '31.0.0' });
-
-    const result = await prepareTestEnvironmentModules({
-      projects: [createProject(root, { prebundle: true })],
-      rootPath: root,
-    });
-
-    try {
-      expect(result.modules.get('jsdom')?.bundlePath).toBeTruthy();
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('updates the live module map when a synthetic environment is reused', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-live-update-'),
-    );
-    createPackage(root, 'export class JSDOM {}');
-    createPackage(root, 'export class Window {}', {
-      name: 'happy-dom',
-      version: '20.11.1',
-    });
-    const environmentName = 'default-environment-1';
-    const result = await prepareTestEnvironmentModules({
-      projects: [
-        createProject(root, {
-          environmentName: 'jsdom',
-          prebundle: true,
-        }),
-      ].map((project) => ({ ...project, environmentName })),
-      rootPath: root,
-    });
-    const liveModules = result.modules;
-
-    try {
-      expect(liveModules.get(environmentName)?.name).toBe('jsdom');
-
-      await result.update(
-        [
+      const result = await prepareTestEnvironmentModules({
+        projects: [
           createProject(root, {
             environmentName: 'happy-dom',
             prebundle: true,
           }),
-        ].map((project) => ({ ...project, environmentName })),
+        ],
+        rootPath: root,
+      });
+
+      try {
+        const moduleReference = result.modules.get('happy-dom');
+        expect(moduleReference?.bundlePath).toBeTruthy();
+        if (!moduleReference?.bundlePath) {
+          throw new Error('Expected happy-dom to be bundled.');
+        }
+        const bundled = await import(
+          pathToFileURL(moduleReference.bundlePath).href
+        );
+        expect(typeof bundled.Window).toBe('function');
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+
+  it('creates the prebundle independently of the test output module format', async () => {
+    await withTempDir('rstest-env-cjs-', async (root) => {
+      createPackage(root, 'export class JSDOM {}');
+
+      const result = await prepareTestEnvironmentModules({
+        projects: [
+          createProject(root, { outputModule: false, prebundle: true }),
+        ],
+        rootPath: root,
+      });
+
+      try {
+        const moduleReference = result.modules.get('jsdom');
+        expect(moduleReference?.resolvedPath).toBeTruthy();
+        expect(moduleReference?.bundlePath).toBeTruthy();
+        if (!moduleReference?.bundlePath) {
+          throw new Error('Expected jsdom to be bundled.');
+        }
+        const bundled = await import(
+          pathToFileURL(moduleReference.bundlePath).href
+        );
+        expect(typeof bundled.JSDOM).toBe('function');
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+
+  it('does not prebundle when prebundle is false', async () => {
+    await withTempDir('rstest-env-native-', async (root) => {
+      createPackage(root, 'export class JSDOM {}');
+
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(root, { prebundle: false })],
+        rootPath: root,
+      });
+
+      try {
+        expect(result.modules.get('jsdom')).toMatchObject({
+          name: 'jsdom',
+        });
+        expect(result.modules.get('jsdom')?.bundlePath).toBeUndefined();
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+
+  it('does not prebundle by default', async () => {
+    await withTempDir('rstest-env-default-native-', async (root) => {
+      createPackage(root, 'export class JSDOM {}');
+
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(root)],
+        rootPath: root,
+      });
+
+      try {
+        expect(result.modules.get('jsdom')).toMatchObject({
+          name: 'jsdom',
+        });
+        expect(result.modules.get('jsdom')?.bundlePath).toBeUndefined();
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+
+  it('falls back to the native entry when the prebundle build fails', async () => {
+    await withTempDir('rstest-env-build-fallback-', async (root) => {
+      const resolvedPath = createPackage(
+        root,
+        `import './missing-dependency.js';
+export class JSDOM {}`,
       );
 
-      expect(result.modules).toBe(liveModules);
-      expect(liveModules.get(environmentName)).toMatchObject({
-        name: 'happy-dom',
-        packageName: 'happy-dom',
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(root, { prebundle: true })],
+        rootPath: root,
       });
-      expect(liveModules.get(environmentName)?.bundlePath).toBeTruthy();
-    } finally {
-      await result.cleanup();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+
+      try {
+        expect(result.modules.get('jsdom')).toEqual({
+          name: 'jsdom',
+          packageName: 'jsdom',
+          resolvedPath,
+          bundlePath: undefined,
+        });
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+
+  it('forces the prebundle outside the automatic version matrix', async () => {
+    await withTempDir('rstest-env-force-', async (root) => {
+      createPackage(root, 'export class JSDOM {}', { version: '31.0.0' });
+
+      const result = await prepareTestEnvironmentModules({
+        projects: [createProject(root, { prebundle: true })],
+        rootPath: root,
+      });
+
+      try {
+        expect(result.modules.get('jsdom')?.bundlePath).toBeTruthy();
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+
+  it('updates the live module map when a synthetic environment is reused', async () => {
+    await withTempDir('rstest-env-live-update-', async (root) => {
+      createPackage(root, 'export class JSDOM {}');
+      createPackage(root, 'export class Window {}', {
+        name: 'happy-dom',
+        version: '20.11.1',
+      });
+      const environmentName = 'default-environment-1';
+      const result = await prepareTestEnvironmentModules({
+        projects: [
+          createProject(root, {
+            environmentName: 'jsdom',
+            prebundle: true,
+          }),
+        ].map((project) => ({ ...project, environmentName })),
+        rootPath: root,
+      });
+      const liveModules = result.modules;
+
+      try {
+        expect(liveModules.get(environmentName)?.name).toBe('jsdom');
+
+        await result.update(
+          [
+            createProject(root, {
+              environmentName: 'happy-dom',
+              prebundle: true,
+            }),
+          ].map((project) => ({ ...project, environmentName })),
+        );
+
+        expect(result.modules).toBe(liveModules);
+        expect(liveModules.get(environmentName)).toMatchObject({
+          name: 'happy-dom',
+          packageName: 'happy-dom',
+        });
+        expect(liveModules.get(environmentName)?.bundlePath).toBeTruthy();
+      } finally {
+        await result.cleanup();
+      }
+    });
   });
 });

--- a/packages/core/tests/helpers/tempDir.test.ts
+++ b/packages/core/tests/helpers/tempDir.test.ts
@@ -1,0 +1,30 @@
+import { existsSync } from 'node:fs';
+import { describe, expect, it } from '@rstest/core';
+import { withTempDir } from './tempDir';
+
+describe('withTempDir', () => {
+  it('removes the directory after successful completion', async () => {
+    let directory = '';
+
+    await withTempDir('rstest-helper-success-', (tempDirectory) => {
+      directory = tempDirectory;
+      expect(existsSync(directory)).toBe(true);
+    });
+
+    expect(existsSync(directory)).toBe(false);
+  });
+
+  it('removes the directory and propagates callback rejection', async () => {
+    const error = new Error('callback failed');
+    let directory = '';
+
+    await expect(
+      withTempDir('rstest-helper-rejection-', (tempDirectory) => {
+        directory = tempDirectory;
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(existsSync(directory)).toBe(false);
+  });
+});

--- a/packages/core/tests/helpers/tempDir.ts
+++ b/packages/core/tests/helpers/tempDir.ts
@@ -1,0 +1,16 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const withTempDir = async <T>(
+  prefix: string,
+  callback: (directory: string) => T | Promise<T>,
+): Promise<T> => {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+
+  try {
+    return await callback(directory);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+};

--- a/packages/core/tests/runner/resolveDynamicImport.test.ts
+++ b/packages/core/tests/runner/resolveDynamicImport.test.ts
@@ -1,11 +1,5 @@
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
+import { withTempDir } from '../helpers/tempDir';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { join } from 'pathe';
 import {
@@ -96,8 +90,7 @@ describe('finalizeDynamicImport — node: interop skip', () => {
 
 describe('federation dynamic import fallback', () => {
   it('resolves relative specifiers against the injected origin', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'rstest-federation-import-'));
-    try {
+    await withTempDir('rstest-federation-import-', async (dir) => {
       const depPath = join(dir, 'dep.mjs');
       const origin = join(dir, 'source.mjs');
       writeFileSync(depPath, 'export const marker = "from-origin";');
@@ -122,14 +115,11 @@ describe('federation dynamic import fallback', () => {
       );
 
       expect(mod?.marker).toBe('from-origin');
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it('uses the worker origin when the injected origin is unavailable', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'rstest-federation-import-'));
-    try {
+    await withTempDir('rstest-federation-import-', async (dir) => {
       const depPath = join(dir, 'dep.mjs');
       writeFileSync(depPath, 'export const marker = "from-worker-origin";');
 
@@ -154,14 +144,11 @@ describe('federation dynamic import fallback', () => {
       );
 
       expect(mod?.marker).toBe('from-worker-origin');
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it('resolves bare specifiers against the injected origin', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'rstest-federation-import-'));
-    try {
+    await withTempDir('rstest-federation-import-', async (dir) => {
       const packageDir = join(dir, 'node_modules', 'origin-only-pkg');
       mkdirSync(packageDir, { recursive: true });
       writeFileSync(
@@ -193,9 +180,7 @@ describe('federation dynamic import fallback', () => {
       );
 
       expect(mod?.marker).toBe('from-origin-package');
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 });
 

--- a/packages/core/tests/runtime/worker/env/testEnvironmentModule.test.ts
+++ b/packages/core/tests/runtime/worker/env/testEnvironmentModule.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from '@rstest/core';
+import { withTempDir } from '../../../helpers/tempDir';
 import { loadTestEnvironmentModule } from '../../../../src/runtime/worker/env/testEnvironmentModule';
 
 const writeModule = (root: string, name: string, source: string): string => {
@@ -19,9 +19,7 @@ ${jsdomClass}
 
 describe('loadTestEnvironmentModule', () => {
   it('loads the prebundle when its exports are valid', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-env-loader-'));
-
-    try {
+    await withTempDir('rstest-env-loader-', async (root) => {
       const resolvedPath = writeModule(
         root,
         'resolved.mjs',
@@ -62,17 +60,11 @@ describe('loadTestEnvironmentModule', () => {
           bundlePath,
         }),
       ).toBe(loaded);
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('falls back when the jsdom bundle fails its runtime probe', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-probe-fallback-'),
-    );
-
-    try {
+    await withTempDir('rstest-env-probe-fallback-', async (root) => {
       const resolvedPath = writeModule(
         root,
         'resolved.mjs',
@@ -104,17 +96,11 @@ describe('loadTestEnvironmentModule', () => {
       expect(
         (loaded.module.JSDOM as unknown as { source: string }).source,
       ).toBe('resolved');
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('falls back when the jsdom prebundle omits a required export', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-export-fallback-'),
-    );
-
-    try {
+    await withTempDir('rstest-env-export-fallback-', async (root) => {
       const resolvedPath = writeModule(
         root,
         'resolved.mjs',
@@ -146,15 +132,11 @@ describe('loadTestEnvironmentModule', () => {
       expect(
         (loaded.module.JSDOM as unknown as { source: string }).source,
       ).toBe('resolved');
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('falls back to the resolved package entry when the prebundle is invalid', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rstest-env-fallback-'));
-
-    try {
+    await withTempDir('rstest-env-fallback-', async (root) => {
       const resolvedPath = writeModule(
         root,
         'resolved.mjs',
@@ -180,17 +162,11 @@ describe('loadTestEnvironmentModule', () => {
       expect(
         (loaded.module.GlobalWindow as unknown as { source: string }).source,
       ).toBe('resolved');
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('falls back when the prebundle cannot be imported', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-import-fallback-'),
-    );
-
-    try {
+    await withTempDir('rstest-env-import-fallback-', async (root) => {
       const resolvedPath = writeModule(
         root,
         'resolved.mjs',
@@ -215,17 +191,11 @@ describe('loadTestEnvironmentModule', () => {
       expect(
         (loaded.module.JSDOM as unknown as { source: string }).source,
       ).toBe('resolved');
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('reports the native module path and expected exports', async () => {
-    const root = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'rstest-env-invalid-native-'),
-    );
-
-    try {
+    await withTempDir('rstest-env-invalid-native-', async (root) => {
       const resolvedPath = writeModule(
         root,
         'resolved.mjs',
@@ -241,8 +211,6 @@ describe('loadTestEnvironmentModule', () => {
       ).rejects.toThrow(
         `Invalid jsdom test environment dependency loaded from ${resolvedPath}. Expected exports: CookieJar, JSDOM, VirtualConsole.`,
       );
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/packages/core/tests/utils/environmentComments.test.ts
+++ b/packages/core/tests/utils/environmentComments.test.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { withTempDir } from '../helpers/tempDir';
+import { writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { normalize } from 'pathe';
 import { groupProjectEntriesByEnvironment } from '../../src/core/environmentGroups';
@@ -169,16 +169,13 @@ const regexp = /"/;
   });
 
   it('reads comments from the file head', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const file = path.join(root, 'index.test.ts');
       writeFileSync(file, '// @rstest-environment jsdom\n');
       await expect(parseEnvironmentCommentFromFile(file)).resolves.toEqual({
         name: 'jsdom',
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('ignores virtual entries without physical files', async () => {
@@ -188,8 +185,7 @@ const regexp = /"/;
   });
 
   it('preserves global setup claims across synthetic environment groups', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -216,14 +212,11 @@ const regexp = /"/;
       expect(grouped.changed).toBe(true);
       expect(grouped.projects).toHaveLength(2);
       expect(grouped.projects.every((item) => item._globalSetups)).toBe(true);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('marks only one synthetic environment group eligible for global setup', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -252,14 +245,11 @@ const regexp = /"/;
         false,
         true,
       ]);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('keeps the base environment group eligible for global setup regardless of file order', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -298,14 +288,11 @@ const regexp = /"/;
           globalSetupsClaimed: false,
         },
       ]);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('preserves the base project name for files without environment comments', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -340,14 +327,11 @@ const regexp = /"/;
       expect(grouped.entriesCache.get('default')?.entries).toEqual({
         node: nodeFile,
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('creates a synthetic environment when all files override the environment', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(jsdomFile, '// @rstest-environment jsdom\n');
 
@@ -380,14 +364,11 @@ const regexp = /"/;
       expect(
         grouped.entriesCache.get('default-environment-1')?.entries,
       ).toEqual({ jsdom: jsdomFile });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('does not split projects when environment markers only appear in code strings', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const file = path.join(root, 'code-string.test.ts');
       writeFileSync(
         file,
@@ -420,14 +401,11 @@ const jsdom = '// @rstest-environment jsdom';
       ).toEqual({
         file,
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('refreshes environment partitions from the source project under shard', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'a.test.ts');
       const jsdomFile = path.join(root, 'b.test.ts');
       const newNodeFile = path.join(root, 'c.test.ts');
@@ -481,14 +459,11 @@ const jsdom = '// @rstest-environment jsdom';
       ).toEqual({
         'b~test~ts': normalize(jsdomFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('preserves a modified base environment when refreshing partitions', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -541,14 +516,11 @@ const jsdom = '// @rstest-environment jsdom';
       ).toEqual({
         'jsdom~test~ts': normalize(jsdomFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('keeps project names unique when refreshing renamed partitions', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const implicitJsdomFile = path.join(root, 'implicit-jsdom.test.ts');
       const initialNodeFile = path.join(root, 'initial-node.test.ts');
       const explicitJsdomFile = path.join(root, 'explicit-jsdom.test.ts');
@@ -629,14 +601,11 @@ const jsdom = '// @rstest-environment jsdom';
       ).toEqual({
         'explicit-node~test~ts': normalize(explicitNodeFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('ignores invalid environment comments before config hooks can exclude them', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const invalidFile = path.join(root, 'invalid.test.ts');
       const validFile = path.join(root, 'valid.test.ts');
       writeFileSync(invalidFile, '// @rstest-environment custom\n');
@@ -677,14 +646,11 @@ const jsdom = '// @rstest-environment jsdom';
       expect(refreshed.entriesCache.get('default')?.entries).toEqual({
         'valid~test~ts': normalize(validFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('keeps browser entries when refreshing node environment partitions', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       const browserFile = path.join(root, 'browser.test.ts');
@@ -746,14 +712,11 @@ const jsdom = '// @rstest-environment jsdom';
       expect(refreshed.entriesCache.get('browser')?.entries).toEqual({
         'browser~test~ts': normalize(browserFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('recreates a missing base partition when refreshed entries need it', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -809,14 +772,11 @@ const jsdom = '// @rstest-environment jsdom';
       ).toEqual({
         'jsdom~test~ts': normalize(jsdomFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('preserves synthetic project discovery changes during refresh', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       const newJsdomFile = path.join(root, 'new-jsdom.test.ts');
@@ -871,14 +831,11 @@ const jsdom = '// @rstest-environment jsdom';
       expect(refreshed.entriesCache.get('default')?.entries).toEqual({
         'node~test~ts': normalize(nodeFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('preserves claimed global setup when refresh recreates the base partition', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -937,14 +894,11 @@ const jsdom = '// @rstest-environment jsdom';
           globalSetupsClaimed: true,
         },
       ]);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('preserves a modified base environment for option-only partitions', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const file = path.join(root, 'options.test.ts');
       writeFileSync(
         file,
@@ -997,14 +951,11 @@ const jsdom = '// @rstest-environment jsdom';
       ).toEqual({
         'options~test~ts': normalize(file),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('moves implicit entries when the base environment changes during refresh', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const implicitNodeFile = path.join(root, 'implicit-node.test.ts');
       const explicitNodeFile = path.join(root, 'explicit-node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
@@ -1080,14 +1031,11 @@ const jsdom = '// @rstest-environment jsdom';
         'explicit-node~test~ts': normalize(explicitNodeFile),
         'jsdom~test~ts': normalize(jsdomFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('recomputes global setup owner when refresh removes the base partition', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'node.test.ts');
       const jsdomFile = path.join(root, 'jsdom.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -1137,14 +1085,11 @@ const jsdom = '// @rstest-environment jsdom';
       ).toEqual({
         'jsdom~test~ts': normalize(jsdomFile),
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('moves global setup owner to a sharded partition with entries', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'a.test.ts');
       const jsdomFile = path.join(root, 'b.test.ts');
       writeFileSync(nodeFile, '// node test\n');
@@ -1206,14 +1151,11 @@ const jsdom = '// @rstest-environment jsdom';
           globalSetupsClaimed: false,
         },
       ]);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('refreshes sharded browser entries after list partition refresh', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const nodeFile = path.join(root, 'a.test.ts');
       const jsdomFile = path.join(root, 'b.test.ts');
       const browserFile = path.join(root, 'c.test.ts');
@@ -1295,14 +1237,11 @@ const jsdom = '// @rstest-environment jsdom';
           '0~test~ts': normalize(newBrowserFile),
         },
       });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('validates ignored environment comment errors on the final run plan', async () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'rstest-env-comment-'));
-    try {
+    await withTempDir('rstest-env-comment-', async (root) => {
       const file = path.join(root, 'invalid.test.ts');
       writeFileSync(file, '// @rstest-environment custom\n');
 
@@ -1335,8 +1274,6 @@ const jsdom = '// @rstest-environment jsdom';
       await expect(planState.validateEnvironmentComments()).rejects.toThrow(
         'Unsupported test environment "custom"',
       );
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Centralize callback-scoped temporary directory creation and cleanup in a test-only `withTempDir` helper.
- Migrate 63 isolated `@rstest/core` test cases without changing their system-temp location, fixture contents, production calls, assertions, or cleanup ordering.
- Ensure temporary roots are removed when fixture setup or the test callback rejects.

## Checklist

- [x] Tests updated.
- [x] Documentation not required; this is a test-only refactor.