### PR TITLE
fix(browser): defer coverage provider loading during discovery

### DIFF
--- a/packages/browser/src/hostController.ts
+++ b/packages/browser/src/hostController.ts
@@ -342,9 +342,10 @@ export const runBrowserController = async (
   const coverageConfig = browserProjects.find(
     (project) => project.normalizedConfig.coverage?.enabled,
   )?.normalizedConfig.coverage;
-  const coverageProvider = coverageConfig?.enabled
-    ? await createCoverageProvider(coverageConfig, context.rootPath)
-    : null;
+  const coverageProvider =
+    !filesOnly && context.command !== 'list' && coverageConfig?.enabled
+      ? await createCoverageProvider(coverageConfig, context.rootPath)
+      : null;
   const browserCoverageCapabilityError =
     !filesOnly &&
     context.command !== 'list' &&


### PR DESCRIPTION
## Summary

Browser Mode's files-only discovery boot loaded the coverage provider before core could check and auto-install the missing package. This PR skips provider creation during files-only discovery and `list`, leaving provider loading to real test runs after dependency checks complete.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).