### PR TITLE
fix(core): skip suite hooks without runnable tests

### DIFF
--- a/e2e/browser-mode/fixtures/empty-suite/empty.test.ts
+++ b/e2e/browser-mode/fixtures/empty-suite/empty.test.ts
@@ -1,0 +1,11 @@
+import { afterAll, beforeAll, describe } from '@rstest/core';
+
+beforeAll(() => {
+  throw new Error('EMPTY_SUITE_HOOK_RAN:beforeAll');
+});
+
+afterAll(() => {
+  throw new Error('EMPTY_SUITE_HOOK_RAN:afterAll');
+});
+
+describe('empty suite', () => {});

--- a/e2e/browser-mode/fixtures/empty-suite/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/empty-suite/rstest.config.mts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rstest/core';
+import { BROWSER_PORTS } from '../ports';
+
+export default defineConfig({
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+    port: BROWSER_PORTS['empty-suite'],
+    strictPort: true,
+  },
+});

--- a/e2e/browser-mode/fixtures/ports.ts
+++ b/e2e/browser-mode/fixtures/ports.ts
@@ -57,6 +57,7 @@ export const BROWSER_PORTS = {
   'browser-coverage-config-warnings': 5272,
   'browser-coverage-v8': 5280,
   'browser-coverage-v8-webkit': 5282,
+  'empty-suite': 5284,
   'watch-setup': 5278,
   'basic-federation': 5274,
   'basic-federation-watch': 5276,

--- a/e2e/browser-mode/noTests.test.ts
+++ b/e2e/browser-mode/noTests.test.ts
@@ -3,7 +3,11 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
 import { sleep } from '../scripts';
-import { runBrowserCliWithCwd, runBrowserWatchCli } from './utils';
+import {
+  runBrowserCli,
+  runBrowserCliWithCwd,
+  runBrowserWatchCli,
+} from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,6 +16,23 @@ const countMarkers = (output: string, marker: string): number =>
   output.match(new RegExp(marker, 'g'))?.length ?? 0;
 
 describe('browser mode - no tests', () => {
+  it('does not run suite hooks when a test file has no runnable tests', async () => {
+    const { cli, expectExecFailed } = await runBrowserCli('empty-suite');
+
+    await expectExecFailed();
+    expect(cli.log).toContain('No test found in suite');
+    expect(cli.log).not.toContain('EMPTY_SUITE_HOOK_RAN');
+  });
+
+  it('does not run empty suite hooks with passWithNoTests', async () => {
+    const { cli, expectExecSuccess } = await runBrowserCli('empty-suite', {
+      args: ['--passWithNoTests'],
+    });
+
+    await expectExecSuccess();
+    expect(cli.log).not.toContain('EMPTY_SUITE_HOOK_RAN');
+  });
+
   it('should exit with code 1 by default when no tests found', async () => {
     const { cli, expectExecFailed } = await runBrowserCliWithCwd(
       join(__dirname, 'fixtures', 'no-tests'),

--- a/e2e/noTests/fixtures/noTestInSuite.test.ts
+++ b/e2e/noTests/fixtures/noTestInSuite.test.ts
@@ -1,3 +1,18 @@
-import { describe } from '@rstest/core';
+import { afterAll, beforeAll, describe } from '@rstest/core';
 
-describe('no tests', () => {});
+const logUnexpectedHook = (hook: string) => {
+  console.log(`[empty-suite-hook] ${hook}`);
+};
+
+beforeAll(() => logUnexpectedHook('root beforeAll'));
+afterAll(() => logUnexpectedHook('root afterAll'));
+
+describe('no tests', () => {
+  beforeAll(() => logUnexpectedHook('suite beforeAll'));
+  afterAll(() => logUnexpectedHook('suite afterAll'));
+
+  describe('nested no tests', () => {
+    beforeAll(() => logUnexpectedHook('nested beforeAll'));
+    afterAll(() => logUnexpectedHook('nested afterAll'));
+  });
+});

--- a/e2e/noTests/index.test.ts
+++ b/e2e/noTests/index.test.ts
@@ -28,6 +28,7 @@ describe('no tests', () => {
       logs.find((log) => log.includes('Test Files 3 failed')),
     ).toBeDefined();
     expect(logs.find((log) => log.includes('Tests no tests'))).toBeDefined();
+    expect(cli.log).not.toContain('[empty-suite-hook]');
   });
 
   it('should passWithNoTests with passWithNoTests flag', async () => {
@@ -51,6 +52,7 @@ describe('no tests', () => {
       logs.find((log) => log.includes('Test Files 3 passed')),
     ).toBeDefined();
     expect(logs.find((log) => log.includes('Tests no tests'))).toBeDefined();
+    expect(cli.log).not.toContain('[empty-suite-hook]');
   });
 
   it('should not check coverage provider when no tests match', async () => {

--- a/packages/core/src/runtime/runner/runner.ts
+++ b/packages/core/src/runtime/runner/runner.ts
@@ -578,22 +578,23 @@ export class TestRunner {
             if (test.tests.length === 0) {
               if (['todo', 'skip'].includes(test.runMode)) {
                 defaultStatus = 'skip';
-                hooks.onTestSuiteResult?.(result);
-                return result;
-              }
-              if (passWithNoTests) {
+              } else if (passWithNoTests) {
                 result.status = 'pass';
-                hooks.onTestSuiteResult?.(result);
-                return result;
+              } else {
+                result.status = 'fail';
+                result.errors?.push({
+                  message: `No test found in suite: ${test.name}`,
+                  name: 'No tests',
+                });
               }
-              const noTestError = {
-                message: `No test found in suite: ${test.name}`,
-                name: 'No tests',
-              };
 
-              result.errors?.push(noTestError);
+              hooks.onTestSuiteResult?.(result);
+              return result;
             }
 
+            const shouldRunSuiteHooks =
+              test.hasRunnableTests === true &&
+              ['run', 'only'].includes(test.runMode);
             const cleanups: ((ctx: SuiteContext) => void)[] = [];
             let hasBeforeAllError = false;
             const suiteContext: SuiteContext = {
@@ -609,10 +610,7 @@ export class TestRunner {
               },
             };
 
-            if (
-              ['run', 'only'].includes(test.runMode) &&
-              test.beforeAllListeners
-            ) {
+            if (shouldRunSuiteHooks && test.beforeAllListeners) {
               try {
                 for (const fn of test.beforeAllListeners) {
                   const cleanupFn = await fn(suiteContext);
@@ -641,7 +639,7 @@ export class TestRunner {
               .reverse()
               .concat(cleanups);
 
-            if (['run', 'only'].includes(test.runMode) && afterAllFns.length) {
+            if (shouldRunSuiteHooks && afterAllFns.length) {
               try {
                 for (const fn of afterAllFns) {
                   await fn(suiteContext);

--- a/packages/core/src/runtime/runner/task.ts
+++ b/packages/core/src/runtime/runner/task.ts
@@ -116,6 +116,7 @@ const traverseUpdateTestRunModeWithContext = (
   context: TestModeContext,
 ): void => {
   if (testSuite.tests.length === 0) {
+    testSuite.hasRunnableTests = false;
     return;
   }
 
@@ -131,6 +132,7 @@ const traverseUpdateTestRunModeWithContext = (
   const runSubOnly =
     runOnly && testSuite.runMode !== 'only' ? runOnly : childrenHaveOnly;
   let hasRunTest = false;
+  let hasRunnableTests = false;
   let allTodoTest = true;
 
   for (const test of testSuite.tests) {
@@ -154,10 +156,20 @@ const traverseUpdateTestRunModeWithContext = (
       hasRunTest = true;
     }
 
+    if (
+      (test.type === 'case' &&
+        (test.runMode === 'run' || test.runMode === 'only')) ||
+      (test.type === 'suite' && test.hasRunnableTests)
+    ) {
+      hasRunnableTests = true;
+    }
+
     if (test.runMode !== 'todo') {
       allTodoTest = false;
     }
   }
+
+  testSuite.hasRunnableTests = hasRunnableTests;
 
   if (testSuite.runMode !== 'run') {
     return;

--- a/packages/core/src/types/testSuite.ts
+++ b/packages/core/src/types/testSuite.ts
@@ -127,6 +127,8 @@ export type TestSuiteInfo = {
 };
 
 export type TestSuite = TestSuiteInfo & {
+  /** @internal */
+  hasRunnableTests?: boolean;
   each?: boolean;
   inTestEach?: boolean;
   concurrent?: boolean;

--- a/packages/core/tests/runner/runner.test.ts
+++ b/packages/core/tests/runner/runner.test.ts
@@ -29,6 +29,7 @@ describe('traverseUpdateTest', () => {
       traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
 
       expect(testA.runMode).toBe('run');
+      expect((testA as TestSuite).hasRunnableTests).toBe(true);
     });
 
     it('should set the suite to skip when all tests are skip', () => {
@@ -48,6 +49,7 @@ describe('traverseUpdateTest', () => {
       traverseUpdateTestRunMode(testA as TestSuite, 'run', false);
 
       expect(testA.runMode).toBe('skip');
+      expect((testA as TestSuite).hasRunnableTests).toBe(false);
     });
 
     it('should update nested test suite run mode correctly', () => {
@@ -85,6 +87,34 @@ describe('traverseUpdateTest', () => {
 
       expect(testA.runMode).toBe('run');
       expect(testA.tests[2]?.runMode).toBe('skip');
+    });
+
+    it('should track runnable tests without changing empty suite run modes', () => {
+      const emptySuite: TestSuite = {
+        testId: 'empty',
+        testPath: '/test',
+        project: 'test',
+        name: 'empty',
+        runMode: 'run',
+        type: 'suite',
+        tests: [],
+      };
+      const testA: TestSuite = {
+        testId: 'testA',
+        testPath: '/test',
+        project: 'test',
+        name: 'testA',
+        runMode: 'run',
+        type: 'suite',
+        tests: [emptySuite],
+      };
+
+      traverseUpdateTestRunMode(testA, 'run', false);
+
+      expect(testA.runMode).toBe('run');
+      expect(emptySuite.runMode).toBe('run');
+      expect(testA.hasRunnableTests).toBe(false);
+      expect(emptySuite.hasRunnableTests).toBe(false);
     });
   });
 
@@ -279,6 +309,7 @@ describe('traverseUpdateTest', () => {
     expect(tests).toMatchInlineSnapshot(`
       [
         {
+          "hasRunnableTests": true,
           "name": "testA",
           "parentNames": [],
           "runMode": "run",
@@ -300,6 +331,7 @@ describe('traverseUpdateTest', () => {
               "type": "case",
             },
             {
+              "hasRunnableTests": true,
               "name": "test-2",
               "parentNames": [
                 "testA",

--- a/website/docs/en/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/en/api/runtime-api/test-api/hooks.mdx
@@ -15,6 +15,8 @@ Hooks allow you to run setup and teardown logic before or after your tests or te
 
 Runs once before all tests in the current suite.
 
+Rstest does not run this hook when the current suite has no tests to run. For example, this happens when all tests are skipped, excluded by test name filtering, or not selected by `test.only`.
+
 ```ts
 import { beforeAll } from '@rstest/core';
 
@@ -45,6 +47,8 @@ beforeAll(async () => {
 - **Type:** `(fn: (ctx: SuiteContext) => void | Promise<void>, timeout?: number) => void`
 
 Runs once after all tests in the current suite.
+
+Rstest does not run this hook when the current suite has no tests to run. For example, this happens when all tests are skipped, excluded by test name filtering, or not selected by `test.only`.
 
 ```ts
 import { afterAll } from '@rstest/core';

--- a/website/docs/zh/api/runtime-api/test-api/hooks.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/hooks.mdx
@@ -15,6 +15,8 @@ Hooks 允许你在测试或测试套件执行之前或之后运行初始化和�
 
 在当前套件的所有测试之前运行。
 
+当前套件中没有可执行的测试时，例如所有测试都被跳过、被测试名称筛选排除，或未被 `test.only` 选中，Rstest 不会执行该 hook。
+
 ```ts
 import { beforeAll } from '@rstest/core';
 
@@ -45,6 +47,8 @@ beforeAll(async () => {
 - **类型：** `(fn: (ctx: SuiteContext) => void | Promise<void>, timeout?: number) => void`
 
 在当前套件的所有测试之后运行。
+
+当前套件中没有可执行的测试时，例如所有测试都被跳过、被测试名称筛选排除，或未被 `test.only` 选中，Rstest 不会执行该 hook。
 
 ```ts
 import { afterAll } from '@rstest/core';


### PR DESCRIPTION
## Summary

- Skip `beforeAll` and `afterAll` when a suite has no runnable tests, including file-level hooks and ancestors that contain only empty suites.
- Track runnable descendants during the existing test-mode traversal without changing `runMode` semantics.
- Keep `passWithNoTests` limited to deciding whether an empty suite passes or fails, and document the hook behavior in English and Chinese.
- Add Node.js and Browser Mode regression coverage.

## Related Links

- Review context: https://github.com/web-infra-dev/rstest/pull/1732#discussion_r3820529132

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).