### PR TITLE
feat(core): support project-level silent config

### DIFF
--- a/e2e/browser-mode/console.test.ts
+++ b/e2e/browser-mode/console.test.ts
@@ -66,6 +66,16 @@ describe('browser mode - console forwarding', () => {
     },
   );
 
+  it('should use each project silent config', async () => {
+    const { expectExecSuccess, cli } = await runBrowserCli('silent', {
+      args: ['-c', 'rstest.projects.config.mts'],
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).not.toContain('console from browser-silent');
+    expect(cli.stdout).toContain('console from browser-loud');
+  });
+
   // `silent: 'passed-only'` buffers logs and replays only the failing tasks'
   // logs through the shared silent-console controller — the same engine the node
   // pool uses. Replayed logs now go through the owning project's `onConsoleLog`

--- a/e2e/browser-mode/fixtures/silent/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/silent/rstest.config.mts
@@ -8,6 +8,6 @@ export default defineConfig({
     headless: true,
     port: BROWSER_PORTS.silent,
   },
-  include: ['tests/**/*.test.ts'],
+  include: ['tests/silent.test.ts'],
   testTimeout: BROWSER_TEST_TIMEOUT,
 });

--- a/e2e/browser-mode/fixtures/silent/rstest.onConsoleLogFalse.config.mts
+++ b/e2e/browser-mode/fixtures/silent/rstest.onConsoleLogFalse.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
     headless: true,
     port: BROWSER_PORTS.silent,
   },
-  include: ['tests/**/*.test.ts'],
+  include: ['tests/silent.test.ts'],
   testTimeout: BROWSER_TEST_TIMEOUT,
   onConsoleLog: () => false,
 });

--- a/e2e/browser-mode/fixtures/silent/rstest.projects.config.mts
+++ b/e2e/browser-mode/fixtures/silent/rstest.projects.config.mts
@@ -1,0 +1,37 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS, BROWSER_TEST_TIMEOUT } from '../ports';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'browser-silent',
+      include: ['tests/projects.test.ts'],
+      silent: 'passed-only',
+      env: {
+        RSTEST_E2E_SILENT_PROJECT: 'browser-silent',
+      },
+      browser: {
+        enabled: true,
+        provider: 'playwright',
+        headless: true,
+        port: BROWSER_PORTS.silent,
+      },
+      testTimeout: BROWSER_TEST_TIMEOUT,
+    },
+    {
+      name: 'browser-loud',
+      include: ['tests/projects.test.ts'],
+      silent: false,
+      env: {
+        RSTEST_E2E_SILENT_PROJECT: 'browser-loud',
+      },
+      browser: {
+        enabled: true,
+        provider: 'playwright',
+        headless: true,
+        port: BROWSER_PORTS.silent,
+      },
+      testTimeout: BROWSER_TEST_TIMEOUT,
+    },
+  ],
+});

--- a/e2e/browser-mode/fixtures/silent/tests/projects.test.ts
+++ b/e2e/browser-mode/fixtures/silent/tests/projects.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+it('uses the project silent config', () => {
+  console.log(`console from ${import.meta.env.RSTEST_E2E_SILENT_PROJECT}`);
+  expect(1 + 1).toBe(2);
+});

--- a/e2e/reporter/fixtures/silentProjects.config.mts
+++ b/e2e/reporter/fixtures/silentProjects.config.mts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'silent-a',
+      root: 'fixtures',
+      include: ['silentProjects.test.ts'],
+      silent: true,
+      env: {
+        RSTEST_E2E_SILENT_PROJECT: 'silent-a',
+      },
+    },
+    {
+      name: 'loud-b',
+      root: 'fixtures',
+      include: ['silentProjects.test.ts'],
+      silent: false,
+      env: {
+        RSTEST_E2E_SILENT_PROJECT: 'loud-b',
+      },
+    },
+  ],
+});

--- a/e2e/reporter/fixtures/silentProjects.test.ts
+++ b/e2e/reporter/fixtures/silentProjects.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from '@rstest/core';
+
+it('uses the project silent config', () => {
+  console.log(`console from ${process.env.RSTEST_E2E_SILENT_PROJECT}`);
+  expect(1 + 1).toBe(2);
+});

--- a/e2e/reporter/index.test.ts
+++ b/e2e/reporter/index.test.ts
@@ -110,6 +110,27 @@ describe.concurrent('reporters', () => {
     expect(cli.stdout).not.toContain('passing case log');
   });
 
