### PR TITLE
fix(browser): track expect.element assertions

### DIFF
--- a/e2e/browser-mode/fixtures/locator-api/tests/locatorApi.test.ts
+++ b/e2e/browser-mode/fixtures/locator-api/tests/locatorApi.test.ts
@@ -127,3 +127,30 @@ test('locator + expect.element proxy works', async () => {
     .element(page.getByPlaceholder('Name').or(page.getByPlaceholder('Email')))
     .toHaveCount(2);
 });
+
+test('counts a retried element assertion once', async () => {
+  expect.assertions(1);
+
+  const delayed = document.createElement('div');
+  delayed.id = 'delayed-assertion-count';
+  setTimeout(() => document.body.appendChild(delayed), 50);
+
+  await expect.element(page.locator('#delayed-assertion-count')).toBeAttached();
+  delayed.remove();
+});
+
+test.concurrent(
+  'supports element assertions on context expect',
+  async ({ expect: contextExpect }) => {
+    contextExpect.hasAssertions();
+
+    const target = document.createElement('div');
+    target.textContent = 'Context element assertion';
+    document.body.appendChild(target);
+
+    await contextExpect
+      .element(page.getByText('Context element assertion'))
+      .toBeVisible();
+    target.remove();
+  },
+);

--- a/packages/browser/src/client/api.ts
+++ b/packages/browser/src/client/api.ts
@@ -1,4 +1,5 @@
 import type { BrowserElementExpect } from '../augmentExpect';
