### PR TITLE
fix(browser): publish compiled browser client

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -100,14 +100,12 @@
     },
     "packages/browser": {
       "entry": [
-        // Browser-side iframe entry (loaded at runtime by hostController)
-        "src/client/entry.ts",
         // Test files
         "tests/**/*.ts",
       ],
-      "ignoreDependencies": [
-        // Virtual module resolved at build time by rspack alias in hostController.ts
-        "@rstest/browser-manifest",
+      "ignoreUnresolved": [
+        // Virtual module injected by each browser project's Rsbuild alias
+        "__rstest_virtual_browser_manifest__",
       ],
     },
     "packages/browser-ui": {

--- a/packages/browser-ui/rsbuild.config.ts
+++ b/packages/browser-ui/rsbuild.config.ts
@@ -2,7 +2,6 @@ import { resolve } from 'node:path';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
-import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 const root = __dirname;
 
@@ -36,10 +35,5 @@ export default defineConfig({
   },
   html: {
     template: resolve(root, './src/index.html'),
-  },
-  tools: {
-    rspack: {
-      plugins: [rsdoctorCIPlugin()].filter(Boolean),
-    },
   },
 });

--- a/packages/browser/AGENTS.md
+++ b/packages/browser/AGENTS.md
@@ -28,9 +28,9 @@ Responses always travel back as transport replies — `dispatchRouter` handles i
 
 ## Runner runtime invariants (`src/client`)
 
-- `entry.ts` is the only bootstrap entry and decides `collect` vs `run` mode.
+- `runner.ts` is the only bootstrap entry and decides `collect` vs `run` mode.
 - Console interception is per test file and must restore the original console methods in `finally`.
-- An unhandled window error or `unhandledrejection` that escapes a test file fails the file even when every test passed. The runner deliberately yields macrotasks before finalizing each file result so late-dispatched rejections are still observed — the timing rationale is commented in `entry.ts`.
+- An unhandled window error or `unhandledrejection` that escapes a test file fails the file even when every test passed. The runner deliberately yields macrotasks before finalizing each file result so late-dispatched rejections are still observed — the timing rationale is commented in `runner.ts`.
 
 ## Provider-agnostic design
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -21,8 +21,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/browser.d.ts",
-      "default": "./dist/browser.js"
+      "types": "./dist/client/client/index.d.ts",
+      "default": "./dist/client/index.js"
     },
     "./internal": {
       "types": "./dist/index.d.ts",
@@ -32,10 +32,10 @@
       "default": "./package.json"
     }
   },
-  "main": "./dist/browser.js",
+  "main": "./dist/client/index.js",
+  "types": "./dist/client/client/index.d.ts",
   "files": [
     "dist",
-    "src",
     "NOTICE",
     "LICENSE-APACHE-2.0"
   ],

--- a/packages/browser/rslib.config.ts
+++ b/packages/browser/rslib.config.ts
@@ -33,7 +33,6 @@ export default defineConfig({
         tsconfigPath: './tsconfig.json',
         entry: {
           index: './src/index.ts',
-          browser: './src/browser.ts',
         },
       },
       tools: {
@@ -54,6 +53,34 @@ export default defineConfig({
             }),
             rsdoctorCIPlugin(),
           ].filter(Boolean),
+        },
+      },
+    },
+    {
+      id: 'rstest-browser-client',
+      syntax: 'es2023',
+      dts: {
+        isolated: true,
+        bundle: false,
+      },
+      output: {
+        target: 'web',
+        distPath: 'dist/client',
+        // Resolved by each browser project's Rsbuild alias.
+        externals: ['__rstest_virtual_browser_manifest__'],
+      },
+      source: {
+        tsconfigPath: './tsconfig.json',
+        entry: {
+          index: './src/client/index.ts',
+          runner: './src/client/runner.ts',
+        },
+      },
+      tools: {
+        rspack: {
+          plugins: [rsdoctorCIPlugin({ reportDir: '.rsdoctor/client' })].filter(
+            Boolean,
+          ),
         },
       },
     },

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -1,3 +1,0 @@
-import './augmentExpect';
-
-export * from './client/api';

--- a/packages/browser/src/browserRsbuild.ts
+++ b/packages/browser/src/browserRsbuild.ts
@@ -817,14 +817,10 @@ export const collectProjectEntries = async (
   );
 };
 
