### PR TITLE
fix(browser): recover watch after initial fatal error

### DIFF
--- a/e2e/browser-mode/watch.test.ts
+++ b/e2e/browser-mode/watch.test.ts
@@ -182,6 +182,38 @@ describe('browser mode - watch', () => {
     await deleteFixtureTarget(fs, fixturesTargetPath);
   }, 60_000);
 
+  it('recovers when the initial browser cycle fails fatally', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures/fixtures-test-browser-watch-initial-fatal`;
+    const setupPath = path.join(fixturesTargetPath, 'setup.ts');
+    const initialFatal = "throw new Error('initial browser setup failed');\n";
+
+    const { fs } = await prepareFixtures({
+      fixturesPath: `${__dirname}/fixtures/watch`,
+      fixturesTargetPath,
+    });
+    fs.delete(path.join(fixturesTargetPath, 'tests/another.test.ts'));
+    fs.update(setupPath, (content) => initialFatal + content);
+
+    const { cli } = await runBrowserWatchCliWithCwd(fixturesTargetPath);
+
+    try {
+      await cli.waitForStderr('initial browser setup failed');
+      await cli.waitForStdout('Waiting for file changes...');
+
+      cli.resetStd();
+      fs.update(setupPath, (content) => content.replace(initialFatal, ''));
+
+      await cli.waitForStdout(
+        '[Watch] Setup file changed, re-running all test files of the project',
+      );
+      await cli.waitForStdout('Re-running 1 affected test file(s)');
+      await cli.waitForStdout('Test Files 1 passed');
+    } finally {
+      await killCliProcessTree(cli);
+      await deleteFixtureTarget(fs, fixturesTargetPath);
+    }
+  }, 60_000);
+
   // The bundler keeps no file watcher attached while its dev-compile hook is
   // pending, so a rerun trigger signalled from that hook must hand the cycle to
   // core and return. Holding the hook for the whole cycle makes every file

--- a/e2e/browser-mode/watchHeaded.test.ts
+++ b/e2e/browser-mode/watchHeaded.test.ts
@@ -50,4 +50,46 @@ describe('browser mode - headed watch', () => {
       }
     },
   );
+
+  it.runIf(shouldRunHeadedBrowserTests)(
+    'should keep the watch session live after an initial fatal error',
+    async () => {
+      const fixturesTargetPath = `${__dirname}/fixtures/fixtures-test-browser-watch-headed-initial-fatal`;
+      const setupPath = path.join(fixturesTargetPath, 'setup.ts');
+      const initialFatal = "throw new Error('initial headed setup failed');\n";
+
+      const { fs } = await prepareFixtures({
+        fixturesPath: `${__dirname}/fixtures/watch`,
+        fixturesTargetPath,
+      });
+      fs.delete(path.join(fixturesTargetPath, 'tests/another.test.ts'));
+      fs.update(setupPath, (content) => initialFatal + content);
+
+      const { cli } = await runBrowserWatchCliWithCwd(fixturesTargetPath, {
+        args: [
+          '--browser.headless',
+          'false',
+          `--browser.port=${BROWSER_PORTS['watch-headed']}`,
+        ],
+      });
+      const waitForOutput = (marker: string) =>
+        Promise.race([cli.waitForStdout(marker), cli.waitForStderr(marker)]);
+
+      try {
+        await waitForOutput('initial headed setup failed');
+        await waitForOutput('Waiting for file changes...');
+
+        fs.update(setupPath, (content) => content.replace(initialFatal, ''));
+        await cli.waitForStdout(
+          '[Watch] Setup file changed, re-running all test files of the project',
+        );
+        await cli.waitForStdout('Re-running 1 affected test file(s)');
+        await cli.waitForStdout('Test Files 1 passed');
+      } finally {
+        await killCliProcessTree(cli);
+        await deleteFixtureTarget(fs, fixturesTargetPath);
+      }
+    },
+    60_000,
+  );
 });

--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -525,7 +525,10 @@ export const runBrowserController = async (
   ): BrowserWatchSession => ({
     runCycle: async (testPaths) => {
       const rerunStartTime = Date.now();
-      const fatalErrorBeforeRun = fatalErrorRef.current;
+      // A fatal error is one cycle's outcome, not permanent session state. The
+      // headed scheduler also uses this ref to stop the rest of a failed cycle,
+      // so carrying it forward would prevent the next cycle from reloading.
+      fatalErrorRef.current = null;
       let rerunError: Error | undefined;
 
       try {
@@ -537,10 +540,7 @@ export const runBrowserController = async (
         rerunError = toError(error);
       }
 
-      const rerunFatalError =
-        fatalErrorRef.current && fatalErrorRef.current !== fatalErrorBeforeRun
-          ? fatalErrorRef.current
-          : undefined;
+      const rerunFatalError = fatalErrorRef.current ?? undefined;
       return buildRerunOutcome({
         rerunTestPaths: testPaths,
         testTime: Math.max(0, Date.now() - rerunStartTime),
@@ -1042,17 +1042,20 @@ export const runBrowserController = async (
         },
       });
 
+  // The first build must not trigger a duplicate cycle, but a fatal test cycle
+  // does not invalidate the session the scheduler already established.
+  watchState.hooksEnabled = watchSession !== undefined;
+
   // A fatal error the run reported outranks its results: it rides the returned
   // outcome into core's finalize, which raises the exit code from it.
   if (fatalErrorRef.current) {
-    return failWithError(fatalErrorRef.current, close);
+    return {
+      ...(await failWithError(fatalErrorRef.current, close)),
+      watchSession,
+    };
   }
 
   context.updateReporterResultState(reporterResults, caseResults);
-
-  // Enable the compile hooks only after the initial cycle, so the first build
-  // never triggers a duplicate run.
-  watchState.hooksEnabled = isWatchMode;
 
   return {
     results: reporterResults,


### PR DESCRIPTION
## Summary

- Preserve the browser watch session and enable compile hooks when the initial client cycle reports a fatal error, allowing file changes to trigger recovery runs.
- Reset fatal state at the start of each watch cycle so a previous headed failure cannot block the next browser reload.
- Cover initial setup-file fatal recovery in both headless and headed browser watch E2E tests.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).