### PR TITLE
fix(core): warn when environment prebundle falls back

### DIFF
--- a/packages/core/src/core/envDependencies.ts
+++ b/packages/core/src/core/envDependencies.ts
@@ -44,6 +44,12 @@ export const createTestEnvironmentLoadError = (
   return error;
 };
 
+export const formatTestEnvironmentPrebundleFallbackWarning = (
+  packageName: string,
+  reason: unknown,
+): string =>
+  `Failed to load the test environment prebundle for "${packageName}"; falling back to its native entry. The failed prebundle attempt adds startup overhead.\n${String(reason)}`;
+
 export const installTestEnvironmentDependency = (
   packageName: string,
   root: string,

--- a/packages/core/src/core/testEnvironmentModule.ts
+++ b/packages/core/src/core/testEnvironmentModule.ts
@@ -21,6 +21,7 @@ import {
 import {
   createTestEnvironmentLoadError,
   environmentDependencyPackages,
+  formatTestEnvironmentPrebundleFallbackWarning,
   getTestEnvironmentResolutionRoots,
   type EnvironmentDependencyName,
 } from './envDependencies';
@@ -457,8 +458,8 @@ export const prepareTestEnvironmentModules = async ({
           reference,
           tempRoot,
         }).catch((error: unknown) => {
-          logger.debug(
-            `Failed to prebundle test environment ${packageName}; falling back to its native entry: ${String(error)}`,
+          logger.warn(
+            formatTestEnvironmentPrebundleFallbackWarning(packageName, error),
           );
           return undefined;
         });

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -29,6 +29,7 @@ import { isMemorySufficient } from '../utils/memory';
 import { getNumCpus, parseWorkers } from '../utils/workers';
 import { selectMemoryGate } from './memoryGate';
 import { getEnvironmentKey } from '../core/environmentGroups';
+import { formatTestEnvironmentPrebundleFallbackWarning } from '../core/envDependencies';
 import { projectRuntimeConfig } from '../core/runtimeConfigProjection';
 import {
   createRunnerEventSink,
@@ -372,7 +373,7 @@ export const createPool = async ({
     memoryGate: selectMemoryGate(workerKind),
     onTestEnvironmentFallback: ({ packageName, reason }) => {
       logger.warn(
-        `Failed to load the test environment prebundle for "${packageName}"; falling back to its native entry. The failed prebundle attempt adds startup overhead.\n${reason}`,
+        formatTestEnvironmentPrebundleFallbackWarning(packageName, reason),
       );
     },
   });

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -20,6 +20,7 @@ import {
   getFileTaskId,
   getForceColorEnv,
   isDeno,
+  logger,
   needFlagExperimentalDetectModule,
   toError,
 } from '../utils';
@@ -369,6 +370,11 @@ export const createPool = async ({
       ...process.env,
     } as Record<string, string>,
     memoryGate: selectMemoryGate(workerKind),
+    onTestEnvironmentFallback: ({ packageName, reason }) => {
+      logger.warn(
+        `Failed to load the test environment prebundle for "${packageName}"; falling back to its native entry. The failed prebundle attempt adds startup overhead.\n${reason}`,
+      );
+    },
   });
 
   const createProjectSink = (project: ProjectContext): RunnerEventSink =>

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -1,6 +1,9 @@
 import type { TestFileResult } from '../types';
 import { PoolRunner } from './poolRunner';
-import type { CollectTaskResult } from './protocol';
+import type {
+  CollectTaskResult,
+  TestEnvironmentModuleFallback,
+} from './protocol';
 import type { PoolOptions, PoolTask } from './types';
 import { createPoolWorker } from './workers';
 
@@ -33,12 +36,24 @@ export class Pool {
    * motivated restoring this.
    */
   private readonly slotInUse = new Set<number>();
+  private readonly reportedEnvironmentFallbacks = new Set<string>();
   private isClosing = false;
   private isClosed = false;
 
   constructor(options: PoolOptions) {
     this.options = options;
   }
+
+  private readonly handleTestEnvironmentFallback = (
+    fallback: TestEnvironmentModuleFallback,
+  ): void => {
+    const key = `${fallback.bundlePath}\0${fallback.resolvedPath}`;
+    if (this.reportedEnvironmentFallbacks.has(key)) {
+      return;
+    }
+    this.reportedEnvironmentFallbacks.add(key);
+    this.options.onTestEnvironmentFallback?.(fallback);
+  };
 
   async runTest(task: PoolTask): Promise<TestFileResult> {
     return this.dispatch(task, 'run') as Promise<TestFileResult>;
@@ -136,7 +151,11 @@ export class Pool {
       const workerId = this.acquireWorkerId();
       const worker = createPoolWorker(task, this.options, workerId);
       gate?.attachWorker(worker);
-      const runner = new PoolRunner(worker, { workerId, environmentKey });
+      const runner = new PoolRunner(worker, {
+        workerId,
+        environmentKey,
+        onTestEnvironmentFallback: this.handleTestEnvironmentFallback,
+      });
       this.activeRunners.add(runner);
       try {
         await runner.start();

--- a/packages/core/src/pool/poolRunner.ts
+++ b/packages/core/src/pool/poolRunner.ts
@@ -7,6 +7,7 @@ import {
   deserializeError,
   isRpcEnvelope,
   isWorkerResponseEnvelope,
+  type TestEnvironmentModuleFallback,
   type WorkerResponse,
   wrapRpc,
 } from './protocol';
@@ -60,6 +61,7 @@ let nextTaskSeq = 0;
 type PoolRunnerOptions = {
   workerId: number;
   environmentKey: string;
+  onTestEnvironmentFallback?: (fallback: TestEnvironmentModuleFallback) => void;
 };
 
 /**
@@ -95,10 +97,14 @@ export class PoolRunner {
    * never recycles a poisoned runner. See review for rstest#1142.
    */
   private crashed = false;
+  private readonly onTestEnvironmentFallback?: (
+    fallback: TestEnvironmentModuleFallback,
+  ) => void;
 
   constructor(worker: PoolWorker, options: PoolRunnerOptions) {
     this.workerId = options.workerId;
     this.environmentKey = options.environmentKey;
+    this.onTestEnvironmentFallback = options.onTestEnvironmentFallback;
     this.worker = worker;
 
     this.handleMessage = this.handleMessage.bind(this);
@@ -327,6 +333,9 @@ export class PoolRunner {
         return;
       case 'collectFinished':
         this.resolveTask('collect', response.taskId, response.result);
+        return;
+      case 'testEnvironmentFallback':
+        this.onTestEnvironmentFallback?.(response.fallback);
         return;
       case 'fatal_error': {
         const error = deserializeError(response.error);

--- a/packages/core/src/pool/protocol.ts
+++ b/packages/core/src/pool/protocol.ts
@@ -34,6 +34,14 @@ export type WorkerMemoryReport = {
   rss: number;
 };
 
+/** Worker-to-host notification that a test environment prebundle was rejected. */
+export type TestEnvironmentModuleFallback = {
+  packageName: string;
+  bundlePath: string;
+  resolvedPath: string;
+  reason: string;
+};
+
 export type WorkerResponse =
   | { type: 'started'; pid: number }
   | {
@@ -47,6 +55,10 @@ export type WorkerResponse =
       taskId: number;
       result: CollectTaskResult;
       memory?: WorkerMemoryReport;
+    }
+  | {
+      type: 'testEnvironmentFallback';
+      fallback: TestEnvironmentModuleFallback;
     }
   | {
       type: 'fatal_error';

--- a/packages/core/src/pool/types.ts
+++ b/packages/core/src/pool/types.ts
@@ -1,5 +1,6 @@
 import type { RuntimeRPC, RunWorkerOptions } from '../types';
 import type { MemoryGate } from './memoryGate';
+import type { TestEnvironmentModuleFallback } from './protocol';
 
 export type PoolWorkerKind = 'forks' | 'threads';
 
@@ -30,4 +31,6 @@ export type PoolOptions = {
    * a fresh `MemoryGate` by default.
    */
   memoryGate?: MemoryGate;
+  /** Receives each distinct environment prebundle fallback once. */
+  onTestEnvironmentFallback?: (fallback: TestEnvironmentModuleFallback) => void;
 };

--- a/packages/core/src/runtime/worker/env/testEnvironmentModule.ts
+++ b/packages/core/src/runtime/worker/env/testEnvironmentModule.ts
@@ -1,4 +1,5 @@
 import { pathToFileURL } from 'node:url';
+import type { TestEnvironmentModuleFallback } from '../../../pool/protocol';
 import type { TestEnvironmentModuleReference } from '../../../types';
 import { logger } from '../../../utils';
 import { finalizeDynamicImport } from '../resolveDynamicImport';
@@ -85,6 +86,7 @@ const probeBundledDependency = (loaded: LoadedTestEnvironmentModule): void => {
 
 const loadModule = async (
   reference: TestEnvironmentModuleReference,
+  onFallback?: (fallback: TestEnvironmentModuleFallback) => void,
 ): Promise<LoadedTestEnvironmentModule> => {
   if (reference.bundlePath) {
     try {
@@ -97,9 +99,16 @@ const loadModule = async (
       logger.debug(`loaded bundled test environment ${reference.packageName}`);
       return loaded;
     } catch (error) {
+      const reason = String(error);
       logger.debug(
-        `Failed to load bundled test environment ${reference.packageName}; falling back to its native entry: ${String(error)}`,
+        `Failed to load bundled test environment ${reference.packageName}; falling back to its native entry: ${reason}`,
       );
+      onFallback?.({
+        packageName: reference.packageName,
+        bundlePath: reference.bundlePath,
+        resolvedPath: reference.resolvedPath,
+        reason,
+      });
     }
   }
 
@@ -112,6 +121,7 @@ const loadModule = async (
 
 export const loadTestEnvironmentModule = (
   reference: TestEnvironmentModuleReference | undefined,
+  onFallback?: (fallback: TestEnvironmentModuleFallback) => void,
 ): Promise<LoadedTestEnvironmentModule | undefined> => {
   if (!reference) {
     return Promise.resolve(undefined);
@@ -124,7 +134,7 @@ export const loadTestEnvironmentModule = (
   ].join('\0');
   let loaded = moduleCache.get(cacheKey);
   if (!loaded) {
-    loaded = loadModule(reference);
+    loaded = loadModule(reference, onFallback);
     moduleCache.set(cacheKey, loaded);
   }
   return loaded;

--- a/packages/core/src/runtime/worker/index.ts
+++ b/packages/core/src/runtime/worker/index.ts
@@ -110,7 +110,9 @@ const runTask = async (
   currentTaskId = request.taskId;
 
   try {
-    const result = await runInPool(request.options);
+    const result = await runInPool(request.options, (fallback) => {
+      send({ type: 'testEnvironmentFallback', fallback });
+    });
     send({
       type: RESPONSE_TYPE[kind],
       taskId: request.taskId,

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -9,6 +9,7 @@ import type {
   TestInfo,
   WorkerState,
 } from '../../types';
+import type { TestEnvironmentModuleFallback } from '../../pool/protocol';
 import { globalApis, RSTEST_API_GLOBAL_KEY } from '../../utils/constants';
 import { getFileTaskId } from '../../utils/helper';
 import { color } from '../../utils/logger';
@@ -156,6 +157,7 @@ const preparePool = async (
     environmentKey,
   }: RunWorkerOptions['options'],
   tracker?: PhaseTracker,
+  onTestEnvironmentFallback?: (fallback: TestEnvironmentModuleFallback) => void,
 ) => {
   // Reset globalCleanups only when preparePool is called again (running without isolation)
   globalCleanups.forEach((fn) => {
@@ -327,7 +329,10 @@ const preparePool = async (
     const scope = isolate ? 'file' : 'worker';
     const [{ setup }, environmentModule] = await Promise.all([
       loadEnvironment(),
-      loadTestEnvironmentModule(context.testEnvironmentModule),
+      loadTestEnvironmentModule(
+        context.testEnvironmentModule,
+        onTestEnvironmentFallback,
+      ),
     ]);
     const { teardown } = await setup(
       global,
@@ -463,6 +468,7 @@ const loadFiles = async ({
 
 export const runInPool = async (
   options: RunWorkerOptions['options'],
+  onTestEnvironmentFallback?: (fallback: TestEnvironmentModuleFallback) => void,
 ): Promise<
   | {
       tests: TestInfo[];
@@ -551,7 +557,7 @@ export const runInPool = async (
         cleanup,
         unhandledErrors,
         interopDefault,
-      } = await preparePool(options);
+      } = await preparePool(options, undefined, onTestEnvironmentFallback);
       const { assetFiles, sourceMaps: sourceMapsFromAssets } =
         assets || (await rpc.getAssetsByEntry());
       sourceMaps = sourceMapsFromAssets;
@@ -616,7 +622,7 @@ export const runInPool = async (
       unhandledErrors,
       interopDefault,
       taskContext: preparedTaskContext,
-    } = await preparePool(options, tracker);
+    } = await preparePool(options, tracker, onTestEnvironmentFallback);
     taskContext = preparedTaskContext;
     if (detectAsyncLeaks) {
       asyncLeakDetector = createAsyncLeakDetector(taskContext);

--- a/packages/core/tests/core/testEnvironmentModule.test.ts
+++ b/packages/core/tests/core/testEnvironmentModule.test.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
 import type { ProjectContext, TestEnvironmentPrebundle } from '../../src/types';
 import { prepareTestEnvironmentModules } from '../../src/core/testEnvironmentModule';
+import { logger } from '../../src/utils';
 
 const createProject = (
   rootPath: string,
@@ -548,26 +549,43 @@ exports.canvasInstalled = canvasInstalled;
 
   it('falls back to the native entry when the prebundle build fails', async () => {
     await withTempDir('rstest-env-build-fallback-', async (root) => {
+      const warn = rs.spyOn(logger, 'warn').mockImplementation(() => {});
       const resolvedPath = createPackage(
         root,
         `import './missing-dependency.js';
 export class JSDOM {}`,
       );
 
-      const result = await prepareTestEnvironmentModules({
-        projects: [createProject(root, { prebundle: true })],
-        rootPath: root,
-      });
-
       try {
-        expect(result.modules.get('jsdom')).toEqual({
-          name: 'jsdom',
-          packageName: 'jsdom',
-          resolvedPath,
-          bundlePath: undefined,
+        const result = await prepareTestEnvironmentModules({
+          projects: [
+            createProject(root, { prebundle: true }),
+            createProject(root, { prebundle: true }),
+          ],
+          rootPath: root,
         });
+
+        try {
+          expect(result.modules.get('jsdom')).toEqual({
+            name: 'jsdom',
+            packageName: 'jsdom',
+            resolvedPath,
+            bundlePath: undefined,
+          });
+          expect(warn).toHaveBeenCalledTimes(1);
+          expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'Failed to load the test environment prebundle for "jsdom"',
+            ),
+          );
+          expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining('Error: Rspack build failed.'),
+          );
+        } finally {
+          await result.cleanup();
+        }
       } finally {
-        await result.cleanup();
+        warn.mockRestore();
       }
     });
   });

--- a/packages/core/tests/pool/fixtures/testWorker.mjs
+++ b/packages/core/tests/pool/fixtures/testWorker.mjs
@@ -9,6 +9,8 @@
  *   - 'stderr-crash'       → write to stderr then exit(1)
  *   - 'stderr-large'       → write >64KB of stderr then exit(1)
  *   - 'stderr-late'        → write to stderr and exit(1) immediately
+ *   - 'environment-fallback' → report an environment prebundle fallback,
+ *                                then succeed.
  *   - 'spawn-orphan'       → spawn a long-lived grandchild that inherits
  *                             stdio, then send result and exit normally.
  *                             Tests that `exit` (not `close`) drives the
@@ -150,6 +152,20 @@ const handleRun = (request) => {
     );
     // Include grandchild PID so the test can clean it up.
     finish({ _grandchildPid: grandchild.pid });
+    return;
+  }
+
+  if (mode === 'environment-fallback') {
+    send({
+      type: 'testEnvironmentFallback',
+      fallback: {
+        packageName: 'happy-dom',
+        bundlePath: '/tmp/happy-dom-bundle.mjs',
+        resolvedPath: '/project/node_modules/happy-dom/cjs/index.cjs',
+        reason: 'Error: Expected exports: GlobalWindow or Window.',
+      },
+    });
+    finish();
     return;
   }
 

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -76,6 +76,33 @@ describe('Pool - basic', () => {
   });
 });
 
+describe('Pool - environment prebundle fallback', () => {
+  it('reports the same fallback only once across isolated workers', async () => {
+    const onTestEnvironmentFallback = rs.fn();
+    const pool = new Pool(
+      createPoolOptions({ onTestEnvironmentFallback, maxWorkers: 1 }),
+    );
+    try {
+      await pool.runTest(
+        createTask('run', { __testMode: 'environment-fallback' }),
+      );
+      await pool.runTest(
+        createTask('run', { __testMode: 'environment-fallback' }),
+      );
+
+      expect(onTestEnvironmentFallback).toHaveBeenCalledTimes(1);
+      expect(onTestEnvironmentFallback).toHaveBeenCalledWith({
+        packageName: 'happy-dom',
+        bundlePath: '/tmp/happy-dom-bundle.mjs',
+        resolvedPath: '/project/node_modules/happy-dom/cjs/index.cjs',
+        reason: 'Error: Expected exports: GlobalWindow or Window.',
+      });
+    } finally {
+      await pool.close();
+    }
+  });
+});
+
 // ── fatal_error attribution ─────────────────────────────────────────────────
 
 describe('Pool - fatal error', () => {

--- a/packages/core/tests/runtime/worker/env/testEnvironmentModule.test.ts
+++ b/packages/core/tests/runtime/worker/env/testEnvironmentModule.test.ts
@@ -137,6 +137,7 @@ describe('loadTestEnvironmentModule', () => {
 
   it('falls back to the resolved package entry when the prebundle is invalid', async () => {
     await withTempDir('rstest-env-fallback-', async (root) => {
+      const onFallback = rs.fn();
       const resolvedPath = writeModule(
         root,
         'resolved.mjs',
@@ -148,12 +149,15 @@ describe('loadTestEnvironmentModule', () => {
         'export const unrelated = true;',
       );
 
-      const loaded = await loadTestEnvironmentModule({
-        name: 'happy-dom',
-        packageName: 'happy-dom',
-        resolvedPath,
-        bundlePath,
-      });
+      const loaded = await loadTestEnvironmentModule(
+        {
+          name: 'happy-dom',
+          packageName: 'happy-dom',
+          resolvedPath,
+          bundlePath,
+        },
+        onFallback,
+      );
 
       expect(loaded?.name).toBe('happy-dom');
       if (loaded?.name !== 'happy-dom') {
@@ -162,6 +166,15 @@ describe('loadTestEnvironmentModule', () => {
       expect(
         (loaded.module.GlobalWindow as unknown as { source: string }).source,
       ).toBe('resolved');
+      expect(onFallback).toHaveBeenCalledTimes(1);
+      expect(onFallback).toHaveBeenCalledWith({
+        packageName: 'happy-dom',
+        bundlePath,
+        resolvedPath,
+        reason: expect.stringContaining(
+          'Expected exports: GlobalWindow or Window.',
+        ),
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Emit a visible warning when a test environment prebundle fails and Rstest falls back to the native entry.
- Forward the fallback from the worker to the host and deduplicate it per bundle, avoiding one warning per isolated test file.
- Include the fallback reason and clarify that the failed attempt adds startup overhead.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1663

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).