### PR TITLE
perf(core): preserve binary assets across workers

### DIFF
--- a/e2e/federation/fixtures/basic/index.test.ts
+++ b/e2e/federation/fixtures/basic/index.test.ts
@@ -1,4 +1,6 @@
+import { resolve } from 'node:path';
 import { expect, it } from '@rstest/core';
+import imagePath from '../../../../examples/federation/component-app/src/MF.jpeg';
 
 it('should expose the federation flag and dynamic import fallback', async () => {
   expect((globalThis as any).__rstest_federation__).toBe(true);
@@ -25,4 +27,22 @@ it('should load absolute file paths through the dynamic import fallback', async 
 
 it('should set the federation flag during global setup', () => {
   expect(process.env.RSTEST_E2E_FEDERATION_IN_SETUP).toBe('true');
+});
+
+it('should preserve emitted binary assets in the virtual file system', () => {
+  const fs = require('node:fs');
+  const emittedImagePath = resolve(__dirname, 'dist/.rstest-temp', imagePath);
+  expect(fs.existsSync(emittedImagePath)).toBe(true);
+
+  fs.readFileSync(emittedImagePath, 'utf8');
+  const mutatedContent = fs.readFileSync(emittedImagePath);
+  mutatedContent[0] = 0;
+  const content = fs.readFileSync(emittedImagePath);
+  const sourceContent = fs.readFileSync(
+    resolve(
+      __dirname,
+      '../../../../examples/federation/component-app/src/MF.jpeg',
+    ),
+  );
+  expect(content.equals(sourceContent)).toBe(true);
 });

--- a/e2e/federation/fixtures/basic/rstest.config.ts
+++ b/e2e/federation/fixtures/basic/rstest.config.ts
@@ -3,4 +3,7 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   federation: true,
   globalSetup: ['./setup.ts'],
+  output: {
+    emitAssets: true,
+  },
 });

--- a/packages/core/src/core/browser/globalSetupStage.ts
+++ b/packages/core/src/core/browser/globalSetupStage.ts
@@ -178,7 +178,7 @@ export async function runBrowserGlobalSetupStage(
     project: ProjectContext;
     entryCount: number;
     globalSetupEntries: EntryInfo[];
-    assetFiles: Record<string, string>;
+    assetFiles: Record<string, Buffer>;
     sourceMaps: Record<string, string>;
   }[];
   try {

--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -8,7 +8,11 @@ import type {
   ExecutorRunCycleOptions,
   TestExecutor,
 } from '../../types';
-import type { CoverageMap, CoverageProvider } from '../../types/coverage';
+import type {
+  CoverageMap,
+  CoverageProvider,
+  RawCoverageResolveOptions,
+} from '../../types/coverage';
 import { clearScreen, color, logger, type TraceRun } from '../../utils';
 import { ensureTestEnvironmentDependencies } from '../envDependencies';
 import {
@@ -37,10 +41,7 @@ type NodeAssetResource = Pick<
   RsbuildStats,
   'assetNames' | 'getAssetFiles' | 'getSourceMaps'
 >;
-type CoverageResourceLoaders = {
-  loadAssetFiles: NodeAssetResource['getAssetFiles'];
-  loadSourceMaps: NodeAssetResource['getSourceMaps'];
-};
+type CoverageResourceLoaders = Required<RawCoverageResolveOptions>;
 
 export const createCoverageResourceLoaders = (
   items: NodeAssetResource[],
@@ -113,9 +114,11 @@ export const createCoverageResourceLoaders = (
         );
         for (const [assetName, requestedNames] of requests) {
           const content = loaded[assetName];
-          if (typeof content !== 'string') continue;
+          if (content == null) continue;
+          const text =
+            typeof content === 'string' ? content : content.toString('utf8');
           for (const requestedName of requestedNames) {
-            resources[requestedName] = content;
+            resources[requestedName] = text;
           }
         }
       }),

--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -9,6 +9,7 @@ import {
   getWorkerSerialization,
   killAndWait,
 } from '../utils';
+import { prepareAssetFilesForIPC } from '../utils/assetFiles';
 
 /**
  * Single owner of the once-per-project global-setup gate.
@@ -194,7 +195,7 @@ export async function runGlobalSetup({
   federation,
 }: {
   globalSetupEntries: EntryInfo[];
-  assetFiles: Record<string, string>;
+  assetFiles: Record<string, Buffer>;
   sourceMaps: Record<string, string>;
   interopDefault: boolean;
   outputModule: boolean;
@@ -220,7 +221,7 @@ export async function runGlobalSetup({
     type: 'setup',
     payload: {
       entries: globalSetupEntries,
-      assetFiles,
+      assetFiles: prepareAssetFilesForIPC(assetFiles, 'forks'),
       interopDefault,
       outputModule,
       federation,

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -349,8 +349,8 @@ const calcEntriesToRerun = (
   return { affectedEntries, deletedEntries: deletedPaths };
 };
 
-class AssetsMemorySafeMap extends Map<string, string> {
-  override set(key: string, value: string): this {
+class AssetsMemorySafeMap<T = string> extends Map<string, T> {
+  override set(key: string, value: T): this {
     if (this.has(key)) {
       return this;
     }
@@ -389,7 +389,7 @@ export const createRsbuildServer = async ({
     setupEntries: EntryInfo[];
     globalSetupEntries: EntryInfo[];
     assetNames: string[];
-    getAssetFiles: (names: string[]) => Promise<Record<string, string>>;
+    getAssetFiles: (names: string[]) => Promise<Record<string, Buffer>>;
     getSourceMaps: (names: string[]) => Promise<Record<string, string>>;
     /** affected test entries only available in watch mode */
     affectedEntries: EntryInfo[];
@@ -436,19 +436,17 @@ export const createRsbuildServer = async ({
   }
 
   // Ensure that when readFile is called in parallel, the file content will not be read into memory repeatedly
-  const cachedReadFilePromises = new Map<string, Promise<string>>();
+  const cachedReadFilePromises = new Map<string, Promise<Buffer>>();
   const readFile = async (fileName: string) => {
     if (cachedReadFilePromises.has(fileName))
       return cachedReadFilePromises.get(fileName)!;
-    const promise = new Promise<string>((resolve, reject) => {
+    const promise = new Promise<Buffer>((resolve, reject) => {
       outputFileSystem.readFile(fileName, (err, data) => {
         if (err) {
           reject(err);
+          return;
         }
-        const content =
-          typeof data === 'string' ? data : data!.toString('utf-8');
-
-        resolve(content);
+        resolve(typeof data === 'string' ? Buffer.from(data) : data!);
       });
     });
     cachedReadFilePromises.set(fileName, promise);
@@ -607,7 +605,7 @@ export const createRsbuildServer = async ({
         )
       : { affectedEntries: [], deletedEntries: [] };
 
-    const cachedAssetFiles = new AssetsMemorySafeMap();
+    const cachedAssetFiles = new AssetsMemorySafeMap<Buffer>();
     const cachedSourceMaps = new AssetsMemorySafeMap();
 
     const readFileWithCache = async (name: string) => {
@@ -634,10 +632,10 @@ export const createRsbuildServer = async ({
       let content = null;
 
       if (inlineSourceMap) {
-        const file = await readFile(sourceMapPath);
+        const file = (await readFile(sourceMapPath)).toString('utf8');
         content = parseInlineSourceMapStr(file);
       } else {
-        const sourceMap = await readFile(sourceMapPath);
+        const sourceMap = (await readFile(sourceMapPath)).toString('utf8');
         content = sourceMap;
       }
 

--- a/packages/core/src/pool/AGENTS.md
+++ b/packages/core/src/pool/AGENTS.md
@@ -25,11 +25,11 @@
 - `WorkerRequest`/`WorkerResponse` in `protocol.ts` ↔ worker-side dispatch in `../runtime/worker/index.ts` and host-side handling in `poolRunner.ts`.
 - A new `PoolWorkerKind` → `createPoolWorker`'s switch (exhaustiveness-checked) and `selectMemoryGate`.
 - The `--require` path for `rstestSuppressWarnings.cjs` in `index.ts` ↔ the `.cjs` copy list in `../../rslib.config.ts` — the path resolves relative to dist, so renaming/moving the `.cjs` needs both sides.
-- Assets have two delivery paths that must both stay alive: eager on the task when host memory suffices, else lazily pulled by the worker via `rpc.getAssetsByEntry`.
+- Assets have two delivery paths that must both stay alive: eager on the task when host memory suffices, else lazily pulled by the worker via `rpc.getAssetsByEntry`. Both pass Rspack output bytes through `prepareAssetFilesForIPC`; worker consumers must use `getAssetText` or `getAssetBuffer` rather than assuming a transport-specific value shape.
 
 ## Gotchas
 
-- Bun forces `json` IPC serialization for forks — values that only survive structured clone will not round-trip there.
+- Bun forces `json` IPC serialization for forks, so `prepareAssetFilesForIPC` sends valid UTF-8 assets as strings and other bytes as tagged base64. Node forks keep `Buffer`; worker threads receive `Uint8Array` through structured clone.
 - stderr attribution: the buffer resets per task on reused workers, task rejection is deferred briefly so stderr can settle, and attached stderr is truncated head+tail.
 - Fork stop escalates SIGTERM → SIGKILL after a grace period; thread stop is a bare `terminate()` and `force` is a no-op.
 - `minWorkers` is internal-only — a floor for retained idle runners, not a reuse cap; a pending slot waiter always wins reuse.

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -31,6 +31,7 @@ import { selectMemoryGate } from './memoryGate';
 import { getEnvironmentKey } from '../core/environmentGroups';
 import { formatTestEnvironmentPrebundleFallbackWarning } from '../core/envDependencies';
 import { projectRuntimeConfig } from '../core/runtimeConfigProjection';
+import { prepareAssetFilesForIPC } from '../utils/assetFiles';
 import {
   createRunnerEventSink,
   type RunnerEventSink,
@@ -47,7 +48,7 @@ const getRuntimeConfig = (context: ProjectContext): RuntimeConfig =>
 
 const filterAssetsByEntry = async (
   entryInfo: EntryInfo,
-  getAssetFiles: (names: string[]) => Promise<Record<string, string>>,
+  getAssetFiles: (names: string[]) => Promise<Record<string, Buffer>>,
   getSourceMaps: (names: string[]) => Promise<Record<string, string>>,
   setupAssets: string[],
   allAssetNames: string[] | undefined,
@@ -84,7 +85,7 @@ const getNodeExecArgv = () => {
 type PoolDispatchParams = {
   entries: EntryInfo[];
   assetNames: string[];
-  getAssetFiles: (names: string[]) => Promise<Record<string, string>>;
+  getAssetFiles: (names: string[]) => Promise<Record<string, Buffer>>;
   getSourceMaps: (names: string[]) => Promise<Record<string, string>>;
   setupEntries: EntryInfo[];
   updateSnapshot: SnapshotUpdateState;
@@ -134,8 +135,8 @@ const buildTask = async ({
   testEnvironmentModule?: TestEnvironmentModuleReference;
   buildId?: number;
 }) => {
-  const getAssets = () =>
-    filterAssetsByEntry(
+  const getAssets = async () => {
+    const assets = await filterAssetsByEntry(
       entryInfo,
       getAssetFiles,
       getSourceMaps,
@@ -143,6 +144,11 @@ const buildTask = async ({
       assetNames,
       project.normalizedConfig.federation,
     );
+    return {
+      ...assets,
+      assetFiles: prepareAssetFilesForIPC(assets.assetFiles, workerKind),
+    };
+  };
   const traceArgs = {
     project: project.name,
     testPath: entryInfo.testPath,
@@ -289,7 +295,7 @@ export const createPool = async ({
   runTests: (params: {
     entries: EntryInfo[];
     assetNames: string[];
-    getAssetFiles: (names: string[]) => Promise<Record<string, string>>;
+    getAssetFiles: (names: string[]) => Promise<Record<string, Buffer>>;
     getSourceMaps: (names: string[]) => Promise<Record<string, string>>;
     setupEntries: EntryInfo[];
     updateSnapshot: SnapshotUpdateState;

--- a/packages/core/src/runtime/worker/globalSetupWorker.ts
+++ b/packages/core/src/runtime/worker/globalSetupWorker.ts
@@ -1,5 +1,6 @@
 import { install } from 'source-map-support';
-import type { FormattedError } from '../../types';
+import type { AssetFiles, FormattedError } from '../../types';
+import { getAssetText } from '../../utils/assetFiles';
 import { color } from '../../utils/logger';
 import { formatTestError } from '../util';
 import { setFederationDynamicImportOrigin } from './runtimeHooks';
@@ -43,7 +44,7 @@ const runGlobalSetup = async (data: {
     runtimeDistPath?: string;
     testPath: string;
   }[];
-  assetFiles: Record<string, string>;
+  assetFiles: AssetFiles;
   sourceMaps: Record<string, string>;
   interopDefault: boolean;
   outputModule: boolean;
@@ -84,7 +85,6 @@ const runGlobalSetup = async (data: {
 
     for (const entry of data.entries) {
       const { distPath, runtimeDistPath, testPath } = entry;
-      const setupCodeContent = data.assetFiles[distPath]!;
       setFederationDynamicImportOrigin(data.federation, testPath);
       const { loadModule } = data.outputModule
         ? await import('./loadEsModule')
@@ -93,7 +93,7 @@ const runGlobalSetup = async (data: {
       const virtualFsAssetFiles = data.federation ? data.assetFiles : undefined;
 
       const module = await loadModule({
-        codeContent: setupCodeContent,
+        codeContent: getAssetText(data.assetFiles, distPath),
         distPath,
         runtimeDistPath,
         testPath,

--- a/packages/core/src/runtime/worker/loadEsModule.ts
+++ b/packages/core/src/runtime/worker/loadEsModule.ts
@@ -3,6 +3,8 @@ import { createRequire as createNativeRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import vm, { type SourceTextModule } from 'node:vm';
 import path from 'pathe';
+import type { AssetFiles } from '../../types/worker';
+import { getAssetText } from '../../utils/assetFiles';
 import { logger } from '../../utils/logger';
 import { clearCacheCleaners, clearSyntheticModuleCache } from './interop';
 import {
@@ -54,7 +56,7 @@ const defineRstestRequireResolve =
   }: {
     testPath: string;
     distPath: string;
-    assetFiles: Record<string, string>;
+    assetFiles: AssetFiles;
   }) =>
   (
     specifier: string,
@@ -75,7 +77,7 @@ const defineRstestRequireResolve =
       joinedPath.startsWith('file://') ? fileURLToPath(joinedPath) : joinedPath,
     );
 
-    if (assetFiles[normalizedPath]) {
+    if (assetFiles[normalizedPath] !== undefined) {
       return normalizedPath;
     }
 
@@ -93,7 +95,7 @@ const defineRstestDynamicImport =
     runtimeDistPath,
   }: {
     esmMode: EsmMode;
-    assetFiles: Record<string, string>;
+    assetFiles: AssetFiles;
     returnModule?: boolean;
     distPath: string;
     runtimeDistPath?: string;
@@ -114,8 +116,6 @@ const defineRstestDynamicImport =
       joinedPath.startsWith('file://') ? fileURLToPath(joinedPath) : joinedPath,
     );
 
-    const content = assetFiles[normalizedPath];
-
     // `.wasm` always resolves to an on-disk source file (wasmLoader.mjs rewrites
     // direct imports; `new URL(...)` resolves source-relative, #1455). Resolve
     // against the source origin — like the CJS loader and the dynamic
@@ -135,10 +135,10 @@ const defineRstestDynamicImport =
       }
     }
 
-    if (content) {
+    if (assetFiles[normalizedPath] !== undefined) {
       try {
         return await loadModule({
-          codeContent: content,
+          codeContent: getAssetText(assetFiles, normalizedPath),
           testPath,
           distPath: joinedPath,
           runtimeDistPath,
@@ -172,7 +172,7 @@ const esmCache = new Map<string, SourceTextModule>();
 // Paths are globally unique per build, so merging never collides; the map is
 // reset only on a full `clearModuleCache`.
 // See https://github.com/web-infra-dev/rstest/issues/1373.
-const accumulatedAssetFiles: Record<string, string> = {};
+const accumulatedAssetFiles: AssetFiles = {};
 
 // Every shared runtime chunk this (possibly reused) worker has loaded under
 // `isolate: false`. The pool has no environment affinity — with multiple node
@@ -200,7 +200,7 @@ export const loadModule = async ({
   runtimeDistPath?: string;
   testPath: string;
   rstestContext: Record<string, any>;
-  assetFiles: Record<string, string>;
+  assetFiles: AssetFiles;
 }): Promise<any> => {
   // Fold this file's assets into the persistent map. Recursive loads (dynamic
   // imports) re-pass that same map, so skip the no-op self-merge.

--- a/packages/core/src/runtime/worker/loadModule.ts
+++ b/packages/core/src/runtime/worker/loadModule.ts
@@ -3,6 +3,8 @@ import { createRequire as createNativeRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
 import path from 'pathe';
+import type { AssetFiles } from '../../types/worker';
+import { getAssetBuffer, getAssetText } from '../../utils/assetFiles';
 import { logger } from '../../utils/logger';
 import { clearCacheCleaners, clearSyntheticModuleCache } from './interop';
 import {
@@ -17,21 +19,27 @@ import {
 
 const isRelativePath = (p: string) => /^\.\.?\//.test(p);
 
-const getAssetContent = (
-  assetFiles: Record<string, string>,
+const getAssetName = (
+  assetFiles: AssetFiles,
   filePath: unknown,
 ): string | undefined => {
   if (typeof filePath === 'string') {
-    return assetFiles[path.normalize(filePath)];
+    const name = path.normalize(filePath);
+    return assetFiles[name] === undefined ? undefined : name;
   }
   if (filePath instanceof URL && filePath.protocol === 'file:') {
-    return assetFiles[path.normalize(fileURLToPath(filePath))];
+    const name = path.normalize(fileURLToPath(filePath));
+    return assetFiles[name] === undefined ? undefined : name;
   }
   return undefined;
 };
 
-const formatAssetContent = (content: string, options?: unknown) => {
-  const buffer = Buffer.from(content);
+const formatAssetContent = (
+  assetFiles: AssetFiles,
+  name: string,
+  options?: unknown,
+) => {
+  const buffer = getAssetBuffer(assetFiles, name);
   const encoding =
     typeof options === 'string'
       ? options
@@ -45,13 +53,13 @@ const formatAssetContent = (content: string, options?: unknown) => {
 
 const createVirtualFsAssetProxy = (
   fsModule: typeof import('node:fs'),
-  assetFiles: Record<string, string>,
+  assetFiles: AssetFiles,
 ): typeof import('node:fs') =>
   new Proxy(fsModule, {
     get(target, property, receiver) {
       if (property === 'existsSync') {
         return (filePath: unknown) =>
-          getAssetContent(assetFiles, filePath) !== undefined ||
+          getAssetName(assetFiles, filePath) !== undefined ||
           target.existsSync(
             filePath as Parameters<typeof target.existsSync>[0],
           );
@@ -67,11 +75,14 @@ const createVirtualFsAssetProxy = (
             typeof optionsOrCallback === 'function'
               ? optionsOrCallback
               : maybeCallback;
-          const content = getAssetContent(assetFiles, filePath);
+          const name = getAssetName(assetFiles, filePath);
 
-          if (content !== undefined && typeof callback === 'function') {
+          if (name !== undefined && typeof callback === 'function') {
             queueMicrotask(() =>
-              callback(null, formatAssetContent(content, optionsOrCallback)),
+              callback(
+                null,
+                formatAssetContent(assetFiles, name, optionsOrCallback),
+              ),
             );
             return;
           }
@@ -88,9 +99,9 @@ const createVirtualFsAssetProxy = (
 
       if (property === 'readFileSync') {
         return (filePath: unknown, options?: unknown) => {
-          const content = getAssetContent(assetFiles, filePath);
-          if (content !== undefined) {
-            return formatAssetContent(content, options);
+          const name = getAssetName(assetFiles, filePath);
+          if (name !== undefined) {
+            return formatAssetContent(assetFiles, name, options);
           }
           return target.readFileSync(
             filePath as Parameters<typeof target.readFileSync>[0],
@@ -104,13 +115,15 @@ const createVirtualFsAssetProxy = (
           get(promisesTarget, promisesProperty, promisesReceiver) {
             if (promisesProperty === 'readFile') {
               return (filePath: unknown, options?: unknown) => {
-                const content = getAssetContent(assetFiles, filePath);
-                return content === undefined
+                const name = getAssetName(assetFiles, filePath);
+                return name === undefined
                   ? Reflect.apply(promisesTarget.readFile, promisesTarget, [
                       filePath,
                       options,
                     ])
-                  : Promise.resolve(formatAssetContent(content, options));
+                  : Promise.resolve(
+                      formatAssetContent(assetFiles, name, options),
+                    );
               };
             }
             return Reflect.get(
@@ -134,7 +147,7 @@ const defineRstestRequireResolve =
   }: {
     testPath: string;
     distPath: string;
-    assetFiles: Record<string, string>;
+    assetFiles: AssetFiles;
   }) =>
   (
     specifier: string,
@@ -157,7 +170,7 @@ const defineRstestRequireResolve =
       : specifier;
     const normalizedPath = path.normalize(joinedPath);
 
-    if (assetFiles[normalizedPath]) {
+    if (assetFiles[normalizedPath] !== undefined) {
       return normalizedPath;
     }
 
@@ -168,9 +181,9 @@ const createRequire = (
   filename: string,
   distPath: string,
   rstestContext: Record<string, any>,
-  assetFiles: Record<string, string>,
+  assetFiles: AssetFiles,
   interopDefault: boolean,
-  virtualFsAssetFiles?: Record<string, string>,
+  virtualFsAssetFiles?: AssetFiles,
 ): NodeJS.Require => {
   const _require = (() => {
     try {
@@ -195,12 +208,12 @@ const createRequire = (
       ? path.join(currentDirectory, id)
       : id;
 
-    const content = getAssetContent(assetFiles, joinedPath);
+    const assetName = getAssetName(assetFiles, joinedPath);
 
-    if (content) {
+    if (assetName !== undefined) {
       try {
         return cacheableLoadModule({
-          codeContent: content,
+          codeContent: getAssetText(assetFiles, assetName),
           testPath: joinedPath,
           distPath: joinedPath,
           rstestContext,
@@ -272,7 +285,7 @@ const defineRstestDynamicImport =
 // Persistent asset map for the kept runtime chunk under `isolate: false` (the
 // per-module hooks closed over this reference). Mirrors the ESM loader — see
 // `loadEsModule.ts` for the full rationale.
-const accumulatedAssetFiles: Record<string, string> = {};
+const accumulatedAssetFiles: AssetFiles = {};
 
 // Every shared runtime chunk this (possibly reused) worker has loaded under
 // `isolate: false`. Mirrors the ESM loader — a reused worker can serve multiple
@@ -296,8 +309,8 @@ export const loadModule = ({
   distPath: string;
   testPath: string;
   rstestContext: Record<string, any>;
-  assetFiles: Record<string, string>;
-  virtualFsAssetFiles?: Record<string, string>;
+  assetFiles: AssetFiles;
+  virtualFsAssetFiles?: AssetFiles;
 }): any => {
   // Fold this file's assets into the persistent map. Recursive loads (require /
   // dynamic imports) re-pass that same map, so skip the no-op self-merge.
@@ -379,8 +392,8 @@ export const cacheableLoadModule = ({
   distPath: string;
   testPath: string;
   rstestContext: Record<string, any>;
-  assetFiles: Record<string, string>;
-  virtualFsAssetFiles?: Record<string, string>;
+  assetFiles: AssetFiles;
+  virtualFsAssetFiles?: AssetFiles;
 }): any => {
   if (moduleCache.has(testPath)) {
     return moduleCache.get(testPath);

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -2,6 +2,7 @@ import type { FileCoverageData } from 'istanbul-lib-coverage';
 import { isMainThread, threadId } from 'node:worker_threads';
 import { install } from 'source-map-support';
 import type {
+  AssetFiles,
   MaybePromise,
   Rstest,
   RunWorkerOptions,
@@ -10,6 +11,7 @@ import type {
   WorkerState,
 } from '../../types';
 import type { TestEnvironmentModuleFallback } from '../../pool/protocol';
+import { getAssetText } from '../../utils/assetFiles';
 import { globalApis, RSTEST_API_GLOBAL_KEY } from '../../utils/constants';
 import { getFileTaskId } from '../../utils/helper';
 import { color } from '../../utils/logger';
@@ -395,7 +397,7 @@ const loadFiles = async ({
   tracker,
 }: {
   setupEntries: RunWorkerOptions['options']['setupEntries'];
-  assetFiles: Record<string, string>;
+  assetFiles: AssetFiles;
   rstestContext: Record<string, any>;
   distPath: string;
   runtimeDistPath?: string;
@@ -437,11 +439,10 @@ const loadFiles = async ({
     distPath: setupDistPath,
     testPath: setupTestPath,
   } of setupEntries) {
-    const setupCodeContent = assetFiles[setupDistPath]!;
     setFederationDynamicImportOrigin(federation, setupTestPath);
 
     await loadModule({
-      codeContent: setupCodeContent,
+      codeContent: getAssetText(assetFiles, setupDistPath),
       distPath: setupDistPath,
       runtimeDistPath,
       testPath: setupTestPath,
@@ -455,7 +456,7 @@ const loadFiles = async ({
   tracker?.transition('collect');
   setFederationDynamicImportOrigin(federation, testPath);
   await loadModule({
-    codeContent: assetFiles[distPath]!,
+    codeContent: getAssetText(assetFiles, distPath),
     distPath,
     runtimeDistPath,
     testPath,
@@ -770,7 +771,11 @@ export const runInPool = async (
       const provider = coverageProvider;
       tracker.transition('coverage');
       const collectOptions = {
-        assetFiles,
+        assetFiles: Object.fromEntries(
+          Object.keys(assetFiles)
+            .filter((name) => /\.[cm]?js$/.test(name))
+            .map((name) => [name, getAssetText(assetFiles, name)]),
+        ),
         sourceMaps,
         outputModule: options.context.outputModule,
       };

--- a/packages/core/src/types/worker.ts
+++ b/packages/core/src/types/worker.ts
@@ -25,6 +25,16 @@ export type EntryInfo = {
   size?: number;
 };
 
+export type Base64AssetFile = {
+  encoding: 'base64';
+  data: string;
+};
+
+/** Asset representation accepted by every node worker transport. */
+export type AssetFileContent = string | Uint8Array | Base64AssetFile;
+
+export type AssetFiles = Record<string, AssetFileContent>;
+
 /** Server to Runtime */
 export type ServerRPC = object;
 
@@ -33,7 +43,7 @@ export type RuntimeRPC = {
   onTestFileStart: (test: TestFileInfo) => Promise<void>;
   onTestFileReady: (test: TestFileInfo) => Promise<void>;
   getAssetsByEntry: () => Promise<{
-    assetFiles: Record<string, string>;
+    assetFiles: AssetFiles;
     sourceMaps: Record<string, string>;
   }>;
   onTestSuiteStart: (test: TestSuiteInfo) => Promise<void>;
@@ -141,7 +151,7 @@ export type RunWorkerOptions = {
     type: 'run' | 'collect';
     /** assets is only defined when memory is sufficient, otherwise we should get them via rpc getAssetsByEntry method */
     assets?: {
-      assetFiles: Record<string, string>;
+      assetFiles: AssetFiles;
       sourceMaps: Record<string, string>;
     };
   };

--- a/packages/core/src/utils/assetFiles.ts
+++ b/packages/core/src/utils/assetFiles.ts
@@ -1,0 +1,75 @@
+import { isUtf8 } from 'node:buffer';
+import type { PoolWorkerKind } from '../pool/types';
+import type { AssetFileContent, AssetFiles } from '../types/worker';
+
+type BinaryAssetFileContent = Exclude<AssetFileContent, string>;
+
+const bufferCache = new WeakMap<BinaryAssetFileContent, Buffer>();
+const textCache = new WeakMap<BinaryAssetFileContent, string>();
+
+const toBuffer = (content: BinaryAssetFileContent): Buffer => {
+  if ('encoding' in content) {
+    return Buffer.from(content.data, 'base64');
+  }
+  if (Buffer.isBuffer(content)) {
+    return content;
+  }
+  return Buffer.from(content.buffer, content.byteOffset, content.byteLength);
+};
+
+export const prepareAssetFilesForIPC = (
+  assetFiles: Record<string, Buffer>,
+  workerKind: PoolWorkerKind,
+): AssetFiles => {
+  if (workerKind === 'threads' || process.versions.bun === undefined) {
+    return assetFiles;
+  }
+
+  return Object.fromEntries(
+    Object.entries(assetFiles).map(([name, content]) => [
+      name,
+      isUtf8(content)
+        ? content.toString('utf8')
+        : { encoding: 'base64', data: content.toString('base64') },
+    ]),
+  );
+};
+
+const getCachedBuffer = (content: BinaryAssetFileContent): Buffer => {
+  const cached = bufferCache.get(content);
+  if (cached) {
+    return cached;
+  }
+
+  const buffer = toBuffer(content);
+  bufferCache.set(content, buffer);
+  return buffer;
+};
+
+export const getAssetBuffer = (
+  assetFiles: AssetFiles,
+  name: string,
+): Buffer => {
+  const content = assetFiles[name]!;
+  if (typeof content === 'string') {
+    return Buffer.from(content, 'utf8');
+  }
+
+  return Buffer.from(getCachedBuffer(content));
+};
+
+export const getAssetText = (assetFiles: AssetFiles, name: string): string => {
+  const content = assetFiles[name]!;
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  const cached = textCache.get(content);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const text = getCachedBuffer(content).toString('utf8');
+  textCache.set(content, text);
+  return text;
+};

--- a/packages/core/tests/core/nodeExecutor.test.ts
+++ b/packages/core/tests/core/nodeExecutor.test.ts
@@ -9,7 +9,9 @@ describe('createCoverageResourceLoaders', () => {
     const windowsAlias = 'c:\\repo\\dist\\other.js';
     const requestedAssets = [privateAlias, windowsAlias];
     const getAssetFiles = rs.fn(async (names: string[]) =>
-      Object.fromEntries(names.map((name) => [name, `source:${name}`])),
+      Object.fromEntries(
+        names.map((name) => [name, Buffer.from(`source:${name}`)]),
+      ),
     );
     const getSourceMaps = rs.fn(async (names: string[]) =>
       Object.fromEntries(names.map((name) => [name, `map:${name}`])),

--- a/packages/core/tests/pool/fixtures/testWorker.mjs
+++ b/packages/core/tests/pool/fixtures/testWorker.mjs
@@ -11,6 +11,7 @@
  *   - 'stderr-late'        → write to stderr and exit(1) immediately
  *   - 'environment-fallback' → report an environment prebundle fallback,
  *                                then succeed.
+ *   - 'asset-transport'     → echo the received asset byte shape.
  *   - 'spawn-orphan'       → spawn a long-lived grandchild that inherits
  *                             stdio, then send result and exit normally.
  *                             Tests that `exit` (not `close`) drives the
@@ -166,6 +167,15 @@ const handleRun = (request) => {
       },
     });
     finish();
+    return;
+  }
+
+  if (mode === 'asset-transport') {
+    const content = request.options.assets.assetFiles['/asset.bin'];
+    finish({
+      _assetBytes: Array.from(content),
+      _assetConstructor: content.constructor.name,
+    });
     return;
   }
 

--- a/packages/core/tests/pool/pool.test.ts
+++ b/packages/core/tests/pool/pool.test.ts
@@ -74,6 +74,25 @@ describe('Pool - basic', () => {
       await pool.close();
     }
   });
+
+  it('preserves Buffer assets over advanced IPC', async () => {
+    const pool = new Pool(createPoolOptions());
+    try {
+      const result = await pool.runTest(
+        createTask('run', {
+          __testMode: 'asset-transport',
+          assets: {
+            assetFiles: { '/asset.bin': Buffer.from([0, 0xff, 0x80, 0x41]) },
+            sourceMaps: {},
+          },
+        }),
+      );
+      expect((result as any)._assetConstructor).toBe('Buffer');
+      expect((result as any)._assetBytes).toEqual([0, 0xff, 0x80, 0x41]);
+    } finally {
+      await pool.close();
+    }
+  });
 });
 
 describe('Pool - environment prebundle fallback', () => {

--- a/packages/core/tests/pool/threadsPool.test.ts
+++ b/packages/core/tests/pool/threadsPool.test.ts
@@ -69,6 +69,25 @@ describe('ThreadsPool - basic', () => {
       await pool.close();
     }
   });
+
+  it('preserves Buffer assets as Uint8Array over structured clone', async () => {
+    const pool = new Pool(createPoolOptions());
+    try {
+      const result = await pool.runTest(
+        createTask('run', {
+          __testMode: 'asset-transport',
+          assets: {
+            assetFiles: { '/asset.bin': Buffer.from([0, 0xff, 0x80, 0x41]) },
+            sourceMaps: {},
+          },
+        }),
+      );
+      expect((result as any)._assetConstructor).toBe('Uint8Array');
+      expect((result as any)._assetBytes).toEqual([0, 0xff, 0x80, 0x41]);
+    } finally {
+      await pool.close();
+    }
+  });
 });
 
 // ── fatal_error attribution ─────────────────────────────────────────────────

--- a/packages/core/tests/runner/requireResolveOrigin.test.ts
+++ b/packages/core/tests/runner/requireResolveOrigin.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import vm from 'node:vm';
 import { onTestFinished, rs } from '@rstest/core';
 import path from 'pathe';
+import type { AssetFiles } from '../../src/types';
 import {
   clearModuleCache as clearEsModuleCache,
   loadModule as loadEsModule,
@@ -97,9 +98,12 @@ describe('require.resolve origin runtime helper', () => {
       'dist',
       'chunk.js',
     );
-    const assetFiles = {
+    const assetFiles: AssetFiles = {
       [virtualFile]: 'virtual chunk',
     };
+    const binaryFile = path.join(path.dirname(virtualFile), 'asset.bin');
+    const binaryContent = Buffer.from([0, 0xff, 0x80, 0x41]);
+    assetFiles[binaryFile] = binaryContent;
     const loadOptions = {
       codeContent: `
         const fs = require('node:fs');
@@ -121,6 +125,22 @@ describe('require.resolve origin runtime helper', () => {
           promise: fs.existsSync(${JSON.stringify(virtualFile)})
             ? fs.promises.readFile(${JSON.stringify(virtualFile)}, 'utf-8')
             : undefined,
+          binary: fs.existsSync(${JSON.stringify(binaryFile)})
+            ? fs.readFileSync(${JSON.stringify(binaryFile)})
+            : undefined,
+          binaryText: fs.existsSync(${JSON.stringify(binaryFile)})
+            ? fs.readFileSync(${JSON.stringify(binaryFile)}, 'utf8')
+            : undefined,
+          mutatedBinary: fs.existsSync(${JSON.stringify(binaryFile)})
+            ? (() => {
+                const content = fs.readFileSync(${JSON.stringify(binaryFile)});
+                content[0] = 42;
+                return content;
+              })()
+            : undefined,
+          binaryAfterMutation: fs.existsSync(${JSON.stringify(binaryFile)})
+            ? fs.readFileSync(${JSON.stringify(binaryFile)})
+            : undefined,
         };
       `,
       distPath: path.join(os.tmpdir(), `rstest-virtual-fs-${Date.now()}.js`),
@@ -139,6 +159,10 @@ describe('require.resolve origin runtime helper', () => {
       syncText: undefined,
       callback: undefined,
       promise: undefined,
+      binary: undefined,
+      binaryText: undefined,
+      mutatedBinary: undefined,
+      binaryAfterMutation: undefined,
     });
     const virtual = loadModule({
       ...loadOptions,
@@ -150,6 +174,11 @@ describe('require.resolve origin runtime helper', () => {
     expect(virtual.syncText).toBe('virtual chunk');
     expect(Buffer.isBuffer(await virtual.callback)).toBe(true);
     expect(await virtual.promise).toBe('virtual chunk');
+    expect(Buffer.isBuffer(virtual.binary)).toBe(true);
+    expect(virtual.binary).toEqual(binaryContent);
+    expect(virtual.binaryText).toBe('\0\ufffd\ufffdA');
+    expect(virtual.mutatedBinary).toEqual(Buffer.from([42, 0xff, 0x80, 0x41]));
+    expect(virtual.binaryAfterMutation).toEqual(binaryContent);
   });
 
   it('binds top-level this to exports in CommonJS modules', () => {

--- a/packages/core/tests/utils/assetFiles.test.ts
+++ b/packages/core/tests/utils/assetFiles.test.ts
@@ -1,0 +1,102 @@
+import {
+  getAssetBuffer,
+  getAssetText,
+  prepareAssetFilesForIPC,
+} from '../../src/utils/assetFiles';
+
+describe('asset files', () => {
+  it('keeps buffers for Node worker transports', () => {
+    const content = Buffer.from([0, 0xff, 0x80, 0x41]);
+    const assetFiles = { '/asset.bin': content };
+
+    expect(prepareAssetFilesForIPC(assetFiles, 'forks')).toBe(assetFiles);
+  });
+
+  it('uses JSON-safe strings for Bun forks', () => {
+    const originalBunVersion = process.versions.bun;
+    process.versions.bun = originalBunVersion ?? '1.0.0';
+
+    try {
+      expect(
+        prepareAssetFilesForIPC(
+          {
+            '/entry.js': Buffer.from('export default 1'),
+            '/asset.bin': Buffer.from([0, 0xff, 0x80, 0x41]),
+          },
+          'forks',
+        ),
+      ).toEqual({
+        '/entry.js': 'export default 1',
+        '/asset.bin': {
+          encoding: 'base64',
+          data: Buffer.from([0, 0xff, 0x80, 0x41]).toString('base64'),
+        },
+      });
+    } finally {
+      if (originalBunVersion === undefined) {
+        Reflect.deleteProperty(process.versions, 'bun');
+      } else {
+        process.versions.bun = originalBunVersion;
+      }
+    }
+  });
+
+  it('keeps buffers for Bun threads', () => {
+    const originalBunVersion = process.versions.bun;
+    process.versions.bun = originalBunVersion ?? '1.0.0';
+    const assetFiles = {
+      '/asset.bin': Buffer.from([0, 0xff, 0x80, 0x41]),
+    };
+
+    try {
+      expect(prepareAssetFilesForIPC(assetFiles, 'threads')).toBe(assetFiles);
+    } finally {
+      if (originalBunVersion === undefined) {
+        Reflect.deleteProperty(process.versions, 'bun');
+      } else {
+        process.versions.bun = originalBunVersion;
+      }
+    }
+  });
+
+  it('normalizes thread and Bun payloads at the text or buffer consumer', () => {
+    const backing = Uint8Array.from([1, 2, 0, 0xff, 0x80, 0x41, 3]);
+    const threadContent = backing.subarray(2, 6);
+    const assetFiles = {
+      '/thread.bin': threadContent,
+      '/bun.bin': {
+        encoding: 'base64' as const,
+        data: Buffer.from([0, 0xff, 0x80, 0x41]).toString('base64'),
+      },
+      '/entry.js': Buffer.from('export default 1'),
+    };
+
+    expect(getAssetBuffer(assetFiles, '/thread.bin')).toEqual(
+      Buffer.from([0, 0xff, 0x80, 0x41]),
+    );
+    expect(getAssetBuffer(assetFiles, '/bun.bin')).toEqual(
+      Buffer.from([0, 0xff, 0x80, 0x41]),
+    );
+    expect(getAssetText(assetFiles, '/entry.js')).toBe('export default 1');
+  });
+
+  it('preserves canonical bytes across text and buffer reads', () => {
+    const content = Buffer.from([0xff, 0x80, 0x41]);
+    const assetFiles = { '/asset.bin': content };
+
+    expect(getAssetText(assetFiles, '/asset.bin')).toBe('\ufffd\ufffdA');
+    expect(getAssetBuffer(assetFiles, '/asset.bin')).toEqual(content);
+    expect(assetFiles['/asset.bin']).toBe(content);
+  });
+
+  it('returns isolated buffers', () => {
+    const content = Buffer.from([0, 0xff, 0x80, 0x41]);
+    const assetFiles = { '/asset.bin': content };
+    const first = getAssetBuffer(assetFiles, '/asset.bin');
+
+    first[0] = 42;
+
+    expect(getAssetBuffer(assetFiles, '/asset.bin')).toEqual(content);
+    expect(assetFiles['/asset.bin']).toBe(content);
+  });
+});


### PR DESCRIPTION
## Summary

This PR keeps compiled asset contents in byte form across the host, pool, and worker boundaries, and decodes only at semantic text-consumption points. This avoids UTF-8 corruption/expansion for binary assets while preserving text-module behavior.

- Node fork/thread transports retain byte content; Bun uses a JSON-safe representation when required.
- Virtual filesystem reads return exact binary bytes.
- The asset-heavy fixture used below contains about **16.9 MB of non-UTF-8 resources**. The previously observed **~30.1 MB** UTF-8 re-count reflects decoding expansion/corruption risk, not exact IPC wire size.

### Performance evidence

Same source, same test set, same Node version, and 5-run warm medians:

| Scenario | Metric | UTF-8 string | Buffer-first | Change |
| --- | --- | ---: | ---: | ---: |
| Text-only transport (`emitAssets: false`) | CLI wall | 2.13s | 1.96s | **-8%** |
|  | Rstest Duration | 841ms | 748ms | **-11%** |
|  | Peak RSS | 1,042.5MB | 1,014.1MB | **-2.7%** |
| Asset transport enabled (`emitAssets: true`) | CLI wall | 3.36s | 2.24s | **-33%** |
|  | Rstest Duration | 1,560ms | 909ms | **-42%** |
|  | Peak RSS | 1,156.1MB | 1,083.1MB | **-6.3%** |

The binary-heavy case shows a material benefit, while the text-only case remains broadly stable.

For an additional text-only Rsbuild compatibility suite (56 files, 378 tests), the measured change was 1.42s → 1.35s CLI wall (-4.9%) and 318MB → 313MB peak RSS (-1.6%), which is not a material overall difference.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).