### PR TITLE
fix(core): run global teardown after executor cleanup

### DIFF
--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-browser/rstest.config.mts
@@ -6,6 +6,16 @@ export default defineConfig({
   include: ['tests/**/*.test.ts'],
   testTimeout: BROWSER_TEST_TIMEOUT,
   globalSetup: ['./globalSetup.ts'],
+  plugins: [
+    {
+      name: 'test-browser-global-teardown-order',
+      setup(api) {
+        api.onCloseDevServer(() => {
+          console.log('[mixed-browser-dev-server] closed');
+        });
+      },
+    },
+  ],
   browser: {
     enabled: true,
     provider: 'playwright',

--- a/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup-mixed/project-node/rstest.config.mts
@@ -4,4 +4,14 @@ export default defineConfig({
   name: 'project-node',
   include: ['tests/**/*.test.ts'],
   globalSetup: ['./globalSetup.ts'],
+  plugins: [
+    {
+      name: 'test-node-global-teardown-order',
+      setup(api) {
+        api.onCloseDevServer(() => {
+          console.log('[mixed-node-dev-server] closed');
+        });
+      },
+    },
+  ],
 });

--- a/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
@@ -18,6 +18,16 @@ export default defineConfig({
   include: ['tests/**/*.test.ts'],
   testTimeout: BROWSER_TEST_TIMEOUT,
   globalSetup: ['./globalSetup.ts'],
+  plugins: [
+    {
+      name: 'test-global-teardown-order',
+      setup(api) {
+        api.onCloseDevServer(() => {
+          console.log('[browser-dev-server] closed');
+        });
+      },
+    },
+  ],
   env: {
     RSTEST_E2E_GS_OVERRIDE: 'from-config',
   },

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -133,11 +133,14 @@ describe('browser mode - globalSetup', () => {
     const teardownIndex = cli.stdout.indexOf(
       '[browser-global-teardown] executed',
     );
+    const serverCloseIndex = cli.stdout.lastIndexOf(
+      '[browser-dev-server] closed',
+    );
 
-    // Setup runs before any browser test output, teardown after all of it.
     expect(setupIndex).toBeGreaterThanOrEqual(0);
     expect(testIndex).toBeGreaterThan(setupIndex);
-    expect(teardownIndex).toBeGreaterThan(testIndex);
+    expect(serverCloseIndex).toBeGreaterThan(testIndex);
+    expect(teardownIndex).toBeGreaterThan(serverCloseIndex);
   });
 
   it('runs globalSetup and teardown around browser test collection', async () => {
@@ -155,10 +158,14 @@ describe('browser mode - globalSetup', () => {
     const teardownIndex = cli.stdout.indexOf(
       '[browser-global-teardown] executed',
     );
+    const serverCloseIndex = cli.stdout.lastIndexOf(
+      '[browser-dev-server] closed',
+    );
 
     expect(setupIndex).toBeGreaterThanOrEqual(0);
     expect(testIndex).toBeGreaterThan(setupIndex);
-    expect(teardownIndex).toBeGreaterThan(testIndex);
+    expect(serverCloseIndex).toBeGreaterThan(testIndex);
+    expect(teardownIndex).toBeGreaterThan(serverCloseIndex);
   });
 
   it('skips globalSetup when the shard slice has no files for the project', async () => {
@@ -201,6 +208,21 @@ describe('browser mode - globalSetup', () => {
     expect(cli.stdout).toContain('[mixed-node-global-teardown] executed');
     expect(cli.stdout).toContain('[mixed-browser-global-teardown] executed');
     expect(cli.stdout).toMatch(/Tests.*2 passed/);
+
+    const firstTeardownIndex = Math.min(
+      cli.stdout.indexOf('[mixed-node-global-teardown] executed'),
+      cli.stdout.indexOf('[mixed-browser-global-teardown] executed'),
+    );
+    const nodeServerCloseIndex = cli.stdout.lastIndexOf(
+      '[mixed-node-dev-server] closed',
+    );
+    const browserServerCloseIndex = cli.stdout.lastIndexOf(
+      '[mixed-browser-dev-server] closed',
+    );
+    expect(nodeServerCloseIndex).toBeGreaterThanOrEqual(0);
+    expect(browserServerCloseIndex).toBeGreaterThanOrEqual(0);
+    expect(nodeServerCloseIndex).toBeLessThan(firstTeardownIndex);
+    expect(browserServerCloseIndex).toBeLessThan(firstTeardownIndex);
   });
 
   for (const [name, args] of [

--- a/e2e/globalSetup/fixtures/basic/rstest.config.ts
+++ b/e2e/globalSetup/fixtures/basic/rstest.config.ts
@@ -2,4 +2,14 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   globalSetup: ['./setups/defaultExport.ts', './setups/namedExports.ts'],
+  plugins: [
+    {
+      name: 'test-global-teardown-order',
+      setup(api) {
+        api.onCloseDevServer(() => {
+          console.log('[rstest-dev-server] closed');
+        });
+      },
+    },
+  ],
 });

--- a/e2e/globalSetup/index.test.ts
+++ b/e2e/globalSetup/index.test.ts
@@ -31,10 +31,38 @@ describe('globalSetup', async () => {
         "[global-setup-named] executed",
         "[rstest] Running basic tests",
         "[rstest] Running basic tests",
+        "[rstest-dev-server] closed",
         "[global-teardown-named] executed",
         "[global-teardown-default] executed",
       ]
     `);
+  });
+
+  it('should close list resources before global teardown', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['list'],
+      options: {
+        nodeOptions: {
+          env: { ISOLATE: undefined },
+          cwd: join(__dirname, 'fixtures/basic'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+
+    const cleanupLogs = cli.stdout
+      .split('\n')
+      .filter(
+        (log) =>
+          log.includes('[rstest-dev-server]') ||
+          log.includes('[global-teardown-default]'),
+      );
+    expect(cleanupLogs).toEqual([
+      '[rstest-dev-server] closed',
+      '[global-teardown-default] executed',
+    ]);
   });
 
   it('should fail when global setup throws an error', async () => {
@@ -121,6 +149,20 @@ describe('globalSetup', async () => {
         expect(
           cli.stdout.match(/\[global-teardown-default\] executed/g),
         ).toHaveLength(2);
+        expect(
+          cli.stdout
+            .split('\n')
+            .filter(
+              (log) =>
+                log.includes('[rstest-dev-server]') ||
+                log.includes('[global-teardown-default]'),
+            ),
+        ).toEqual([
+          '[rstest-dev-server] closed',
+          '[global-teardown-default] executed',
+          '[rstest-dev-server] closed',
+          '[global-teardown-default] executed',
+        ]);
       } finally {
         await cli.killProcessTree();
         fs.delete(fixturesTargetPath);

--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -11,11 +11,7 @@ import type {
 import type { CoverageMap, CoverageProvider } from '../../types/coverage';
 import { clearScreen, color, logger, type TraceRun } from '../../utils';
 import { ensureTestEnvironmentDependencies } from '../envDependencies';
-import {
-  claimGlobalSetupOnce,
-  runGlobalSetup,
-  runGlobalTeardown,
-} from '../globalSetup';
+import { claimGlobalSetupOnce, runGlobalSetup } from '../globalSetup';
 import { applyOnlyFailuresSelection } from '../onlyFailures';
 import type { RunProjectPlan } from '../projectPlan';
 import { createRsbuildServer } from '../rsbuild';
@@ -222,7 +218,7 @@ export function createNodeExecutor(
     Promise<NonNullable<typeof runResources>> | undefined;
   let runDependencyValidationPromise: Promise<void> | undefined;
   let entryFiles: string[] = [];
-  let didRunGlobalTeardown = false;
+  let didClose = false;
   // When a dev compile starts. Paired with the compile's end into a completed
   // span below; on its own it is not a build time, because cycles are queued
   // and the wait for the queue is not build work.
@@ -595,34 +591,30 @@ export function createNodeExecutor(
   // Idempotent: the single `executors.close()` exit path may race a signal
   // handler, and closing a pool/server twice throws.
   const close = async (): Promise<void> => {
-    if (didRunGlobalTeardown) {
+    if (didClose) {
       return;
     }
-    didRunGlobalTeardown = true;
-    try {
-      await runGlobalTeardown();
-    } finally {
-      if (runDependencyValidationPromise) {
-        await runDependencyValidationPromise.catch(() => undefined);
-      }
-      // Settle an in-flight resource start first: a close racing startup (e.g. a
-      // config-change restart during watch boot) must tear down the server and
-      // pool that start is about to produce, not skip them.
-      if (runResourcesPromise) {
-        await runResourcesPromise.catch(() => undefined);
-      }
-      if (runResources) {
-        const resources = runResources;
-        runResources = undefined;
-        runResourcesPromise = undefined;
+    didClose = true;
+    if (runDependencyValidationPromise) {
+      await runDependencyValidationPromise.catch(() => undefined);
+    }
+    // Settle an in-flight resource start first: a close racing startup (e.g. a
+    // config-change restart during watch boot) must tear down the server and
+    // pool that start is about to produce, not skip them.
+    if (runResourcesPromise) {
+      await runResourcesPromise.catch(() => undefined);
+    }
+    if (runResources) {
+      const resources = runResources;
+      runResources = undefined;
+      runResourcesPromise = undefined;
+      try {
+        await resources.pool.close();
+      } finally {
         try {
-          await resources.pool.close();
+          await resources.closeServer();
         } finally {
-          try {
-            await resources.closeServer();
-          } finally {
-            await resources.cleanupTestEnvironmentModules();
-          }
+          await resources.cleanupTestEnvironmentModules();
         }
       }
     }

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -335,11 +335,7 @@ const collectNodeTests = async ({
         return (await resource?.getSourceMaps([name]))?.[name];
       },
       close: async () => {
-        try {
-          await runGlobalTeardown();
-        } finally {
-          await closeResources();
-        }
+        await closeResources();
       },
     };
   } catch (error) {
@@ -393,11 +389,7 @@ const collectBrowserTests = async ({
     }));
 
   const close = async () => {
-    try {
-      await runGlobalTeardown();
-    } finally {
-      await executor.close();
-    }
+    await executor.close();
   };
 
   try {
@@ -557,7 +549,9 @@ const collectAllTests = async ({
       list: [...nodeResult.list, ...browserResult.list],
       getSourceMap: nodeResult.getSourceMap,
       close: async () => {
-        await Promise.all([nodeResult.close(), browserResult.close()]);
+        const closePromises = [nodeResult.close(), browserResult.close()];
+        await Promise.allSettled(closePromises);
+        await Promise.all(closePromises);
       },
     };
   }
@@ -601,7 +595,9 @@ const collectAllTests = async ({
     list: [...nodeResult.list, ...browserResult.list],
     getSourceMap: nodeResult.getSourceMap,
     close: async () => {
-      await Promise.all([nodeResult.close(), browserResult.close()]);
+      const closePromises = [nodeResult.close(), browserResult.close()];
+      await Promise.allSettled(closePromises);
+      await Promise.all(closePromises);
     },
   };
 };
@@ -810,6 +806,13 @@ export async function listTests(
     throw error;
   }
   const { list, close, getSourceMap, errors = [] } = collected;
+  const closeCollection = async () => {
+    try {
+      await close();
+    } finally {
+      await runGlobalTeardown();
+    }
+  };
 
   const tests: ListedTest[] = [];
 
@@ -876,7 +879,7 @@ export async function listTests(
       }
     }
 
-    await close();
+    await closeCollection();
     return list;
   }
 
@@ -948,7 +951,7 @@ export async function listTests(
     }
   }
 
-  await close();
+  await closeCollection();
 
   return list;
 }

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -240,14 +240,10 @@ export async function runTests(context: Rstest): Promise<void> {
     // executor pushed inside the try below is covered — including when its own
     // load/init fails with the node resources above already up.
     //
-    // Three things about this net are deliberate on every run shape, zero-node
-    // included, and none is free to drift: executors close first and
-    // `runGlobalTeardown()` drains in the `finally`, so a user `globalSetup`
-    // teardown callback runs after the browser host and its dev servers are
-    // gone; the signal path uses that same order; and the exit handler is
-    // registered unconditionally, so a mid-run unexpected exit prints and sets
-    // a failing code rather than ending quietly. A teardown callback that needs
-    // a live server is the one reason to revisit the first of those.
+    // The run owns the shared globalSetup queue: every executor must close
+    // before user teardown starts, including on the signal path. The exit
+    // handler is registered unconditionally so a mid-run unexpected exit
+    // prints and sets a failing code rather than ending quietly.
     let didCloseExecutors = false;
     const closeExecutors = async () => {
       if (didCloseExecutors) {
@@ -255,16 +251,13 @@ export async function runTests(context: Rstest): Promise<void> {
       }
       didCloseExecutors = true;
       try {
-        await Promise.all(
-          executors.map((executor) =>
-            runLifecycleStep('executor cleanup', () => executor.close()),
-          ),
+        const closePromises = executors.map((executor) =>
+          runLifecycleStep('executor cleanup', () => executor.close()),
         );
+        await Promise.allSettled(closePromises);
+        await Promise.all(closePromises);
       } finally {
-        // `executors` excludes the node executor when only browser tests run,
-        // so `NodeExecutor.close()` alone cannot drain the browser stage's
-        // setups. A second drain is a no-op, and it must run even when an
-        // executor close throws.
+        // User teardown must still run when an executor close throws.
         await runLifecycleStep('global teardown', () => runGlobalTeardown());
       }
     };

--- a/packages/core/src/core/watchSession.ts
+++ b/packages/core/src/core/watchSession.ts
@@ -584,11 +584,8 @@ export function createWatchTeardown({
       for (const executor of executors) {
         await step('executor cleanup', () => executor.close());
       }
-      // Same order and the same reason as the non-watch net in `runTests.ts`:
-      // a user `globalSetup` teardown callback runs after the browser host and
-      // its dev servers are gone. `NodeExecutor.close()` drains too, so this is
-      // a no-op for a mixed session — but a browser-only watch has no node
-      // executor to drain the browser stage's setups.
+      // The watch session owns the shared queue and drains it only after every
+      // executor has closed.
       await step('global teardown', () => runGlobalTeardown());
     } finally {
       try {


### PR DESCRIPTION
## Summary

`globalTeardown` callbacks were owned by individual executors and collectors, so a mixed run could drain both Node and Browser callbacks while sibling resources were still closing. This PR makes the run, watch, and list session owners wait for every executor to close before draining the shared teardown queue, while `NodeExecutor` now owns only its pool and server cleanup.

Regression coverage observes the Rsbuild dev-server close hook relative to user teardown across Node run/list/watch, Browser run/list, and mixed Node + Browser runs.

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required; no public API or config changes).