### PR TITLE
chore: reproduce #1718 bundle diff with AI analysis

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,19 +21,6 @@
       groupSlug: 'babel',
     },
     {
-      groupName: 'rsbuild',
-      matchPackageNames: ['@rsbuild/**'],
-      groupSlug: 'rsbuild',
-      extends: ['schedule:daily'],
-      allowedVersions: '!/-canary-/',
-    },
-    {
-      groupName: 'rslib',
-      matchPackageNames: ['@rslib/**'],
-      groupSlug: 'rslib',
-      extends: ['schedule:daily'],
-    },
-    {
       groupName: 'rspress',
       matchPackageNames: ['@rspress/**'],
       groupSlug: 'rspress',
@@ -54,6 +41,22 @@
       groupSlug: 'all-non-major',
       matchPackageNames: ['**'],
       matchUpdateTypes: ['patch', 'minor'],
+    },
+    {
+      groupName: 'rslib',
+      matchPackageNames: ['@rslib/**'],
+      groupSlug: 'rslib',
+      extends: ['schedule:daily'],
+    },
+    {
+      groupName: 'rsbuild and rspack',
+      matchPackageNames: ['@rsbuild/**', '@rspack/**'],
+      groupSlug: 'rsbuild-rspack',
+      extends: ['schedule:daily'],
+    },
+    {
+      matchPackageNames: ['@rsbuild/**'],
+      allowedVersions: '!/-canary-/',
     },
     {
       groupName: 'rslint',

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rsbuild/rslib.config.mts
+++ b/packages/adapter-rsbuild/rslib.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -24,6 +25,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/rslib.config.mts
+++ b/packages/adapter-rslib/rslib.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -23,6 +24,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@rspack/cli": "^2.0.0",
     "@rspack/core": "^2.0.0",
-    "@rstest/core": "workspace:^"
+    "@rstest/core": "^0.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapter-rspack/rslib.config.mts
+++ b/packages/adapter-rspack/rslib.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -23,6 +24,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser-react/rslib.config.ts
+++ b/packages/browser-react/rslib.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -34,6 +35,7 @@ export default defineConfig({
   },
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/browser/rslib.config.ts
+++ b/packages/browser/rslib.config.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import { defineConfig, rspack } from '@rslib/core';
 import { dirname, resolve } from 'pathe';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 const require = createRequire(import.meta.url);
@@ -89,5 +90,8 @@ export default defineConfig({
     define: {
       RSTEST_VERSION: JSON.stringify(require('./package.json').version),
     },
+  },
+  tools: {
+    rspack: rslibRspackConfig,
   },
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,6 +1,7 @@
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { defineConfig, rspack, type Rsbuild } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 import {
   peerDependencies,
@@ -234,6 +235,7 @@ export default defineConfig({
   },
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       watchOptions: {
         ignored: /\.git/,
       },

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/rslib.config.ts
+++ b/packages/coverage-istanbul/rslib.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -17,6 +18,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/rslib.config.ts
+++ b/packages/coverage-v8/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rslib/core';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -12,6 +13,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/playwright",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Playwright fixture integration for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/playwright",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Playwright fixture integration for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/rslib.config.ts
+++ b/packages/playwright/rslib.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rslib/core';
 import { publishCheckPlugins } from '../../scripts/publishCheckPlugins';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 export default defineConfig({
@@ -19,6 +20,7 @@ export default defineConfig({
   ],
   tools: {
     rspack: {
+      ...rslibRspackConfig,
       plugins: [rsdoctorCIPlugin()].filter(Boolean),
     },
   },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { defineConfig, rspack } from '@rslib/core';
+import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
 const require = createRequire(import.meta.url);
@@ -76,4 +77,7 @@ export default defineConfig({
       },
     },
   ],
+  tools: {
+    rspack: rslibRspackConfig,
+  },
 });

--- a/scripts/rslibConfig.ts
+++ b/scripts/rslibConfig.ts
@@ -1,0 +1,11 @@
+export const rslibRspackConfig = {
+  module: {
+    parser: {
+      javascript: {
+        // Avoid embedding build-time dependency file URLs in published output.
+        // https://github.com/web-infra-dev/rslib/pull/1814
+        createRequire: false,
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Purpose

Temporarily recreate the Rsdoctor Bundle Diff produced for #1718 so the newly configured `AI_TOKEN` can analyze the same change direction.

The original report fell back to commit `77b5d0f5` for its baseline. This PR therefore compares that baseline state with the repository state after #1718 (`c7fff14e`), while keeping the AI-enabled Bundle Diff workflow identical on both branches.

## Setup

- Base branch: `agent/repro-1718-base`
- Head branch: `agent/repro-1718-head`
- Rsdoctor Action: `v1.1.4` commit `2fbd50933702502f12d2bbef5273afbfd829a289`
- AI credential: repository secret `AI_TOKEN`

## Impact

Temporary analysis only. This PR must not be merged.

## Validation

- Workflow diff between base and head is empty.
- PR diff reconstructs the original fallback-baseline comparison.
- `git diff --check` passed for the workflow changes.

After the AI report is available, close this PR and delete both temporary branches.