### PR TITLE
chore(deps): upgrade Module Federation packages to 2.9.0

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "test:threads": "cross-env RSTEST_POOL_TYPE=threads rstest run --pool.type threads"
   },
   "devDependencies": {
-    "@module-federation/rstest": "https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6",
+    "@module-federation/rstest": "2.9.0",
     "@rsbuild/core": "~2.2.0-beta.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "1.0.0-beta.3",

--- a/examples/federation/component-app/package.json
+++ b/examples/federation/component-app/package.json
@@ -16,8 +16,8 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@module-federation/rsbuild-plugin": "https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301",
-    "@module-federation/rstest": "https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6",
+    "@module-federation/rsbuild-plugin": "2.9.0",
+    "@module-federation/rstest": "2.9.0",
     "@rsbuild/core": "~2.2.0-beta.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/core": "workspace:*",

--- a/examples/federation/main-app/package.json
+++ b/examples/federation/main-app/package.json
@@ -14,8 +14,8 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@module-federation/rsbuild-plugin": "https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301",
-    "@module-federation/rstest": "https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6",
+    "@module-federation/rsbuild-plugin": "2.9.0",
+    "@module-federation/rstest": "2.9.0",
     "@rsbuild/core": "~2.2.0-beta.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/browser": "workspace:*",

--- a/examples/federation/node-local-remote/package.json
+++ b/examples/federation/node-local-remote/package.json
@@ -8,7 +8,7 @@
     "serve:node": "serve dist-node -p 3004"
   },
   "devDependencies": {
-    "@module-federation/rsbuild-plugin": "https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301",
+    "@module-federation/rsbuild-plugin": "2.9.0",
     "@rsbuild/core": "~2.2.0-beta.2",
     "serve": "14.2.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,17 +86,17 @@ importers:
   e2e:
     devDependencies:
       '@module-federation/rstest':
-        specifier: https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        specifier: 2.9.0
+        version: 2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/browser':
         specifier: workspace:*
         version: link:../packages/browser
@@ -189,10 +189,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)))
+        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)))
       '@rspack/core':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../../packages/adapter-rspack
@@ -238,10 +238,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -336,7 +336,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -380,7 +380,7 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -411,10 +411,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -445,10 +445,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -498,7 +498,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -544,16 +544,16 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(supports-color@8.1.1)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -584,7 +584,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -619,17 +619,17 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@module-federation/rsbuild-plugin':
-        specifier: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        specifier: 2.9.0
+        version: 2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@module-federation/rstest':
-        specifier: https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        specifier: 2.9.0
+        version: 2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -650,17 +650,17 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@module-federation/rsbuild-plugin':
-        specifier: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        specifier: 2.9.0
+        version: 2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@module-federation/rstest':
-        specifier: https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        specifier: 2.9.0
+        version: 2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../../packages/browser
@@ -689,11 +689,11 @@ importers:
   examples/federation/node-local-remote:
     devDependencies:
       '@module-federation/rsbuild-plugin':
-        specifier: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301
-        version: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        specifier: 2.9.0
+        version: 2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       serve:
         specifier: 14.2.6
         version: 14.2.6(supports-color@8.1.1)
@@ -717,7 +717,7 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -742,10 +742,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -782,10 +782,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -825,16 +825,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)))
+        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)))
       '@rspack/core':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: ~2.2.0
-        version: 2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rspack/plugin-react-refresh':
         specifier: ~2.0.2
-        version: 2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -877,13 +877,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)))
+        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)))
       '@rspack/core':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: ~2.2.0
-        version: 2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/adapter-rspack':
         specifier: workspace:*
         version: link:../../packages/adapter-rspack
@@ -913,10 +913,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-svelte':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.56.10)(typescript@6.0.3)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.56.10)(typescript@6.0.3)
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -941,16 +941,16 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(supports-color@8.1.1)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -974,10 +974,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -989,7 +989,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1007,13 +1007,13 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rspack/cli':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)))
+        version: 2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)))
       '@rspack/core':
         specifier: ~2.2.0-rc.0
-        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1044,7 +1044,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/browser-ui':
         specifier: workspace:*
         version: link:../browser-ui
@@ -1080,7 +1080,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1123,13 +1123,13 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)
+        version: 2.0.5(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1150,7 +1150,7 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@types/chai':
         specifier: ^5.2.3
         version: 5.2.3
@@ -1172,16 +1172,16 @@ importers:
         version: 7.59.0(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))
+        version: 1.4.6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -1310,10 +1310,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1365,10 +1365,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1398,7 +1398,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1416,10 +1416,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ~2.2.0-beta.2
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)
+        version: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1482,7 +1482,7 @@ importers:
     dependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.6.3
-        version: 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+        version: 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rstest/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1494,10 +1494,10 @@ importers:
         version: 0.6.0
       rsbuild-plugin-arethetypeswrong:
         specifier: ^0.3.1
-        version: 0.3.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(typescript@6.0.3)
+        version: 0.3.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))
+        version: 1.0.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))
       shell-quote:
         specifier: ^1.10.0
         version: 1.10.0
@@ -1511,19 +1511,19 @@ importers:
         version: 2.6.2
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))
+        version: 2.0.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))
       '@rspress/core':
         specifier: 2.0.19
-        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
       '@rspress/plugin-algolia':
         specifier: 2.0.19
-        version: 2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@rspress/plugin-client-redirects':
         specifier: 2.0.19
-        version: 2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
+        version: 2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
       '@rstack-dev/doc-ui':
         specifier: 1.14.8
