### PR TITLE
docs: prefer tsconfig for Rstest types

### DIFF
--- a/website/docs/en/config/test/globals.mdx
+++ b/website/docs/en/config/test/globals.mdx
@@ -68,15 +68,17 @@ When `globals` is enabled, Rstest injects the following globals:
 
 ### TypeScript support
 
-To enable TypeScript to properly recognize the global APIs, add the `@rstest/core/globals` type declaration in your `tsconfig.json`:
+To enable TypeScript to properly recognize the global APIs, we recommend adding `@rstest/core/globals` to `compilerOptions.types` in the `tsconfig.json` for your test files:
 
-```ts title=tsconfig.json
+```json title=tsconfig.json
 {
   "compilerOptions": {
     "types": ["@rstest/core/globals"]
   }
 }
 ```
+
+> If your `tsconfig.json` already configures `compilerOptions.types`, append this type to the existing list.
 
 Alternatively, create a `src/rstestEnv.d.ts` file to reference the type definitions:
 

--- a/website/docs/en/config/test/include-source.mdx
+++ b/website/docs/en/config/test/include-source.mdx
@@ -77,7 +77,19 @@ export default defineConfig({
 
 ### TypeScript
 
-To get TypeScript support for `import.meta.rstest`, you can create a `src/rstestEnv.d.ts` file to reference:
+To get TypeScript support for `import.meta.rstest`, we recommend adding `@rstest/core/importMeta` to `compilerOptions.types` in the `tsconfig.json` for your test files:
+
+```json title=tsconfig.json
+{
+  "compilerOptions": {
+    "types": ["@rstest/core/importMeta"]
+  }
+}
+```
+
+> If your `tsconfig.json` already configures `compilerOptions.types`, append this type to the existing list.
+
+Alternatively, reference the type in `src/rstestEnv.d.ts`:
 
 ```ts title=rstestEnv.d.ts
 /// <reference types="@rstest/core/importMeta" />

--- a/website/docs/zh/config/test/globals.mdx
+++ b/website/docs/zh/config/test/globals.mdx
@@ -68,15 +68,17 @@ describe('Index', () => {
 
 ### 类型支持
 
-为了让 TypeScript 正确识别全局 API，在 `tsconfig.json` 中添加 `@rstest/core/globals` 类型声明：
+为了让 TypeScript 正确识别全局 API，推荐在测试文件对应的 `tsconfig.json` 中，将 `@rstest/core/globals` 添加到 `compilerOptions.types`：
 
-```ts title=tsconfig.json
+```json title=tsconfig.json
 {
   "compilerOptions": {
     "types": ["@rstest/core/globals"]
   }
 }
 ```
+
+> 如果已有 `compilerOptions.types` 配置，请将该类型追加到现有列表中。
 
 或者创建一个 `src/rstestEnv.d.ts` 文件来引用类型定义：
 

--- a/website/docs/zh/config/test/include-source.mdx
+++ b/website/docs/zh/config/test/include-source.mdx
@@ -77,7 +77,19 @@ export default defineConfig({
 
 ### TypeScript
 
-如需让 TypeScript 支持 `import.meta.rstest`，你可以创建一个 `src/rstestEnv.d.ts` 文件来引用：
+如需让 TypeScript 支持 `import.meta.rstest`，推荐在测试文件对应的 `tsconfig.json` 中，将 `@rstest/core/importMeta` 添加到 `compilerOptions.types`：
+
+```json title=tsconfig.json
+{
+  "compilerOptions": {
+    "types": ["@rstest/core/importMeta"]
+  }
+}
+```
+
+> 如果已有 `compilerOptions.types` 配置，请将该类型追加到现有列表中。
+
+也可以在 `src/rstestEnv.d.ts` 中引用类型：
 
 ```ts title=rstestEnv.d.ts
 /// <reference types="@rstest/core/importMeta" />


### PR DESCRIPTION
## Summary

This PR recommends adding `@rstest/core/globals` and `@rstest/core/importMeta` through `compilerOptions.types` in the `tsconfig.json` for test files. It keeps triple-slash reference examples as an alternative and aligns the English and Chinese documentation.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).