### PR TITLE
release: 0.11.9

### DIFF
--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rsbuild",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Rstest adapter for rsbuild configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rslib",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Rstest adapter for rslib configuration",
   "keywords": [
     "rstest",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/adapter-rspack",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Rstest adapter for rspack configuration",
   "keywords": [
     "rstest",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser-react",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "React component testing support for Rstest browser mode",
   "keywords": [
     "rstest",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/browser",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Browser mode support for Rstest testing framework.",
   "keywords": [
     "rstest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/core",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "The Rsbuild-based test tool.",
   "keywords": [
     "rstest",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-istanbul",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Istanbul coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/coverage-v8",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "V8 coverage provider for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rstest/playwright",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Playwright fixture integration for Rstest",
   "keywords": [
     "rstest",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -46,7 +46,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rstest/core": "workspace:^",
+    "@rstest/core": "^0.11.9",
     "playwright": "^1.49.1"
   },
   "engines": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstest",
   "displayName": "Rstest",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "private": true,
   "description": "VS Code extension for Rstest",
   "categories": [


### PR DESCRIPTION
## What's Changed
* chore(deps): refine Rstack Renovate groups by @9aoy in https://github.com/web-infra-dev/rstest/pull/1718
* feat(core): support worker-scoped named fixtures by @9aoy in https://github.com/web-infra-dev/rstest/pull/1708
* fix(core): resolve rstest list through the run path's planner barrier by @fi3ework in https://github.com/web-infra-dev/rstest/pull/1722
* chore(deps): update rsbuild and rspack by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1720
* chore(deps): update dependency @rslib/core to v1.0.0-beta.3 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1719
* chore(deps): update all non-major dependencies by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1723
* test(e2e): stabilize commonjs fixture cleanup reporter by @9aoy in https://github.com/web-infra-dev/rstest/pull/1725
* fix(core): make config-file restart watching reliable by @stormslowly in https://github.com/web-infra-dev/rstest/pull/1727
* feat(watcher): enable rspack native watcher by @stormslowly in https://github.com/web-infra-dev/rstest/pull/1441
* perf(playwright): reuse browser across worker files by @9aoy in https://github.com/web-infra-dev/rstest/pull/1726
* chore(deps): update dependency @rslint/core to ^0.8.0 by @renovate[bot] in https://github.com/web-infra-dev/rstest/pull/1724
* feat(core): add test context signal by @9aoy in https://github.com/web-infra-dev/rstest/pull/1730
* fix: can not rerun all tests when has command filter by @9aoy in https://github.com/web-infra-dev/rstest/pull/502

## New Contributors
* @stormslowly made their first contribution in https://github.com/web-infra-dev/rstest/pull/1727

**Full Changelog**: https://github.com/web-infra-dev/rstest/compare/v0.11.8...v0.11.9