### PR TITLE
fix(core): unify matcher state ownership

### DIFF
--- a/e2e/expect/test/index.test.ts
+++ b/e2e/expect/test/index.test.ts
@@ -98,10 +98,26 @@ describe('Expect API', () => {
     contextExpect(1 + 2).toBe(3);
   });
 
-  it('uses one expect instance for sequential tests', ({
+  it('shares context assertion counts with imported expect', ({
     expect: contextExpect,
   }) => {
-    expect(contextExpect).toBe(expect);
+    contextExpect.assertions(2);
+    expect(1 + 1).toBe(2);
+    contextExpect(1 + 2).toBe(3);
+  });
+
+  it('satisfies imported hasAssertions with context expect', ({
+    expect: contextExpect,
+  }) => {
+    expect.hasAssertions();
+    contextExpect(1 + 1).toBe(2);
+  });
+
+  it('satisfies context hasAssertions with imported expect', ({
+    expect: contextExpect,
+  }) => {
+    contextExpect.hasAssertions();
+    expect(1 + 1).toBe(2);
   });
 
   it.fails(

--- a/e2e/expect/test/index.test.ts
+++ b/e2e/expect/test/index.test.ts
@@ -90,6 +90,36 @@ describe('Expect API', () => {
     expect(1 + 3).toBe(4);
   });
 
+  it('shares assertion counts between imported and context expect', ({
+    expect: contextExpect,
+  }) => {
+    expect.assertions(2);
+    expect(1 + 1).toBe(2);
+    contextExpect(1 + 2).toBe(3);
+  });
+
+  it('uses one expect instance for sequential tests', ({
+    expect: contextExpect,
+  }) => {
+    expect(contextExpect).toBe(expect);
+  });
+
+  it.fails(
+    'enforces imported assertion counts for context expect',
+    ({ expect: contextExpect }) => {
+      expect.assertions(2);
+      contextExpect(1 + 1).toBe(2);
+    },
+  );
+
+  it.fails(
+    'enforces imported hasAssertions for context expect',
+    ({ expect: contextExpect }) => {
+      expect.hasAssertions();
+      void contextExpect;
+    },
+  );
+
   it('passes the full test name to custom matchers', ({ expect }) => {
     expect.extend({
       toHaveCurrentTestName(_, expected) {

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -55,19 +55,31 @@ export function setupChaiConfig(config: ChaiConfig): void {
   Object.assign(chaiConfig, config);
 }
 
-/**
- * The per-file slate of `expect` state: assertion bookkeeping cleared and
- * `testPath` (re-)established as a live getter — the runner pins `testPath` to
- * a plain value per test, so each file must restore the getter.
- */
-const freshExpectState = (
-  getWorkerState: () => WorkerState,
-): Partial<MatcherState> => ({
+const EXPECT_BOOKKEEPING_STATE = {
   assertionCalls: 0,
   isExpectingAssertions: false,
   isExpectingAssertionsError: null,
   expectedAssertionsNumber: null,
   expectedAssertionsNumberErrorGen: null,
+} satisfies Partial<MatcherState>;
+
+export const resetExpectState = (
+  expect: RstestExpect,
+  state: Partial<MatcherState>,
+): void => {
+  setState<MatcherState>(EXPECT_BOOKKEEPING_STATE, expect);
+  // Keep this separate from the bookkeeping reset: setState preserves getters
+  // such as the file-level testPath binding, while object spread would not.
+  setState<MatcherState>(state, expect);
+};
+
+/**
+ * The runner pins `testPath` to a plain value per test, so each file must
+ * restore this live getter.
+ */
+const fileExpectState = (
+  getWorkerState: () => WorkerState,
+): Partial<MatcherState> => ({
   // `testPath` is user-facing; expose the OS-native path (equal to
   // `import.meta.filename`) for every expect instance — global and the
   // public per-test `context.expect` alike. Internally it stays POSIX (#1465).
@@ -75,6 +87,13 @@ const freshExpectState = (
     return toNativePath(getWorkerState().testPath);
   },
 });
+
+type GlobalWithExpect = typeof globalThis & {
+  [GLOBAL_EXPECT]: RstestExpect;
+};
+
+export const getGlobalExpect = (): RstestExpect =>
+  (globalThis as GlobalWithExpect)[GLOBAL_EXPECT];
 
 // Vitest 4.1 types `returned(value)`, while its runtime also accepts no arguments.
 const ReturnedAlias: ChaiPlugin = (chai, utils) => {
@@ -86,6 +105,13 @@ const ReturnedAlias: ChaiPlugin = (chai, utils) => {
     };
   });
 };
+
+// These plugins mutate Chai's process-level prototype, not an expect instance.
+use(JestExtend);
+use(JestChaiExpect);
+use(ChaiStyleAssertions);
+use(ReturnedAlias);
+use(JestAsymmetricMatchers);
 
 export function createExpect({
   getCurrentTest,
@@ -102,14 +128,9 @@ export function createExpect({
   getCurrentTest: () => TestCase | undefined;
   snapshotPlugin?: ChaiPlugin;
 }): RstestExpect {
-  use(JestExtend);
-  use(JestChaiExpect);
-  use(ChaiStyleAssertions);
-  use(ReturnedAlias);
   if (snapshotPlugin) {
     use(snapshotPlugin);
   }
-  use(JestAsymmetricMatchers);
 
   const expect = ((value: any, message?: string): Assertion => {
     const { assertionCalls } = getState(expect);
@@ -131,9 +152,7 @@ export function createExpect({
   const globalState = getState((globalThis as any)[GLOBAL_EXPECT]) || {};
 
   setState<MatcherState>({ ...globalState }, expect);
-  // Separate call: `setState` merges property DESCRIPTORS, which keeps the
-  // `testPath` getter that a spread literal would have eagerly evaluated.
-  setState<MatcherState>(freshExpectState(getWorkerState), expect);
+  resetExpectState(expect, fileExpectState(getWorkerState));
 
   // @ts-expect-error chai.expect.extend untyped
   expect.extend = (matchers) => chaiExpect.extend(expect, matchers);
@@ -209,9 +228,9 @@ const getContextWorkerState = (): WorkerState => fileContext().workerState;
  * time, so any value-copied reference (`expect.poll`, `.soft`, `{ ...api }`)
  * captured in a module shared under `isolate: false` stays live — no
  * delegation needed, there is only one instance. Per-file state is RESET, not
- * rebuilt. The per-test local expect (`context.expect`, created via
- * `createExpect` in the runner) intentionally stays a pinned per-test instance
- * to keep `test.concurrent` isolation.
+ * rebuilt. Sequential tests use this same instance for `context.expect`, so
+ * assertion bookkeeping has one owner. Concurrent tests get a pinned local
+ * instance to keep their state isolated.
  */
 export const createFileExpect = (snapshotPlugin: ChaiPlugin): RstestExpect => {
   if (!fileExpect) {
@@ -231,6 +250,6 @@ export const createFileExpect = (snapshotPlugin: ChaiPlugin): RstestExpect => {
   }
   // Later files reuse the singleton on a clean slate, mirroring the previous
   // per-file rebuild (which also carried non-bookkeeping state forward).
-  setState<MatcherState>(freshExpectState(getContextWorkerState), fileExpect);
+  resetExpectState(fileExpect, fileExpectState(getContextWorkerState));
   return fileExpect;
 };

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -228,9 +228,9 @@ const getContextWorkerState = (): WorkerState => fileContext().workerState;
  * time, so any value-copied reference (`expect.poll`, `.soft`, `{ ...api }`)
  * captured in a module shared under `isolate: false` stays live — no
  * delegation needed, there is only one instance. Per-file state is RESET, not
- * rebuilt. Sequential tests use this same instance for `context.expect`, so
- * assertion bookkeeping has one owner. Concurrent tests get a pinned local
- * instance to keep their state isolated.
+ * rebuilt. The per-test local expect (`context.expect`, created by the runner)
+ * stays pinned to its test so concurrent tests and callbacks that outlive a
+ * timeout cannot write into another test's matcher state.
  */
 export const createFileExpect = (snapshotPlugin: ChaiPlugin): RstestExpect => {
   if (!fileExpect) {

--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -30,10 +30,9 @@ import { createRstestUtilities } from './utilities';
  *   - expect (incl. `.poll`/`.soft`) → `createFileExpect`      (./expect)
  *   - rstest / rs                    → `createRstestUtilities` (./utilities)
  *
- * Sequential `context.expect` resolves the same singleton, keeping assertion
- * bookkeeping on one owner. The one intentional exception is concurrent
- * `context.expect`: created inside the running test, it stays pinned to keep
- * concurrent assertion and snapshot state isolated.
+ * The per-test local expect (`context.expect`) stays pinned to its test. The
+ * runner reconciles its assertion bookkeeping with the file singleton for
+ * sequential tests, while concurrent tests keep local-only state.
  *
  * See https://github.com/web-infra-dev/rstest/issues/1376.
  */

--- a/packages/core/src/runtime/api/index.ts
+++ b/packages/core/src/runtime/api/index.ts
@@ -30,9 +30,10 @@ import { createRstestUtilities } from './utilities';
  *   - expect (incl. `.poll`/`.soft`) → `createFileExpect`      (./expect)
  *   - rstest / rs                    → `createRstestUtilities` (./utilities)
  *
- * The one intentional exception is the per-test local expect
- * (`context.expect`): created inside the running test, it can never be stale
- * and stays pinned to keep `test.concurrent` isolation.
+ * Sequential `context.expect` resolves the same singleton, keeping assertion
+ * bookkeeping on one owner. The one intentional exception is concurrent
+ * `context.expect`: created inside the running test, it stays pinned to keep
+ * concurrent assertion and snapshot state isolated.
  *
  * See https://github.com/web-infra-dev/rstest/issues/1376.
  */

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -1,11 +1,10 @@
-import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect';
+import { getState } from '@vitest/expect';
 import type { SnapshotClient, SnapshotState } from '@vitest/snapshot';
 import type {
   AfterEachListener,
   BeforeEachListener,
   CoverageProvider,
   FormattedError,
-  MatcherState,
   OnTestFailedHandler,
   OnTestFinishedHandler,
   Rstest,
@@ -29,7 +28,7 @@ import {
   getTaskNameWithPrefix,
   toNativePath,
 } from '../../utils/helper';
-import { createExpect } from '../api/expect';
+import { createExpect, getGlobalExpect, resetExpectState } from '../api/expect';
 import { formatTestError, TestSkipError } from '../util';
 import type { TaskContext } from '../worker/taskContext';
 import { createFixtureResolver } from './fixtures';
@@ -66,6 +65,7 @@ export class TestRunner {
   /** current test case */
   private _test: TestCase | undefined;
   private workerState: WorkerState | undefined;
+  private readonly localExpects = new WeakMap<TestContext, RstestExpect>();
 
   constructor(private readonly taskContext: TaskContext) {}
 
@@ -337,9 +337,7 @@ export class TestRunner {
                 timeout: test.timeout,
                 stackTraceError: test.stackTraceError,
                 getAssertionCalls: () => {
-                  const expect = (test.context as any)._useLocalExpect
-                    ? test.context.expect
-                    : (globalThis as any)[GLOBAL_EXPECT];
+                  const expect = this.resolveTestExpect(test);
                   const { assertionCalls } = getState(expect);
 
                   return assertionCalls;
@@ -834,8 +832,6 @@ export class TestRunner {
       throw new Error('done() callback is deprecated, use promise instead');
     }) as unknown as TestContext;
 
-    let _expect: RstestExpect | undefined;
-
     const current = this._test;
 
     context.task = {
@@ -854,13 +850,19 @@ export class TestRunner {
 
     Object.defineProperty(context, 'expect', {
       get: () => {
-        if (!_expect) {
-          _expect = createExpect({
+        if (!test.concurrent) {
+          return getGlobalExpect();
+        }
+
+        let expect = this.localExpects.get(context);
+        if (!expect) {
+          expect = createExpect({
             getWorkerState: () => this.workerState!,
             getCurrentTest: () => current,
           });
+          this.localExpects.set(context, expect);
         }
-        return _expect;
+        return expect;
       },
     });
 
@@ -871,9 +873,7 @@ export class TestRunner {
     });
 
     Object.defineProperty(context, '_useLocalExpect', {
-      get() {
-        return _expect != null;
-      },
+      get: () => this.localExpects.has(context),
     });
 
     Object.defineProperty(context, 'onTestFinished', {
@@ -940,22 +940,14 @@ export class TestRunner {
     // @vitest/expect records soft failures on the test object; each attempt must
     // start clean because retry history is preserved separately in retryErrors.
     test.result = undefined;
-    setState<MatcherState>(
-      {
-        assertionCalls: 0,
-        isExpectingAssertions: false,
-        isExpectingAssertionsError: null,
-        expectedAssertionsNumber: null,
-        expectedAssertionsNumberErrorGen: null,
-        // `expect.getState().testPath` is user-facing; expose the OS-native
-        // path (equal to `import.meta.filename`). Internal consumers
-        // (snapshot, reporter, related) keep the POSIX `test.testPath` (#1465).
-        testPath: toNativePath(test.testPath),
-        snapshotState,
-        currentTestName: getTaskNameWithPrefix(test),
-      },
-      (globalThis as any)[GLOBAL_EXPECT],
-    );
+    resetExpectState(getGlobalExpect(), {
+      // `expect.getState().testPath` is user-facing; expose the OS-native
+      // path (equal to `import.meta.filename`). Internal consumers
+      // (snapshot, reporter, related) keep the POSIX `test.testPath` (#1465).
+      testPath: toNativePath(test.testPath),
+      snapshotState,
+      currentTestName: getTaskNameWithPrefix(test),
+    });
 
     const context = this.createTestContext(test, retryCount);
 
@@ -984,11 +976,12 @@ export class TestRunner {
     });
   }
 
+  private resolveTestExpect(test: TestCase): RstestExpect {
+    return this.localExpects.get(test.context) ?? getGlobalExpect();
+  }
+
   private afterRunTest(test: TestCase): void {
-    // @ts-expect-error
-    const expect = test.context._useLocalExpect
-      ? test.context.expect
-      : (globalThis as any)[GLOBAL_EXPECT];
+    const expect = this.resolveTestExpect(test);
 
     const {
       assertionCalls,

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -337,10 +337,7 @@ export class TestRunner {
                 timeout: test.timeout,
                 stackTraceError: test.stackTraceError,
                 getAssertionCalls: () => {
-                  const expect = this.resolveTestExpect(test);
-                  const { assertionCalls } = getState(expect);
-
-                  return assertionCalls;
+                  return this.getAssertionState(test).assertionCalls;
                 },
               });
               await fn(test.context);
@@ -850,10 +847,6 @@ export class TestRunner {
 
     Object.defineProperty(context, 'expect', {
       get: () => {
-        if (!test.concurrent) {
-          return getGlobalExpect();
-        }
-
         let expect = this.localExpects.get(context);
         if (!expect) {
           expect = createExpect({
@@ -976,23 +969,58 @@ export class TestRunner {
     });
   }
 
-  private resolveTestExpect(test: TestCase): RstestExpect {
-    return this.localExpects.get(test.context) ?? getGlobalExpect();
+  private getAssertionState(test: TestCase) {
+    const globalExpect = getGlobalExpect();
+    const globalState = getState(globalExpect);
+    const localExpect = this.localExpects.get(test.context);
+    if (!localExpect) {
+      return globalState;
+    }
+
+    const localState = getState(localExpect);
+    if (test.concurrent) {
+      return localState;
+    }
+
+    const assertionCalls =
+      globalState.assertionCalls + localState.assertionCalls;
+    const hasLocalAssertionCount = localState.expectedAssertionsNumber !== null;
+    const hasLocalAssertionRequirement = localState.isExpectingAssertions;
+
+    return {
+      ...localState,
+      assertionCalls,
+      expectedAssertionsNumber: hasLocalAssertionCount
+        ? localState.expectedAssertionsNumber
+        : globalState.expectedAssertionsNumber,
+      expectedAssertionsNumberErrorGen: hasLocalAssertionCount
+        ? localState.expectedAssertionsNumberErrorGen
+        : globalState.expectedAssertionsNumberErrorGen,
+      isExpectingAssertions:
+        globalState.isExpectingAssertions || localState.isExpectingAssertions,
+      isExpectingAssertionsError: hasLocalAssertionRequirement
+        ? localState.isExpectingAssertionsError
+        : globalState.isExpectingAssertionsError,
+    };
   }
 
   private afterRunTest(test: TestCase): void {
-    const expect = this.resolveTestExpect(test);
-
     const {
       assertionCalls,
       expectedAssertionsNumber,
       expectedAssertionsNumberErrorGen,
       isExpectingAssertions,
       isExpectingAssertionsError,
-    } = getState(expect);
+    } = this.getAssertionState(test);
 
     if (test.result?.state === 'fail') {
       throw test.result.errors;
+    }
+
+    const localExpect = this.localExpects.get(test.context);
+    if (localExpect && !test.concurrent) {
+      getGlobalExpect().setState({ assertionCalls });
+      localExpect.setState({ assertionCalls });
     }
 
     if (


### PR DESCRIPTION
## Summary

- Fix assertion bookkeeping becoming split when a sequential test mixes imported `expect` with `context.expect`, which could cause `expect.assertions()` and `expect.hasAssertions()` constraints to be ignored.
- Keep `context.expect` pinned to its test so timed-out callbacks and concurrent tests cannot write through another test's matcher state, while reconciling imported and context assertion bookkeeping for sequential tests at the runner boundary.
- Install process-level Chai plugins once instead of repeating the installation for every expect instance. Browser-specific `expect.element` integration remains unchanged.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1680

## Validation

- Core build, lint, typecheck, and unused checks.
- Core expect/fixture unit tests.
- Expect, concurrent-context, and timeout E2E tests.
- Timeout regression repeated five times.

## Checklist

- [x] Tests updated.
- [x] Documentation not required (no public API change).