-const resolveBrowserFile = (relativePath: string): string => {
-  // __dirname points to packages/browser/dist when running from built code
-  // or packages/browser/src when running from source
+const resolveBrowserDistFile = (relativePath: string): string => {
   const candidates = [
-    // When running from built dist: look in ../src for source files
-    resolve(__dirname, '../src', relativePath),
-    // When running from source (dev mode)
     resolve(__dirname, relativePath),
+    resolve(__dirname, '../dist', relativePath),
   ];
 
   for (const candidate of candidates) {
@@ -833,7 +829,7 @@ const resolveBrowserFile = (relativePath: string): string => {
     }
   }
 
-  throw new Error(`Unable to resolve browser client file: ${relativePath}`);
+  throw new Error(`Unable to resolve browser dist file: ${relativePath}`);
 };
 
 export const resolveContainerDist = (): string => {
@@ -860,7 +856,7 @@ const toSafeVarName = (name: string): string => {
   return name.replace(/[^a-zA-Z0-9_]/g, '_');
 };
 
-// Host-side mirror of the browser runtime's `toContextKey` (client/entry.ts):
+// Host-side mirror of the browser runtime's `toContextKey` (client/runner.ts):
 // `./<path-relative-to-project-root>` with forward slashes. The runtime derives
 // the same key from the target test file, so the non-watch import map below must
 // key by the identical form for `loadTest(key)` to resolve.
@@ -1260,7 +1256,7 @@ export const createBrowserRuntime = async ({
     import.meta.resolve('@rstest/core/internal/browser-runtime'),
   );
 
-  // Shared by every project — only the per-project `@rstest/browser-manifest`
+  // Shared by every project — only the per-project virtual manifest
   // alias varies (one virtual manifest per server).
   const staticRstestAliases = {
     // User test code `import { describe, it } from '@rstest/core'` is NOT
@@ -1268,8 +1264,8 @@ export const createBrowserRuntime = async ({
     // `globalThis['@rstest/core']` (node parity), which also keeps the mock
     // hoister's provider-import ordering correct for `rs.hoisted` callbacks.
     // User test code: import { page } from '@rstest/browser'
-    '@rstest/browser': resolveBrowserFile('browser.ts'),
-    // Browser runtime APIs for entry.ts
+    '@rstest/browser': resolveBrowserDistFile('client/index.js'),
+    // Browser runner runtime APIs
     // Uses dist file with extractSourceMap to preserve sourcemap chain for inline snapshots
     '@rstest/core/internal/browser-runtime': browserRuntimePath,
   };
@@ -1434,7 +1430,7 @@ export const createBrowserRuntime = async ({
     });
 
     const rstestInternalAliases = {
-      '@rstest/browser-manifest': manifestPath,
+      __rstest_virtual_browser_manifest__: manifestPath,
       ...staticRstestAliases,
     };
 
@@ -1635,7 +1631,7 @@ export const createBrowserRuntime = async ({
               // This must be done after mergeEnvironmentConfig to ensure highest priority.
               merged.source = merged.source || {};
               merged.source.entry = {
-                runner: resolveBrowserFile('client/entry.ts'),
+                runner: resolveBrowserDistFile('client/runner.js'),
               };
 
               return merged;

--- a/packages/browser/src/client/api.ts
+++ b/packages/browser/src/client/api.ts
@@ -1,6 +1,6 @@
-import type { BrowserElementExpect } from '../augmentExpect';
 import { registerElementExpect } from '@rstest/core/internal/browser-runtime';
 import type { BrowserLocatorText, BrowserRpcRequest } from '../rpcProtocol';
+import type { BrowserElementExpect } from './augmentExpect';
 import { callBrowserRpc } from './browserRpc';
 import {
   isLocator,

--- a/packages/browser/src/client/augmentExpect.ts
+++ b/packages/browser/src/client/augmentExpect.ts
@@ -1,4 +1,4 @@
-import type { Locator } from './client/locator';
+import type { Locator } from './locator';
 
 export type BrowserElementExpect = {
   not: BrowserElementExpect;

--- a/packages/browser/src/client/dispatchTransport.ts
+++ b/packages/browser/src/client/dispatchTransport.ts
@@ -11,7 +11,7 @@ import {
 } from '../protocol';
 
 // Coincidentally equal to the host-side RUNNER_FRAMES_READY_TIMEOUT_MS and the
-// runner's CONFIG_WAIT_TIMEOUT_MS (entry.ts), but a semantically distinct
+// runner's CONFIG_WAIT_TIMEOUT_MS (runner.ts), but a semantically distinct
 // default in a different runtime, so deliberately not shared with them.
 const DEFAULT_RPC_TIMEOUT_MS = 30_000;
 

--- a/packages/browser/src/client/index.ts
+++ b/packages/browser/src/client/index.ts
@@ -1,0 +1,3 @@
+import './augmentExpect';
+
+export * from './api';

--- a/packages/browser/src/client/runner.ts
+++ b/packages/browser/src/client/runner.ts
@@ -5,7 +5,7 @@ import {
   // Multi-project APIs
   projects,
   projectTestContexts,
-} from '@rstest/browser-manifest';
+} from '__rstest_virtual_browser_manifest__';
 import type {
   CoverageMapData,
   CurrentTaskInfo,
@@ -408,9 +408,8 @@ const run = async () => {
 
   setRealTimers();
 
-  // Preload runner.js sourcemap for inline snapshot support.
-  // The snapshot code runs in runner.js, so we need its sourcemap
-  // to map stack traces back to original source files.
+  // Snapshot code runs in runner.js, so preload its sourcemap to map stack
+  // traces back to original source files.
   await preloadRunnerSourceMap();
 
   // Find the project for this test file

--- a/packages/browser/src/env.d.ts
+++ b/packages/browser/src/env.d.ts
@@ -5,7 +5,7 @@ import type {
   BrowserHostConfig,
 } from './protocol';
 
-declare module '@rstest/browser-manifest' {
+declare module '__rstest_virtual_browser_manifest__' {
   export type ManifestProjectConfig = {
     name: string;
     environmentName: string;

--- a/packages/browser/src/headedScheduler.ts
+++ b/packages/browser/src/headedScheduler.ts
@@ -139,7 +139,7 @@ export const createHeadedScheduler = async ({
   const { browser, browserLaunchOptions, watchState, wss } = runtime;
   let currentTestFiles = allTestFiles;
   // Coincidentally equal to the runner-side CONFIG_WAIT_TIMEOUT_MS and
-  // DEFAULT_RPC_TIMEOUT_MS (client/entry.ts, client/dispatchTransport.ts) but
+  // DEFAULT_RPC_TIMEOUT_MS (client/runner.ts, client/dispatchTransport.ts) but
   // semantically distinct and in a different runtime, so deliberately NOT shared
   // with them. Invariant worth preserving: a runner must be able to receive its
   // config (config-wait) before the host declares its frames un-ready, i.e.

--- a/packages/browser/src/manifest.d.ts
+++ b/packages/browser/src/manifest.d.ts
@@ -1,4 +1,4 @@
-declare module '@rstest/browser-manifest' {
+declare module '__rstest_virtual_browser_manifest__' {
   /** Project configuration from manifest */
   export type ManifestProjectConfig = {
     name: string;

--- a/packages/browser/tests/browserRpcRegistryConsistency.test.ts
+++ b/packages/browser/tests/browserRpcRegistryConsistency.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from '@rstest/core';
-import type { BrowserElementExpect } from '../src/augmentExpect';
 import {
   supportedExpectElementMatchers,
   supportedLocatorActions,
 } from '../src/browserRpcRegistry';
+import type { BrowserElementExpect } from '../src/client/augmentExpect';
 import { Locator } from '../src/client/locator';
 import type { BrowserRpcRequest } from '../src/protocol';
 import { dispatchPlaywrightBrowserRpc } from '../src/providers/playwright/dispatchBrowserRpc';

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -74,7 +74,7 @@ Contracts between modules or processes — not readable from any single file.
 - Everything in `src/runtime/` executes inside the test execution context (forks child, worker thread, or browser page — browser-safe parts re-exported through `src/browserRuntime.ts`), never in the host CLI process.
 - Live-binding contract: under `isolate: false` one worker runs many files while user modules persist, so every injected API member is built once with a stable identity and resolves the running file's `FileContext` at call time — never as a per-file closure.
 - A new `Rstest` API member → add to `globalApiList` (compile-enforced exhaustiveness) and export a forwarder in `src/runtime/api/public.ts`.
-- A new `RunnerHooks` callback → forward it in `runInPool`'s hooks object and in the browser client entry (`packages/browser/src/client/entry.ts`), which builds its own hooks.
+- A new `RunnerHooks` callback → forward it in `runInPool`'s hooks object and in the browser client entry (`packages/browser/src/client/runner.ts`), which builds its own hooks.
 
 ### Reporters (`src/reporter`)
 

--- a/packages/core/src/browserRuntime.ts
+++ b/packages/core/src/browserRuntime.ts
@@ -4,7 +4,7 @@
  * without any Node.js or build tool dependencies.
  *
  * Used by:
- * - packages/browser/src/client/entry.ts (runtime APIs)
+ * - packages/browser/src/client/runner.ts (runtime APIs)
  *
  * User test code importing '@rstest/core' is not aliased here; the browser
  * build keeps that request external against `globalThis['@rstest/core']`


### PR DESCRIPTION
## Summary

- Stop publishing the Browser client TypeScript sources and make the host consume compiled JavaScript from `dist/client`.
- Build the public API and runner in one web compilation so they can share runtime chunks while preserving the existing `@rstest/browser` API and type augmentation.
- Mark the per-project generated manifest with the internal `__rstest_virtual_browser_manifest__` sentinel instead of presenting it as a package dependency.
- Skip the standalone Rsdoctor report for the private Browser UI because its copied assets are already covered by the Browser package report.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).