### PR TITLE
fix(core): reset soft assertion errors before retry

### DIFF
--- a/e2e/browser-mode/fixtures/basic/tests/retryContext.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/retryContext.test.ts
@@ -18,6 +18,12 @@ test(
   },
 );
 
+let softAttempts = 0;
+test('soft assertion retry can recover', { retry: 1 }, () => {
+  softAttempts += 1;
+  expect.soft(softAttempts).toBe(2);
+});
+
 afterAll(() => {
   expect(retryCounts).toEqual([0, 1]);
 });

--- a/e2e/expect/test/fixtures/soft.test.ts
+++ b/e2e/expect/test/fixtures/soft.test.ts
@@ -5,3 +5,15 @@ test('expect.soft test', () => {
   expect.soft(1 + 2).toBe(4); // should mark the test as fail and continue
   expect.soft(1 + 3).toBe(4);
 });
+
+let attempts = 0;
+test('expect.soft retry can recover', { retry: 1 }, () => {
+  attempts += 1;
+  expect.soft(attempts).toBe(2);
+});
+
+let failedAttempts = 0;
+test('expect.soft preserves failed retry errors', { retry: 1 }, () => {
+  failedAttempts += 1;
+  expect.soft(failedAttempts).toBe(100);
+});

--- a/e2e/expect/test/soft.test.ts
+++ b/e2e/expect/test/soft.test.ts
@@ -28,5 +28,16 @@ describe('Expect Soft API', () => {
     expect(
       logs.find((log) => log.includes('AssertionError: expected 3 to be 4')),
     ).toBeTruthy();
+    expect(cli.stdout).toContain('✓ expect.soft retry can recover');
+    expect(
+      logs.filter((log) =>
+        log.includes('AssertionError: expected 1 to be 100'),
+      ),
+    ).toHaveLength(1);
+    expect(
+      logs.filter((log) =>
+        log.includes('AssertionError: expected 2 to be 100'),
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -937,6 +937,9 @@ export class TestRunner {
     fixtureCleanups: (() => Promise<void>)[],
     retryCount: number,
   ): FixtureResolver {
+    // @vitest/expect records soft failures on the test object; each attempt must
+    // start clean because retry history is preserved separately in retryErrors.
+    test.result = undefined;
     setState<MatcherState>(
       {
         assertionCalls: 0,


### PR DESCRIPTION
## Summary

- Fix `expect.soft` failures from a previous attempt leaking into a successful retry and incorrectly failing the test.
- Reset attempt-local test results before each run while preserving failed-attempt history through the existing `retryErrors` aggregation.
- Add Node and Browser mode regression coverage for successful recovery, plus coverage that errors from fully failed retries remain reported exactly once.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).