+  it('default - each project uses its own silent config', async ({
+    onTestFinished,
+  }) => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', 'fixtures/silentProjects.config.mts'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).toContain('[silent-a]');
+    expect(cli.stdout).toContain('[loud-b]');
+    expect(cli.stdout).not.toContain('console from silent-a');
+    expect(cli.stdout).toContain('console from loud-b');
+  });
+
   it('dot - silent passed-only', async ({ onTestFinished }) => {
     const { cli } = await runRstestCli({
       command: 'rstest',

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -761,23 +761,40 @@ export const runBrowserController = async (
     return sink;
   };
 
-  // Silent-console buffering runs through the shared controller — the same
-  // engine the node worker uses — so `silent: 'passed-only'` buffers logs and
-  // replays only the failing tasks'. Intercepted replays route through the
-  // owning project's sink, so they honor per-project `onConsoleLog` and
-  // `disableConsoleIntercept` (the browser host previously flushed straight to
-  // reporters, bypassing both). `writeOriginalLog` is a host-side no-op: page
-  // logs have no host "original stream" — the page console and headed terminal
-  // forwarding already show them, so re-emitting here would double-print.
-  const silentConsoleController = createSilentConsoleController({
-    runtimeConfig: {
-      silent: context.normalizedConfig.silent,
-      disableConsoleIntercept: context.normalizedConfig.disableConsoleIntercept,
-    },
-    emitInterceptedLog: (log) =>
-      sinkForProjectName(log.project).onConsoleLog(log),
-    writeOriginalLog: () => {},
-  });
+  // Each project owns its silent-console buffer. Besides preserving each
+  // project's config, this keeps concurrent projects that run the same test path
+  // from sharing task-id keyed buffered logs. Controllers that are not using
+  // `passed-only` never buffer, so lifecycle handlers can flush unconditionally.
+  // `writeOriginalLog` is a host-side no-op: page logs have no host "original
+  // stream" — the page console and headed terminal forwarding already show them,
+  // so re-emitting here would double-print.
+  const silentConsoleControllers = new Map<
+    string,
+    ReturnType<typeof createSilentConsoleController>
+  >(
+    browserProjects.map((project) => [
+      project.name,
+      createSilentConsoleController({
+        runtimeConfig: {
+          silent: project.normalizedConfig.silent,
+          disableConsoleIntercept:
+            project.normalizedConfig.disableConsoleIntercept,
+        },
+        emitInterceptedLog: (log) =>
+          sinkForProjectName(log.project).onConsoleLog(log),
+        writeOriginalLog: () => {},
+      }),
+    ]),
+  );
+  const silentConsoleControllerForProjectName = (projectName: string) => {
+    const controller = silentConsoleControllers.get(projectName);
+    if (!controller) {
+      throw new Error(
+        `No silent console controller for project "${projectName}"`,
+      );
+    }
+    return controller;
+  };
 
   const snapshotRpcMethods = {
     async resolveSnapshotPath(testPath: string): Promise<string> {
@@ -860,15 +877,15 @@ export const runBrowserController = async (
       ?.recordSuiteResult(payload);
     await sinkForProjectName(payload.project).onTestSuiteResult(payload);
 
-    if (context.normalizedConfig.silent === 'passed-only') {
-      silentConsoleController.flushBufferedLogsForTask({
-        taskId: payload.testId,
-        status: payload.status,
-        taskParentNames: payload.parentNames,
-        taskType: 'suite',
-        testPath: payload.testPath,
-      });
-    }
+    silentConsoleControllerForProjectName(
+      payload.project,
+    ).flushBufferedLogsForTask({
+      taskId: payload.testId,
+      status: payload.status,
+      taskParentNames: payload.parentNames,
+      taskType: 'suite',
+      testPath: payload.testPath,
+    });
   };
 
   const handleTestCaseStart = async (
@@ -888,15 +905,15 @@ export const runBrowserController = async (
       ?.recordCaseResult(payload);
     await sinkForProjectName(payload.project).onTestCaseResult(payload);
 
-    if (context.normalizedConfig.silent === 'passed-only') {
-      silentConsoleController.flushBufferedLogsForTask({
-        taskId: payload.testId,
-        status: payload.status,
-        taskParentNames: payload.parentNames,
-        taskType: 'case',
-        testPath: payload.testPath,
-      });
-    }
+    silentConsoleControllerForProjectName(
+      payload.project,
+    ).flushBufferedLogsForTask({
+      taskId: payload.testId,
+      status: payload.status,
+      taskParentNames: payload.parentNames,
+      taskType: 'case',
+      testPath: payload.testPath,
+    });
   };
 
   const handleTestFileComplete = async (
@@ -916,15 +933,15 @@ export const runBrowserController = async (
       }
     }
 
-    if (context.normalizedConfig.silent === 'passed-only') {
-      silentConsoleController.flushBufferedLogsForTask({
-        taskId: payload.testId,
-        status: payload.status,
-        taskParentNames: payload.parentNames,
-        taskType: 'file',
-        testPath: payload.testPath,
-      });
-    }
+    silentConsoleControllerForProjectName(
+      payload.project,
+    ).flushBufferedLogsForTask({
+      taskId: payload.testId,
+      status: payload.status,
+      taskParentNames: payload.parentNames,
+      taskType: 'file',
+      testPath: payload.testPath,
+    });
 
     // Feeds stateManager, fans out onTestFileResult to reporters, and ingests
     // payload.snapshotResult (the snapshotManager.add moved into the sink).
@@ -945,7 +962,9 @@ export const runBrowserController = async (
       type: payload.type,
       trace: payload.trace,
     };
-    silentConsoleController.onConsoleLog(log);
+    silentConsoleControllerForProjectName(payload.projectName).onConsoleLog(
+      log,
+    );
   };
 
   // Every failing file and every fatal error reaches core through the cycle

--- a/packages/core/src/core/modifyRstestConfig.ts
+++ b/packages/core/src/core/modifyRstestConfig.ts
@@ -566,7 +566,6 @@ const createRstestExposeAPI = (
       coverage: context.normalizedConfig.coverage,
       resolveSnapshotPath: context.normalizedConfig.resolveSnapshotPath,
       onConsoleLog: context.normalizedConfig.onConsoleLog,
-      silent: context.normalizedConfig.silent,
       bail: context.normalizedConfig.bail,
       update: context.normalizedConfig.update,
       onlyFailures: context.normalizedConfig.onlyFailures,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -153,7 +153,6 @@ export type ProjectConfig = Omit<
   | 'coverage'
   | 'resolveSnapshotPath'
   | 'onConsoleLog'
-  | 'silent'
   | 'bail'
   | 'output'
 > & {

--- a/packages/core/tests/core/rsbuild.test.ts
+++ b/packages/core/tests/core/rsbuild.test.ts
@@ -450,7 +450,7 @@ describe('prepareRsbuild', () => {
         resolve: {},
         source: {},
         output: { module: true },
-        silent: false,
+        silent: true,
         tools: {},
         update: false,
         testEnvironment: {
@@ -503,7 +503,7 @@ describe('prepareRsbuild', () => {
       passWithNoTests: true,
       performance: undefined,
       shard: { count: 2, index: 1 },
-      silent: 'passed-only',
+      silent: false,
       update: true,
     });
     expect(getterGlobalConfig.get('from-project-b')).toEqual({
@@ -512,7 +512,7 @@ describe('prepareRsbuild', () => {
       passWithNoTests: true,
       performance: undefined,
       shard: { count: 2, index: 1 },
-      silent: 'passed-only',
+      silent: true,
       update: true,
     });
     expect(getterOutput.get('from-project-a')).toEqual({

--- a/packages/core/tests/core/rstest.test.ts
+++ b/packages/core/tests/core/rstest.test.ts
@@ -104,4 +104,31 @@ describe('rstest context', () => {
       expect(project.normalizedConfig.onConsoleLog).toBe(onConsoleLog);
     }
   });
+
+  it('preserves the silent value of each project', () => {
+    const rstestContext = new Rstest(
+      {
+        cwd: rootPath,
+        command: 'run',
+        projects: [
+          {
+            config: { root: join(rootPath, 'a'), name: 'a', silent: true },
+          },
+          {
+            config: {
+              root: join(rootPath, 'b'),
+              name: 'b',
+              silent: 'passed-only',
+            },
+          },
+          { config: { root: join(rootPath, 'c'), name: 'c' } },
+        ],
+      },
+      { silent: true },
+    );
+
+    expect(
+      rstestContext.projects.map((project) => project.normalizedConfig.silent),
+    ).toEqual([true, 'passed-only', false]);
+  });
 });


### PR DESCRIPTION
## Summary

- Allow `silent` in project configs and expose each project's effective value through `getRstestConfig()`.
- Route browser console handling through per-project controllers so projects can use different `silent` values and `passed-only` buffers cannot collide when projects share test paths.
- Add Node and browser regressions covering independent silent and non-silent projects.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; project config scoping is already documented).
