### PR TITLE
fix(browser): rerun headed watch on test file changes

### DIFF
--- a/e2e/browser-mode/utils.ts
+++ b/e2e/browser-mode/utils.ts
@@ -1,6 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runRstestCli } from '../scripts';
+import { type prepareFixtures, runRstestCli } from '../scripts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -81,6 +81,7 @@ const WINDOWS_PROCESS_CLEANUP_RETRY_COUNT = 40;
 const POSIX_PROCESS_CLEANUP_RETRY_COUNT = 20;
 
 type BrowserCli = Awaited<ReturnType<typeof runRstestCli>>['cli'];
+type BrowserFixtureFs = Awaited<ReturnType<typeof prepareFixtures>>['fs'];
 
 /**
  * Kill a spawned rstest process tree before the fixture directory is removed.
@@ -220,6 +221,74 @@ export const runBrowserWatchCliWithCwd = async (
       expectNoFrameworkWarnings(result.cli);
     },
   };
+};
+
+export const runBrowserWatchCrud = async ({
+  cli,
+  fixtureFs,
+  fixtureRoot,
+}: {
+  cli: BrowserCli;
+  fixtureFs: BrowserFixtureFs;
+  fixtureRoot: string;
+}): Promise<void> => {
+  const addedTestPath = join(fixtureRoot, 'tests/added.test.ts');
+  const renamedTestPath = join(fixtureRoot, 'tests/renamed.test.ts');
+  const waitForWatchReady = async (): Promise<void> => {
+    if (!cli.stdout.includes('Waiting for file changes...')) {
+      await cli.waitForStdout('Waiting for file changes...');
+    }
+  };
+
+  cli.resetStd();
+  fixtureFs.create(
+    addedTestPath,
+    `import { expect, test } from '@rstest/core';
+
+test('added watch test', () => {
+  expect('watch').toBe('watch');
+});`,
+  );
+  await cli.waitForStdout('Test file set changed, re-running 3 file(s)');
+  await cli.waitForStdout('✓ tests/added.test.ts');
+  await cli.waitForStdout('Test Files 3 passed');
+  await waitForWatchReady();
+
+  cli.resetStd();
+  fixtureFs.update(addedTestPath, (content) =>
+    content.replace("toBe('watch')", "toBe('changed')"),
+  );
+  await cli.waitForStdout("expected 'watch' to be 'changed'");
+  await waitForWatchReady();
+
+  cli.resetStd();
+  fixtureFs.update(addedTestPath, (content) =>
+    content.replace("toBe('changed')", "toBe('watch')"),
+  );
+  await cli.waitForStdout('✓ tests/added.test.ts');
+  await cli.waitForStdout('Test Files 3 passed');
+  await waitForWatchReady();
+
+  cli.resetStd();
+  fixtureFs.rename(addedTestPath, renamedTestPath);
+  await cli.waitForStdout('Test file set changed, re-running 3 file(s)');
+  await cli.waitForStdout('✓ tests/renamed.test.ts');
+  await cli.waitForStdout('Test Files 3 passed');
+  await waitForWatchReady();
+
+  cli.resetStd();
+  fixtureFs.delete(renamedTestPath);
+  await cli.waitForStdout('Test file set changed, re-running 2 file(s)');
+  await cli.waitForStdout('✓ tests/index.test.ts');
+  await cli.waitForStdout('✓ tests/another.test.ts');
+  await cli.waitForStdout('Test Files 2 passed');
+  await waitForWatchReady();
+
+  cli.resetStd();
+  fixtureFs.delete(join(fixtureRoot, 'tests/index.test.ts'));
+  fixtureFs.delete(join(fixtureRoot, 'tests/another.test.ts'));
+  await cli.waitForStdout('No browser test files remain after update.');
+  await cli.waitForStdout('No test files need re-run.');
 };
 
 /**

--- a/e2e/browser-mode/watch.test.ts
+++ b/e2e/browser-mode/watch.test.ts
@@ -7,6 +7,7 @@ import {
   killCliProcessTree,
   runBrowserWatchCli,
   runBrowserWatchCliWithCwd,
+  runBrowserWatchCrud,
 } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,90 +94,11 @@ describe('browser mode - watch', () => {
       await cli.waitForStdout('Waiting for file changes...');
     }
 
-    const newTestPath = path.join(fixturesTargetPath, 'tests/new.test.ts');
-    const renamedTestPath = path.join(
-      fixturesTargetPath,
-      'tests/renamed.test.ts',
-    );
-    const waitForRerunSignal = async () => {
-      const marker = 'File changed, re-running tests...';
-      if (!cli.stdout.includes(marker)) {
-        await cli.waitForStdout(marker);
-      }
-      expect(cli.stdout).toContain(marker);
-    };
-    const waitForOutput = async (marker: string | RegExp) => {
-      if (typeof marker === 'string') {
-        if (cli.stdout.includes(marker)) {
-          return;
-        }
-      } else if (cli.stdout.match(marker)) {
-        return;
-      }
-      await cli.waitForStdout(marker);
-    };
-
-    const waitForRerunResult = async (marker: string | RegExp) => {
-      const state = await Promise.race([
-        waitForOutput(marker).then(() => 'expected' as const),
-        waitForOutput('Build error:').then(() => 'build-error' as const),
-        waitForOutput('error   build failed').then(
-          () => 'build-failed' as const,
-        ),
-      ]);
-
-      if (state !== 'expected') {
-        throw new Error(
-          `Unexpected build error during browser watch cycle:\n${cli.stdout}`,
-        );
-      }
-    };
-    // ========== Create: Add new test file ==========
-    cli.resetStd();
-    fs.create(
-      newTestPath,
-      `import { describe, expect, it } from '@rstest/core';
-    describe('new test', () => {
-  it('should pass', () => {
-    expect('new').toBe('new');
-  });
-});`,
-    );
-    await waitForRerunSignal();
-    await waitForRerunResult('✓ tests/new.test.ts');
-    expect(cli.stdout).toContain('✓ tests/new.test.ts');
-
-    // ========== Update (break): Modify new test file to fail ==========
-    cli.resetStd();
-    fs.update(newTestPath, (content) => {
-      return content.replace("toBe('new')", "toBe('modified')");
+    await runBrowserWatchCrud({
+      cli,
+      fixtureFs: fs,
+      fixtureRoot: fixturesTargetPath,
     });
-    await waitForRerunSignal();
-    await waitForRerunResult("expected 'new' to be 'modified'");
-    expect(cli.stdout).toContain("expected 'new' to be 'modified'");
-
-    // ========== Update (fix): Fix the test file ==========
-    cli.resetStd();
-    fs.update(newTestPath, (content) => {
-      return content.replace("toBe('modified')", "toBe('new')");
-    });
-    await waitForRerunSignal();
-    await waitForRerunResult('✓ tests/new.test.ts');
-    expect(cli.stdout).toContain('✓ tests/new.test.ts');
-
-    // ========== Rename: Rename new.test.ts to renamed.test.ts ==========
-    cli.resetStd();
-    fs.rename(newTestPath, renamedTestPath);
-    await waitForRerunSignal();
-    await waitForRerunResult('✓ tests/renamed.test.ts');
-    expect(cli.stdout).toContain('✓ tests/renamed.test.ts');
-
-    // ========== Delete: Remove the renamed test file ==========
-    cli.resetStd();
-    fs.delete(renamedTestPath);
-    await waitForRerunSignal();
-    await waitForRerunResult('✓ tests/index.test.ts');
-    expect(cli.stdout).toContain('✓ tests/index.test.ts');
 
     await killCliProcessTree(cli);
     await deleteFixtureTarget(fs, fixturesTargetPath);

--- a/e2e/browser-mode/watchHeaded.test.ts
+++ b/e2e/browser-mode/watchHeaded.test.ts
@@ -7,6 +7,7 @@ import {
   deleteFixtureTarget,
   killCliProcessTree,
   runBrowserWatchCliWithCwd,
+  runBrowserWatchCrud,
   shouldRunHeadedBrowserTests,
 } from './utils';
 
@@ -18,11 +19,8 @@ describe('browser mode - headed watch', () => {
   // `shouldEnableBrowserHmr`); every other fixture in the matrix runs
   // headless or one-shot, so this smoke is the sole coverage between an
   // HMR-runtime-only regression and users' default local `--watch`.
-  // Deliberately boot + first run only, no file-change rerun: headed browser
-  // sessions are expensive on CI, and the initial run already covers the
-  // HMR-runtime bundle shape.
   it.runIf(shouldRunHeadedBrowserTests)(
-    'should run tests in headed watch mode',
+    'should run tests and track file-set changes in headed watch mode',
     async () => {
       const fixturesTargetPath = `${__dirname}/fixtures/fixtures-test-browser-watch-headed`;
 
@@ -42,6 +40,13 @@ describe('browser mode - headed watch', () => {
       try {
         await cli.waitForStdout('Duration');
         expect(cli.stdout).toMatch('Test Files 2 passed');
+        await cli.waitForStdout('Waiting for file changes...');
+
+        await runBrowserWatchCrud({
+          cli,
+          fixtureFs: fs,
+          fixtureRoot: fixturesTargetPath,
+        });
       } finally {
         // A leaked headed browser is costlier than the headless leaks other
         // watch tests tolerate — always tear down, even on assertion failure.
@@ -49,6 +54,7 @@ describe('browser mode - headed watch', () => {
         await deleteFixtureTarget(fs, fixturesTargetPath);
       }
     },
+    60_000,
   );
 
   it.runIf(shouldRunHeadedBrowserTests)(

--- a/packages/browser/src/browserRsbuild.ts
+++ b/packages/browser/src/browserRsbuild.ts
@@ -696,8 +696,7 @@ const getAffectedTestFiles = ({
   // Headed watch compiles chunks on demand (lazyCompilation), so an entry's
   // first appearance in stats means "just loaded", not "just added": its first
   // sighting establishes the baseline instead of marking a change. Genuinely
-  // new and deleted test files are owned by the test-file-set diff in
-  // `planWatchRerun` / `collectDeletedTestPaths`.
+  // new and deleted test files are owned by `planWatchRerun`'s file-set diff.
   const seedFirstSeen = (
     baseline: EntryHashSnapshot | undefined,
     current: EntryHashSnapshot,

--- a/packages/browser/src/headedScheduler.ts
+++ b/packages/browser/src/headedScheduler.ts
@@ -28,7 +28,7 @@ import type {
   TestFileInfo,
 } from './protocol';
 import type { BrowserProviderContext, BrowserProviderPage } from './providers';
-import { collectDeletedTestPaths, planWatchRerun } from './watchRerunPlanner';
+import { commitWatchFileSetUpdate, planWatchRerun } from './watchRerunPlanner';
 import type {
   BrowserWatchSession,
   DispatchPageResolver,
@@ -579,45 +579,32 @@ export const createHeadedScheduler = async ({
         affectedTestFiles: drainPendingAffectedTestFiles(watchState),
       });
 
-      if (rerunPlan.filesChanged) {
-        const deletedTestPaths = collectDeletedTestPaths(
-          watchState.lastTestFiles,
-          rerunPlan.currentTestFiles,
-        );
-        if (deletedTestPaths.length > 0) {
-          context.updateReporterResultState([], [], deletedTestPaths);
-        }
-        watchState.lastTestFiles = rerunPlan.currentTestFiles;
-        currentTestFiles = rerunPlan.currentTestFiles;
+      commitWatchFileSetUpdate(
+        rerunPlan.fileSetUpdate,
+        watchState,
+        (deletedTestPaths) =>
+          context.updateReporterResultState([], [], deletedTestPaths),
+      );
+
+      if (rerunPlan.fileSetUpdate) {
+        currentTestFiles = rerunPlan.fileSetUpdate.currentTestFiles;
         await rpcManager.notifyTestFileUpdate(currentTestFiles);
-        if (currentTestFiles.length === 0) {
-          logger.log(
-            color.cyan('No browser test files remain after update.\n'),
+        if (currentTestFiles.length > 0) {
+          await waitForRunnerFramesReady(
+            currentTestFiles.map((file) => file.testPath),
           );
-          logWatchReady();
-          return;
         }
-        await waitForRunnerFramesReady(
-          currentTestFiles.map((file) => file.testPath),
-        );
       }
 
-      if (rerunPlan.normalizedAffectedTestFiles.length > 0) {
-        logger.log(
-          color.cyan(
-            `Re-running ${rerunPlan.normalizedAffectedTestFiles.length} affected test file(s)...\n`,
-          ),
-        );
-        await watchSignals.signalInvalidation(
-          rerunPlan.normalizedAffectedTestFiles,
-        );
+      logger.log(color.cyan(rerunPlan.decision.message));
+      if (rerunPlan.decision.kind === 'idle') {
+        logWatchReady();
         return;
       }
 
-      if (!rerunPlan.filesChanged) {
-        logger.log(color.cyan('Tests will be re-executed automatically\n'));
-      }
-      logWatchReady();
+      await watchSignals.signalInvalidation(
+        rerunPlan.decision.kind === 'empty' ? [] : rerunPlan.decision.testPaths,
+      );
     });
 
     runUiRequestedRerun = async (file, testNamePattern) => {

--- a/packages/browser/src/headlessScheduler.ts
+++ b/packages/browser/src/headlessScheduler.ts
@@ -38,7 +38,7 @@ import {
   RunSessionLifecycle,
 } from './runSession';
 import { RunnerSessionRegistry } from './sessionRegistry';
-import { collectDeletedTestPaths, planWatchRerun } from './watchRerunPlanner';
+import { commitWatchFileSetUpdate, planWatchRerun } from './watchRerunPlanner';
 import type {
   BrowserWatchSession,
   DispatchPageResolver,
@@ -497,53 +497,22 @@ export const createHeadlessScheduler = async ({
         affectedTestFiles: drainPendingAffectedTestFiles(watchState),
       });
 
-      if (rerunPlan.filesChanged) {
-        const deletedTestPaths = collectDeletedTestPaths(
-          watchState.lastTestFiles,
-          rerunPlan.currentTestFiles,
-        );
-        if (deletedTestPaths.length > 0) {
-          context.updateReporterResultState([], [], deletedTestPaths);
-        }
-        watchState.lastTestFiles = rerunPlan.currentTestFiles;
-        if (rerunPlan.currentTestFiles.length === 0) {
-          logger.log(
-            color.cyan('No browser test files remain after update.\n'),
-          );
-          // Still one cycle: core's finalize reports the emptied run.
-          await watchSignals.signalInvalidation([]);
-          return;
-        }
+      commitWatchFileSetUpdate(
+        rerunPlan.fileSetUpdate,
+        watchState,
+        (deletedTestPaths) =>
+          context.updateReporterResultState([], [], deletedTestPaths),
+      );
 
-        logger.log(
-          color.cyan(
-            `Test file set changed, re-running ${rerunPlan.currentTestFiles.length} file(s)...\n`,
-          ),
-        );
-        await watchSignals.signalInvalidation([
-          ...new Set(rerunPlan.currentTestFiles.map((file) => file.testPath)),
-        ]);
-        return;
-      }
-
-      if (rerunPlan.affectedTestFiles.length === 0) {
-        logger.log(
-          color.cyan(
-            'No affected browser test files detected, skipping re-run.\n',
-          ),
-        );
+      logger.log(color.cyan(rerunPlan.decision.message));
+      if (rerunPlan.decision.kind === 'idle') {
         logWatchReady();
         return;
       }
 
-      logger.log(
-        color.cyan(
-          `Re-running ${rerunPlan.affectedTestFiles.length} affected test file(s)...\n`,
-        ),
+      await watchSignals.signalInvalidation(
+        rerunPlan.decision.kind === 'empty' ? [] : rerunPlan.decision.testPaths,
       );
-      await watchSignals.signalInvalidation([
-        ...new Set(rerunPlan.affectedTestFiles.map((file) => file.testPath)),
-      ]);
     });
 
     watchSession = createWatchSession(runScope);

--- a/packages/browser/src/watchRerunPlanner.ts
+++ b/packages/browser/src/watchRerunPlanner.ts
@@ -1,21 +1,6 @@
 import { normalize } from 'pathe';
 import type { TestFileInfo } from './protocol';
 
-/**
- * Paths the previous cycle ran that the current file set no longer contains.
- * Core prunes its own state from this, so a file deleted mid-session stops
- * being reported instead of lingering as a passing result.
- */
-export const collectDeletedTestPaths = (
-  previous: TestFileInfo[],
-  current: TestFileInfo[],
-): string[] => {
-  const currentPathSet = new Set(current.map((file) => file.testPath));
-  return previous
-    .map((file) => file.testPath)
-    .filter((testPath) => !currentPathSet.has(testPath));
-};
-
 type WatchPlannerProjectEntry = {
   project: {
     name: string;
@@ -29,11 +14,29 @@ type WatchRerunPlannerInput = {
   affectedTestFiles: string[];
 };
 
-type WatchRerunPlan = {
+type WatchFileSetUpdate = {
   currentTestFiles: TestFileInfo[];
-  filesChanged: boolean;
-  normalizedAffectedTestFiles: string[];
-  affectedTestFiles: TestFileInfo[];
+  deletedTestPaths: string[];
+};
+
+type WatchRerunDecision =
+  | {
+      kind: 'rerun';
+      testPaths: string[];
+      message: string;
+    }
+  | {
+      kind: 'empty';
+      message: string;
+    }
+  | {
+      kind: 'idle';
+      message: string;
+    };
+
+type WatchRerunPlan = {
+  fileSetUpdate?: WatchFileSetUpdate;
+  decision: WatchRerunDecision;
 };
 
 const serializeTestFiles = (files: TestFileInfo[]): string => {
@@ -47,6 +50,20 @@ const normalizeTestFiles = (files: TestFileInfo[]): TestFileInfo[] => {
     ...file,
     testPath: normalize(file.testPath),
   }));
+};
+
+const collectTestPaths = (files: TestFileInfo[]): string[] => {
+  return [...new Set(files.map((file) => file.testPath))];
+};
+
+const collectDeletedTestPaths = (
+  previous: TestFileInfo[],
+  current: TestFileInfo[],
+): string[] => {
+  const currentPathSet = new Set(current.map((file) => file.testPath));
+  return previous
+    .map((file) => file.testPath)
+    .filter((testPath) => !currentPathSet.has(testPath));
 };
 
 export const collectWatchTestFiles = (
@@ -67,22 +84,72 @@ export const planWatchRerun = ({
 }: WatchRerunPlannerInput): WatchRerunPlan => {
   const currentTestFiles = collectWatchTestFiles(projectEntries);
   const normalizedPrevious = normalizeTestFiles(previousTestFiles);
-  const filesChanged =
+  const fileSetChanged =
     serializeTestFiles(currentTestFiles) !==
     serializeTestFiles(normalizedPrevious);
 
-  const normalizedAffectedTestFiles = affectedTestFiles.map((testFile) =>
-    normalize(testFile),
+  if (fileSetChanged) {
+    const fileSetUpdate = {
+      currentTestFiles,
+      deletedTestPaths: collectDeletedTestPaths(
+        normalizedPrevious,
+        currentTestFiles,
+      ),
+    };
+    if (currentTestFiles.length === 0) {
+      return {
+        fileSetUpdate,
+        decision: {
+          kind: 'empty',
+          message: 'No browser test files remain after update.\n',
+        },
+      };
+    }
+
+    return {
+      fileSetUpdate,
+      decision: {
+        kind: 'rerun',
+        testPaths: collectTestPaths(currentTestFiles),
+        message: `Test file set changed, re-running ${currentTestFiles.length} file(s)...\n`,
+      },
+    };
+  }
+
+  const affectedPathSet = new Set(
+    affectedTestFiles.map((testFile) => normalize(testFile)),
   );
-  const affectedPathSet = new Set(normalizedAffectedTestFiles);
-  const matchedAffectedFiles = currentTestFiles.filter((file) =>
-    affectedPathSet.has(file.testPath),
+  const matchedAffectedFiles = currentTestFiles.filter(({ testPath }) =>
+    affectedPathSet.has(testPath),
   );
+  if (matchedAffectedFiles.length === 0) {
+    return {
+      decision: {
+        kind: 'idle',
+        message: 'No affected browser test files detected, skipping re-run.\n',
+      },
+    };
+  }
 
   return {
-    currentTestFiles,
-    filesChanged,
-    normalizedAffectedTestFiles,
-    affectedTestFiles: matchedAffectedFiles,
+    decision: {
+      kind: 'rerun',
+      testPaths: collectTestPaths(matchedAffectedFiles),
+      message: `Re-running ${matchedAffectedFiles.length} affected test file(s)...\n`,
+    },
   };
+};
+
+export const commitWatchFileSetUpdate = (
+  update: WatchFileSetUpdate | undefined,
+  watchState: { lastTestFiles: TestFileInfo[] },
+  pruneDeletedTestPaths: (testPaths: string[]) => void,
+): void => {
+  if (!update) {
+    return;
+  }
+  if (update.deletedTestPaths.length > 0) {
+    pruneDeletedTestPaths(update.deletedTestPaths);
+  }
+  watchState.lastTestFiles = update.currentTestFiles;
 };

--- a/packages/browser/tests/watchRerunPlanner.test.ts
+++ b/packages/browser/tests/watchRerunPlanner.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@rstest/core';
 import {
   collectWatchTestFiles,
+  commitWatchFileSetUpdate,
   planWatchRerun,
 } from '../src/watchRerunPlanner';
 
@@ -17,11 +18,20 @@ describe('watch rerun planner', () => {
       affectedTestFiles: [],
     });
 
-    expect(plan.filesChanged).toBe(true);
-    expect(plan.currentTestFiles).toEqual([
-      { testPath: '/a.test.ts', projectName: 'project-a' },
-      { testPath: '/b.test.ts', projectName: 'project-a' },
-    ]);
+    expect(plan).toEqual({
+      fileSetUpdate: {
+        currentTestFiles: [
+          { testPath: '/a.test.ts', projectName: 'project-a' },
+          { testPath: '/b.test.ts', projectName: 'project-a' },
+        ],
+        deletedTestPaths: [],
+      },
+      decision: {
+        kind: 'rerun',
+        testPaths: ['/a.test.ts', '/b.test.ts'],
+        message: 'Test file set changed, re-running 2 file(s)...\n',
+      },
+    });
   });
 
   it('should preserve all project entries for affected test paths', () => {
@@ -46,19 +56,16 @@ describe('watch rerun planner', () => {
       ],
     });
 
-    expect(plan.filesChanged).toBe(false);
-    expect(plan.normalizedAffectedTestFiles).toEqual([
-      'tests/a.test.ts',
-      'tests/a.test.ts',
-      'tests/missing.test.ts',
-    ]);
-    expect(plan.affectedTestFiles).toEqual([
-      { testPath: 'tests/a.test.ts', projectName: 'project-a' },
-      { testPath: 'tests/a.test.ts', projectName: 'project-b' },
-    ]);
+    expect(plan).toEqual({
+      decision: {
+        kind: 'rerun',
+        testPaths: ['tests/a.test.ts'],
+        message: 'Re-running 2 affected test file(s)...\n',
+      },
+    });
   });
 
-  it('should return empty affected lists when no changes are present', () => {
+  it('should remain idle when no changes are present', () => {
     const projectEntries = [
       {
         project: { name: 'project-a' },
@@ -72,8 +79,42 @@ describe('watch rerun planner', () => {
       affectedTestFiles: [],
     });
 
-    expect(plan.filesChanged).toBe(false);
-    expect(plan.normalizedAffectedTestFiles).toEqual([]);
-    expect(plan.affectedTestFiles).toEqual([]);
+    expect(plan).toEqual({
+      decision: {
+        kind: 'idle',
+        message: 'No affected browser test files detected, skipping re-run.\n',
+      },
+    });
+  });
+
+  it('should commit an empty file-set decision and prune deleted files', () => {
+    const previousTestFiles = [
+      { testPath: '/a.test.ts', projectName: 'project-a' },
+    ];
+    const plan = planWatchRerun({
+      projectEntries: [{ project: { name: 'project-a' }, testFiles: [] }],
+      previousTestFiles,
+      affectedTestFiles: [],
+    });
+
+    expect(plan).toEqual({
+      fileSetUpdate: {
+        currentTestFiles: [],
+        deletedTestPaths: ['/a.test.ts'],
+      },
+      decision: {
+        kind: 'empty',
+        message: 'No browser test files remain after update.\n',
+      },
+    });
+
+    const watchState = { lastTestFiles: previousTestFiles };
+    const pruned: string[][] = [];
+    commitWatchFileSetUpdate(plan.fileSetUpdate, watchState, (testPaths) => {
+      pruned.push(testPaths);
+    });
+
+    expect(watchState.lastTestFiles).toEqual([]);
+    expect(pruned).toEqual([['/a.test.ts']]);
   });
 });


### PR DESCRIPTION
## Summary

- In headed watch mode, creating, renaming, or deleting a test file refreshed the Browser UI file list but did not schedule the corresponding Core rerun, so newly discovered tests could remain unexecuted.
- Make the shared watch planner return explicit rerun, empty, or idle decisions and have both headed and headless schedulers execute the same file-set policy, including pruning deleted results and finalizing an empty cycle.
- Exercise the same create, update, rename, delete, and delete-all flow in headed and headless watch sessions through one shared fixture driver.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).