### PR TITLE
test(e2e): stabilize commonjs fixture cleanup reporter

### DIFF
--- a/e2e/rstest.config.mts
+++ b/e2e/rstest.config.mts
@@ -19,8 +19,17 @@ const NO_ISOLATE_EXCLUDES = ['watch/**', 'mock/**', 'browser-mode/**'];
  */
 const THREADS_EXCLUDES = ['browser-mode/**'];
 
+const E2E_MODE =
+  process.env.RSTEST_OUTPUT_MODULE === 'false'
+    ? 'commonjs'
+    : process.env.ISOLATE === 'false'
+      ? 'no-isolate'
+      : process.env.RSTEST_POOL_TYPE === 'threads'
+        ? 'threads'
+        : undefined;
+
 export default defineConfig({
-  name: 'rstest:e2e',
+  name: E2E_MODE ? `rstest:e2e:${E2E_MODE}` : 'rstest:e2e',
   setupFiles: ['../scripts/rstest.setup.ts'],
   // Increased timeout for CI to handle slower environments (e.g., Node.js 22 on Windows)
   // and reduce flaky timeouts caused by resource contention under high parallelism.

--- a/e2e/test-api/index.test.ts
+++ b/e2e/test-api/index.test.ts
@@ -244,7 +244,11 @@ describe('Test API', () => {
     const start = Date.now();
     const { cli, expectExecFailed } = await runRstestCli({
       command: 'rstest',
-      args: ['run', 'fixtures/namedFixtureCleanupTimeout.test.ts'],
+      args: [
+        'run',
+        'fixtures/namedFixtureCleanupTimeout.test.ts',
+        '--disableConsoleIntercept',
+      ],
       options: {
         nodeOptions: {
           cwd: dirname(fileURLToPath(import.meta.url)),
@@ -254,18 +258,13 @@ describe('Test API', () => {
 
     await expectExecFailed();
     expect(Date.now() - start).toBeLessThan(10_000);
-    expect(`${cli.stdout}\n${cli.stderr}`).toContain(
-      'fixture setup timed out in 100ms',
-    );
-    expect(cli.stdout).toContain('RSTEST_NAMED_FIXTURE_SETUP_TIMEOUT_CLEANUP');
-    expect(cli.stdout).toContain('RSTEST_NAMED_FIXTURE_LATE_CLEANUP');
-    expect(cli.stdout).toContain('RSTEST_NAMED_FIXTURE_LATE_CLEANUP_ORDER_OK');
-    expect(`${cli.stdout}\n${cli.stderr}`).toContain(
-      'fixture cleanup timed out in 100ms',
-    );
-    expect(`${cli.stdout}\n${cli.stderr}`).toContain(
-      'RSTEST_NAMED_FIXTURE_LATE_CLEANUP_FAILED',
-    );
+    const output = `${cli.stdout}\n${cli.stderr}`;
+    expect(output).toContain('fixture setup timed out in 100ms');
+    expect(output).toContain('RSTEST_NAMED_FIXTURE_SETUP_TIMEOUT_CLEANUP');
+    expect(output).toContain('RSTEST_NAMED_FIXTURE_LATE_CLEANUP');
+    expect(output).toContain('RSTEST_NAMED_FIXTURE_LATE_CLEANUP_ORDER_OK');
+    expect(output).toContain('fixture cleanup timed out in 100ms');
+    expect(output).toContain('RSTEST_NAMED_FIXTURE_LATE_CLEANUP_FAILED');
   });
 
   it('preserves setup timeout when cancellation cleanup fails', async () => {


### PR DESCRIPTION
## Summary

This PR stabilizes the named fixture cleanup e2e regression that intermittently failed in the CommonJS run when intercepted console logs were lost during worker shutdown.

- Run the nested fixture CLI with `--disableConsoleIntercept` so cleanup markers use the original stdout path.
- Include the e2e mode in the project name so GitHub Actions summaries distinguish default, CommonJS, no-isolate, and threads runs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).