-        version: 1.14.8(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
+        version: 1.14.8(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1544,13 +1544,13 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))
+        version: 1.0.6(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))
+        version: 1.1.3(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
-        version: 1.0.4(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
+        version: 1.0.4(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
       rspress-plugin-sitemap:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2395,29 +2395,16 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@module-federation/bridge-react-webpack-plugin@https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-8jCDkpBh73HQTcI3wH2lEY5X1vww/LU+D2XGyDunljL6Sd1Cy+/SWb1y3A54ZgrUgV+7vzFZl+JT73JWHm2QcQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/bridge-react-webpack-plugin@2.9.0':
+    resolution: {integrity: sha512-hv3fuQkGERQ/COBKTVbFV1GWovReSg/bzJzDuxWR1F84h6NYtbYMWQqX8Egvb7HKMtn9Rflzw0GeaLr8F08vDg==}
 
-  '@module-federation/bridge-react-webpack-plugin@https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-5WTabIf8orP+CmklOjWNAffFFfYrmqPNjLJoolhOFPT60TvE4XY4GtTR3IiDYGVVjQ4PLK0j1j3wOW/DXVHW9Q==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/cli@https://pkg.pr.new/module-federation/core/@module-federation/cli@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-XpM5hWYclrO5h9dJDGxlgM4qSytpcj6rcLmIBbgQ/EGU0N3JN2oiD4GybCvbLEpAN6QVP/BRlYxDc0Ig49Hs8w==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/cli@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/cli@2.9.0':
+    resolution: {integrity: sha512-r9RdlLRy3zWxuWQRonif48xdDu1reBGx18QpkZwLQ4JfSrOARjycNIGY2Y7QaUw7dedzxyee4FtKFeX/kOVLYQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
 
-  '@module-federation/cli@https://pkg.pr.new/module-federation/core/@module-federation/cli@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-RB+hf6sA/58ZGIg14AUelToGgF1aQMR0t5BEtuvWdVRYL2TkkIP9yJJYg2RkbfkecFwur0pRdtRROlDz8ksbFw==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/cli@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-    engines: {node: '>=16.0.0'}
-    hasBin: true
-
-  '@module-federation/dts-plugin@https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-R34pQnt1HqjRcuoF47zKpC/qh8onEXtTB6pwh3bzeFNhtpn01DWzzsWtZbHC9fBXCjotKF3ucsKUYbZTEYE3wQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/dts-plugin@2.9.0':
+    resolution: {integrity: sha512-uMGqEG/p9odG2BVr7WRbBe2OgrvzBd3LPzcp5WP+bm3djBdUJ4PZ3ozqKp6qpy+NFnlh6vnM815Xn6AXkKy1Vw==}
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
       vue-tsc: '>=1.0.24'
@@ -2425,19 +2412,8 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/dts-plugin@https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-bhMtrfTYCDNQYrJOSAuqM37wuFKbCrH1MrX+11+VPiq0WjMp59Ms6izoHBKSbD6vYnDrEAaC3/azHtsstnDKpQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-    peerDependencies:
-      typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-      vue-tsc: '>=1.0.24'
-    peerDependenciesMeta:
-      vue-tsc:
-        optional: true
-
-  '@module-federation/enhanced@https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-dVAI9OmDkeUkQaf3vnF9iK5bMajs92eGLB/KaVsg5Q3waPOvvjNDaM7R4+Vo6gBPY04KzkAMy23log7KyDqEXQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/enhanced@2.9.0':
+    resolution: {integrity: sha512-Jd/JHoFL9fNKL4Nnzo/9hf6FD/oQo3gKpE8xt6EGuhxmrvg6wM0radPtqgHiSSWLMW7CiXr2agNjKvquKd83rw==}
     hasBin: true
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -2451,82 +2427,30 @@ packages:
       webpack:
         optional: true
 
-  '@module-federation/enhanced@https://pkg.pr.new/module-federation/core/@module-federation/enhanced@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-skk7FfBVXd/Vhvr38LPfxP3GeAg7KCGEeNW/yJYoI3x8zNpzPoEqEgz+ExAiOxqaCwZhbLNd5Bp0za7wnSrTDQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/enhanced@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-    hasBin: true
+  '@module-federation/error-codes@2.9.0':
+    resolution: {integrity: sha512-IGpd+VRlji3NyGOGGTsk7YEmPRKcDoBK4YHqIuP+OQwyb2YhHCUHO2vW9RXeQxCuKwi+c6xkTweRYG+Umy+0Zw==}
+
+  '@module-federation/inject-external-runtime-core-plugin@2.9.0':
+    resolution: {integrity: sha512-k3wCSZsY21HjYQ61wmIJUQleOgcHgqx/sX4qXYw0XnJnzHuFo64rzMvgr+TuBIgZ1peAQtfILLlTnWyTRjtZHw==}
     peerDependencies:
-      typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-      vue-tsc: '>=1.0.24'
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      vue-tsc:
-        optional: true
-      webpack:
-        optional: true
+      '@module-federation/runtime-tools': 2.9.0
 
-  '@module-federation/error-codes@2.8.1':
-    resolution: {integrity: sha512-0mQ+bWt1LRCZyURx3g2b8G+aAlvk8iXIgrp3Jit/75blrlVda/eVqnHz1L+YOxwkP3xSrdbUb4423AoWti31ZQ==}
+  '@module-federation/managers@2.9.0':
+    resolution: {integrity: sha512-8KhB2PF4g+M0hGaethU1H4GVWabLn5sF5TvnM6VxgAcDL4TfLY8aC/YobAXHG/SV0jpU5lsGe6s6xy6ccV0MQw==}
 
-  '@module-federation/error-codes@https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-Gaog9904EmxYOQV0hli3XQ7jXeFaADfh5bnBtTCtbZ37Qd/Sz9kQfd+gYQRyIj7RGmkv9DPiN/SsmrTMrTymKw==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/manifest@2.9.0':
+    resolution: {integrity: sha512-Zhm9luVOw9XPou50eTwsvdgr208CszoQ6cGORQDCPAMhjpGb5oYFtilJ+LKW7hQ1LktD15bEZmGhC1anvgXEiQ==}
 
-  '@module-federation/error-codes@https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-0mQ+bWt1LRCZyURx3g2b8G+aAlvk8iXIgrp3Jit/75blrlVda/eVqnHz1L+YOxwkP3xSrdbUb4423AoWti31ZQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/inject-external-runtime-core-plugin@https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-wP31UROIz7fMsLu37PZVMRVSTCK9Na5BB3ahuuLuX31M90w8RPVK5pYy1YEAdqHqtnVT6tchRaHu6HrjDFUCDw==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
-    peerDependencies:
-      '@module-federation/runtime-tools': 2.8.0
-
-  '@module-federation/inject-external-runtime-core-plugin@https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-uyV/CxwEqmrTS7Gf9srAOf/a61v7/8iWIcsiwF5cce36qGOUln34O2jgQz9AFpe9vOsEs+Whn/OPuhMCxnLp2Q==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-    peerDependencies:
-      '@module-federation/runtime-tools': 2.8.1
-
-  '@module-federation/managers@https://pkg.pr.new/module-federation/core/@module-federation/managers@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-ycuGzVvmP+/DIHj7dXTahJjO+COV6vYYN1e+DnBGAT/NQes24aNTFYDykAdcEiUrncW1ovVLxygRz7AlIuvrUA==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/managers@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
-
-  '@module-federation/managers@https://pkg.pr.new/module-federation/core/@module-federation/managers@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-kNutZLn6/rf7bEHUsPFRc4m2uGFwPFgrfseNq6kdvG40Vqi0q7VMSaVJHXBugslRV6J51cyjJVgu4sl0goWHSA==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/managers@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/manifest@https://pkg.pr.new/module-federation/core/@module-federation/manifest@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-gN9UT92vJv70aQ4+avLY3jG1PtwRf/IDAXi9GTsv3Nobbn0VK7NXneXG6enKIqGstaAchp0GHdnhXIZqGpwmeA==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/manifest@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
-
-  '@module-federation/manifest@https://pkg.pr.new/module-federation/core/@module-federation/manifest@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-cG+LsXYlcY3FrxDQwxPDNyaR1h15DJ3WpBXPOY3vQ6wkt5mTgzTIyGA3ucGfoJqIaTx8ggJBHR1yXCqA3/K7xQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/manifest@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/node@https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-4uOwMja+zIODaEIXuhS0Zy3zP02twFsyFJCg4aAl0gb3w5vGbzSkiwUZ4aIYf+mighXJFQHju+cRsdBlioInOQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.7.47
+  '@module-federation/node@2.7.50':
+    resolution: {integrity: sha512-mbpQRdafyeWgsmYoJfdhOQf76zS6onOGpC2X1ELpWXB1Y4BcZGloL0CLjNMNon9m3ucfpc99tOGAQqFzQVkSBQ==}
     peerDependencies:
       webpack: ^5.40.0
     peerDependenciesMeta:
       webpack:
         optional: true
 
-  '@module-federation/node@https://pkg.pr.new/module-federation/core/@module-federation/node@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-1XvzjmoMejeDRcObKWXLJvsUWeZJS1eMNJylvZYIFX2idAI+ltOphD3QTUtK/jOdvq4+de0b399Pr4nhNxVX4A==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/node@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.7.48
-    peerDependencies:
-      webpack: ^5.40.0
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-
-  '@module-federation/rsbuild-plugin@https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301':
-    resolution: {integrity: sha512-U+d6t9kiioHjYDf1acsxP5qaV7Lsrm42+CUnpBrXoXSBHSiDDxuNGoz7cIWnChJ/Py8kpkSNZSRWXjeJTJwUrQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301}
-    version: 2.8.0
+  '@module-federation/rsbuild-plugin@2.9.0':
+    resolution: {integrity: sha512-CaWAxZg+zOMw/BfgRXQdNBQZ/e5U7DBZvE13LzG13GEclt7yxaMQgKH0si3uOsq9f/X2NC8UnuhNHLIkloqlqA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rsbuild/core': ^1.3.21 || ^2.0.0-0
@@ -2534,9 +2458,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@module-federation/rspack@https://pkg.pr.new/module-federation/core/@module-federation/rspack@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-VF3QJbCpIGUZZgIaYlZxJnF31ncBIAq7xymyXTExut0Qt2zt0gd6Qhdwhre7iGvZ1m9SjMoLXN1kTGhQlV5jpg==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/rspack@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/rspack@2.9.0':
+    resolution: {integrity: sha512-9zSlmQYKRHKVWqhlZSMyjstp2A3VVrQV2Of8mrF5NXhngFemNx7Hw35+MTo+gsRfF5glpN8bAzLyIokRUo1Cog==}
     peerDependencies:
       '@rspack/core': ^0.7.0 || ^1.0.0 || ^2.0.0-0
       typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -2547,22 +2470,8 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/rspack@https://pkg.pr.new/module-federation/core/@module-federation/rspack@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-Z8Zgddu2chOFWbvvTb5TdiSTi035i87C/cdo1S8Re4ACAxr7/1vCMPJHiyD8keyAS2uungzeLYWFRaKldy2nvQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/rspack@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-    peerDependencies:
-      '@rspack/core': ^0.7.0 || ^1.0.0 || ^2.0.0-0
-      typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-      vue-tsc: '>=1.0.24'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      vue-tsc:
-        optional: true
-
-  '@module-federation/rstest@https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6':
-    resolution: {integrity: sha512-jiVXifRbUuplN8VDYIF4OR+BLdxa3XaqFs0Rn7IGN18rxQW+SisUjGla3IC2vsVHjk5cJyvOD5ykikHDxRIw6A==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6}
-    version: 2.8.0
+  '@module-federation/rstest@2.9.0':
+    resolution: {integrity: sha512-gAagP7OHXjYyfiiJVCxs/ccqHwSqncasgjtYNNPS+GlgtxUbgobaFhzmQY/M2WR5Did6SNSqFzX0fH22BWgALw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rsbuild/core': ^1.3.21 || ^2.0.0
@@ -2573,68 +2482,23 @@ packages:
       '@rstest/core':
         optional: true
 
-  '@module-federation/runtime-core@2.8.1':
-    resolution: {integrity: sha512-Dif+3u7fvq6qBATFIv5qB7ay6Rgo2HNzhaNOt1yRfpVXjiJqQ3UPnHZ+TLP9znkXiZvg6Bg5W9EV2ZX4nH2S0w==}
+  '@module-federation/runtime-core@2.9.0':
+    resolution: {integrity: sha512-dLykRYfpbEJBTdk2NlbNoVVTB196O3qujawTBguLABJkPCWETJNk60NR1yZO34eI+DTH+eGwHU3m7FddAWnbnw==}
 
-  '@module-federation/runtime-core@https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-ETI97+L41F5s5mOQIEbbqxDwDAIETXKGgsgY28HDKvl59riD+nznyQf86NavqWkftbHn/xgRLq7LjPTAUndUkw==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/runtime-tools@2.9.0':
+    resolution: {integrity: sha512-u2puqsaHiw1bVvLNk1uh98iPo6UzaBuci/aTvOFwKvbT/RF18C3vGGnm+ShHPKQEnoN6ctPtnygyOZDPR+8cgg==}
 
-  '@module-federation/runtime-core@https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-2nicTr3COdAOCDtHRqI75hRtCLiCQrw7pA0KP9FzrWtW6TmXqrPhqzGusDj3hR/1watyOrnPMcRfflBzxPXwmw==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
+  '@module-federation/runtime@2.9.0':
+    resolution: {integrity: sha512-3cyAav0hWP+dNvB7qrcK9CKxQn+JvkbRvLtZz3zS2g0EyxtDFDjgbHY0Afcf7oHf8IHhKeEdzb/3Kjr1Pjmr7A==}
 
-  '@module-federation/runtime-tools@2.8.1':
-    resolution: {integrity: sha512-CIQ9dPqWOiitXKCYqgHXfr0hehtxsZDfiuFaesJAJnXtqkM5+nVkkBNkY07cDV5wOi00/aiOhEWYoCcz+cRQtQ==}
+  '@module-federation/sdk@2.9.0':
+    resolution: {integrity: sha512-IMjObgBGQTXd33jTTCYcxvz8iOQGLsZ2QIPOj90rDxuBtJsN4WJwYyXqligrhY/e5p/BipUPdbIgKmWL7zFhTw==}
 
-  '@module-federation/runtime-tools@https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-MV9q2iKcjoBHsfUQvoacJ4IfVE/wTB784aQcU8faHEUm2ciTBYHs+hl5FTlIMam5wiOWFxYXlWZ08XEj9iXhVA==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
+  '@module-federation/third-party-dts-extractor@2.9.0':
+    resolution: {integrity: sha512-R1Xuqnqzw6wQxWV3yU9fX1FydXAeZF2TNVFAVo1N1oLBA2j5y7aUO/Fc3VSNgd9/gxMzJgTVBdA+nMiD2SFCgg==}
 
-  '@module-federation/runtime-tools@https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-9YcdyRtKyyEM8Ppo2kaCWT7XOpXDx7SnDwxj18jmAd/in8btI0PpVseTPLLrjYgfy6XpEOAoWI4F5xApEi1nJw==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/runtime@2.8.1':
-    resolution: {integrity: sha512-+xpq/r6Om4plbGJisZp6/rl7usEUlQszz34E+JUKgl9uW3QIRzVgxwOAzGiF7U+dqOKxMqmiq+nTJwK2wAwteA==}
-
-  '@module-federation/runtime@https://pkg.pr.new/module-federation/core/@module-federation/runtime@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-ClrAhZ4Q4xTmhGtmAEIk10i+70dSdR/V4MEX0TdlOmsEVIFdSW9wlZFaZZL3d6Ej97+l5sNKyMTat8Hnc4a9zA==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/runtime@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
-
-  '@module-federation/runtime@https://pkg.pr.new/module-federation/core/@module-federation/runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-osOx2MRE4D1l8WxSYPGSlAhfp+njs0oOK/4L28bp+9e16ncZyprzsqp066okhvmYyaS+2Y76PuX+1k4PEBc0hw==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/sdk@2.8.1':
-    resolution: {integrity: sha512-3EVljiNilY2pFIG2RO4KNCC6gIPnYc9J+p5U6Nn8D5X3PtJeEcPyBvKGttxZnSLlXCi+YXQfgexBOfnkvEuzuQ==}
-
-  '@module-federation/sdk@https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-FkAAiKSmX4HtNHP2BE2qB+BLdCkFbjnAu/sF9JtKOynuXsMFbkZtsWIXsxfSNXM9LNL/BG9Y/B81RGDfFmmMzA==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
-
-  '@module-federation/sdk@https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-3EVljiNilY2pFIG2RO4KNCC6gIPnYc9J+p5U6Nn8D5X3PtJeEcPyBvKGttxZnSLlXCi+YXQfgexBOfnkvEuzuQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/third-party-dts-extractor@https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-nAMlr74OKIylkfRwlunOhytQbmsgb3gCqdXWnPQhG+ZtqWXGELLfMT4a1Q1ht3cS+sRpWj2SZRqK2M7GadI6tA==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
-
-  '@module-federation/third-party-dts-extractor@https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-6ulu7vqv5wyM5YWwxjUHzZ+8Sg6e+/vn+gskiUBs6EPqe/w3XMdRoUrFjAI3EW62xi0e0xbWLsjbQs9jCAj8ig==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
-
-  '@module-federation/webpack-bundler-runtime@2.8.1':
-    resolution: {integrity: sha512-dGFlrTLimhxpHohysx/qPRuIRaAiutqFfX0xFzDchEkY0DXpS2sOhuJ2foNcCIQK/FKFJW1YeaaIUkZ5FWMcOg==}
-
-  '@module-federation/webpack-bundler-runtime@https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@115230134ddcaad07e2299514f005186d931a39b':
-    resolution: {integrity: sha512-TC6arR7pdJzCJCJeETwO+c/AIzLPKOpHneDPr0cBXYYDdpKdfauHts/LtcJqDp7B/4YsFcbFby/LXR/XYYBK+Q==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@115230134ddcaad07e2299514f005186d931a39b}
-    version: 2.8.0
-
-  '@module-federation/webpack-bundler-runtime@https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    resolution: {integrity: sha512-FegarebZUeTlmf0MuCmt6yRJV4gZvIc6/I1BRTO5IPzeJ360ZBOaEcAYKIF/cPixne6ReY1X/TOq/U+YucV3sQ==, tarball: https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f}
-    version: 2.8.1
+  '@module-federation/webpack-bundler-runtime@2.9.0':
+    resolution: {integrity: sha512-MdU6NQibT57MaJG3KPBjC30IVBrz5eU7IcjHoVDYnMh7OmASw3stagBu7hYjdMTP31luNdtzUn85s9axvdwTlw==}
 
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
@@ -8900,8 +8764,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unhead@2.1.16:
@@ -10245,18 +10109,14 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@module-federation/bridge-react-webpack-plugin@https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@115230134ddcaad07e2299514f005186d931a39b':
+  '@module-federation/bridge-react-webpack-plugin@2.9.0':
     dependencies:
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/sdk': 2.9.0
 
-  '@module-federation/bridge-react-webpack-plugin@https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
+  '@module-federation/cli@2.9.0(typescript@6.0.3)':
     dependencies:
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-
-  '@module-federation/cli@https://pkg.pr.new/module-federation/core/@module-federation/cli@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)':
-    dependencies:
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/dts-plugin': 2.9.0(typescript@6.0.3)
+      '@module-federation/sdk': 2.9.0
       commander: 11.1.0
       jiti: 2.4.2
     transitivePeerDependencies:
@@ -10265,61 +10125,34 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@https://pkg.pr.new/module-federation/core/@module-federation/cli@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)':
+  '@module-federation/dts-plugin@2.9.0(typescript@6.0.3)':
     dependencies:
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      commander: 11.1.0
-      jiti: 2.4.2
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
-  '@module-federation/dts-plugin@https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)':
-    dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/third-party-dts-extractor': https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/managers': 2.9.0
+      '@module-federation/sdk': 2.9.0
+      '@module-federation/third-party-dts-extractor': 2.9.0
       adm-zip: 0.6.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
       typescript: 6.0.3
-      undici: 7.28.0
+      undici: 7.29.0
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/dts-plugin@https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)':
+  '@module-federation/enhanced@2.9.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/third-party-dts-extractor': https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      adm-zip: 0.6.0
-      isomorphic-ws: 5.0.0(ws@8.21.0)
-      typescript: 6.0.3
-      undici: 7.28.0
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@module-federation/enhanced@https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/cli': https://pkg.pr.new/module-federation/core/@module-federation/cli@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/inject-external-runtime-core-plugin': https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@115230134ddcaad07e2299514f005186d931a39b(@module-federation/runtime-tools@https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b)
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/manifest': https://pkg.pr.new/module-federation/core/@module-federation/manifest@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
-      '@module-federation/rspack': https://pkg.pr.new/module-federation/core/@module-federation/rspack@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)
-      '@module-federation/runtime-tools': https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/webpack-bundler-runtime': https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/bridge-react-webpack-plugin': 2.9.0
+      '@module-federation/cli': 2.9.0(typescript@6.0.3)
+      '@module-federation/dts-plugin': 2.9.0(typescript@6.0.3)
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/inject-external-runtime-core-plugin': 2.9.0(@module-federation/runtime-tools@2.9.0)
+      '@module-federation/managers': 2.9.0
+      '@module-federation/manifest': 2.9.0(typescript@6.0.3)
+      '@module-federation/rspack': 2.9.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
+      '@module-federation/runtime-tools': 2.9.0
+      '@module-federation/sdk': 2.9.0
+      '@module-federation/webpack-bundler-runtime': 2.9.0
       schema-utils: 4.3.0
       tapable: 2.3.0
     optionalDependencies:
@@ -10330,78 +10163,32 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@https://pkg.pr.new/module-federation/core/@module-federation/enhanced@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@module-federation/error-codes@2.9.0': {}
+
+  '@module-federation/inject-external-runtime-core-plugin@2.9.0(@module-federation/runtime-tools@2.9.0)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/cli': https://pkg.pr.new/module-federation/core/@module-federation/cli@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/inject-external-runtime-core-plugin': https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@module-federation/runtime-tools@2.8.1)
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/manifest': https://pkg.pr.new/module-federation/core/@module-federation/manifest@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)
-      '@module-federation/rspack': https://pkg.pr.new/module-federation/core/@module-federation/rspack@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)
-      '@module-federation/runtime-tools': https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/webpack-bundler-runtime': https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      schema-utils: 4.3.0
-      tapable: 2.3.0
-    optionalDependencies:
-      typescript: 6.0.3
-      webpack: 5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - utf-8-validate
+      '@module-federation/runtime-tools': 2.9.0
 
-  '@module-federation/error-codes@2.8.1': {}
-
-  '@module-federation/error-codes@https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b': {}
-
-  '@module-federation/error-codes@https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f': {}
-
-  '@module-federation/inject-external-runtime-core-plugin@https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@115230134ddcaad07e2299514f005186d931a39b(@module-federation/runtime-tools@https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b)':
+  '@module-federation/managers@2.9.0':
     dependencies:
-      '@module-federation/runtime-tools': https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/sdk': 2.9.0
 
-  '@module-federation/inject-external-runtime-core-plugin@https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@module-federation/runtime-tools@2.8.1)':
+  '@module-federation/manifest@2.9.0(typescript@6.0.3)':
     dependencies:
-      '@module-federation/runtime-tools': 2.8.1
-
-  '@module-federation/managers@https://pkg.pr.new/module-federation/core/@module-federation/managers@115230134ddcaad07e2299514f005186d931a39b':
-    dependencies:
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
-
-  '@module-federation/managers@https://pkg.pr.new/module-federation/core/@module-federation/managers@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    dependencies:
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-
-  '@module-federation/manifest@https://pkg.pr.new/module-federation/core/@module-federation/manifest@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)':
-    dependencies:
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/dts-plugin': 2.9.0(typescript@6.0.3)
+      '@module-federation/managers': 2.9.0
+      '@module-federation/sdk': 2.9.0
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@https://pkg.pr.new/module-federation/core/@module-federation/manifest@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)':
+  '@module-federation/node@2.7.50(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
-  '@module-federation/node@https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
-    dependencies:
-      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/runtime': https://pkg.pr.new/module-federation/core/@module-federation/runtime@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/runtime': 2.9.0
+      '@module-federation/sdk': 2.9.0
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
@@ -10414,30 +10201,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@https://pkg.pr.new/module-federation/core/@module-federation/node@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/runtime': https://pkg.pr.new/module-federation/core/@module-federation/runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      encoding: 0.1.13
-      node-fetch: 2.7.0(encoding@0.1.13)
-      tapable: 2.3.0
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/node': 2.7.50(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/sdk': 2.9.0
     optionalDependencies:
-      webpack: 5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
-  '@module-federation/rsbuild-plugin@https://pkg.pr.new/module-federation/core/@module-federation/rsbuild-plugin@1152301(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
-    dependencies:
-      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/node': https://pkg.pr.new/module-federation/core/@module-federation/node@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
-    optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -10446,45 +10216,29 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@https://pkg.pr.new/module-federation/core/@module-federation/rspack@115230134ddcaad07e2299514f005186d931a39b(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@module-federation/rspack@2.9.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
-      '@module-federation/inject-external-runtime-core-plugin': https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@115230134ddcaad07e2299514f005186d931a39b(@module-federation/runtime-tools@https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b)
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/manifest': https://pkg.pr.new/module-federation/core/@module-federation/manifest@115230134ddcaad07e2299514f005186d931a39b(typescript@6.0.3)
-      '@module-federation/runtime-tools': https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
-      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@module-federation/bridge-react-webpack-plugin': 2.9.0
+      '@module-federation/dts-plugin': 2.9.0(typescript@6.0.3)
+      '@module-federation/inject-external-runtime-core-plugin': 2.9.0(@module-federation/runtime-tools@2.9.0)
+      '@module-federation/managers': 2.9.0
+      '@module-federation/manifest': 2.9.0(typescript@6.0.3)
+      '@module-federation/runtime-tools': 2.9.0
+      '@module-federation/sdk': 2.9.0
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@https://pkg.pr.new/module-federation/core/@module-federation/rspack@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@module-federation/rstest@2.9.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': https://pkg.pr.new/module-federation/core/@module-federation/bridge-react-webpack-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/dts-plugin': https://pkg.pr.new/module-federation/core/@module-federation/dts-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)
-      '@module-federation/inject-external-runtime-core-plugin': https://pkg.pr.new/module-federation/core/@module-federation/inject-external-runtime-core-plugin@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@module-federation/runtime-tools@2.8.1)
-      '@module-federation/managers': https://pkg.pr.new/module-federation/core/@module-federation/managers@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/manifest': https://pkg.pr.new/module-federation/core/@module-federation/manifest@b1b37d66b1a846d4a00f46529929b6a288f1c29f(typescript@6.0.3)
-      '@module-federation/runtime-tools': https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/node': 2.7.50(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@module-federation/sdk': 2.9.0
     optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@module-federation/rstest@https://pkg.pr.new/module-federation/core/@module-federation/rstest@b1b37d6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
-    dependencies:
-      '@module-federation/enhanced': https://pkg.pr.new/module-federation/core/@module-federation/enhanced@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/node': https://pkg.pr.new/module-federation/core/@module-federation/node@b1b37d66b1a846d4a00f46529929b6a288f1c29f(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(typescript@6.0.3)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-    optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
       '@rstest/core': link:packages/core
     transitivePeerDependencies:
       - '@rspack/core'
@@ -10494,81 +10248,31 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/runtime-core@2.8.1':
+  '@module-federation/runtime-core@2.9.0':
     dependencies:
-      '@module-federation/error-codes': 2.8.1
-      '@module-federation/sdk': 2.8.1
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/sdk': 2.9.0
 
-  '@module-federation/runtime-core@https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@115230134ddcaad07e2299514f005186d931a39b':
+  '@module-federation/runtime-tools@2.9.0':
     dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
+      '@module-federation/runtime': 2.9.0
+      '@module-federation/webpack-bundler-runtime': 2.9.0
 
-  '@module-federation/runtime-core@https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
+  '@module-federation/runtime@2.9.0':
     dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/runtime-core': 2.9.0
+      '@module-federation/sdk': 2.9.0
 
-  '@module-federation/runtime-tools@2.8.1':
+  '@module-federation/sdk@2.9.0': {}
+
+  '@module-federation/third-party-dts-extractor@2.9.0': {}
+
+  '@module-federation/webpack-bundler-runtime@2.9.0':
     dependencies:
-      '@module-federation/runtime': 2.8.1
-      '@module-federation/webpack-bundler-runtime': 2.8.1
-
-  '@module-federation/runtime-tools@https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@115230134ddcaad07e2299514f005186d931a39b':
-    dependencies:
-      '@module-federation/runtime': https://pkg.pr.new/module-federation/core/@module-federation/runtime@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/webpack-bundler-runtime': https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@115230134ddcaad07e2299514f005186d931a39b
-
-  '@module-federation/runtime-tools@https://pkg.pr.new/module-federation/core/@module-federation/runtime-tools@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    dependencies:
-      '@module-federation/runtime': https://pkg.pr.new/module-federation/core/@module-federation/runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/webpack-bundler-runtime': https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-
-  '@module-federation/runtime@2.8.1':
-    dependencies:
-      '@module-federation/error-codes': 2.8.1
-      '@module-federation/runtime-core': 2.8.1
-      '@module-federation/sdk': 2.8.1
-
-  '@module-federation/runtime@https://pkg.pr.new/module-federation/core/@module-federation/runtime@115230134ddcaad07e2299514f005186d931a39b':
-    dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/runtime-core': https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
-
-  '@module-federation/runtime@https://pkg.pr.new/module-federation/core/@module-federation/runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/runtime-core': https://pkg.pr.new/module-federation/core/@module-federation/runtime-core@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-
-  '@module-federation/sdk@2.8.1': {}
-
-  '@module-federation/sdk@https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b': {}
-
-  '@module-federation/sdk@https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f': {}
-
-  '@module-federation/third-party-dts-extractor@https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@115230134ddcaad07e2299514f005186d931a39b': {}
-
-  '@module-federation/third-party-dts-extractor@https://pkg.pr.new/module-federation/core/@module-federation/third-party-dts-extractor@b1b37d66b1a846d4a00f46529929b6a288f1c29f': {}
-
-  '@module-federation/webpack-bundler-runtime@2.8.1':
-    dependencies:
-      '@module-federation/error-codes': 2.8.1
-      '@module-federation/runtime': 2.8.1
-      '@module-federation/sdk': 2.8.1
-
-  '@module-federation/webpack-bundler-runtime@https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@115230134ddcaad07e2299514f005186d931a39b':
-    dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/runtime': https://pkg.pr.new/module-federation/core/@module-federation/runtime@115230134ddcaad07e2299514f005186d931a39b
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@115230134ddcaad07e2299514f005186d931a39b
-
-  '@module-federation/webpack-bundler-runtime@https://pkg.pr.new/module-federation/core/@module-federation/webpack-bundler-runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f':
-    dependencies:
-      '@module-federation/error-codes': https://pkg.pr.new/module-federation/core/@module-federation/error-codes@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/runtime': https://pkg.pr.new/module-federation/core/@module-federation/runtime@b1b37d66b1a846d4a00f46529929b6a288f1c29f
-      '@module-federation/sdk': https://pkg.pr.new/module-federation/core/@module-federation/sdk@b1b37d66b1a846d4a00f46529929b6a288f1c29f
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/runtime': 2.9.0
+      '@module-federation/sdk': 2.9.0
 
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     optional: true
@@ -11312,21 +11016,21 @@ snapshots:
       '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
       '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
-  '@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1)':
+  '@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0)':
     dependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)':
+  '@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)':
     dependencies:
-      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(supports-color@8.1.1)':
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
@@ -11335,27 +11039,27 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      babel-loader: 10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       acorn: 8.17.0
       browserslist-to-es-version: 1.2.0
@@ -11363,21 +11067,21 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      less-loader: 12.3.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -11403,45 +11107,45 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -11449,9 +11153,9 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -11459,15 +11163,15 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.56.10)(typescript@6.0.3)':
+  '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.56.10)(typescript@6.0.3)':
     dependencies:
       svelte: 5.56.10
       svelte-loader: 3.2.4(svelte@5.56.10)
       svelte-preprocess: 6.0.5(@babel/core@7.29.7(supports-color@8.1.1))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.56.10)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -11480,37 +11184,37 @@ snapshots:
       - sugarss
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(supports-color@8.1.1)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-vue-jsx@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(supports-color@8.1.1)':
+  '@rsbuild/plugin-vue-jsx@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(supports-color@8.1.1)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       babel-plugin-vue-jsx-hmr: 1.0.0(supports-color@8.1.1)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3))
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -11518,13 +11222,13 @@ snapshots:
 
   '@rsdoctor/client@1.6.3': {}
 
-  '@rsdoctor/core@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/core@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))
-      '@rsdoctor/graph': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/sdk': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))
+      '@rsdoctor/graph': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/sdk': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@rspack/resolver': 0.2.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.49.0
@@ -11542,10 +11246,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/graph@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       es-toolkit: 1.49.0
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -11553,15 +11257,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/rspack-plugin@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
-      '@rsdoctor/core': 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/graph': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/sdk': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/core': 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/graph': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/sdk': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -11571,12 +11275,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/sdk@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@rsdoctor/client': 1.6.3
-      '@rsdoctor/graph': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
-      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/graph': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/utils': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1(supports-color@8.1.1)
@@ -11588,20 +11292,20 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/types@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       webpack: 5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
 
-  '@rsdoctor/utils@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
+  '@rsdoctor/utils@1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
+      '@rsdoctor/types': 1.6.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19))
       '@types/estree': 1.0.5
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -11619,10 +11323,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.8.1)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
-      rsbuild-plugin-dts: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(typescript@6.0.3)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
+      rsbuild-plugin-dts: 1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@22.18.6)
       typescript: 6.0.3
