### PR TITLE
release: 0.11.7

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@rspack/cli": "^2.0.0",
     "@rspack/core": "^2.0.0",
-    "@rstest/core": "workspace:^"
+    "@rstest/core": "^0.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/playwright",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Playwright fixture integration for Rstest",
   "keywords": [
     "rstest",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
## What's Changed
### New Features 🎉
* feat(core): add named fixture form by @9aoy in https://github.com/web-infra-dev/rstest/pull/1667
* feat(core): support project-level silent config by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1677
* feat(browser): support Module Federation in Browser Mode by @9aoy in https://github.com/web-infra-dev/rstest/pull/1639
* feat(core): add bundle coverage debug output by @9aoy in https://github.com/web-infra-dev/rstest/pull/1694
* feat(core): add file-scoped named fixtures by @9aoy in https://github.com/web-infra-dev/rstest/pull/1678
* feat(browser): support native v8 coverage in chromium by @9aoy in https://github.com/web-infra-dev/rstest/pull/1700
### Performance 🚀
* perf(core): reuse compile cache in workers by @chenjiahan in https://github.com/web-infra-dev/rstest/pull/1684
* perf(core): skip tsconfig paths for environment prebundles by @9aoy in https://github.com/web-infra-dev/rstest/pull/1688
* perf(core): preserve binary assets across workers by @9aoy in https://github.com/web-infra-dev/rstest/pull/1695
### Bug Fixes 🐞
* fix(browser): recover watch after initial fatal error by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1679
* fix(core): reset soft assertion errors before retry by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1680
* fix(core): unify matcher state ownership by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1681
* fix(browser): track expect.element assertions by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1682
* fix(browser): rerun headed watch on test file changes by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1685
* fix(core): warn when environment prebundle falls back by @9aoy in https://github.com/web-infra-dev/rstest/pull/1683
* fix(browser): publish compiled browser client by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1689
* fix(core): run global teardown after executor cleanup by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1697
* fix(browser): avoid cleanup acknowledgement timeout by @9aoy in https://github.com/web-infra-dev/rstest/pull/1701
* fix(coverage): finalize blob coverage in merge-reports by @9aoy in https://github.com/web-infra-dev/rstest/pull/1699
* fix(adapter-rspack): preserve compatible compiler options by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1702
* fix(core): restore console and APIs in reused workers by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1704
* fix(playwright): keep test wrappers in sync with core APIs by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1705
* fix(browser): defer coverage provider loading during discovery by @9aoy in https://github.com/web-infra-dev/rstest/pull/1706
* fix(browser): settle pending headed reloads when the file set drops them by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1690
* fix(core): reject invalid third test argument by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1711
* fix(browser): disable browser RPC timeout by @9aoy in https://github.com/web-infra-dev/rstest/pull/1707
* fix(core): scope import.meta.rstest to test entries by @9aoy in https://github.com/web-infra-dev/rstest/pull/1655
### Refactor 🔨
* refactor(e2e): consolidate coverage provider tests by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1674
* refactor(e2e): consolidate fan-out and shard fixtures by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1675
### Document 📖
* docs: document the --trace CLI flag in the profiling guide by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1693
* docs: clarify tsconfig transform settings by @9aoy in https://github.com/web-infra-dev/rstest/pull/1698
* docs: keep config overview in sync by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1703
* docs: add build config examples for in-source tests by @chenjiahan in https://github.com/web-infra-dev/rstest/pull/1712
* docs: prefer tsconfig for Rstest types by @chenjiahan in https://github.com/web-infra-dev/rstest/pull/1713
### Other Changes
* test(core): centralize test temp directory cleanup by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1676
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1670
* test(core): fix flaky pool capacity assertion by @9aoy in https://github.com/web-infra-dev/rstest/pull/1687
* test(core): replace finalize source guard with behavioral coverage by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1692
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1709
* test(vscode): isolate extension test profile by @9aoy in https://github.com/web-infra-dev/rstest/pull/1714
* release: 0.11.7 by @9aoy in https://github.com/web-infra-dev/rstest/pull/1715

**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.11.6...v0.11.7