### PR TITLE
fix(core): load fake timers via createRequire instead of bare require

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -236,6 +236,18 @@ export default defineConfig({
   tools: {
     rspack: {
       ...rslibRspackConfig,
+      module: {
+        ...rslibRspackConfig.module,
+        rules: [
+          {
+            // `fakeTimers.ts` loads `@sinonjs/fake-timers` through
+            // `createRequire(import.meta.url)`; let Rspack bundle that call so
+            // the dependency stays in the chunk for the Node and browser targets.
+            test: /[\\/]runtime[\\/]api[\\/]fakeTimers\.ts$/,
+            parser: { createRequire: true },
+          },
+        ],
+      },
       watchOptions: {
         ignored: /\.git/,
       },

--- a/packages/core/src/runtime/api/fakeTimers.ts
+++ b/packages/core/src/runtime/api/fakeTimers.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of https://github.com/facebook/jest.
  */
 
+import { createRequire } from 'node:module';
 import type {
   Config as FakeTimerInstallOpts,
   FakeTimers as FakeTimerWithContext,
@@ -39,12 +40,15 @@ const isDate = (value: unknown): value is Date =>
   Object.prototype.toString.call(value) === '[object Date]';
 
 const loadFakeTimersModule = () => {
-  // TODO: Switch back to createRequire(import.meta.url) once Rspack supports
-  // preserving that pattern without breaking bundling/runtime resolution.
-  // Preserve the public sync timer API while avoiding module init work
-  // on worker startup when fake timers are never used.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const loaded = require('@sinonjs/fake-timers');
+  // Rspack bundles this `createRequire` call (parser enabled for this file in
+  // rslib.config.ts), so the dependency stays inside the chunk for both the
+  // Node and browser targets. Preserve the public sync timer API while
+  // avoiding module init work on worker startup when fake timers are never used.
+  const require = createRequire(import.meta.url);
+  const loaded: Pick<
+    typeof import('@sinonjs/fake-timers'),
+    'withGlobal'
+  > = require('@sinonjs/fake-timers');
   return { withGlobal: loaded.withGlobal };
 };
 


### PR DESCRIPTION
## Summary

`fakeTimers.ts` loaded `@sinonjs/fake-timers` through a bare `require()` inside a closure so the module is only evaluated when fake timers are actually used. That relies on Rspack parsing `.ts` files as `javascript/auto`; web-infra-dev/rspack#15266 classifies `.ts` files in `type: module` packages as `javascript/esm`, where a bare `require()` is no longer a bundled dependency and the call leaks into the published output (Node would `require` a devDependency at runtime and the browser runtime has no `require` at all).

- Switch the loader to `createRequire(import.meta.url)` and drop the TODO; the lazy evaluation inside the closure is unchanged.
- Enable Rspack's `createRequire` parser for `fakeTimers.ts` only. #1716 keeps it disabled repo-wide because third-party ESM dependencies (for example `fdir`) would otherwise get build-time `file:///` URLs embedded in the bundle; a file-scoped rule keeps that protection while letting Rspack bundle this one call for both the Node and browser targets.

The built `dist/` output is byte-identical to `main`, and also stays identical when `.ts` is forced to `javascript/esm` to simulate the upstream change.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/15266
- https://github.com/web-infra-dev/rstest/pull/1716
- https://github.com/web-infra-dev/rspack/pull/14813

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
