### PR TITLE
fix(build): disable Rslib createRequire parser

### DIFF
--- a/packages/adapter-rsbuild/rslib.config.mts
+++ b/packages/adapter-rsbuild/rslib.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -24,6 +25,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/adapter-rslib/rslib.config.mts
+++ b/packages/adapter-rslib/rslib.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -23,6 +24,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/adapter-rspack/rslib.config.mts
+++ b/packages/adapter-rspack/rslib.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -23,6 +24,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/browser-react/rslib.config.ts
+++ b/packages/browser-react/rslib.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -34,6 +35,7 @@ export default defineConfig({
   },
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/browser/rslib.config.ts
+++ b/packages/browser/rslib.config.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import { defineConfig, rspack } from '@rslib/core';
 import { dirname, resolve } from 'pathe';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 const require = createRequire(import.meta.url);
@@ -89,5 +90,8 @@ export default defineConfig({
     define: {
       RSTEST_VERSION: JSON.stringify(require('./package.json').version),
     },
+  },
+  tools: {
+    rspack: rslibRspackConfig,
   },
 });

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,6 +1,7 @@
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { defineConfig, rspack, type Rsbuild } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 import {
   peerDependencies,
@@ -234,6 +235,7 @@ export default defineConfig({
   },
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       watchOptions: {
         ignored: /\.git/,
       },

--- a/packages/coverage-istanbul/rslib.config.ts
+++ b/packages/coverage-istanbul/rslib.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -17,6 +18,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/coverage-v8/rslib.config.ts
+++ b/packages/coverage-v8/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rslib/core';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -12,6 +13,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/playwright/rslib.config.ts
+++ b/packages/playwright/rslib.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -19,6 +20,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { defineConfig, rspack } from '@rslib/core';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 const require = createRequire(import.meta.url);
@@ -76,4 +77,7 @@ export default defineConfig({
       },
     },
   ],
+  tools: {
+    rspack: rslibRspackConfig,
+  },
 });

--- a/scripts/rslibConfig.ts
+++ b/scripts/rslibConfig.ts
@@ -1,0 +1,11 @@
+export const rslibRspackConfig = {
+  module: {
+    parser: {
+      javascript: {
+        // Avoid embedding build-time dependency file URLs in published output.
+        // https://github.com/web-infra-dev/rslib/pull/1814
+        createRequire: false,
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Rslib 1.0.0-beta.2 enables `createRequire` parsing by default, which can embed dependency build-time file URLs in published bundles. This PR disables the parser through a shared Rspack config applied to every Rslib-built package, preserving runtime-relative `createRequire` calls and preventing local workspace paths from leaking into output.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1814
- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.2

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).