### PR TITLE
test(core): fix flaky pool capacity assertion

### DIFF
--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -425,10 +425,12 @@ describe('Pool - capacity', () => {
       expect(iv.end).toBeTypeOf('number');
     }
 
-    // Upper bound: at no point were more than maxWorkers tasks running.
+    // Concurrency can only increase when a task starts, so sampling every
+    // start proves the upper bound without combining overlaps from
+    // different moments in the sampled task's lifetime.
     for (const point of intervals) {
       const concurrent = intervals.filter(
-        (iv) => iv.start < point.end && iv.end > point.start,
+        (iv) => iv.start <= point.start && iv.end > point.start,
       ).length;
       expect(concurrent).toBeLessThanOrEqual(maxWorkers);
     }

--- a/packages/core/tests/pool/threadsPool.test.ts
+++ b/packages/core/tests/pool/threadsPool.test.ts
@@ -245,10 +245,12 @@ describe('ThreadsPool - capacity', () => {
         end: (r as any)._finishedAt as number,
       }));
 
-      // Upper bound: at no point were more than maxWorkers tasks running.
+      // Concurrency can only increase when a task starts, so sampling every
+      // start proves the upper bound without combining overlaps from
+      // different moments in the sampled task's lifetime.
       for (const point of intervals) {
         const concurrent = intervals.filter(
-          (iv) => iv.start < point.end && iv.end > point.start,
+          (iv) => iv.start <= point.start && iv.end > point.start,
         ).length;
         expect(concurrent).toBeLessThanOrEqual(maxWorkers);
       }


### PR DESCRIPTION
## Summary

The pool capacity tests could report three concurrent tasks when one interval overlapped different tasks at separate moments. This PR samples concurrency at each task start—the only point where concurrency can increase—and applies the corrected assertion to both forks and threads pools.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).