### PR TITLE
fix(core): restore console and APIs in reused workers

### DIFF
--- a/e2e/no-isolate/fixtures/project-state-cleanup/marker.ts
+++ b/e2e/no-isolate/fixtures/project-state-cleanup/marker.ts
@@ -1,0 +1,6 @@
+import { join } from 'node:path';
+
+export const projectAFinishedMarker = join(
+  process.cwd(),
+  '.project-a-finished',
+);

--- a/e2e/no-isolate/fixtures/project-state-cleanup/project-a.test.ts
+++ b/e2e/no-isolate/fixtures/project-state-cleanup/project-a.test.ts
@@ -1,0 +1,13 @@
+import { writeFileSync } from 'node:fs';
+import { afterAll, expect, test } from '@rstest/core';
+import { projectAFinishedMarker } from './marker';
+
+test('installs project A global APIs', () => {
+  expect(Reflect.has(globalThis, 'test')).toBe(true);
+  expect(Reflect.has(globalThis, 'expect')).toBe(true);
+  console.log('PROJECT_A_INTERCEPTED_LOG');
+});
+
+afterAll(() => {
+  writeFileSync(projectAFinishedMarker, '');
+});

--- a/e2e/no-isolate/fixtures/project-state-cleanup/project-b.test.ts
+++ b/e2e/no-isolate/fixtures/project-state-cleanup/project-b.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@rstest/core';
+
+test('does not inherit project A global APIs or console', () => {
+  console.log('PROJECT_B_RAW_LOG');
+  expect(Reflect.has(globalThis, 'test')).toBe(false);
+  expect(Reflect.has(globalThis, 'expect')).toBe(false);
+});

--- a/e2e/no-isolate/fixtures/project-state-cleanup/rstest.config.ts
+++ b/e2e/no-isolate/fixtures/project-state-cleanup/rstest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  isolate: false,
+  pool: { maxWorkers: 1 },
+  onConsoleLog: () => false,
+  projects: [
+    {
+      name: 'project-a',
+      include: ['project-a.test.ts'],
+      globals: true,
+    },
+    {
+      name: 'project-b',
+      include: ['project-b.test.ts'],
+      globals: false,
+      disableConsoleIntercept: true,
+      globalSetup: './waitForProjectA.ts',
+    },
+  ],
+});

--- a/e2e/no-isolate/fixtures/project-state-cleanup/waitForProjectA.ts
+++ b/e2e/no-isolate/fixtures/project-state-cleanup/waitForProjectA.ts
@@ -1,0 +1,15 @@
+import { access } from 'node:fs/promises';
+import { projectAFinishedMarker } from './marker';
+
+export default async function waitForProjectA() {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      await access(projectAFinishedMarker);
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error('Timed out waiting for project A to finish');
+}

--- a/e2e/no-isolate/moduleSharing.test.ts
+++ b/e2e/no-isolate/moduleSharing.test.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, it } from '@rstest/core';
-import { runRstestCli } from '../scripts/';
+import { describe, expect, it } from '@rstest/core';
+import { prepareFixtures, runRstestCli } from '../scripts/';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,6 +22,36 @@ describe('module state sharing under isolate: false', () => {
     });
 
     await expectExecSuccess();