@@ -11794,48 +11498,48 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.2.0-rc.0
       '@rspack/binding-win32-x64-msvc': 2.2.0-rc.0
 
-  '@rspack/cli@2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)))':
+  '@rspack/cli@2.2.0-rc.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)))':
     dependencies:
-      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
     optionalDependencies:
-      '@rspack/dev-server': 2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+      '@rspack/dev-server': 2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
 
-  '@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.10
     optionalDependencies:
-      '@module-federation/runtime-tools': 2.8.1
+      '@module-federation/runtime-tools': 2.9.0
       '@swc/helpers': 0.5.23
 
-  '@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
+  '@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.2.0-rc.0
     optionalDependencies:
-      '@module-federation/runtime-tools': 2.8.1
+      '@module-federation/runtime-tools': 2.9.0
       '@swc/helpers': 0.5.23
 
-  '@rspack/dev-middleware@2.0.3(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))':
+  '@rspack/dev-middleware@2.0.3(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
     optionalDependencies:
-      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
-  '@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))':
+  '@rspack/dev-server@2.2.0(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
-      '@rspack/dev-middleware': 2.0.3(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/dev-middleware': 2.0.3(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -11888,13 +11592,13 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))
-      '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.1)(supports-color@8.1.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))
+      '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.9.0)(supports-color@8.1.1)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
       '@types/react': 19.2.18
@@ -11936,11 +11640,11 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-algolia@2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@rspress/plugin-algolia@2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -11949,13 +11653,13 @@ snapshots:
       - algoliasearch
       - search-insights
 
-  '@rspress/plugin-client-redirects@2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))':
+  '@rspress/plugin-client-redirects@2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
 
-  '@rspress/shared@2.0.19(@module-federation/runtime-tools@2.8.1)(supports-color@8.1.1)':
+  '@rspress/shared@2.0.19(@module-federation/runtime-tools@2.9.0)(supports-color@8.1.1)':
     dependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
@@ -11965,9 +11669,9 @@ snapshots:
       - core-js
       - supports-color
 
-  '@rstack-dev/doc-ui@1.14.8(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))':
+  '@rstack-dev/doc-ui@1.14.8(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))':
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
 
   '@rushstack/node-core-library@5.24.0(@types/node@22.18.6)':
     dependencies:
@@ -13145,12 +12849,12 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
-  babel-loader@10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
+  babel-loader@10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       webpack: 5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
 
   babel-plugin-vue-jsx-hmr@1.0.0(supports-color@8.1.1):
@@ -13424,7 +13128,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -14886,7 +14590,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -15023,11 +14727,11 @@ snapshots:
       lefthook-windows-arm64: 2.1.10
       lefthook-windows-x64: 2.1.10
 
-  less-loader@12.3.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
+  less-loader@12.3.3(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       webpack: 5.109.2(csso@5.0.5)(lightningcss@1.32.0)(postcss@8.5.19)
 
   less@4.6.7:
@@ -16652,48 +16356,48 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(typescript@6.0.3):
+  rsbuild-plugin-arethetypeswrong@0.3.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-dts@1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1))(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.3(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@22.18.6)
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1)):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1)):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.8.1)):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.9.0)):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.9.0)
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3)):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.41)(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.41
       vue: 3.5.41(typescript@6.0.3)
 
-  rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)):
+  rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
 
   rspress-plugin-sitemap@1.2.1: {}
 
@@ -17490,7 +17194,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unhead@2.1.16:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,10 +17,6 @@ allowBuilds:
 
 autoInstallPeers: false
 
-# The federation examples consume `@module-federation/rstest` canaries from
-# pkg.pr.new (not yet published to npm), which pnpm treats as exotic.
-blockExoticSubdeps: false
-
 # for vsce
 hoistPattern: ['@secretlint/*']
 


### PR DESCRIPTION
## Summary

Upgrade the federation examples and e2e workspace from pkg.pr.new canaries to the published Module Federation 2.9.0 packages. This also removes the canary-only pnpm exotic dependency setting. Federation e2e coverage passes with the published packages.

## Related Links

- https://www.npmjs.com/package/@module-federation/rsbuild-plugin
- https://www.npmjs.com/package/@module-federation/rstest

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).