### PR TITLE
fix(browser): avoid cleanup acknowledgement timeout

### DIFF
--- a/packages/browser/src/client/dispatchTransport.ts
+++ b/packages/browser/src/client/dispatchTransport.ts
@@ -47,7 +47,7 @@ export const createRequestId = (prefix: string): string => {
  *
  * Lifecycle events (`file-ready`, `suite-start`, `suite-result`, `case-start`)
  * share the dispatch-rpc envelope but are delivered fire-and-forget via
- * {@link sendRunnerLifecycle}, so the request id only needs to be unique — it is
+ * {@link sendDispatchRequest}, so the request id only needs to be unique — it is
  * produced by the shared {@link createRequestId} factory rather than a bespoke
  * per-runner counter.
  */
@@ -62,14 +62,14 @@ export const createRunnerLifecycleRequest = (
 });
 
 /**
- * Deliver a runner-lifecycle request fire-and-forget.
+ * Deliver a dispatch request fire-and-forget.
  *
  * Unlike {@link dispatchRpc}, this never awaits, unwraps, id-matches, or times
  * out: the host echoes a response but the runner ignores it. Failures surface
  * only through the optional `onError` hook (debug logging at the call site),
  * keeping the hot test loop non-blocking.
  */
-export const sendRunnerLifecycle = (
+export const sendDispatchRequest = (
   request: BrowserDispatchRequest,
   onError?: (error: unknown) => void,
 ): void => {

--- a/packages/browser/src/client/runner.ts
+++ b/packages/browser/src/client/runner.ts
@@ -42,7 +42,7 @@ import {
   createRunnerLifecycleRequest,
   dispatchRpc,
   getRpcTimeout,
-  sendRunnerLifecycle,
+  sendDispatchRequest,
 } from './dispatchTransport';
 import { BrowserSnapshotEnvironment } from './snapshot';
 import {
@@ -233,7 +233,7 @@ const dispatchRunnerLifecycle = (
   method: RunnerLifecycleMethod,
   payload: unknown,
 ): void => {
-  sendRunnerLifecycle(
+  sendDispatchRequest(
     createRunnerLifecycleRequest(method, payload),
     (error: unknown) => {
       debugLog('[Runner] Failed to dispatch lifecycle method:', method, error);
@@ -668,21 +668,29 @@ const run = async () => {
     const dispatchFileCleanup = async (
       method: FileCleanupDispatchMethod,
       result?: FileCleanupDispatchPayload['result'],
+      waitForAcknowledgement = true,
     ): Promise<void> => {
       const requestId = createRequestId(`file-cleanup-${method}`);
+      const request = {
+        requestId,
+        namespace: DISPATCH_NAMESPACE_FILE_CLEANUP,
+        method,
+        args: {
+          projectName: projectRuntime.name,
+          result,
+          runId: options.runId,
+          testPath,
+        } satisfies FileCleanupDispatchPayload,
+      };
+
+      if (!waitForAcknowledgement) {
+        sendDispatchRequest(request);
+        return;
+      }
+
       await dispatchRpc<void>({
         requestId,
-        request: {
-          requestId,
-          namespace: DISPATCH_NAMESPACE_FILE_CLEANUP,
-          method,
-          args: {
-            projectName: projectRuntime.name,
-            result,
-            runId: options.runId,
-            testPath,
-          } satisfies FileCleanupDispatchPayload,
-        },
+        request,
         timeoutMs: getRpcTimeout(),
         timeoutMessage: `File cleanup ${method} acknowledgement timed out for ${testPath}.`,
         staleMessage: `File cleanup ${method} became stale for ${testPath}.`,
@@ -694,9 +702,10 @@ const run = async () => {
         if (result && globalThis.__coverage__) {
           result.coverage = globalThis.__coverage__ as CoverageMapData;
         }
-        await dispatchFileCleanup('start', result);
+        await dispatchFileCleanup('start', result, window.parent !== window);
       },
-      onFileCleanupEnd: () => dispatchFileCleanup('end'),
+      onFileCleanupEnd: () =>
+        dispatchFileCleanup('end', undefined, window.parent !== window),
       onTestFileReady: async (test) => {
         dispatchRunnerLifecycle('file-ready', test);
       },

--- a/packages/browser/src/headlessScheduler.ts
+++ b/packages/browser/src/headlessScheduler.ts
@@ -240,6 +240,7 @@ export const createHeadlessScheduler = async ({
     let settled = false;
     let resolveDone: (() => void) | null = null;
     let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
+    let fileCleanupFinished = false;
     let provisionalResult: TestFileResult | undefined;
 
     const markDone = (): void => {
@@ -288,17 +289,24 @@ export const createHeadlessScheduler = async ({
       });
       sessionId = session.id;
 
-      const finishFileCleanup = (): void => {
+      const clearFileCleanupTimeout = (): void => {
         if (cleanupTimer) {
           clearTimeout(cleanupTimer);
           cleanupTimer = undefined;
         }
       };
+      const finishFileCleanup = (): void => {
+        fileCleanupFinished = true;
+        clearFileCleanupTimeout();
+      };
       fileCleanupHandlers.set(session.id, {
         end: finishFileCleanup,
         start: (result) => {
+          if (fileCleanupFinished) {
+            return;
+          }
           provisionalResult = result;
-          finishFileCleanup();
+          clearFileCleanupTimeout();
           cleanupTimer = setTimeout(() => {
             void (async () => {
               if (settled) {

--- a/packages/browser/tests/dispatchTransport.test.ts
+++ b/packages/browser/tests/dispatchTransport.test.ts
@@ -7,7 +7,7 @@ import {
 
 const loadModule = () => import('../src/client/dispatchTransport');
 
-describe('runner-lifecycle dispatch transport', () => {
+describe('dispatch transport', () => {
   afterEach(() => {
     rstest.unstubAllGlobals();
     rstest.resetModules();
@@ -34,11 +34,11 @@ describe('runner-lifecycle dispatch transport', () => {
     win.parent = win;
     rstest.stubGlobal('window', win);
 
-    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+    const { createRunnerLifecycleRequest, sendDispatchRequest } =
       await loadModule();
     const req = createRunnerLifecycleRequest('file-ready', { f: 1 });
     const onError = rstest.fn();
-    sendRunnerLifecycle(req, onError);
+    sendDispatchRequest(req, onError);
 
     expect(bridge).toHaveBeenCalledTimes(1);
     expect(bridge).toHaveBeenCalledWith(req);
@@ -52,11 +52,11 @@ describe('runner-lifecycle dispatch transport', () => {
     win.parent = win;
     rstest.stubGlobal('window', win);
 
-    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+    const { createRunnerLifecycleRequest, sendDispatchRequest } =
       await loadModule();
     const onError = rstest.fn();
     expect(() =>
-      sendRunnerLifecycle(
+      sendDispatchRequest(
         createRunnerLifecycleRequest('case-start', null),
         onError,
       ),
@@ -73,10 +73,10 @@ describe('runner-lifecycle dispatch transport', () => {
     win.parent = win;
     rstest.stubGlobal('window', win);
 
-    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+    const { createRunnerLifecycleRequest, sendDispatchRequest } =
       await loadModule();
     const onError = rstest.fn();
-    sendRunnerLifecycle(
+    sendDispatchRequest(
       createRunnerLifecycleRequest('suite-result', null),
       onError,
     );
@@ -88,10 +88,10 @@ describe('runner-lifecycle dispatch transport', () => {
     const postMessage = rstest.fn();
     rstest.stubGlobal('window', { parent: { postMessage } });
 
-    const { createRunnerLifecycleRequest, sendRunnerLifecycle } =
+    const { createRunnerLifecycleRequest, sendDispatchRequest } =
       await loadModule();
     const req = createRunnerLifecycleRequest('suite-start', { s: 1 });
-    sendRunnerLifecycle(req);
+    sendDispatchRequest(req);
 
     expect(postMessage).toHaveBeenCalledTimes(1);
     expect(postMessage).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Headless browser coverage runs can exceed the cleanup RPC acknowledgement timeout while serializing coverage data, causing otherwise successful test files to fail. This keeps cleanup lifecycle dispatch non-blocking in headless mode, preserves the timeout result, and ignores a delayed start after cleanup has finished.

## Related Links

- https://github.com/web-infra-dev/rstest/actions/runs/31362938416/job/93375966324

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).