### PR TITLE
chore(deps): refine Rstack Renovate groups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,19 +21,6 @@
       groupSlug: 'babel',
     },
     {
-      groupName: 'rsbuild',
-      matchPackageNames: ['@rsbuild/**'],
-      groupSlug: 'rsbuild',
-      extends: ['schedule:daily'],
-      allowedVersions: '!/-canary-/',
-    },
-    {
-      groupName: 'rslib',
-      matchPackageNames: ['@rslib/**'],
-      groupSlug: 'rslib',
-      extends: ['schedule:daily'],
-    },
-    {
       groupName: 'rspress',
       matchPackageNames: ['@rspress/**'],
       groupSlug: 'rspress',
@@ -54,6 +41,22 @@
       groupSlug: 'all-non-major',
       matchPackageNames: ['**'],
       matchUpdateTypes: ['patch', 'minor'],
+    },
+    {
+      groupName: 'rslib',
+      matchPackageNames: ['@rslib/**'],
+      groupSlug: 'rslib',
+      extends: ['schedule:daily'],
+    },
+    {
+      groupName: 'rsbuild and rspack',
+      matchPackageNames: ['@rsbuild/**', '@rspack/**'],
+      groupSlug: 'rsbuild-rspack',
+      extends: ['schedule:daily'],
+    },
+    {
+      matchPackageNames: ['@rsbuild/**'],
+      allowedVersions: '!/-canary-/',
     },
     {
       groupName: 'rslint',


### PR DESCRIPTION
## Summary

Renovate's catch-all non-major rule could override the dedicated Rstack groups, causing Rslib upgrades to be mixed into broad dependency PRs. This PR keeps `@rslib/**` updates isolated and groups `@rsbuild/**` with `@rspack/**` after the catch-all rule, while preserving the existing Rsbuild canary exclusion.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/1709
- https://github.com/web-infra-dev/rstest/pull/1716

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).