### PR TITLE
feat(core): add bundle coverage debug output

### DIFF
--- a/e2e/test-coverage/v8.test.ts
+++ b/e2e/test-coverage/v8.test.ts
@@ -7,6 +7,51 @@ const fixturePath = join(__dirname, 'fixtures');
 const enableConfig = 'rstest.enable.v8.config.ts';
 
 describe('coverage v8-specific behavior', () => {
+  it('writes bundle assets alongside raw V8 coverage for debugging', async ({
+    onTestFinished,
+  }) => {
+    const debugDirectory = join(fixturePath, '.rstest');
+    const removeDebugOutput = () => fs.removeSync(debugDirectory);
+    removeDebugOutput();
+    onTestFinished(removeDebugOutput);
+
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', '-c', enableConfig, '--coverage.reporters', 'text-summary'],
+      options: {
+        nodeOptions: {
+          cwd: fixturePath,
+          env: { DEBUG: 'rstest:bundle-coverage' },
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const files = fs
+      .readdirSync(debugDirectory)
+      .filter((file) => file.startsWith('bundle-coverage-'));
+    expect(files).toHaveLength(1);
+
+    const output = fs.readJsonSync(join(debugDirectory, files[0]!)) as {
+      version: number;
+      tests: {
+        assets: Record<string, number>;
+        rawV8: { entries: { filePath: string }[] };
+      }[];
+    };
+    expect(output.version).toBe(1);
+    expect(output.tests.length).toBeGreaterThan(0);
+
+    for (const test of output.tests) {
+      expect(Object.keys(test.assets).length).toBeGreaterThan(0);
+      expect(test.rawV8.entries.length).toBeGreaterThan(0);
+      expect(
+        test.rawV8.entries.every((entry) => entry.filePath in test.assets),
+      ).toBeTruthy();
+    }
+  });
+
   it('preserves the configured provider with --coverage', async ({
     onTestFinished,
   }) => {

--- a/packages/core/src/core/bundleCoverage.ts
+++ b/packages/core/src/core/bundleCoverage.ts
@@ -1,0 +1,43 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'pathe';
+import { color, logger } from '../utils';
+
+const BUNDLE_COVERAGE_DEBUG = 'rstest:bundle-coverage';
+
+export type BundleCoverageResult = {
+  project: string;
+  testPath: string;
+  assets: Record<string, number>;
+  rawV8: unknown | null;
+};
+
+export const isBundleCoverageDebugEnabled = (): boolean =>
+  process.env.DEBUG?.toLowerCase().split(',').includes(BUNDLE_COVERAGE_DEBUG) ??
+  false;
+
+export const writeBundleCoverageResults = async (
+  rootPath: string,
+  results: BundleCoverageResult[],
+): Promise<void> => {
+  if (!results.length) return;
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace('Z', '');
+  const outputPath = resolve(
+    rootPath,
+    '.rstest',
+    `bundle-coverage-${stamp}.json`,
+  );
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(
+    outputPath,
+    JSON.stringify({
+      version: 1,
+      tests: results.toSorted(
+        (a, b) =>
+          a.project.localeCompare(b.project) ||
+          a.testPath.localeCompare(b.testPath),
+      ),
+    }),
+  );
+  logger.log(color.gray('  Bundle coverage file: '), color.cyan(outputPath));
+};

--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../types';
 import type { CoverageMap, CoverageProvider } from '../../types/coverage';
 import { clearScreen, color, logger, type TraceRun } from '../../utils';
+import { writeBundleCoverageResults } from '../bundleCoverage';
 import { ensureTestEnvironmentDependencies } from '../envDependencies';
 import {
   claimGlobalSetupOnce,
@@ -437,6 +438,7 @@ export function createNodeExecutor(
               return {
                 results: [],
                 testResults: [],
+                bundleCoverage: [],
                 errors,
                 assetNames,
                 getAssetFiles,
@@ -452,7 +454,7 @@ export function createNodeExecutor(
           );
 
           currentEntries.push(...sortedEntries);
-          const { results, testResults } = await pool.runTests({
+          const { results, testResults, bundleCoverage } = await pool.runTests({
             entries: sortedEntries,
             assetNames,
             getSourceMaps,
@@ -471,6 +473,7 @@ export function createNodeExecutor(
           return {
             results,
             testResults,
+            bundleCoverage,
             assetNames,
             getAssetFiles,
             getSourceMaps,
@@ -501,6 +504,11 @@ export function createNodeExecutor(
 
     const returns = await Promise.all(
       projectPlans.map((plan) => plan.execute(plan.finalEntries)),
+    );
+
+    await writeBundleCoverageResults(
+      rootPath,
+      returns.flatMap((result) => result.bundleCoverage),
     );
 
     // A cycle no rebuild triggered measures its own build: the span from

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -32,12 +32,16 @@ import { getEnvironmentKey } from '../core/environmentGroups';
 import { formatTestEnvironmentPrebundleFallbackWarning } from '../core/envDependencies';
 import { projectRuntimeConfig } from '../core/runtimeConfigProjection';
 import {
+  type BundleCoverageResult,
+  isBundleCoverageDebugEnabled,
+} from '../core/bundleCoverage';
+import {
   createRunnerEventSink,
   type RunnerEventSink,
   sinkToRuntimeRpc,
 } from '../core/runnerEventSink';
 import { Pool } from './pool';
-import type { PoolWorkerKind } from './types';
+import type { PoolTask, PoolWorkerKind } from './types';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -115,6 +119,7 @@ const buildTask = async ({
   traceSpan,
   testEnvironmentModule,
   buildId = 0,
+  captureBundleCoverage = false,
 }: {
   type: 'run' | 'collect';
   workerKind: PoolWorkerKind;
@@ -133,9 +138,15 @@ const buildTask = async ({
   traceSpan: TraceSpan;
   testEnvironmentModule?: TestEnvironmentModuleReference;
   buildId?: number;
-}) => {
-  const getAssets = () =>
-    filterAssetsByEntry(
+  captureBundleCoverage?: boolean;
+}): Promise<{
+  task: PoolTask;
+  bundleCoverageAssets?: Record<string, number>;
+}> => {
+  const bundleCoverageAssets: Record<string, number> | undefined =
+    captureBundleCoverage ? {} : undefined;
+  const getAssets = async () => {
+    const assets = await filterAssetsByEntry(
       entryInfo,
       getAssetFiles,
       getSourceMaps,
@@ -143,6 +154,13 @@ const buildTask = async ({
       assetNames,
       project.normalizedConfig.federation,
     );
+    if (bundleCoverageAssets) {
+      for (const [name, content] of Object.entries(assets.assetFiles)) {
+        bundleCoverageAssets[name] = Buffer.byteLength(content);
+      }
+    }
+    return assets;
+  };
   const traceArgs = {
     project: project.name,
     testPath: entryInfo.testPath,
@@ -150,55 +168,58 @@ const buildTask = async ({
   };
 
   return {
-    worker: workerKind,
-    type,
-    options: {
-      entryInfo,
-      // Known limit: the config portion is `stableJson`, so environment option
-      // values JSON cannot express (an `html` ArrayBuffer, a `beforeParse`
-      // function, a `virtualConsole` instance) collapse to identical bytes —
-      // two projects differing only in such values may share a worker's
-      // environment under `isolate: false`. Accepted as too narrow to guard;
-      // if it ever matters, fall back to a project-scoped key when the config
-      // is not JSON-representable instead of trying to serialize those values.
-      environmentKey: getEnvironmentKey(
-        runtimeConfig.testEnvironment,
-        testEnvironmentModule,
-      ),
-      context: {
-        outputModule: project.outputModule,
-        taskId: index + 1,
-        buildId,
-        project: project.name,
-        rootPath: context.rootPath,
-        projectRoot: project.rootPath,
-        runtimeConfig,
-        testEnvironmentModule,
-        trace: context.trace,
-      },
+    task: {
+      worker: workerKind,
       type,
-      setupEntries,
-      updateSnapshot,
-      // Federation entries need the complete compilation asset map. Fetch it
-      // when a worker starts the task so concurrent task preparation cannot
-      // retain one full copy per test entry.
-      assets:
-        isMemorySufficient() && !project.normalizedConfig.federation
-          ? await traceSpan('host:get-assets-by-entry', 'host', getAssets, {
-              ...traceArgs,
-              mode: 'eager',
-            })
-          : undefined,
+      options: {
+        entryInfo,
+        // Known limit: the config portion is `stableJson`, so environment option
+        // values JSON cannot express (an `html` ArrayBuffer, a `beforeParse`
+        // function, a `virtualConsole` instance) collapse to identical bytes —
+        // two projects differing only in such values may share a worker's
+        // environment under `isolate: false`. Accepted as too narrow to guard;
+        // if it ever matters, fall back to a project-scoped key when the config
+        // is not JSON-representable instead of trying to serialize those values.
+        environmentKey: getEnvironmentKey(
+          runtimeConfig.testEnvironment,
+          testEnvironmentModule,
+        ),
+        context: {
+          outputModule: project.outputModule,
+          taskId: index + 1,
+          buildId,
+          project: project.name,
+          rootPath: context.rootPath,
+          projectRoot: project.rootPath,
+          runtimeConfig,
+          testEnvironmentModule,
+          trace: context.trace,
+        },
+        type,
+        setupEntries,
+        updateSnapshot,
+        // Federation entries need the complete compilation asset map. Fetch it
+        // when a worker starts the task so concurrent task preparation cannot
+        // retain one full copy per test entry.
+        assets:
+          isMemorySufficient() && !project.normalizedConfig.federation
+            ? await traceSpan('host:get-assets-by-entry', 'host', getAssets, {
+                ...traceArgs,
+                mode: 'eager',
+              })
+            : undefined,
+      },
+      rpcMethods: {
+        ...rpcMethods,
+        // getAssetsByEntry is only used when memory is not sufficient since it may be slow
+        getAssetsByEntry: () =>
+          traceSpan('host:get-assets-by-entry', 'host', getAssets, {
+            ...traceArgs,
+            mode: 'rpc',
+          }),
+      },
     },
-    rpcMethods: {
-      ...rpcMethods,
-      // getAssetsByEntry is only used when memory is not sufficient since it may be slow
-      getAssetsByEntry: () =>
-        traceSpan('host:get-assets-by-entry', 'host', getAssets, {
-          ...traceArgs,
-          mode: 'rpc',
-        }),
-    },
+    bundleCoverageAssets,
   };
 };
 
@@ -306,6 +327,7 @@ export const createPool = async ({
   }) => Promise<{
     results: TestFileResult[];
     testResults: TestResult[];
+    bundleCoverage: BundleCoverageResult[];
   }>;
   collectTests: (params: PoolDispatchParams) => Promise<
     {
@@ -380,6 +402,7 @@ export const createPool = async ({
 
   const createProjectSink = (project: ProjectContext): RunnerEventSink =>
     createRunnerEventSink(context, project.normalizedConfig);
+  const captureBundleCoverage = isBundleCoverageDebugEnabled();
 
   return {
     runTests: async ({
@@ -423,7 +446,7 @@ export const createPool = async ({
               project: projectName,
               testPath: entryInfo.testPath,
             };
-            const task = await traceSpan(
+            const { task, bundleCoverageAssets } = await traceSpan(
               'host:build-task',
               'host',
               () =>
@@ -447,6 +470,7 @@ export const createPool = async ({
                     project.environmentName,
                   ),
                   buildId,
+                  captureBundleCoverage,
                 }),
               traceArgs,
             );
@@ -491,6 +515,15 @@ export const createPool = async ({
               onCoverageResult?.(result.coverage);
               delete result.coverage;
             }
+            const bundleCoverage: BundleCoverageResult | undefined =
+              bundleCoverageAssets
+                ? {
+                    project: projectName,
+                    testPath: entryInfo.testPath,
+                    assets: bundleCoverageAssets,
+                    rawV8: result.coverageRaw ?? null,
+                  }
+                : undefined;
             if (result.coverageRaw != null) {
               onRawCoverageResult?.(result.coverageRaw);
               delete result.coverageRaw;
@@ -500,7 +533,7 @@ export const createPool = async ({
               delete result.traceEvents;
             }
             await sink.onTestFileResult(result);
-            return result;
+            return { result, bundleCoverage };
           } finally {
             // Unblock the next entry even if `buildTask` threw before the
             // dispatch above ran — otherwise the whole chain would deadlock.
@@ -511,9 +544,17 @@ export const createPool = async ({
         }),
       );
 
-      const testResults = results.flatMap((r) => r.results);
+      const fileResults = results.map(({ result }) => result);
+      const testResults = fileResults.flatMap((r) => r.results);
 
-      return { results, testResults, project };
+      return {
+        results: fileResults,
+        testResults,
+        project,
+        bundleCoverage: results.flatMap(({ bundleCoverage }) =>
+          bundleCoverage ? [bundleCoverage] : [],
+        ),
+      };
     },
     collectTests: async ({
       entries,
@@ -531,7 +572,7 @@ export const createPool = async ({
 
       return Promise.all(
         entries.map(async (entryInfo, index) => {
-          const task = await buildTask({
+          const { task } = await buildTask({
             type: 'collect',
             workerKind,
             entryInfo,


### PR DESCRIPTION
## Summary

- Add an experimental `DEBUG=rstest:bundle-coverage` artifact that combines each test entry's asset byte manifest with the unmodified raw V8 coverage payload.
- Keep the diagnostic opt-in and internal: callers must explicitly enable an installed V8 coverage provider, and no public CLI or config API is added.
- In an Rsbuild core test, the artifact identified 26 delivered assets (649,856 bytes), while V8 loaded 3 (638,501 bytes); the remaining 23 named chunks corresponded to unused dynamic imports.

## Related Links

Closes https://github.com/web-infra-dev/rstest/issues/1691

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; this is an experimental DEBUG diagnostic).