### PR TITLE
fix(core): make config-file restart watching reliable

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -940,7 +940,7 @@ export const runRest = async ({
         process.off('unhandledRejection', unexpectedlyExitHandler);
       });
 
-      watchFilesForRestart({
+      await watchFilesForRestart({
         rstest,
         options,
         filters,

--- a/packages/core/src/core/restart.ts
+++ b/packages/core/src/core/restart.ts
@@ -93,6 +93,11 @@ export async function watchFilesForRestart({
     ignoreInitial: true,
     // If watching fails due to read permissions, the errors will be suppressed silently.
     ignorePermissionErrors: true,
+    // `fs.watch` is only armed some time after `ready`, so a config edit right
+    // after startup is dropped. Polling this handful of files is cheap and its
+    // `ready` means the stat baselines are recorded.
+    usePolling: true,
+    interval: 100,
     ...watchOptions,
   });
 

--- a/packages/core/src/utils/watchFiles.ts
+++ b/packages/core/src/utils/watchFiles.ts
@@ -35,5 +35,13 @@ export async function createChokidar(
     }
   }
 
-  return chokidar.watch(Array.from(watchFiles), options);
+  const watcher = chokidar.watch(Array.from(watchFiles), options);
+  // chokidar emits `ready` only after a watched path finishes its initial scan,
+  // so an empty set (globs that matched nothing) would never resolve.
+  if (watchFiles.size > 0) {
+    await new Promise<void>((resolve) =>
+      watcher.once('ready', () => resolve()),
+    );
+  }
+  return watcher;
 }

--- a/packages/core/tests/utils/watchFiles.test.ts
+++ b/packages/core/tests/utils/watchFiles.test.ts
@@ -1,0 +1,34 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import { createChokidar } from '../../src/utils/watchFiles';
+import { withTempDir } from '../helpers/tempDir';
+
+describe('createChokidar', () => {
+  it('resolves when nothing matched, instead of awaiting a `ready` that never comes', async () => {
+    await withTempDir('rstest-watch-files-', async (directory) => {
+      const watcher = await createChokidar(
+        [join(directory, 'missing-*.config.ts')],
+        directory,
+        { ignoreInitial: true },
+      );
+
+      await watcher.close();
+    });
+  });
+
+  it('awaits the initial scan before returning a watcher', async () => {
+    await withTempDir('rstest-watch-files-', async (directory) => {
+      const configFile = join(directory, 'rstest.config.ts');
+      writeFileSync(configFile, '');
+
+      const watcher = await createChokidar([configFile], directory, {
+        ignoreInitial: true,
+      });
+
+      expect(Object.keys(watcher.getWatched())).not.toHaveLength(0);
+
+      await watcher.close();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`rstest watch` restarts itself when a config file changes, watched through chokidar. Today an edit made shortly after startup is silently lost — the watcher is not live yet when the first test run begins. Two separate gaps cause it:

1. **Before `ready`** — the initial scan is still running, so nothing is watched. Nothing waits for it either: `watchFilesForRestart` is called without `await`.
2. **After `ready`** — chokidar v5 dropped `fsevents` (#1031), and the `fs.watch` fallback stays deaf for a short while after `ready` fires. So `ready` does not mean the watcher is live.

Measured on macOS with the current chokidar 5.0.0, editing a watched config file at two moments:

| | edit right at `ready` | edit 200ms after `ready` |
| --- | --- | --- |
| `fs.watch` (today) | **no event** | `change` |
| polling | `change` | `change` |

This PR closes both gaps: await the initial scan before the first test run (gap 1), and poll the config files — a handful of paths at 100ms, where `ready` does mean the stat baselines are recorded (gap 2). Either fix alone leaves the other gap open.

Awaiting `ready` needs one guard: chokidar never emits `ready` for an empty watch set, so `rstest watch` would hang before its first run. That is reachable today — a real config path is routed through glob expansion whenever any ancestor directory contains glob metacharacters, and `tinyglobby` then matches nothing:

```
project (1)/rstest.config.ts        -> 0 matches   # Finder / Explorer duplicate, cloud-sync copy
C:\Program Files (x86)\...          -> 0 matches
```

Split out of #1441, which is about the rspack native watcher and unrelated to this path.

## Related Links

- #1441
- #1031

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
