### PR TITLE
fix(playwright): avoid zero-timeout assertion retries

### DIFF
--- a/e2e/playwright/fixtures/expect-timeout.test.ts
+++ b/e2e/playwright/fixtures/expect-timeout.test.ts
@@ -1,0 +1,19 @@
+import { expect, test as base } from '@rstest/playwright';
+import type { PlaywrightOptions } from '@rstest/playwright';
+
+const test = base.extend({
+  playwright: {
+    browserName: 'chromium',
+    launchOptions: process.env.CI ? { channel: 'chrome' } : undefined,
+  } satisfies PlaywrightOptions,
+});
+
+test('preserves the locator assertion error after timeout', async ({
+  page,
+}) => {
+  await page.setContent('<h1>Visible heading</h1>');
+
+  await expect(
+    page.locator('h1').filter({ hasText: 'Missing heading' }),
+  ).toBeVisible({ timeout: 100 });
+});

--- a/e2e/playwright/fixtures/expect-timeout.test.ts
+++ b/e2e/playwright/fixtures/expect-timeout.test.ts
@@ -15,5 +15,5 @@ test('preserves the locator assertion error after timeout', async ({
 
   await expect(
     page.locator('h1').filter({ hasText: 'Missing heading' }),
-  ).toBeVisible({ timeout: 100 });
+  ).toBeVisible({ timeout: 1000 });
 });

--- a/e2e/playwright/index.test.ts
+++ b/e2e/playwright/index.test.ts
@@ -55,6 +55,24 @@ describe('@rstest/playwright', () => {
     expect(cli.stdout).toContain('RSTEST_PLAYWRIGHT_FOR_FIXTURES_OK');
   });
 
