### PR TITLE
perf(core): reuse compile cache in workers

### DIFF
--- a/packages/core/bin/rstest.js
+++ b/packages/core/bin/rstest.js
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 import nodeModule from 'node:module';
 
-// enable on-disk code caching of all modules loaded by Node.js
+// enable on-disk code caching and share its directory with child workers
 // requires Nodejs >= 22.8.0
-const { enableCompileCache } = nodeModule;
+const { enableCompileCache, constants } = nodeModule;
 if (enableCompileCache) {
   try {
-    enableCompileCache();
+    const { directory, status } = enableCompileCache();
+    // ALREADY_ENABLED returns the active version-specific cache directory.
+    // Passing it to workers would append another version directory.
+    if (directory && status === constants.compileCacheStatus.ENABLED) {
+      process.env.NODE_COMPILE_CACHE = directory;
+    }
   } catch {
     // ignore errors
   }


### PR DESCRIPTION
## Summary

This PR shares the main process's Node.js compile-cache directory with child workers when the Rstest CLI enables the cache itself. Repeated test runs can therefore reuse worker module caches while existing user-provided `NODE_COMPILE_CACHE` behavior remains unchanged.

### Benchmark

Measured on Node.js v24.12.0 (darwin-arm64) against Rsbuild core (45 test files, 318 tests, 8 workers), using seven interleaved warm-cache A/B pairs:

| Entry point | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| `rstest` median wall time | 1107.7 ms | 1071.5 ms | 36.2 ms (3.3%) |
| `rs test` median wall time | 1173.2 ms | 1080.4 ms | 92.8 ms (7.9%) |

The direct `rstest` row measures this change. `rs test` invokes Rstest through Rstack instead of this bin, so its row measures the equivalent compile-cache propagation at the Rstack entry point.

## Related Links

- [Node.js module compile cache](https://nodejs.org/download/release/v24.12.0/docs/api/module.html#module-compile-cache)
- [`NODE_COMPILE_CACHE=dir`](https://nodejs.org/download/release/v24.12.0/docs/api/cli.html#node_compile_cachedir)
- https://github.com/rstackjs/rstack-cli/pull/213

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).