### PR TITLE
feat(core): add test context signal

### DIFF
--- a/e2e/browser-mode/basic.test.ts
+++ b/e2e/browser-mode/basic.test.ts
@@ -21,6 +21,8 @@ describe('browser mode - basic', () => {
     expect(cli.stdout).toContain('fileFixtures.test.ts');
     expect(cli.stdout).toContain('RSTEST_BROWSER_FILE_FIXTURE_CLEANUP_OK');
     expect(cli.stdout).toContain('retryContext.test.ts');
+    expect(cli.stdout).toContain('signalContext.test.ts');
+    expect(cli.stdout).toContain('RSTEST_BROWSER_CONTEXT_SIGNAL_ABORTED');
     expect(cli.stdout).not.toContain('/scheduler.html');
   });
 

--- a/e2e/browser-mode/fixtures/basic/tests/signalContext.test.ts
+++ b/e2e/browser-mode/fixtures/basic/tests/signalContext.test.ts
@@ -1,0 +1,38 @@
+import { afterAll, expect, test } from '@rstest/core';
+
+const signals: AbortSignal[] = [];
+let attempts = 0;
+
+test(
+  'aborts the attempt signal on timeout and refreshes it for retry',
+  { retry: 1, timeout: 100 },
+  async ({ signal }) => {
+    attempts++;
+    signals.push(signal);
+    expect(signal.aborted).toBe(false);
+
+    if (attempts === 1) {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            expect(signal.reason).toMatchObject({
+              message: expect.stringContaining('test timed out in 100ms'),
+            });
+            console.log('RSTEST_BROWSER_CONTEXT_SIGNAL_ABORTED');
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    }
+  },
+);
+
+afterAll(() => {
+  expect(attempts).toBe(2);
+  expect(signals).toHaveLength(2);
+  expect(signals[0]?.aborted).toBe(true);
+  expect(signals[1]?.aborted).toBe(false);
+  expect(signals[0]).not.toBe(signals[1]);
+});

--- a/e2e/test-api/fixtures/testContextSignal.test.ts
+++ b/e2e/test-api/fixtures/testContextSignal.test.ts
@@ -1,0 +1,38 @@
+import { afterAll, expect, test } from '@rstest/core';
+
+const signals: AbortSignal[] = [];
+let attempts = 0;
+
+test(
+  'aborts the attempt signal on timeout and refreshes it for retry',
+  { retry: 1, timeout: 50 },
+  async ({ signal }) => {
+    attempts++;
+    signals.push(signal);
+    expect(signal.aborted).toBe(false);
+
+    if (attempts === 1) {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            expect(signal.reason).toMatchObject({
+              message: expect.stringContaining('test timed out in 50ms'),
+            });
+            console.log('RSTEST_TEST_CONTEXT_SIGNAL_ABORTED');
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    }
+  },
+);
+
+afterAll(() => {
+  expect(attempts).toBe(2);
+  expect(signals).toHaveLength(2);
+  expect(signals[0]?.aborted).toBe(true);
+  expect(signals[1]?.aborted).toBe(false);
+  expect(signals[0]).not.toBe(signals[1]);
+});

--- a/e2e/test-api/fixtures/testContextSignal.test.ts
+++ b/e2e/test-api/fixtures/testContextSignal.test.ts
@@ -1,7 +1,9 @@
-import { afterAll, expect, test } from '@rstest/core';
+import { afterAll, expect, rstest, test } from '@rstest/core';
 
 const signals: AbortSignal[] = [];
 let attempts = 0;
+let synchronousAbortAttempts = 0;
+let failsSignalAborted = false;
 
 test(
   'aborts the attempt signal on timeout and refreshes it for retry',
@@ -29,10 +31,66 @@ test(
   },
 );
 