+  it('preserves Playwright assertion errors at the timeout deadline', async () => {
+    const { cli, expectExecFailed } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'expect-timeout.test.ts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecFailed();
+    expect(cli.stdout).toContain('Expected locator to be visible.');
+    expect(cli.stdout).not.toContain(
+      'Playwright assertion timed out after 0ms.',
+    );
+  });
+
   it('reuses and cleans up a browser across worker files', async () => {
     const cleanupMarker = join(
       __dirname,

--- a/packages/playwright/src/expect.ts
+++ b/packages/playwright/src/expect.ts
@@ -332,20 +332,27 @@ const waitForExpectation = async (
   let lastError: unknown;
   let firstAttempt = true;
 
-  while (firstAttempt || getRealNow() < deadline) {
+  while (true) {
+    const remaining = deadline - getRealNow();
+    if (!firstAttempt && remaining <= 0) {
+      break;
+    }
+
     firstAttempt = false;
     try {
-      await runWithTimeout(check, Math.max(deadline - getRealNow(), 0));
+      await runWithTimeout(check, Math.max(remaining, 0));
       return;
     } catch (error) {
       lastError = error;
 
-      const remaining = deadline - getRealNow();
-      if (remaining <= 0) {
+      const remainingAfterCheck = deadline - getRealNow();
+      if (remainingAfterCheck <= 0) {
         break;
       }
 
-      await waitForRealTime(Math.min(EXPECT_POLL_INTERVAL, remaining));
+      await waitForRealTime(
+        Math.min(EXPECT_POLL_INTERVAL, remainingAfterCheck),
+      );
     }
   }
 

--- a/packages/playwright/src/expect.ts
+++ b/packages/playwright/src/expect.ts
@@ -330,8 +330,10 @@ const waitForExpectation = async (
   const timeout = options?.timeout ?? DEFAULT_EXPECT_TIMEOUT;
   const deadline = getRealNow() + timeout;
   let lastError: unknown;
+  let firstAttempt = true;
 
-  while (getRealNow() <= deadline) {
+  while (firstAttempt || getRealNow() < deadline) {
+    firstAttempt = false;
     try {
       await runWithTimeout(check, Math.max(deadline - getRealNow(), 0));
       return;

--- a/packages/playwright/src/expect.ts
+++ b/packages/playwright/src/expect.ts
@@ -340,13 +340,16 @@ const waitForExpectation = async (
 
     firstAttempt = false;
     try {
-      await runWithTimeout(check, Math.max(remaining, 0));
+      await runWithTimeout(
+        check,
+        Number.isFinite(remaining) ? Math.max(remaining, 0) : 0,
+      );
       return;
     } catch (error) {
       lastError = error;
 
       const remainingAfterCheck = deadline - getRealNow();
-      if (remainingAfterCheck <= 0) {
+      if (!Number.isFinite(remainingAfterCheck) || remainingAfterCheck <= 0) {
         break;
       }
 

--- a/packages/playwright/tests/expect.test.ts
+++ b/packages/playwright/tests/expect.test.ts
@@ -127,13 +127,37 @@ describe('@rstest/playwright expect', () => {
   });
 
   it('retries visibility assertions until the locator becomes visible', async () => {
+    const realTimers = rstest.getRealTimers();
+    let currentTime = 0;
+    let pollTimerResolved = false;
+    const getRealSystemTime = rstest
+      .spyOn(rstest, 'getRealSystemTime')
+      .mockImplementation(() => currentTime);
+    const getRealTimers = rstest
+      .spyOn(rstest, 'getRealTimers')
+      .mockReturnValue({
+        ...realTimers,
+        setTimeout: ((callback: () => void, timeout: number) => {
+          if (timeout === 50 && !pollTimerResolved) {
+            pollTimerResolved = true;
+            currentTime = 50;
+            callback();
+          }
+          return realTimers.setTimeout(() => {}, 0);
+        }) as typeof realTimers.setTimeout,
+      });
     let attempts = 0;
     const locator = {
       ...createLocator({ texts: ['Hello'] }),
       isVisible: async () => ++attempts >= 2,
     } as unknown as Locator;
 
-    await expect(locator).toBeVisible({ timeout: 100 });
+    try {
+      await expect(locator).toBeVisible({ timeout: 100 });
+    } finally {
+      getRealSystemTime.mockRestore();
+      getRealTimers.mockRestore();
+    }
   });
 
   it('supports viewport assertions', async () => {
@@ -299,6 +323,7 @@ describe('@rstest/playwright expect', () => {
   test('does not start a zero-length retry at the assertion deadline', async () => {
     const realTimers = rstest.getRealTimers();
     let currentTime = 0;
+    let pollTimerResolved = false;
     const getRealSystemTime = rstest
       .spyOn(rstest, 'getRealSystemTime')
       .mockImplementation(() => currentTime);
@@ -307,8 +332,11 @@ describe('@rstest/playwright expect', () => {
       .mockReturnValue({
         ...realTimers,
         setTimeout: ((callback: () => void, timeout: number) => {
-          if (timeout <= 50) {
+          if (timeout === 50 && !pollTimerResolved) {
+            pollTimerResolved = true;
             currentTime = 100;
+            callback();
+          } else if (timeout === 0) {
             callback();
           }
           return realTimers.setTimeout(() => {}, 0);
@@ -334,6 +362,17 @@ describe('@rstest/playwright expect', () => {
       getRealSystemTime.mockRestore();
       getRealTimers.mockRestore();
     }
+  });
+
+  test('treats a non-finite assertion timeout as expired', async () => {
+    const locator = {
+      ...createLocator({ texts: ['Hello'] }),
+      isVisible: async () => false,
+    } as unknown as Locator;
+
+    await rstestExpect(
+      expect(locator).toBeVisible({ timeout: Number.NaN }),
+    ).rejects.toThrow('Expected locator to be visible.');
   });
 
   test('clears timeout timers after successful Playwright assertions', async () => {

--- a/packages/playwright/tests/expect.test.ts
+++ b/packages/playwright/tests/expect.test.ts
@@ -127,10 +127,10 @@ describe('@rstest/playwright expect', () => {
   });
 
   it('retries visibility assertions until the locator becomes visible', async () => {
-    const visibleAt = Date.now() + 20;
+    let attempts = 0;
     const locator = {
       ...createLocator({ texts: ['Hello'] }),
-      isVisible: async () => Date.now() >= visibleAt,
+      isVisible: async () => ++attempts >= 2,
     } as unknown as Locator;
 
     await expect(locator).toBeVisible({ timeout: 100 });

--- a/packages/playwright/tests/expect.test.ts
+++ b/packages/playwright/tests/expect.test.ts
@@ -126,6 +126,16 @@ describe('@rstest/playwright expect', () => {
     await expect(locator).not.toBeEmpty();
   });
 
+  it('retries visibility assertions until the locator becomes visible', async () => {
+    const visibleAt = Date.now() + 20;
+    const locator = {
+      ...createLocator({ texts: ['Hello'] }),
+      isVisible: async () => Date.now() >= visibleAt,
+    } as unknown as Locator;
+
+    await expect(locator).toBeVisible({ timeout: 100 });
+  });
+
   it('supports viewport assertions', async () => {
     const locator = createLocator({ texts: ['Hello'] });
 
@@ -283,6 +293,46 @@ describe('@rstest/playwright expect', () => {
       expect(realPerformanceNow() - realStart).toBeLessThan(1000);
     } finally {
       rstest.useRealTimers();
+    }
+  });
+
+  test('does not start a zero-length retry at the assertion deadline', async () => {
+    const realTimers = rstest.getRealTimers();
+    let currentTime = 0;
+    const getRealSystemTime = rstest
+      .spyOn(rstest, 'getRealSystemTime')
+      .mockImplementation(() => currentTime);
+    const getRealTimers = rstest
+      .spyOn(rstest, 'getRealTimers')
+      .mockReturnValue({
+        ...realTimers,
+        setTimeout: ((callback: () => void, timeout: number) => {
+          if (timeout <= 50) {
+            currentTime = 100;
+            callback();
+          }
+          return realTimers.setTimeout(() => {}, 0);
+        }) as typeof realTimers.setTimeout,
+      });
+    let attempts = 0;
+    const locator = {
+      ...createLocator({ texts: ['Hello'] }),
+      isVisible: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return false;
+        }
+        return new Promise<boolean>(() => {});
+      },
+    } as unknown as Locator;
+
+    try {
+      await rstestExpect(
+        expect(locator).toBeVisible({ timeout: 100 }),
+      ).rejects.toThrow('Expected locator to be visible.');
+    } finally {
+      getRealSystemTime.mockRestore();
+      getRealTimers.mockRestore();
     }
   });
 


### PR DESCRIPTION
This PR fixes Playwright-style locator assertions reporting a misleading `0ms` timeout at the polling deadline. The matcher still performs the initial assertion, but no longer starts a new retry once the deadline has been reached. Regression coverage verifies delayed visibility and the deadline boundary behavior.