### PR TITLE
fix(core): expose Rstest API during browser global setup

### DIFF
--- a/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
@@ -1,4 +1,5 @@
-import { defineConfig } from '@rstest/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
+import { defineConfig, type RstestExposeAPI } from '@rstest/core';
 import { BROWSER_PORTS, BROWSER_TEST_TIMEOUT } from '../ports';
 
 // The watch regression test drives stdin through a pipe.
@@ -22,11 +23,14 @@ export default defineConfig({
     {
       name: 'test-global-teardown-order',
       setup(api) {
+        if (!api.useExposed<RstestExposeAPI>('rstest')) {
+          throw new Error('Rstest API is unavailable during plugin setup');
+        }
         api.onCloseDevServer(() => {
           console.log('[browser-dev-server] closed');
         });
       },
-    },
+    } satisfies RsbuildPlugin,
   ],
   env: {
     RSTEST_E2E_GS_OVERRIDE: 'from-config',

--- a/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/rstest.config.mts
@@ -23,9 +23,19 @@ export default defineConfig({
     {
       name: 'test-global-teardown-order',
       setup(api) {
-        if (!api.useExposed<RstestExposeAPI>('rstest')) {
+        const rstestApi = api.useExposed<RstestExposeAPI>('rstest');
+        if (!rstestApi) {
           throw new Error('Rstest API is unavailable during plugin setup');
         }
+        const rstestConfig = rstestApi.getRstestConfig();
+        rstestApi.modifyRstestConfig((config) => {
+          config.env = {
+            ...config.env,
+            RSTEST_E2E_PLUGIN_BROWSER_ENABLED: String(
+              rstestConfig.browser?.enabled,
+            ),
+          };
+        });
         api.onCloseDevServer(() => {
           console.log('[browser-dev-server] closed');
         });

--- a/e2e/browser-mode/fixtures/browser-global-setup/tests/globalSetup.test.ts
+++ b/e2e/browser-mode/fixtures/browser-global-setup/tests/globalSetup.test.ts
@@ -17,4 +17,9 @@ describe(`browser globalSetup env propagation (${import.meta.env.RSTEST_E2E_GS})
     expect(import.meta.env.NODE_ENV).toBe('test');
     expect(process.env.RSTEST).toBe('true');
   });
+
+  it('reads and modifies Rstest config from browser plugin setup', () => {
+    expect(import.meta.env.RSTEST_E2E_PLUGIN_BROWSER_ENABLED).toBe('true');
+    expect(process.env.RSTEST_E2E_PLUGIN_BROWSER_ENABLED).toBe('true');
+  });
 });

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -486,7 +486,7 @@ Module._resolveFilename = function (request, ...args) {
       const initialTestIndex = cli.stdout.indexOf('Test Files 1 passed');
       expect(initialSetupIndex).toBeGreaterThanOrEqual(0);
       expect(initialTestIndex).toBeGreaterThan(initialSetupIndex);
-      expect(cli.stdout).toMatch(/Tests.*3 passed/);
+      expect(cli.stdout).toMatch(/Tests.*4 passed/);
 
       // A rerun stays inside the session, so it must not run setup again.
       await sleep(1000);

--- a/packages/core/src/core/browser/globalSetupStage.ts
+++ b/packages/core/src/core/browser/globalSetupStage.ts
@@ -8,7 +8,10 @@ import type {
 } from '../../types';
 import { isDebug, resolveShardedEntries } from '../../utils';
 import { claimGlobalSetupOnce, runGlobalSetup } from '../globalSetup';
-import { getRsbuildEnvironmentConfig } from '../modifyRstestConfig';
+import {
+  getRsbuildEnvironmentConfig,
+  initModifyRstestConfigHooks,
+} from '../modifyRstestConfig';
 import { getProjectEntries } from '../projectPlan';
 import { pluginBasic } from '../plugins/basic';
 import { pluginEntryWatch } from '../plugins/entry';
@@ -116,10 +119,11 @@ export async function runBrowserGlobalSetupStage(
     return { errors: [] };
   }
 
+  const candidateProjects = candidates.map(({ project }) => project);
   const setupFileState = createSetupFileState();
   setupFileState.refresh({
     setupProjects: [],
-    globalSetupProjects: candidates.map(({ project }) => project),
+    globalSetupProjects: candidateProjects,
   });
 
   const { dev = {} } = context.normalizedConfig;
@@ -141,7 +145,7 @@ export async function runBrowserGlobalSetupStage(
         writeToDisk: dev.writeToDisk || debugMode,
       },
       environments: Object.fromEntries(
-        candidates.map(({ project }) => [
+        candidateProjects.map((project) => [
           project.environmentName,
           getRsbuildEnvironmentConfig(project),
         ]),
@@ -161,6 +165,20 @@ export async function runBrowserGlobalSetupStage(
       ],
     },
   });
+
+  initModifyRstestConfigHooks(
+    context,
+    rsbuildInstance,
+    candidateProjects,
+    candidateProjects,
+    {
+      // Discovery already applied these callbacks. This compile only needs to
+      // expose the settled project config before user plugin setup runs.
+      appliedEnvironmentNames: new Set(
+        candidateProjects.map((project) => project.environmentName),
+      ),
+    },
+  );
 
   const { getRsbuildStats, closeServer } = await createRsbuildServer({
     isWatchMode: false,


### PR DESCRIPTION
## Summary

Browser `globalSetup` uses a dedicated Rsbuild instance that reuses project plugins, but that instance did not expose the Rstest integration API. As a result, `api.useExposed('rstest')` returned `undefined` during plugin setup. This PR registers the settled project API before user plugins initialize, without reapplying `modifyRstestConfig` callbacks. Browser Mode regression coverage now verifies `useExposed`, `getRstestConfig`, and a `modifyRstestConfig` change observed by the browser runtime.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).