### PR TITLE
docs: improve Playwright guide structure

### DIFF
--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -10,7 +10,19 @@ import { PackageManagerTabs } from '@theme';
 
 <ApiMeta addedVersion="0.11.1" />
 
-[@rstest/playwright](https://github.com/web-infra-dev/rstest/tree/main/packages/playwright) provides Playwright fixtures and Playwright-style assertions for Rstest tests that run in Node.js workers. Use it for E2E tests against a complete page or app, such as a local dev server, a preview server, or a deployed URL. The test runs in Node.js and uses Playwright to drive the page.
+[@rstest/playwright](https://github.com/web-infra-dev/rstest/tree/main/packages/playwright) provides [Playwright](https://playwright.dev/) fixtures and Playwright-style assertions for Rstest tests that run in Node.js workers. Use it for E2E tests against a complete page or app, such as a local dev server, a preview server, or a deployed URL. The test runs in Node.js and uses Playwright to drive the page.
+
+## Rstest playwright vs native playwright
+
+`@rstest/playwright` and native Playwright use different runners and configuration files:
+
+| Item          | `@rstest/playwright`                                  | Native Playwright                                  |
+| ------------- | ----------------------------------------------------- | -------------------------------------------------- |
+| Runner        | Rstest runner                                         | Playwright Test runner                             |
+| Configuration | `rstest.config.ts` and `playwright` fixture overrides | `playwright.config.ts`                             |
+| Test API      | Import `test` and `expect` from `@rstest/playwright`  | Import `test` and `expect` from `@playwright/test` |
+
+Use `@rstest/playwright` when you want Playwright-driven E2E tests to run in the same Rstest workflow as the rest of your tests. Use native Playwright when you want the full Playwright Test runner workflow and its configuration model.
 
 ## Rstest browser mode vs playwright
 
@@ -25,19 +37,7 @@ The main difference is the testing scenario: Rstest browser mode web-bundles tes
 
 Because `@rstest/playwright` controls an external page instead of running the test in Rstest's browser runner, it does not use the Browser UI preview iframe. For visual debugging, use headed mode with `PWDEBUG=1`.
 
-## Rstest playwright vs native playwright
-
-`@rstest/playwright` and native Playwright use different runners and configuration files:
-
-| Item          | `@rstest/playwright`                                  | Native Playwright                                  |
-| ------------- | ----------------------------------------------------- | -------------------------------------------------- |
-| Runner        | Rstest runner                                         | Playwright Test runner                             |
-| Configuration | `rstest.config.ts` and `playwright` fixture overrides | `playwright.config.ts`                             |
-| Test API      | Import `test` and `expect` from `@rstest/playwright`  | Import `test` and `expect` from `@playwright/test` |
-
-Use `@rstest/playwright` when you want Playwright-driven E2E tests to run in the same Rstest workflow as the rest of your tests. Use native Playwright when you want the full Playwright Test runner workflow and its configuration model.
-
-## Use an agent prompt
+## Migrate to @rstest/playwright
 
 To migrate an existing Playwright Test project to `@rstest/playwright`, use the [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) skill with a Coding Agent that supports Skills. Agent Skills are domain-specific knowledge packs that help Coding Agents provide more accurate suggestions or perform actions for a specific scenario. The [skills](https://www.npmjs.com/package/skills) package installs these skills into a Coding Agent. The `migrate-to-rstest` skill includes Playwright-specific migration guidance for configuration, fixtures, and behavior parity.
 
@@ -112,6 +112,46 @@ export default defineConfig({
   testEnvironment: 'node',
 });
 ```
+
+## Configure playwright options
+
+Global Playwright configuration in `rstest.config.ts` is not supported yet. If multiple test files use the same options, define a shared module that overrides the `playwright` fixture with `test.extend`, then import `test` and `expect` from that module in every test file:
+
+```ts title="tests/e2e.ts"
+import { expect, test as base } from '@rstest/playwright';
+import type { PlaywrightOptions } from '@rstest/playwright';
+
+export { expect };
+export const test = base.extend({
+  playwright: {
+    contextOptions: {
+      viewport: { width: 390, height: 844 },
+    },
+  } satisfies PlaywrightOptions,
+});
+```
+
+```ts title="tests/home.test.ts"
+import { expect, test } from './e2e';
+
+test('mobile page', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page.locator('main')).toBeAttached();
+});
+```
+
+If only a few tests need different options, call `test.extend` again from those test files using the shared `test` as the base.
+
+The `playwright` fixture supports these options:
+
+| Option           | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| `browserName`    | Browser engine to launch. Currently only `chromium`. |
+| `launchOptions`  | Options passed to `browserType.launch()`.            |
+| `contextOptions` | Options passed to `browser.newContext()`.            |
+| `requestOptions` | Options passed to `request.newContext()`.            |
+| `debug`          | Convenience options for local headed debugging.      |
+| `trace`          | Capture Playwright trace artifacts for debugging.    |
 
 ## Fixtures
 
@@ -286,39 +326,6 @@ await expect(page.locator('.message')).toContainText('Saved', {
 await expect(page.locator('.error')).not.toBeAttached();
 await expect.soft(page).toHaveTitle(/Dashboard/);
 ```
-
-## Configure playwright options
-
-Global `playwright` configuration is not supported yet. Override the `playwright` fixture when a test file needs custom Playwright options:
-
-```ts
-import { expect, test } from '@rstest/playwright';
-import type { PlaywrightOptions } from '@rstest/playwright';
-
-const e2e = test.extend({
-  playwright: {
-    contextOptions: {
-      viewport: { width: 390, height: 844 },
-    },
-  } satisfies PlaywrightOptions,
-});
-
-e2e('mobile page', async ({ page }) => {
-  await page.goto('http://localhost:3000');
-  await expect(page.locator('main')).toBeAttached();
-});
-```
-
-The `playwright` fixture supports these options:
-
-| Option           | Description                                          |
-| ---------------- | ---------------------------------------------------- |
-| `browserName`    | Browser engine to launch. Currently only `chromium`. |
-| `launchOptions`  | Options passed to `browserType.launch()`.            |
-| `contextOptions` | Options passed to `browser.newContext()`.            |
-| `requestOptions` | Options passed to `request.newContext()`.            |
-| `debug`          | Convenience options for local headed debugging.      |
-| `trace`          | Capture Playwright trace artifacts for debugging.    |
 
 ## Trace debugging
 

--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -140,7 +140,7 @@ test('mobile page', async ({ page }) => {
 });
 ```
 
-If only a few tests need different options, call `test.extend` again from those test files using the shared `test` as the base.
+If only a few tests need different options, call `test.extend` again from those test files using the shared `test` as the base. Overriding the `playwright` fixture replaces its value instead of merging it, so the new value must include every shared option that the test should preserve.
 
 The `playwright` fixture supports these options:
 

--- a/website/docs/en/guide/advanced/playwright.mdx
+++ b/website/docs/en/guide/advanced/playwright.mdx
@@ -12,7 +12,7 @@ import { PackageManagerTabs } from '@theme';
 
 [@rstest/playwright](https://github.com/web-infra-dev/rstest/tree/main/packages/playwright) provides [Playwright](https://playwright.dev/) fixtures and Playwright-style assertions for Rstest tests that run in Node.js workers. Use it for E2E tests against a complete page or app, such as a local dev server, a preview server, or a deployed URL. The test runs in Node.js and uses Playwright to drive the page.
 
-## Rstest playwright vs native playwright
+## vs native Playwright
 
 `@rstest/playwright` and native Playwright use different runners and configuration files:
 
@@ -24,7 +24,7 @@ import { PackageManagerTabs } from '@theme';
 
 Use `@rstest/playwright` when you want Playwright-driven E2E tests to run in the same Rstest workflow as the rest of your tests. Use native Playwright when you want the full Playwright Test runner workflow and its configuration model.
 
-## Rstest browser mode vs playwright
+## vs Rstest browser mode
 
 The main difference is the testing scenario: Rstest browser mode web-bundles test modules and runs test code in a browser runtime, while `@rstest/playwright` controls a page that is already prepared by your app or server.
 

--- a/website/docs/zh/guide/advanced/playwright.mdx
+++ b/website/docs/zh/guide/advanced/playwright.mdx
@@ -140,7 +140,7 @@ test('mobile page', async ({ page }) => {
 });
 ```
 
-如果只有少数测试需要不同的选项，可以在对应测试文件中基于共享的 `test` 再次调用 `test.extend`。
+如果只有少数测试需要不同的选项，可以在对应测试文件中基于共享的 `test` 再次调用 `test.extend`。再次覆盖 `playwright` fixture 会替换而不是合并共享选项，因此新的值必须包含该测试需要保留的所有共享选项。
 
 `playwright` fixture 支持以下选项：
 

--- a/website/docs/zh/guide/advanced/playwright.mdx
+++ b/website/docs/zh/guide/advanced/playwright.mdx
@@ -10,7 +10,19 @@ import { PackageManagerTabs } from '@theme';
 
 <ApiMeta addedVersion="0.11.1" />
 
-[@rstest/playwright](https://github.com/web-infra-dev/rstest/tree/main/packages/playwright) 为运行在 Node.js worker 中的 Rstest 测试提供 Playwright fixtures 和 Playwright 风格的断言。它适合对一个完整页面或应用做 E2E 测试，例如本地 dev server、preview server 或线上 URL。测试代码运行在 Node.js 中，并通过 Playwright 控制页面。
+[@rstest/playwright](https://github.com/web-infra-dev/rstest/tree/main/packages/playwright) 为运行在 Node.js worker 中的 Rstest 测试提供 [Playwright](https://playwright.dev/) fixtures 和 Playwright 风格的断言。它适合对一个完整页面或应用做 E2E 测试，例如本地 dev server、preview server 或线上 URL。测试代码运行在 Node.js 中，并通过 Playwright 控制页面。
+
+## 与原生 Playwright 的区别
+
+`@rstest/playwright` 和原生 Playwright 主要区别在 runner 和配置方式：
+
+| 项目     | `@rstest/playwright`                            | 原生 Playwright                               |
+| -------- | ----------------------------------------------- | --------------------------------------------- |
+| Runner   | Rstest runner                                   | Playwright Test runner                        |
+| 配置方式 | `rstest.config.ts` 和 `playwright` fixture 覆盖 | `playwright.config.ts`                        |
+| 测试 API | 从 `@rstest/playwright` 导入 `test` 和 `expect` | 从 `@playwright/test` 导入 `test` 和 `expect` |
+
+如果希望 Playwright E2E 测试和其他 Rstest 测试使用同一套 Rstest 工作流，可以使用 `@rstest/playwright`。如果希望使用完整的 Playwright Test runner 工作流和配置模型，可以使用原生 Playwright。
 
 ## 与 Rstest browser mode 的区别
 
@@ -25,19 +37,7 @@ import { PackageManagerTabs } from '@theme';
 
 由于 `@rstest/playwright` 控制的是外部页面，而不是 Rstest browser mode 的 runner iframe，因此它不走 Browser UI 的预览 iframe。需要本地可视化调试时，可以使用 `PWDEBUG=1` 开启 headed 模式。
 
-## 与原生 Playwright 的区别
-
-`@rstest/playwright` 和原生 Playwright 主要区别在 runner 和配置方式：
-
-| 项目     | `@rstest/playwright`                            | 原生 Playwright                               |
-| -------- | ----------------------------------------------- | --------------------------------------------- |
-| Runner   | Rstest runner                                   | Playwright Test runner                        |
-| 配置方式 | `rstest.config.ts` 和 `playwright` fixture 覆盖 | `playwright.config.ts`                        |
-| 测试 API | 从 `@rstest/playwright` 导入 `test` 和 `expect` | 从 `@playwright/test` 导入 `test` 和 `expect` |
-
-如果希望 Playwright E2E 测试和其他 Rstest 测试使用同一套 Rstest 工作流，可以使用 `@rstest/playwright`。如果希望使用完整的 Playwright Test runner 工作流和配置模型，可以使用原生 Playwright。
-
-## 使用 Agent prompt
+## 迁移到 @rstest/playwright
 
 如果要将现有的 Playwright Test 项目迁移到 `@rstest/playwright`，可以让支持 Skills 的 Coding Agent 使用 [migrate-to-rstest](https://github.com/rstackjs/agent-skills#migrate-to-rstest) skill 辅助完成迁移。Agent Skills 是可以安装到 Coding Agent 中的领域知识包，能够帮助 Agent 针对特定场景提供更准确的建议或执行操作。[skills](https://www.npmjs.com/package/skills) 包用于将这些 skill 安装到 Coding Agent 中。`migrate-to-rstest` skill 包含针对 Playwright 配置、fixtures 和行为一致性的迁移指南。
 
@@ -112,6 +112,46 @@ export default defineConfig({
   testEnvironment: 'node',
 });
 ```
+
+## 配置 Playwright 选项
+
+暂不支持在 `rstest.config.ts` 中添加全局 Playwright 配置项。如果多个测试文件需要使用同一组选项，推荐在共享模块中通过 `test.extend` 覆盖 `playwright` fixture，并让测试文件统一从该模块导入 `test` 和 `expect`：
+
+```ts title="tests/e2e.ts"
+import { expect, test as base } from '@rstest/playwright';
+import type { PlaywrightOptions } from '@rstest/playwright';
+
+export { expect };
+export const test = base.extend({
+  playwright: {
+    contextOptions: {
+      viewport: { width: 390, height: 844 },
+    },
+  } satisfies PlaywrightOptions,
+});
+```
+
+```ts title="tests/home.test.ts"
+import { expect, test } from './e2e';
+
+test('mobile page', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page.locator('main')).toBeAttached();
+});
+```
+
+如果只有少数测试需要不同的选项，可以在对应测试文件中基于共享的 `test` 再次调用 `test.extend`。
+
+`playwright` fixture 支持以下选项：
+
+| 选项             | 说明                                        |
+| ---------------- | ------------------------------------------- |
+| `browserName`    | 要启动的浏览器引擎。目前只支持 `chromium`。 |
+| `launchOptions`  | 传给 `browserType.launch()` 的选项。        |
+| `contextOptions` | 传给 `browser.newContext()` 的选项。        |
+| `requestOptions` | 传给 `request.newContext()` 的选项。        |
+| `debug`          | 用于本地 headed 调试的便捷选项。            |
+| `trace`          | 捕获用于调试的 Playwright trace 产物。      |
 
 ## Fixtures
 
@@ -286,39 +326,6 @@ await expect(page.locator('.message')).toContainText('Saved', {
 await expect(page.locator('.error')).not.toBeAttached();
 await expect.soft(page).toHaveTitle(/Dashboard/);
 ```
-
-## 配置 Playwright 选项
-
-暂不支持在 rstest.config.ts 中添加全局 playwright 配置项。当某个测试文件需要自定义 Playwright 选项时，可以覆盖 `playwright` fixture：
-
-```ts
-import { expect, test } from '@rstest/playwright';
-import type { PlaywrightOptions } from '@rstest/playwright';
-
-const e2e = test.extend({
-  playwright: {
-    contextOptions: {
-      viewport: { width: 390, height: 844 },
-    },
-  } satisfies PlaywrightOptions,
-});
-
-e2e('mobile page', async ({ page }) => {
-  await page.goto('http://localhost:3000');
-  await expect(page.locator('main')).toBeAttached();
-});
-```
-
-`playwright` fixture 支持以下选项：
-
-| 选项             | 说明                                        |
-| ---------------- | ------------------------------------------- |
-| `browserName`    | 要启动的浏览器引擎。目前只支持 `chromium`。 |
-| `launchOptions`  | 传给 `browserType.launch()` 的选项。        |
-| `contextOptions` | 传给 `browser.newContext()` 的选项。        |
-| `requestOptions` | 传给 `request.newContext()` 的选项。        |
-| `debug`          | 用于本地 headed 调试的便捷选项。            |
-| `trace`          | 捕获用于调试的 Playwright trace 产物。      |
 
 ## Trace 调试
 


### PR DESCRIPTION
## Summary

This PR makes the Playwright guide easier to follow in both English and Chinese. It clarifies the migration entry point, reorders the comparison and configuration sections, recommends a shared `test.extend` helper for reusable Playwright options, and links to the official Playwright website.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).