### PR TITLE
fix(core): reject invalid third test argument

### DIFF
--- a/e2e/test-api/fixtures/testOptionsThirdArgument.test.js
+++ b/e2e/test-api/fixtures/testOptionsThirdArgument.test.js
@@ -1,0 +1,3 @@
+import { it } from '@rstest/core';
+
+it('rejects TestOptions in the third position', () => {}, { retry: 2 });

--- a/e2e/test-api/testOptions.test.ts
+++ b/e2e/test-api/testOptions.test.ts
@@ -150,6 +150,23 @@ describe('TestOptions', () => {
     expectStderrLog(/test timed out in 50ms/);
   }, 10000);
 
+  it('rejects TestOptions in the third position at runtime', async () => {
+    const { expectExecFailed, expectStderrLog } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testOptionsThirdArgument.test.js'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecFailed();
+    expectStderrLog(
+      'The third argument must be a number when the second argument is a function. Use (name, fn, timeout) or (name, options, fn).',
+    );
+  });
+
   it('describe options propagate retry to inner tests, per-test wins', async () => {
     const { expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -6,14 +6,18 @@ import type { FormattedError, Test, TestOptions } from '../types';
  * - `(name, fn, timeout?)` — `arg2` is the test fn, `arg3` an optional numeric timeout.
  * - `(name, options, fn?)` — `arg2` is a `TestOptions` object, `arg3` the test fn.
  *
- * In the function-first shape `arg3` is only honored as a numeric timeout; an options
- * object is no longer accepted there (it is a type error and ignored at runtime).
+ * In the function-first shape `arg3` is only accepted as a numeric timeout.
  */
 export const resolveTestArgs = <Fn extends (...args: any[]) => any>(
   arg2?: Fn | TestOptions,
   arg3?: Fn | number,
 ): { fn?: Fn; options: TestOptions } => {
   if (typeof arg2 === 'function') {
+    if (arg3 !== undefined && typeof arg3 !== 'number') {
+      throw new Error(
+        'The third argument must be a number when the second argument is a function. Use (name, fn, timeout) or (name, options, fn).',
+      );
+    }
     return {
       fn: arg2,
       options: typeof arg3 === 'number' ? { timeout: arg3 } : {},

--- a/packages/core/tests/runner/runtime.test.ts
+++ b/packages/core/tests/runner/runtime.test.ts
@@ -161,15 +161,26 @@ describe('RunnerRuntime', () => {
       expect(testCase.meta).toEqual({ custom: 'value', count: 42 });
     });
 
-    it('ignores an options object passed as the third argument', async () => {
-      const instance = createApi(123);
-      // The legacy third-arg object form is no longer supported: it is a type
-      // error and must not leak retry/repeats onto the case at runtime.
-      runtimeAPI.it('case', () => {}, { timeout: 250, retry: 2 } as any);
+    it('rejects a non-numeric third argument for tests and suites', () => {
+      createApi();
+      const invalidOptions = { timeout: 250, retry: 2 } as never;
+      const expectedError =
+        'The third argument must be a number when the second argument is a function. Use (name, fn, timeout) or (name, options, fn).';
+      const declarations = [
+        () => runtimeAPI.it('case', () => {}, invalidOptions),
+        () => runtimeAPI.test('case', () => {}, invalidOptions),
+        () => runtimeAPI.it.each([1])('case %s', () => {}, invalidOptions),
+        () => runtimeAPI.it.for([1])('case %s', () => {}, invalidOptions),
+        () => runtimeAPI.describe('suite', () => {}, invalidOptions),
+        () =>
+          runtimeAPI.describe.each([1])('suite %s', () => {}, invalidOptions),
+        () =>
+          runtimeAPI.describe.for([1])('suite %s', () => {}, invalidOptions),
+      ];
 
-      const testCase = (await instance.getTests())[0] as TestCase;
-      expect(testCase.timeout).toBe(123);
-      expect(testCase.retry).toBeUndefined();
+      for (const declare of declarations) {
+        expect(declare).toThrowError(expectedError);
+      }
     });
 
     it('falls back to config.testTimeout when timeout omitted', async () => {


### PR DESCRIPTION
## Summary

- Reject non-numeric third arguments to test and suite declarations instead of silently discarding them.
- Keep runtime behavior aligned with the supported `(name, fn, timeout)` and `(name, options, fn)` signatures.
- Add runner coverage for direct and parameterized APIs plus a JavaScript E2E regression test.

## Related Links

- Fixes https://github.com/web-infra-dev/rstest/issues/1710

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).