+import { registerElementExpect } from '@rstest/core/internal/browser-runtime';
 import type { BrowserLocatorText, BrowserRpcRequest } from '../rpcProtocol';
 import { callBrowserRpc } from './browserRpc';
 import {
@@ -158,34 +159,7 @@ const element = (locator: unknown): BrowserElementExpect => {
   return createElementExpect(locator, false);
 };
 
-const markBrowserElement = (): void => {
-  Object.defineProperty(element, '__rstestBrowser', {
-    value: true,
-    configurable: false,
-    enumerable: false,
-    writable: false,
-  });
-};
-
-const installExpectElement = (): void => {
-  // In browser runtime, `@rstest/core` exports are proxies that forward property
-  // access to `globalThis.RSTEST_API`. Patch the underlying expect implementation.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const api = (globalThis as any).RSTEST_API as any;
-  const target = api?.expect;
-  if (!target) {
-    throw new Error(
-      'RSTEST_API.expect is not registered yet. This usually indicates @rstest/browser was imported too early.',
-    );
-  }
-
-  if (typeof target.element !== 'function' || !target.element.__rstestBrowser) {
-    markBrowserElement();
-    target.element = element;
-  }
-};
-
-installExpectElement();
+registerElementExpect(element);
 
 export type {
   BrowserPage,

--- a/packages/core/src/browserRuntime.ts
+++ b/packages/core/src/browserRuntime.ts
@@ -13,6 +13,7 @@
 
 // Runtime API for creating test runtime in browser
 export { createRstestRuntime } from './runtime/api';
+export { registerElementExpect } from './runtime/api/expect';
 // Public test APIs (describe, it, expect, etc.)
 export * from './runtime/api/public';
 export { setRealTimers } from './runtime/util';

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -95,6 +95,14 @@ type GlobalWithExpect = typeof globalThis & {
 export const getGlobalExpect = (): RstestExpect =>
   (globalThis as GlobalWithExpect)[GLOBAL_EXPECT];
 
+type ElementExpectHandler = (locator: unknown) => unknown;
+
+let elementExpectHandler: ElementExpectHandler | undefined;
+
+export const registerElementExpect = (handler: ElementExpectHandler): void => {
+  elementExpectHandler = handler;
+};
+
 // Vitest 4.1 types `returned(value)`, while its runtime also accepts no arguments.
 const ReturnedAlias: ChaiPlugin = (chai, utils) => {
   utils.overwriteMethod(chai.Assertion.prototype, 'returned', () => {
@@ -169,12 +177,20 @@ export function createExpect({
     () => getWorkerState().runtimeConfig.expect.poll,
   );
 
-  (expect as any).element = () => {
-    throw new Error(
-      'expect.element() is only available in browser mode. ' +
-        'Enable browser mode in config and import @rstest/browser to install the browser expect adapter.',
-    );
+  const element = (locator: unknown): unknown => {
+    if (!elementExpectHandler) {
+      throw new Error(
+        'expect.element() is only available in browser mode. ' +
+          'Enable browser mode in config and import @rstest/browser to install the browser expect adapter.',
+      );
+    }
+
+    const assertion = elementExpectHandler(locator);
+    const { assertionCalls } = getState(expect);
+    setState({ assertionCalls: assertionCalls + 1 }, expect);
+    return assertion;
   };
+  Object.assign(expect, { element });
 
   expect.unreachable = (message?: string) => {
     assert.fail(`expected ${message ? `"${message}" ` : ''}not to be reached`);

--- a/packages/core/src/runtime/api/poll.ts
+++ b/packages/core/src/runtime/api/poll.ts
@@ -131,10 +131,7 @@ export function createExpectPoll(
           test.onFinished.push(() => {
             if (!awaited) {
               const negated = util.flag(assertion, 'negate') ? 'not.' : '';
-              const name = util.flag(assertion, '_poll.element')
-                ? 'element(locator)'
-                : 'poll(assertion)';
-              const assertionString = `expect.${name}.${negated}${String(key)}()`;
+              const assertionString = `expect.poll(assertion).${negated}${String(key)}()`;
               const error = new Error(
                 `${assertionString} was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not executed to avoid unhandled rejections:\n\nawait ${assertionString}\n`,
               );


### PR DESCRIPTION
## Summary

### Wait, what does the user see?

A Browser Mode user can write one Locator assertion and ask Rstest to verify that it ran:

```ts
test('shows the saved state', async () => {
  expect.assertions(1);

  await expect.element(page.getByText('Saved')).toBeVisible();
});
```

The Locator assertion succeeds, including any Playwright retries, but the test then fails during settlement:

```text
expected number of assertions to be 1, but got 0
```

The concurrent-safe form is more surprising:

```ts
test.concurrent('shows the saved state', async ({ expect }) => {
  expect.assertions(1);

  await expect.element(page.getByText('Saved')).toBeVisible();
});
```

This fails immediately with `expect.element() is only available in browser mode`, even though the test is already running in Browser Mode.

### What are the two `expect` functions?

Rstest exposes the same assertion API in two forms:

```ts
import { expect } from '@rstest/core'; // shared imported expect

test.concurrent('example', ({ expect }) => {
  // per-test expect: its assertion state belongs only to this test
});
```

`@rstest/core` creates both forms and owns their assertion counts. The per-test form is important for concurrent tests because sharing assertion state between concurrently running tests would mix their counts and failures. `@rstest/browser` does not create a separate assertion API; it adds the Locator-specific `.element()` implementation to these existing expect functions.

### Why did they behave differently?

Previously, `@rstest/browser` replaced `.element()` only on the shared imported expect. The replacement bypassed that expect's normal assertion counting, while the per-test expect never received the Browser implementation and kept the “Browser Mode only” placeholder.

This PR gives every expect created by `@rstest/core` a small `.element()` wrapper. `@rstest/browser` now registers only the Locator implementation behind that wrapper. Therefore:

- a successful `expect.element` call satisfies `expect.assertions()` / `expect.hasAssertions()`;
- Playwright's internal retries still count as one assertion;
- the per-test expect records only in its own test's assertion state.

It also removes the unreachable `_poll.element` branch because Browser element retries happen in the Playwright provider, not Core's `expect.poll`.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1681

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