+  });
+
+  it('restores project-scoped globals before reusing a worker', async ({
+    onTestFinished,
+  }) => {
+    const fixturesTargetPath = join(
+      __dirname,
+      `fixtures-test-project-state-cleanup${
+        process.env.RSTEST_OUTPUT_MODULE !== 'false' ? '-module' : ''
+      }`,
+    );
+    await prepareFixtures({
+      fixturesPath: join(__dirname, 'fixtures', 'project-state-cleanup'),
+      fixturesTargetPath,
+    });
+
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run'],
+      onTestFinished,
+      options: {
+        nodeOptions: {
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).not.toContain('PROJECT_A_INTERCEPTED_LOG');
+    expect(cli.stdout).toContain('PROJECT_B_RAW_LOG');
   });
 
   // Runs the whole `sharing` fixture dir (one worker, isolate: false) and

--- a/packages/core/src/runtime/worker/globalProperty.ts
+++ b/packages/core/src/runtime/worker/globalProperty.ts
@@ -1,0 +1,36 @@
+import type { Rstest } from '../../types';
+import { globalApis } from '../../utils/constants';
+
+export const installGlobalProperty = (
+  target: object,
+  key: PropertyKey,
+  value: unknown,
+): (() => void) => {
+  const previousDescriptor = Object.getOwnPropertyDescriptor(target, key);
+  if (!Reflect.set(target, key, value)) {
+    throw new TypeError(`Cannot install global property: ${String(key)}`);
+  }
+
+  return () => {
+    if (previousDescriptor) {
+      Object.defineProperty(target, key, previousDescriptor);
+    } else {
+      Reflect.deleteProperty(target, key);
+    }
+  };
+};
+
+export const installGlobalApis = (
+  api: Rstest,
+  target: object = globalThis,
+): (() => void) => {
+  const restores = globalApis.map((key) =>
+    installGlobalProperty(target, key, api[key]),
+  );
+
+  return () => {
+    for (const restore of restores) {
+      restore();
+    }
+  };
+};

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -4,7 +4,6 @@ import { install } from 'source-map-support';
 import type {
   AssetFiles,
   MaybePromise,
-  Rstest,
   RunnerHooks,
   RunWorkerOptions,
   TestFileResult,
@@ -13,7 +12,7 @@ import type {
 } from '../../types';
 import type { TestEnvironmentModuleFallback } from '../../pool/protocol';
 import { getAssetText } from '../../utils/assetFiles';
-import { globalApis, RSTEST_API_GLOBAL_KEY } from '../../utils/constants';
+import { RSTEST_API_GLOBAL_KEY } from '../../utils/constants';
 import { getFileTaskId } from '../../utils/helper';
 import { color } from '../../utils/logger';
 import { formatTestError, getRealTimers, setRealTimers } from '../util';
@@ -21,6 +20,7 @@ import type { FileCleanupHooks } from '../runner';
 import { createAsyncLeakDetector } from './asyncLeaks';
 import { environmentLoaders } from './env/registry';
 import { loadTestEnvironmentModule } from './env/testEnvironmentModule';
+import { installGlobalApis, installGlobalProperty } from './globalProperty';
 import { PhaseTracker } from './phaseTracker';
 import { createRuntimeRpc, createWorkerRpcOptions } from './rpc';
 import { setFederationDynamicImportOrigin } from './runtimeHooks';
@@ -54,16 +54,12 @@ install({
   },
 });
 
-const registerGlobalApi = (api: Rstest) => {
-  return globalApis.reduce<{
-    [key in keyof Rstest]?: Rstest[key];
-  }>((apis, key) => {
-    // @ts-expect-error register to global
-    globalThis[key] = api[key] as any;
-    return apis;
-  }, {});
-};
-
+/**
+ * Restores task-scoped global mutations at the next task boundary, rather than
+ * file teardown, so late callbacks keep the console and RPC they captured.
+ * Console interception and optional global APIs register their inverses here
+ * before a reused worker can serve another project.
+ */
 const globalCleanups: (() => void)[] = [];
 let isTeardown = false;
 /**
@@ -246,7 +242,7 @@ const preparePool = async (
     // worker first and later replayed to the original worker streams according
     // to the silent policy, instead of being reported to the host.
 
-    global.console = createCustomConsole({
+    const customConsole = createCustomConsole({
       onConsoleLog: (log) => {
         silentConsoleController.onConsoleLog(log);
       },
@@ -255,6 +251,9 @@ const preparePool = async (
       printConsoleTrace: !disableConsoleIntercept && printConsoleTrace,
       getCurrentTask: () => taskContext.getCurrent(),
     });
+    globalCleanups.push(
+      installGlobalProperty(global, 'console', customConsole),
+    );
   }
 
   const interopDefault = true;
@@ -358,7 +357,7 @@ const preparePool = async (
   tracker?.transition('prepare');
 
   if (globals) {
-    registerGlobalApi(api);
+    globalCleanups.push(installGlobalApis(api));
   }
 
   const rstestContext = {

--- a/packages/core/tests/runtime/worker/globalProperty.test.ts
+++ b/packages/core/tests/runtime/worker/globalProperty.test.ts
@@ -1,0 +1,59 @@
+import * as api from '../../../src/runtime/api/public';
+import { globalApis } from '../../../src/utils/constants';
+import {
+  installGlobalApis,
+  installGlobalProperty,
+} from '../../../src/runtime/worker/globalProperty';
+
+describe('installGlobalProperty', () => {
+  it('removes a property that did not exist before installation', () => {
+    const target = {};
+    const value = Symbol('installed value');
+    const restore = installGlobalProperty(target, 'example', value);
+    expect(Reflect.get(target, 'example')).toBe(value);
+
+    restore();
+    expect(Object.hasOwn(target, 'example')).toBe(false);
+  });
+
+  it('restores an existing property descriptor', () => {
+    const target = {};
+    const previousValue = Symbol('previous value');
+    Object.defineProperty(target, 'example', {
+      value: previousValue,
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
+    const previousDescriptor = Object.getOwnPropertyDescriptor(
+      target,
+      'example',
+    );
+
+    const restore = installGlobalProperty(
+      target,
+      'example',
+      Symbol('installed value'),
+    );
+
+    restore();
+    expect(Object.getOwnPropertyDescriptor(target, 'example')).toEqual(
+      previousDescriptor,
+    );
+  });
+});
+
+it('installs and restores all global APIs', () => {
+  const target = {};
+  const restore = installGlobalApis(api, target);
+
+  for (const key of globalApis) {
+    expect(Reflect.get(target, key)).toBe(api[key]);
+  }
+
+  restore();
+
+  for (const key of globalApis) {
+    expect(Object.hasOwn(target, key)).toBe(false);
+  }
+});


### PR DESCRIPTION
## Summary

- Prevent global test APIs and intercepted console state from leaking when an `isolate: false` worker is reused across projects.
- Restore original global property descriptors at the next task boundary, preserving late callbacks and intentional module sharing.
- Add deterministic multi-project e2e coverage and focused unit coverage for reversible global properties.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).