+test(
+  'times out before an abort listener resolves the callback',
+  { retry: 1, timeout: 50 },
+  ({ signal }) => {
+    synchronousAbortAttempts++;
+
+    if (synchronousAbortAttempts === 1) {
+      return new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+    }
+
+    return undefined;
+  },
+);
+
+test.fails(
+  'aborts the signal when a test.fails callback times out',
+  { timeout: 50 },
+  ({ signal }) =>
+    new Promise<void>((resolve) => {
+      signal.addEventListener(
+        'abort',
+        () => {
+          failsSignalAborted = true;
+          resolve();
+        },
+        { once: true },
+      );
+    }),
+);
+
+const objectFixtureTest = test.extend({ signal: 'fixture signal' });
+
+objectFixtureTest('preserves object-form signal fixtures', ({ signal }) => {
+  expect(signal).toBe('fixture signal');
+});
+
+test('captures the native AbortController before globals are stubbed', () => {
+  rstest.stubGlobal(
+    'AbortController',
+    class StubAbortController {
+      constructor() {
+        throw new Error('AbortController was stubbed');
+      }
+    },
+  );
+});
+
+test('creates a signal after AbortController is stubbed', ({ signal }) => {
+  expect(signal).toBeInstanceOf(AbortSignal);
+  rstest.unstubAllGlobals();
+});
+
 afterAll(() => {
   expect(attempts).toBe(2);
   expect(signals).toHaveLength(2);
   expect(signals[0]?.aborted).toBe(true);
   expect(signals[1]?.aborted).toBe(false);
   expect(signals[0]).not.toBe(signals[1]);
+  expect(synchronousAbortAttempts).toBe(2);
+  expect(failsSignalAborted).toBe(true);
 });

--- a/e2e/test-api/testOptions.test.ts
+++ b/e2e/test-api/testOptions.test.ts
@@ -150,6 +150,21 @@ describe('TestOptions', () => {
     expectStderrLog(/test timed out in 50ms/);
   }, 10000);
 
