### PR TITLE
docs: add build config examples for in-source tests

### DIFF
--- a/website/docs/en/config/test/include-source.mdx
+++ b/website/docs/en/config/test/include-source.mdx
@@ -44,7 +44,24 @@ if (import.meta.rstest) {
 
 ### For production
 
-Put the test code inside the `if (import.meta.rstest)` block, and define `import.meta.rstest` as `false` in your build configuration (e.g., `rsbuild.config.ts`), which will help the bundler eliminate dead code.
+Put the test code inside the `if (import.meta.rstest)` block. When generating non-test output, define `import.meta.rstest` as `false` in your project's build configuration so the bundler can eliminate the test code as dead code.
+
+- Use Rspack's [DefinePlugin](https://rspack.rs/plugins/webpack/define-plugin):
+
+```diff title=rspack.config.ts
+import { defineConfig } from '@rspack/cli';
++import { rspack } from '@rspack/core';
+
+export default defineConfig({
++  plugins: [
++    new rspack.DefinePlugin({
++      'import.meta.rstest': false,
++    }),
++  ],
+});
+```
+
+- Use Rsbuild's [source.define](https://rsbuild.rs/config/source/define) option:
 
 ```diff title=rsbuild.config.ts
 import { defineConfig } from '@rsbuild/core';

--- a/website/docs/zh/config/test/include-source.mdx
+++ b/website/docs/zh/config/test/include-source.mdx
@@ -44,7 +44,24 @@ if (import.meta.rstest) {
 
 ### 生产环境构建
 
-将测试代码写在 `if (import.meta.rstest)` 代码块内，并在你的构建配置（如 `rsbuild.config.ts`）中将 `import.meta.rstest` 定义为 `false`，这样将有助于打包工具消除无用代码。
+将测试代码写在 `if (import.meta.rstest)` 代码块内。生成非测试产物时，请在项目的构建配置中将 `import.meta.rstest` 定义为 `false`，这样打包工具就能将测试代码作为无用代码移除。
+
+- 使用 Rspack 的 [DefinePlugin](https://rspack.rs/zh/plugins/webpack/define-plugin)：
+
+```diff title=rspack.config.ts
+import { defineConfig } from '@rspack/cli';
++import { rspack } from '@rspack/core';
+
+export default defineConfig({
++  plugins: [
++    new rspack.DefinePlugin({
++      'import.meta.rstest': false,
++    }),
++  ],
+});
+```
+
+- 使用 Rsbuild 的 [source.define](https://rsbuild.rs/zh/config/source/define) 选项：
 
 ```diff title=rsbuild.config.ts
 import { defineConfig } from '@rsbuild/core';


### PR DESCRIPTION
## Summary

This PR clarifies how to remove in-source tests from non-test builds. It adds Rspack `DefinePlugin` and Rsbuild `source.define` examples, links each option to its official documentation, and keeps the English and Chinese docs aligned.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).