+  it('aborts a fresh context signal for each timed-out attempt', async () => {
+    const { cli, expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'fixtures/testContextSignal.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: __dirname,
+        },
+      },
+    });
+
+    await expectExecSuccess();
+    expect(cli.stdout).toContain('RSTEST_TEST_CONTEXT_SIGNAL_ABORTED');
+  });
+
   it('rejects TestOptions in the third position at runtime', async () => {
     const { expectExecFailed, expectStderrLog } = await runRstestCli({
       command: 'rstest',

--- a/packages/core/src/runtime/runner/fixtures.ts
+++ b/packages/core/src/runtime/runner/fixtures.ts
@@ -19,6 +19,7 @@ const reservedNamedFixtureNames = new Set<string>([
     expect: true,
     onTestFailed: true,
     onTestFinished: true,
+    signal: true,
     skip: true,
     task: true,
   } satisfies Record<keyof TestContext, true>),

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -53,6 +53,7 @@ import {
 } from './task';
 
 const RealDate = Date;
+const RealAbortController = AbortController;
 
 /**
  * Sample heap usage when `logHeapUsage` is enabled. Guarded so the shared
@@ -333,9 +334,23 @@ export class TestRunner {
       }
 
       if (!result) {
+        const runTest = test.fn
+          ? wrapTimeout({
+              name: 'test',
+              fn: test.fn,
+              timeout: test.timeout,
+              stackTraceError: test.stackTraceError,
+              onTimeout: (error) =>
+                this.abortContextSignal(test.context, error),
+              getAssertionCalls: () => {
+                return this.getAssertionState(test).assertionCalls;
+              },
+            })
+          : undefined;
+
         if (test.fails) {
           try {
-            await test.fn?.(test.context);
+            await runTest?.(test.context);
             this.afterRunTest(test);
 
             result = {
@@ -370,20 +385,7 @@ export class TestRunner {
           }
         } else {
           try {
-            if (test.fn) {
-              const fn = wrapTimeout({
-                name: 'test',
-                fn: test.fn,
-                timeout: test.timeout,
-                stackTraceError: test.stackTraceError,
-                onTimeout: (error) =>
-                  this.abortContextSignal(test.context, error),
-                getAssertionCalls: () => {
-                  return this.getAssertionState(test).assertionCalls;
-                },
-              });
-              await fn(test.context);
-            }
+            await runTest?.(test.context);
             this.afterRunTest(test);
             result = {
               testId: test.testId,
@@ -878,10 +880,11 @@ export class TestRunner {
     }) as unknown as TestContext;
 
     const current = this._test;
-    const abortController = new AbortController();
+    const abortController = new RealAbortController();
     this.abortControllers.set(context, abortController);
 
     Object.defineProperty(context, 'signal', {
+      configurable: true,
       value: abortController.signal,
     });
 

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -75,6 +75,10 @@ export class TestRunner {
   private workerState: WorkerState | undefined;
   private readonly fileFixtureManager = new FileFixtureManager();
   private readonly localExpects = new WeakMap<TestContext, RstestExpect>();
+  private readonly abortControllers = new WeakMap<
+    TestContext,
+    AbortController
+  >();
 
   constructor(private readonly taskContext: TaskContext) {}
 
@@ -237,10 +241,14 @@ export class TestRunner {
         };
         let hookExecution: ReturnType<typeof runHook> | undefined;
         try {
-          return await runWithTimeout(fn, (callback) => {
-            hookExecution = runHook(callback);
-            return hookExecution;
-          });
+          return await runWithTimeout(
+            fn,
+            (callback) => {
+              hookExecution = runHook(callback);
+              return hookExecution;
+            },
+            (error) => this.abortContextSignal(test.context, error),
+          );
         } catch (error) {
           const cancellation =
             !callbackStarted && fixtureResolver.cancelPendingFixtures();
@@ -368,6 +376,8 @@ export class TestRunner {
                 fn: test.fn,
                 timeout: test.timeout,
                 stackTraceError: test.stackTraceError,
+                onTimeout: (error) =>
+                  this.abortContextSignal(test.context, error),
                 getAssertionCalls: () => {
                   return this.getAssertionState(test).assertionCalls;
                 },
@@ -868,6 +878,12 @@ export class TestRunner {
     }) as unknown as TestContext;
 
     const current = this._test;
+    const abortController = new AbortController();
+    this.abortControllers.set(context, abortController);
+
+    Object.defineProperty(context, 'signal', {
+      value: abortController.signal,
+    });
 
     context.task = {
       id: test.testId,
@@ -939,6 +955,7 @@ export class TestRunner {
         name: 'onTestFinished hook',
         fn,
         timeout: timeout ?? this.workerState!.runtimeConfig.hookTimeout,
+        onTimeout: (error) => this.abortContextSignal(test.context, error),
         stackTraceError: new Error(SYNTHETIC_STACK_ERROR_MESSAGE),
       }),
     );
@@ -957,6 +974,7 @@ export class TestRunner {
         name: 'onTestFailed hook',
         fn,
         timeout: timeout ?? this.workerState!.runtimeConfig.hookTimeout,
+        onTimeout: (error) => this.abortContextSignal(test.context, error),
         stackTraceError: new Error(SYNTHETIC_STACK_ERROR_MESSAGE),
       }),
     );
@@ -996,7 +1014,10 @@ export class TestRunner {
           name: 'fixture setup',
           fn: setup,
           timeout: test.timeout,
-          onTimeout,
+          onTimeout: (error) => {
+            this.abortContextSignal(context, error);
+            onTimeout();
+          },
           stackTraceError: test.stackTraceError,
         })(),
       wrapNamedFixtureCleanup: (cleanup) =>
@@ -1004,9 +1025,14 @@ export class TestRunner {
           name: 'fixture cleanup',
           fn: cleanup,
           timeout: test.timeout,
+          onTimeout: (error) => this.abortContextSignal(context, error),
           stackTraceError: test.stackTraceError,
         }),
     });
+  }
+
+  private abortContextSignal(context: TestContext, error: Error): void {
+    this.abortControllers.get(context)?.abort(error);
   }
 
   private getAssertionState(test: TestCase) {

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -319,8 +319,8 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
 
         // Create timeout error with the provided stack trace from test registration
         const error = makeError(message, stackTraceError);
-        onTimeout?.(error);
         reject(error);
+        onTimeout?.(error);
       }, timeout);
     });
 

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -284,7 +284,7 @@ type TimeoutOptions<T extends (...args: any[]) => any> = {
   name: string;
   fn: T;
   timeout?: number;
-  onTimeout?: () => void;
+  onTimeout?: (error: Error) => void;
   getAssertionCalls?: () => number;
   stackTraceError: Error;
 };
@@ -317,9 +317,10 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
             : ' (no expect assertions completed)';
         const message = `${name} timed out in ${timeout}ms${getAssertionCalls ? assertionInfo : ''}`;
 
-        onTimeout?.();
         // Create timeout error with the provided stack trace from test registration
-        reject(makeError(message, stackTraceError));
+        const error = makeError(message, stackTraceError);
+        onTimeout?.(error);
+        reject(error);
       }, timeout);
     });
 
@@ -349,6 +350,7 @@ export function wrapTimeout<T extends (...args: any[]) => any>({
 export async function runWithTimeout<T>(
   fn: (...args: any[]) => any,
   run: (callback: (...args: any[]) => any) => T | PromiseLike<T>,
+  onTimeout?: (error: Error) => void,
 ): Promise<T> {
   const options = timeoutOptions.get(fn);
   if (!options) {
@@ -358,6 +360,10 @@ export async function runWithTimeout<T>(
   const wrapped = wrapTimeout({
     ...options,
     fn: () => run(options.fn),
+    onTimeout: (error) => {
+      options.onTimeout?.(error);
+      onTimeout?.(error);
+    },
   });
   return wrapped();
 }

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -31,6 +31,8 @@ export interface TestContext {
     /** Mutable metadata copied to the current test result. */
     meta: TaskMeta;
   };
+  /** Signal aborted with the timeout error when the current attempt times out. */
+  readonly signal: AbortSignal;
   expect: RstestExpect;
   /** Skip the current test during execution. */
   skip: () => never;

--- a/packages/core/tests/runner/task.test.ts
+++ b/packages/core/tests/runner/task.test.ts
@@ -26,4 +26,23 @@ describe('wrapTimeout', () => {
     expect(timeoutError).toBe(rejectedError);
     expect(timeoutError?.message).toBe('test timed out in 10ms');
   });
+
+  it('rejects before aborting a signal when the callback listens synchronously', async () => {
+    setRealTimers();
+    const controller = new AbortController();
+    const run = wrapTimeout({
+      name: 'test',
+      fn: () =>
+        new Promise<void>((resolve) => {
+          controller.signal.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        }),
+      timeout: 10,
+      onTimeout: () => controller.abort(),
+      stackTraceError: new Error('stack'),
+    });
+
+    await expect(run()).rejects.toThrow('test timed out in 10ms');
+  });
 });

--- a/packages/core/tests/runner/task.test.ts
+++ b/packages/core/tests/runner/task.test.ts
@@ -1,0 +1,29 @@
+import { wrapTimeout } from '../../src/runtime/runner/task';
+import { setRealTimers } from '../../src/runtime/util';
+
+describe('wrapTimeout', () => {
+  it('passes the rejected timeout error to onTimeout', async () => {
+    setRealTimers();
+    let timeoutError: Error | undefined;
+    const run = wrapTimeout({
+      name: 'test',
+      fn: () => new Promise(() => {}),
+      timeout: 10,
+      onTimeout: (error) => {
+        timeoutError = error;
+      },
+      stackTraceError: new Error('stack'),
+    });
+
+    let rejectedError: unknown;
+    try {
+      await run();
+    } catch (error) {
+      rejectedError = error;
+    }
+
+    expect(timeoutError).toBeInstanceOf(Error);
+    expect(timeoutError).toBe(rejectedError);
+    expect(timeoutError?.message).toBe('test timed out in 10ms');
+  });
+});

--- a/packages/core/tests/runtime/runner/fixtures.test.ts
+++ b/packages/core/tests/runtime/runner/fixtures.test.ts
@@ -159,6 +159,7 @@ describe('normalizeNamedFixture', () => {
     'expect',
     'onTestFailed',
     'onTestFinished',
+    'signal',
     'skip',
     'task',
   ])('rejects unsupported named fixture name %s', (name) => {

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -644,6 +644,8 @@ export interface TestContext {
     /** Mutable metadata copied to the current test result. Added in 0.11.1. */
     meta: TaskMeta;
   };
+  /** Signal aborted with the timeout error when the current attempt times out. Added in 0.11.9. */
+  readonly signal: AbortSignal;
   /** The `expect` API bound to the current test */
   expect: Expect;
   /** Skip the current test during execution */
@@ -658,6 +660,46 @@ export interface TestContext {
 <ApiMeta addedVersion="0.11.6" />
 
 Use `context.task.retryCount` to read the current retry index from tests, hooks, and fixtures. It is `0` for the initial attempt, `1` for the first retry, and resets to `0` for each run configured through `repeats`.
+
+#### signal
+
+<ApiMeta addedVersion="0.11.9" />
+
+`context.signal` is aborted with the timeout error when the current test attempt times out. This includes timeouts in the test callback, per-test hooks, and fixtures. Every retry and repeat receives a fresh signal, so a timeout in one attempt does not cancel the next attempt.
+
+Pass the signal to APIs that support cancellation so their in-flight work can stop when Rstest stops waiting for the attempt:
+
+```ts
+import { test } from '@rstest/core';
+
+test('loads a user', { timeout: 1_000 }, async ({ signal }) => {
+  await fetch('/api/user', { signal });
+});
+```
+
+Node.js APIs that accept an `AbortSignal` work the same way. For example, pass it to `fs.readFile` when loading a large fixture so the pending file read can be cancelled if the test times out:
+
+```ts
+import { readFile } from 'node:fs/promises';
+import { test } from '@rstest/core';
+
+test('loads a large fixture', { timeout: 1_000 }, async ({ signal }) => {
+  const contents = await readFile('./fixtures/large-data.json', {
+    encoding: 'utf8',
+    signal,
+  });
+
+  JSON.parse(contents);
+});
+```
+
+If the file read is still pending after one second, `signal.reason` is the same error that Rstest reports for the failed attempt:
+
+```text
+Error: test timed out in 1000ms (no expect assertions completed)
+```
+
+APIs may surface cancellation differently. For example, `fs.readFile` rejects with an `AbortError`, while its `cause` points to the timeout error supplied through the signal.
 
 Use `context.task.meta` to attach JSON-serializable metadata to the current test result. You can mutate the metadata object or replace it with a new metadata object. Custom reporters and the programmatic API can read this metadata from `TestResult.meta`:
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -633,6 +633,8 @@ export interface TestContext {
     /** Mutable metadata copied to the current test result. Added in 0.11.1. */
     meta: TaskMeta;
   };
+  /** 当前 attempt 超时时，以 timeout error 中止的 Signal。0.11.9 新增。 */
+  readonly signal: AbortSignal;
   /** The `expect` API bound to the current test */
   expect: Expect;
   /** Skip the current test during execution */
@@ -647,6 +649,46 @@ export interface TestContext {
 <ApiMeta addedVersion="0.11.6" />
 
 你可以通过 `context.task.retryCount` 在测试、Hook 和 fixture 中读取当前的 retry index。初次尝试时该值为 `0`，第一次 retry 时为 `1`；配置 `repeats` 后，每次 repeat 都会从 `0` 重新计数。
+
+#### signal
+
+<ApiMeta addedVersion="0.11.9" />
+
+当前测试 attempt 超时时，`context.signal` 会以对应的 timeout error 中止，包括测试回调、per-test Hook 和 fixture 中发生的超时。每次 retry 和 repeat 都会获得一个新的 signal，因此一次 attempt 超时不会取消下一次 attempt。
+
+将 signal 传给支持取消操作的 API，可以在 Rstest 停止等待当前 attempt 时终止尚未完成的工作：
+
+```ts
+import { test } from '@rstest/core';
+
+test('loads a user', { timeout: 1_000 }, async ({ signal }) => {
+  await fetch('/api/user', { signal });
+});
+```
+
+接受 `AbortSignal` 的 Node.js API 也遵循相同约定。例如，读取大型 fixture 时将 signal 传给 `fs.readFile`，测试超时后就能取消尚未完成的文件读取：
+
+```ts
+import { readFile } from 'node:fs/promises';
+import { test } from '@rstest/core';
+
+test('loads a large fixture', { timeout: 1_000 }, async ({ signal }) => {
+  const contents = await readFile('./fixtures/large-data.json', {
+    encoding: 'utf8',
+    signal,
+  });
+
+  JSON.parse(contents);
+});
+```
+
+如果文件在一秒后仍未读取完成，`signal.reason` 就是 Rstest 为这次失败的 attempt 报告的同一个 error：
+
+```text
+Error: test timed out in 1000ms (no expect assertions completed)
+```
+
+不同 API 暴露取消操作的方式可能不同。例如，`fs.readFile` 会抛出 `AbortError`，其 `cause` 指向通过 signal 传入的 timeout error。
 
 你可以使用 `context.task.meta` 给当前测试结果附加可 JSON 序列化的元数据。既可以修改该对象，也可以整体替换为一个新的 metadata 对象。自定义 Reporter 和 programmatic API 可以从 `TestResult.meta` 读取这些数据：
 


### PR DESCRIPTION
## Summary

- Add a readonly `TestContext.signal` that aborts with the timeout error when a test attempt times out.
- Cover test callbacks, per-test hooks, and fixtures while giving every retry and repeat a fresh signal.
- Document the API in English and Chinese, with Node.js and Fetch cancellation examples.

## Usage

```ts
import { expect, test } from '@rstest/core';

test('loads a user', { timeout: 1_000 }, async ({ signal }) => {
  const response = await fetch('https://example.com/api/user', { signal });
  expect(response.ok).toBe(true);
});
```

When the test times out, Rstest aborts the signal so supported APIs can cancel their pending work.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).