### PR TITLE
fix(core): bridge AbortSignal for jsdom event listeners

### DIFF
--- a/e2e/dom/fixtures/test/abortSignal.test.ts
+++ b/e2e/dom/fixtures/test/abortSignal.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@rstest/core';
+
+test('accepts Node AbortSignal in DOM event listeners', () => {
+  const controller = new AbortController();
+  let calls = 0;
+  const type = 'rstest-abort-signal';
+
+  document.addEventListener(type, () => calls++, {
+    signal: controller.signal,
+  });
+  document.dispatchEvent(new Event(type));
+  expect(calls).toBe(1);
+
+  controller.abort();
+  document.dispatchEvent(new Event(type));
+  expect(calls).toBe(1);
+});

--- a/e2e/dom/fixtures/test/abortSignal.test.ts
+++ b/e2e/dom/fixtures/test/abortSignal.test.ts
@@ -67,3 +67,49 @@ test('reads a Node signal option once', () => {
 
   expect(reads).toBe(1);
 });
+
+test('reads listener options in Web IDL order', () => {
+  const controller = new AbortController();
+  const reads: string[] = [];
+  const options = {
+    get capture() {
+      reads.push('capture');
+      return false;
+    },
+    get once() {
+      reads.push('once');
+      return true;
+    },
+    get passive() {
+      reads.push('passive');
+      return false;
+    },
+    get signal() {
+      reads.push('signal');
+      return controller.signal;
+    },
+  };
+
+  document.addEventListener('rstest-listener-option-order', () => {}, options);
+
+  expect(reads).toEqual(['capture', 'once', 'passive', 'signal']);
+});
+
+test('accepts callable listener options dictionaries', () => {
+  const controller = new AbortController();
+  const options = Object.assign(() => {}, { signal: controller.signal });
+  let calls = 0;
+  const type = 'rstest-callable-listener-options';
+
+  document.addEventListener(
+    type,
+    () => calls++,
+    options as unknown as AddEventListenerOptions,
+  );
+  document.dispatchEvent(new Event(type));
+  expect(calls).toBe(1);
+
+  controller.abort();
+  document.dispatchEvent(new Event(type));
+  expect(calls).toBe(1);
+});

--- a/e2e/dom/fixtures/test/abortSignal.test.ts
+++ b/e2e/dom/fixtures/test/abortSignal.test.ts
@@ -30,6 +30,26 @@ test('preserves an already-aborted Node signal', () => {
   expect(calls).toBe(0);
 });
 
+test('accepts Node AbortSignal in frames event listeners', () => {
+  const iframe = document.createElement('iframe');
+  document.body.append(iframe);
+  const frame = frames[0]!;
+  const frameDocument = frame.document;
+  const controller = new AbortController();
+  let calls = 0;
+  const type = 'rstest-frames-abort-signal';
+
+  frameDocument.addEventListener(type, () => calls++, {
+    signal: controller.signal,
+  });
+  const event = frameDocument.createEvent('Event');
+  event.initEvent(type);
+  frameDocument.dispatchEvent(event);
+
+  expect(calls).toBe(1);
+  iframe.remove();
+});
+
 test('accepts Node AbortSignal in iframe event listeners', () => {
   const iframe = document.createElement('iframe');
   document.body.append(iframe);
@@ -51,5 +71,21 @@ test('accepts Node AbortSignal in iframe event listeners', () => {
 
   controller.abort();
   dispatch();
+  expect(calls).toBe(1);
+  iframe.remove();
+});
+
+test('preserves inherited listener options', () => {
+  const controller = new AbortController();
+  const options = Object.assign(Object.create({ once: true }), {
+    signal: controller.signal,
+  });
+  let calls = 0;
+  const type = 'rstest-inherited-listener-options';
+
+  document.addEventListener(type, () => calls++, options);
+  document.dispatchEvent(new Event(type));
+  document.dispatchEvent(new Event(type));
+
   expect(calls).toBe(1);
 });

--- a/e2e/dom/fixtures/test/abortSignal.test.ts
+++ b/e2e/dom/fixtures/test/abortSignal.test.ts
@@ -11,6 +11,9 @@ test('accepts Node AbortSignal in DOM event listeners', () => {
   document.dispatchEvent(new Event(type));
   expect(calls).toBe(1);
 
+  controller.signal.addEventListener('abort', (event) =>
+    event.stopImmediatePropagation(),
+  );
   controller.abort();
   document.dispatchEvent(new Event(type));
   expect(calls).toBe(1);
@@ -30,21 +33,6 @@ test('preserves an already-aborted Node signal', () => {
   expect(calls).toBe(0);
 });
 
-test('preserves inherited listener options', () => {
-  const controller = new AbortController();
-  const options = Object.assign(Object.create({ once: true }), {
-    signal: controller.signal,
-  });
-  let calls = 0;
-  const type = 'rstest-inherited-listener-options';
-
-  document.addEventListener(type, () => calls++, options);
-  document.dispatchEvent(new Event(type));
-  document.dispatchEvent(new Event(type));
-
-  expect(calls).toBe(1);
-});
-
 test('rejects values that are not AbortSignal instances', () => {
   expect(() => {
     document.addEventListener('rstest-invalid-abort-signal', () => {}, {
@@ -53,63 +41,48 @@ test('rejects values that are not AbortSignal instances', () => {
   }).toThrow("member 'signal' that is not of type 'AbortSignal'");
 });
 
-test('reads a Node signal option once', () => {
-  const controller = new AbortController();
-  let reads = 0;
-  const options = {
-    get signal() {
-      reads++;
-      return controller.signal;
-    },
-  };
-
-  document.addEventListener('rstest-signal-accessor', () => {}, options);
-
-  expect(reads).toBe(1);
-});
-
-test('reads listener options in Web IDL order', () => {
+test('preserves Web IDL conversion order for callable options', () => {
   const controller = new AbortController();
   const reads: string[] = [];
-  const options = {
-    get capture() {
-      reads.push('capture');
-      return false;
-    },
+  const options = () => {};
+  Object.setPrototypeOf(options, {
     get once() {
       reads.push('once');
       return true;
     },
-    get passive() {
-      reads.push('passive');
-      return false;
+  });
+  Object.defineProperties(options, {
+    capture: {
+      get() {
+        reads.push('capture');
+        return false;
+      },
     },
-    get signal() {
-      reads.push('signal');
-      return controller.signal;
+    passive: {
+      get() {
+        reads.push('passive');
+        return false;
+      },
+    },
+    signal: {
+      get() {
+        reads.push('signal');
+        return controller.signal;
+      },
+    },
+  });
+  const type = {
+    toString() {
+      reads.push('type');
+      return 'rstest-listener-option-order';
     },
   };
 
-  document.addEventListener('rstest-listener-option-order', () => {}, options);
-
-  expect(reads).toEqual(['capture', 'once', 'passive', 'signal']);
-});
-
-test('accepts callable listener options dictionaries', () => {
-  const controller = new AbortController();
-  const options = Object.assign(() => {}, { signal: controller.signal });
-  let calls = 0;
-  const type = 'rstest-callable-listener-options';
-
   document.addEventListener(
-    type,
-    () => calls++,
+    type as unknown as string,
+    () => {},
     options as unknown as AddEventListenerOptions,
   );
-  document.dispatchEvent(new Event(type));
-  expect(calls).toBe(1);
 
-  controller.abort();
-  document.dispatchEvent(new Event(type));
-  expect(calls).toBe(1);
+  expect(reads).toEqual(['type', 'capture', 'once', 'passive', 'signal']);
 });

--- a/e2e/dom/fixtures/test/abortSignal.test.ts
+++ b/e2e/dom/fixtures/test/abortSignal.test.ts
@@ -30,51 +30,6 @@ test('preserves an already-aborted Node signal', () => {
   expect(calls).toBe(0);
 });
 
-test('accepts Node AbortSignal in frames event listeners', () => {
-  const iframe = document.createElement('iframe');
-  document.body.append(iframe);
-  const frame = frames[0]!;
-  const frameDocument = frame.document;
-  const controller = new AbortController();
-  let calls = 0;
-  const type = 'rstest-frames-abort-signal';
-
-  frameDocument.addEventListener(type, () => calls++, {
-    signal: controller.signal,
-  });
-  const event = frameDocument.createEvent('Event');
-  event.initEvent(type);
-  frameDocument.dispatchEvent(event);
-
-  expect(calls).toBe(1);
-  iframe.remove();
-});
-
-test('accepts Node AbortSignal in iframe event listeners', () => {
-  const iframe = document.createElement('iframe');
-  document.body.append(iframe);
-  const iframeDocument = iframe.contentDocument!;
-  const controller = new AbortController();
-  let calls = 0;
-  const type = 'rstest-iframe-abort-signal';
-  const dispatch = () => {
-    const event = iframeDocument.createEvent('Event');
-    event.initEvent(type);
-    iframeDocument.dispatchEvent(event);
-  };
-
-  iframeDocument.addEventListener(type, () => calls++, {
-    signal: controller.signal,
-  });
-  dispatch();
-  expect(calls).toBe(1);
-
-  controller.abort();
-  dispatch();
-  expect(calls).toBe(1);
-  iframe.remove();
-});
-
 test('preserves inherited listener options', () => {
   const controller = new AbortController();
   const options = Object.assign(Object.create({ once: true }), {
@@ -88,4 +43,27 @@ test('preserves inherited listener options', () => {
   document.dispatchEvent(new Event(type));
 
   expect(calls).toBe(1);
+});
+
+test('rejects values that are not AbortSignal instances', () => {
+  expect(() => {
+    document.addEventListener('rstest-invalid-abort-signal', () => {}, {
+      signal: { aborted: true } as AbortSignal,
+    });
+  }).toThrow("member 'signal' that is not of type 'AbortSignal'");
+});
+
+test('reads a Node signal option once', () => {
+  const controller = new AbortController();
+  let reads = 0;
+  const options = {
+    get signal() {
+      reads++;
+      return controller.signal;
+    },
+  };
+
+  document.addEventListener('rstest-signal-accessor', () => {}, options);
+
+  expect(reads).toBe(1);
 });

--- a/e2e/dom/fixtures/test/abortSignal.test.ts
+++ b/e2e/dom/fixtures/test/abortSignal.test.ts
@@ -15,3 +15,41 @@ test('accepts Node AbortSignal in DOM event listeners', () => {
   document.dispatchEvent(new Event(type));
   expect(calls).toBe(1);
 });
+
+test('preserves an already-aborted Node signal', () => {
+  const controller = new AbortController();
+  controller.abort();
+  let calls = 0;
+  const type = 'rstest-aborted-signal';
+
+  document.addEventListener(type, () => calls++, {
+    signal: controller.signal,
+  });
+  document.dispatchEvent(new Event(type));
+
+  expect(calls).toBe(0);
+});
+
+test('accepts Node AbortSignal in iframe event listeners', () => {
+  const iframe = document.createElement('iframe');
+  document.body.append(iframe);
+  const iframeDocument = iframe.contentDocument!;
+  const controller = new AbortController();
+  let calls = 0;
+  const type = 'rstest-iframe-abort-signal';
+  const dispatch = () => {
+    const event = iframeDocument.createEvent('Event');
+    event.initEvent(type);
+    iframeDocument.dispatchEvent(event);
+  };
+
+  iframeDocument.addEventListener(type, () => calls++, {
+    signal: controller.signal,
+  });
+  dispatch();
+  expect(calls).toBe(1);
+
+  controller.abort();
+  dispatch();
+  expect(calls).toBe(1);
+});

--- a/e2e/dom/index.test.ts
+++ b/e2e/dom/index.test.ts
@@ -55,6 +55,11 @@ describe('jsdom', () => {
     await expectExecSuccess();
   });
 
+  it('should accept Node AbortSignal in DOM event listeners', async () => {
+    const { expectExecSuccess } = await runCli('test/abortSignal', 'jsdom');
+    await expectExecSuccess();
+  });
+
   it('should only prebundle when explicitly enabled', async ({
     onTestFinished,
   }) => {

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -44,6 +44,48 @@ export const forwardVirtualConsole = (
   }
 };
 
+function patchAddEventListener(window: DOMWindow): () => void {
+  const abortControllers = new WeakMap<AbortSignal, AbortController>();
+  const JSDOMAbortSignal = window.AbortSignal;
+  const JSDOMAbortController = window.AbortController;
+  const prototype = window.EventTarget.prototype;
+  const originalAddEventListener = prototype.addEventListener;
+
+  prototype.addEventListener = function addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    if (typeof options === 'object' && options?.signal != null) {
+      const { signal, ...otherOptions } = options;
+      if (
+        !Object.prototype.isPrototypeOf.call(JSDOMAbortSignal.prototype, signal)
+      ) {
+        let jsdomAbortController = abortControllers.get(signal);
+        if (!jsdomAbortController) {
+          const controller = new JSDOMAbortController();
+          signal.addEventListener('abort', () => {
+            controller.abort(signal.reason);
+          });
+          jsdomAbortController = controller;
+          abortControllers.set(signal, jsdomAbortController);
+        }
+
+        return originalAddEventListener.call(this, type, callback, {
+          ...otherOptions,
+          signal: jsdomAbortController.signal,
+        });
+      }
+    }
+
+    return originalAddEventListener.call(this, type, callback, options);
+  };
+
+  return () => {
+    prototype.addEventListener = originalAddEventListener;
+  };
+}
+
 type JSDOMModule = typeof import('jsdom');
 
 function installJSDOMObjectURL(
@@ -173,6 +215,7 @@ export const setupEnvironment = async (
     },
   });
 
+  const cleanupAddEventListener = patchAddEventListener(dom.window);
   const cleanupGlobal = installGlobal(global, dom.window, {
     additionalKeys: ['URL', 'URLSearchParams'],
   });
@@ -183,6 +226,7 @@ export const setupEnvironment = async (
   return {
     teardown() {
       cleanupHandler();
+      cleanupAddEventListener();
       cleanupObjectURLs();
       cleanupTimers();
       dom.window.close();

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -47,17 +47,43 @@ export const forwardVirtualConsole = (
 function patchAddEventListener(
   window: DOMWindow,
   NodeAbortSignal: typeof AbortSignal,
-  context: TestEnvironmentContext,
 ): () => void {
-  const abortControllers = new WeakMap<AbortSignal, AbortController>();
-  const signalForwarders =
-    context.scope === 'file'
-      ? new Map<AbortSignal, EventListener>()
-      : undefined;
-  const JSDOMAbortSignal = window.AbortSignal;
+  const abortBridges = new WeakMap<
+    AbortSignal,
+    { controller: AbortController; forwardingSignal: AbortSignal }
+  >();
   const JSDOMAbortController = window.AbortController;
   const eventTargetPrototype = window.EventTarget.prototype;
   const originalAddEventListener = eventTargetPrototype.addEventListener;
+
+  const getCompatibleSignal = (signal: unknown): unknown => {
+    if (
+      typeof signal !== 'object' ||
+      signal === null ||
+      !Object.prototype.isPrototypeOf.call(NodeAbortSignal.prototype, signal)
+    ) {
+      return signal;
+    }
+
+    const nodeSignal = signal as AbortSignal;
+    let bridge = abortBridges.get(nodeSignal);
+    if (!bridge) {
+      const controller = new JSDOMAbortController();
+      const forwardingSignal = NodeAbortSignal.any([nodeSignal]);
+      if (forwardingSignal.aborted) {
+        controller.abort(forwardingSignal.reason);
+      } else {
+        forwardingSignal.addEventListener(
+          'abort',
+          () => controller.abort(forwardingSignal.reason),
+          { once: true },
+        );
+      }
+      bridge = { controller, forwardingSignal };
+      abortBridges.set(nodeSignal, bridge);
+    }
+    return bridge.controller.signal;
+  };
 
   eventTargetPrototype.addEventListener = function addEventListener(
     type: string,
@@ -69,51 +95,23 @@ function patchAddEventListener(
       optionsValue !== null &&
       (typeof optionsValue === 'object' || typeof optionsValue === 'function')
     ) {
-      const listenerOptions = optionsValue as AddEventListenerOptions;
-      // Web IDL converts inherited dictionary members first, then this
-      // dictionary's members in lexicographic order.
-      const capture = Boolean(listenerOptions.capture);
-      const once = Boolean(listenerOptions.once);
-      const passive = Boolean(listenerOptions.passive);
-      const signal = listenerOptions.signal;
-      let compatibleSignal = signal;
-
-      if (
-        signal != null &&
-        !Object.prototype.isPrototypeOf.call(
-          JSDOMAbortSignal.prototype,
-          signal,
-        ) &&
-        Object.prototype.isPrototypeOf.call(NodeAbortSignal.prototype, signal)
-      ) {
-        let jsdomAbortController = abortControllers.get(signal);
-        if (!jsdomAbortController) {
-          const controller = new JSDOMAbortController();
-          if (signal.aborted) {
-            controller.abort(signal.reason);
-          } else {
-            const forwardAbort = () => {
-              if (!signal.aborted) {
-                return;
-              }
-              signal.removeEventListener('abort', forwardAbort);
-              signalForwarders?.delete(signal);
-              controller.abort(signal.reason);
-            };
-            signal.addEventListener('abort', forwardAbort);
-            signalForwarders?.set(signal, forwardAbort);
-          }
-          jsdomAbortController = controller;
-          abortControllers.set(signal, jsdomAbortController);
-        }
-        compatibleSignal = jsdomAbortController.signal;
-      }
+      const listenerOptions = optionsValue as object;
+      const read = (key: keyof AddEventListenerOptions) =>
+        Reflect.get(listenerOptions, key, listenerOptions);
 
       return originalAddEventListener.call(this, type, callback, {
-        capture,
-        once,
-        passive,
-        signal: compatibleSignal,
+        get capture() {
+          return read('capture');
+        },
+        get once() {
+          return read('once');
+        },
+        get passive() {
+          return read('passive');
+        },
+        get signal() {
+          return getCompatibleSignal(read('signal')) as AbortSignal | undefined;
+        },
       });
     }
 
@@ -121,10 +119,6 @@ function patchAddEventListener(
   };
 
   return () => {
-    for (const [signal, forwardAbort] of signalForwarders ?? []) {
-      signal.removeEventListener('abort', forwardAbort);
-    }
-    signalForwarders?.clear();
     eventTargetPrototype.addEventListener = originalAddEventListener;
   };
 }
@@ -260,7 +254,6 @@ export const setupEnvironment = async (
   const cleanupAddEventListener = patchAddEventListener(
     dom.window,
     global.AbortSignal,
-    context,
   );
 
   const cleanupGlobal = installGlobal(global, dom.window, {

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -44,129 +44,71 @@ export const forwardVirtualConsole = (
   }
 };
 
-function patchAddEventListener(rootWindow: DOMWindow): () => void {
-  const patchedWindows = new WeakSet<DOMWindow>();
-  const cleanups: Array<() => void> = [];
+function patchAddEventListener(
+  window: DOMWindow,
+  NodeAbortSignal: typeof AbortSignal,
+  context: TestEnvironmentContext,
+): () => void {
+  const abortControllers = new WeakMap<AbortSignal, AbortController>();
+  const signalForwarders =
+    context.scope === 'file'
+      ? new Map<AbortSignal, EventListener>()
+      : undefined;
+  const JSDOMAbortSignal = window.AbortSignal;
+  const JSDOMAbortController = window.AbortController;
+  const eventTargetPrototype = window.EventTarget.prototype;
+  const originalAddEventListener = eventTargetPrototype.addEventListener;
 
-  const patchWindow = (window: DOMWindow): void => {
-    if (patchedWindows.has(window)) {
-      return;
-    }
-    patchedWindows.add(window);
-
-    const abortControllers = new WeakMap<AbortSignal, AbortController>();
-    const signalForwarders = new Map<AbortSignal, EventListener>();
-    const JSDOMAbortSignal = window.AbortSignal;
-    const JSDOMAbortController = window.AbortController;
-    const eventTargetPrototype = window.EventTarget.prototype;
-    const originalAddEventListener = eventTargetPrototype.addEventListener;
-
-    eventTargetPrototype.addEventListener = function addEventListener(
-      type: string,
-      callback: EventListenerOrEventListenerObject | null,
-      options?: AddEventListenerOptions | boolean,
-    ): void {
-      if (typeof options === 'object' && options?.signal != null) {
-        const { signal } = options;
-        if (
-          !Object.prototype.isPrototypeOf.call(
-            JSDOMAbortSignal.prototype,
-            signal,
-          )
-        ) {
-          let jsdomAbortController = abortControllers.get(signal);
-          if (!jsdomAbortController) {
-            const controller = new JSDOMAbortController();
-            if (signal.aborted) {
+  eventTargetPrototype.addEventListener = function addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    if (typeof options === 'object' && options !== null) {
+      const signal = options.signal;
+      if (
+        signal != null &&
+        !Object.prototype.isPrototypeOf.call(
+          JSDOMAbortSignal.prototype,
+          signal,
+        ) &&
+        Object.prototype.isPrototypeOf.call(NodeAbortSignal.prototype, signal)
+      ) {
+        let jsdomAbortController = abortControllers.get(signal);
+        if (!jsdomAbortController) {
+          const controller = new JSDOMAbortController();
+          if (signal.aborted) {
+            controller.abort(signal.reason);
+          } else {
+            const forwardAbort = () => {
+              signalForwarders?.delete(signal);
               controller.abort(signal.reason);
-            } else {
-              const forwardAbort = () => {
-                signalForwarders.delete(signal);
-                controller.abort(signal.reason);
-              };
-              signal.addEventListener('abort', forwardAbort, { once: true });
-              signalForwarders.set(signal, forwardAbort);
-            }
-            jsdomAbortController = controller;
-            abortControllers.set(signal, jsdomAbortController);
+            };
+            signal.addEventListener('abort', forwardAbort, { once: true });
+            signalForwarders?.set(signal, forwardAbort);
           }
-
-          return originalAddEventListener.call(this, type, callback, {
-            capture: options.capture,
-            once: options.once,
-            passive: options.passive,
-            signal: jsdomAbortController.signal,
-          });
+          jsdomAbortController = controller;
+          abortControllers.set(signal, jsdomAbortController);
         }
+
+        return originalAddEventListener.call(this, type, callback, {
+          capture: options.capture,
+          once: options.once,
+          passive: options.passive,
+          signal: jsdomAbortController.signal,
+        });
       }
+    }
 
-      return originalAddEventListener.call(this, type, callback, options);
-    };
-
-    // Each iframe has its own jsdom EventTarget and AbortSignal realm. Patch a
-    // child realm before exposing its window or document to test code.
-    const iframePrototype = window.HTMLIFrameElement.prototype;
-    const contentWindowDescriptor = Object.getOwnPropertyDescriptor(
-      iframePrototype,
-      'contentWindow',
-    )!;
-    const contentDocumentDescriptor = Object.getOwnPropertyDescriptor(
-      iframePrototype,
-      'contentDocument',
-    )!;
-
-    Object.defineProperty(iframePrototype, 'contentWindow', {
-      ...contentWindowDescriptor,
-      get(this: HTMLIFrameElement) {
-        const childWindow: DOMWindow | null =
-          contentWindowDescriptor.get!.call(this);
-        if (childWindow) {
-          patchWindow(childWindow);
-        }
-        return childWindow;
-      },
-    });
-    Object.defineProperty(iframePrototype, 'contentDocument', {
-      ...contentDocumentDescriptor,
-      get(this: HTMLIFrameElement) {
-        const childDocument: Document | null =
-          contentDocumentDescriptor.get!.call(this);
-        if (childDocument) {
-          const childWindow: DOMWindow | null =
-            contentWindowDescriptor.get!.call(this);
-          if (childWindow) {
-            patchWindow(childWindow);
-          }
-        }
-        return childDocument;
-      },
-    });
-
-    cleanups.push(() => {
-      for (const [signal, forwardAbort] of signalForwarders) {
-        signal.removeEventListener('abort', forwardAbort);
-      }
-      signalForwarders.clear();
-      eventTargetPrototype.addEventListener = originalAddEventListener;
-      Object.defineProperty(
-        iframePrototype,
-        'contentWindow',
-        contentWindowDescriptor,
-      );
-      Object.defineProperty(
-        iframePrototype,
-        'contentDocument',
-        contentDocumentDescriptor,
-      );
-    });
+    return originalAddEventListener.call(this, type, callback, options);
   };
 
-  patchWindow(rootWindow);
-
   return () => {
-    for (const cleanup of cleanups.reverse()) {
-      cleanup();
+    for (const [signal, forwardAbort] of signalForwarders ?? []) {
+      signal.removeEventListener('abort', forwardAbort);
     }
+    signalForwarders?.clear();
+    eventTargetPrototype.addEventListener = originalAddEventListener;
   };
 }
 
@@ -275,7 +217,6 @@ export const setupEnvironment = async (
     beforeParse,
     ...restOptions
   } = options as JSDOMOptions;
-  let cleanupAddEventListener = () => {};
   let cleanupObjectURLs = () => {};
   const virtualConsole =
     console && global.console ? new VirtualConsole() : undefined;
@@ -295,11 +236,15 @@ export const setupEnvironment = async (
     userAgent,
     ...restOptions,
     beforeParse(window) {
-      cleanupAddEventListener = patchAddEventListener(window);
       beforeParse?.(window);
       cleanupObjectURLs = installJSDOMObjectURL(window, context);
     },
   });
+  const cleanupAddEventListener = patchAddEventListener(
+    dom.window,
+    global.AbortSignal,
+    context,
+  );
 
   const cleanupGlobal = installGlobal(global, dom.window, {
     additionalKeys: ['URL', 'URLSearchParams'],

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -44,45 +44,127 @@ export const forwardVirtualConsole = (
   }
 };
 
-function patchAddEventListener(window: DOMWindow): () => void {
-  const abortControllers = new WeakMap<AbortSignal, AbortController>();
-  const JSDOMAbortSignal = window.AbortSignal;
-  const JSDOMAbortController = window.AbortController;
-  const prototype = window.EventTarget.prototype;
-  const originalAddEventListener = prototype.addEventListener;
+function patchAddEventListener(rootWindow: DOMWindow): () => void {
+  const patchedWindows = new WeakSet<DOMWindow>();
+  const cleanups: Array<() => void> = [];
 
-  prototype.addEventListener = function addEventListener(
-    type: string,
-    callback: EventListenerOrEventListenerObject | null,
-    options?: AddEventListenerOptions | boolean,
-  ): void {
-    if (typeof options === 'object' && options?.signal != null) {
-      const { signal, ...otherOptions } = options;
-      if (
-        !Object.prototype.isPrototypeOf.call(JSDOMAbortSignal.prototype, signal)
-      ) {
-        let jsdomAbortController = abortControllers.get(signal);
-        if (!jsdomAbortController) {
-          const controller = new JSDOMAbortController();
-          signal.addEventListener('abort', () => {
-            controller.abort(signal.reason);
-          });
-          jsdomAbortController = controller;
-          abortControllers.set(signal, jsdomAbortController);
-        }
-
-        return originalAddEventListener.call(this, type, callback, {
-          ...otherOptions,
-          signal: jsdomAbortController.signal,
-        });
-      }
+  const patchWindow = (window: DOMWindow): void => {
+    if (patchedWindows.has(window)) {
+      return;
     }
+    patchedWindows.add(window);
 
-    return originalAddEventListener.call(this, type, callback, options);
+    const abortControllers = new WeakMap<AbortSignal, AbortController>();
+    const signalForwarders = new Map<AbortSignal, EventListener>();
+    const JSDOMAbortSignal = window.AbortSignal;
+    const JSDOMAbortController = window.AbortController;
+    const eventTargetPrototype = window.EventTarget.prototype;
+    const originalAddEventListener = eventTargetPrototype.addEventListener;
+
+    eventTargetPrototype.addEventListener = function addEventListener(
+      type: string,
+      callback: EventListenerOrEventListenerObject | null,
+      options?: AddEventListenerOptions | boolean,
+    ): void {
+      if (typeof options === 'object' && options?.signal != null) {
+        const { signal, ...otherOptions } = options;
+        if (
+          !Object.prototype.isPrototypeOf.call(
+            JSDOMAbortSignal.prototype,
+            signal,
+          )
+        ) {
+          let jsdomAbortController = abortControllers.get(signal);
+          if (!jsdomAbortController) {
+            const controller = new JSDOMAbortController();
+            if (signal.aborted) {
+              controller.abort(signal.reason);
+            } else {
+              const forwardAbort = () => {
+                signalForwarders.delete(signal);
+                controller.abort(signal.reason);
+              };
+              signal.addEventListener('abort', forwardAbort, { once: true });
+              signalForwarders.set(signal, forwardAbort);
+            }
+            jsdomAbortController = controller;
+            abortControllers.set(signal, jsdomAbortController);
+          }
+
+          return originalAddEventListener.call(this, type, callback, {
+            ...otherOptions,
+            signal: jsdomAbortController.signal,
+          });
+        }
+      }
+
+      return originalAddEventListener.call(this, type, callback, options);
+    };
+
+    // Each iframe has its own jsdom EventTarget and AbortSignal realm. Patch a
+    // child realm before exposing its window or document to test code.
+    const iframePrototype = window.HTMLIFrameElement.prototype;
+    const contentWindowDescriptor = Object.getOwnPropertyDescriptor(
+      iframePrototype,
+      'contentWindow',
+    )!;
+    const contentDocumentDescriptor = Object.getOwnPropertyDescriptor(
+      iframePrototype,
+      'contentDocument',
+    )!;
+
+    Object.defineProperty(iframePrototype, 'contentWindow', {
+      ...contentWindowDescriptor,
+      get(this: HTMLIFrameElement) {
+        const childWindow: DOMWindow | null =
+          contentWindowDescriptor.get!.call(this);
+        if (childWindow) {
+          patchWindow(childWindow);
+        }
+        return childWindow;
+      },
+    });
+    Object.defineProperty(iframePrototype, 'contentDocument', {
+      ...contentDocumentDescriptor,
+      get(this: HTMLIFrameElement) {
+        const childDocument: Document | null =
+          contentDocumentDescriptor.get!.call(this);
+        if (childDocument) {
+          const childWindow: DOMWindow | null =
+            contentWindowDescriptor.get!.call(this);
+          if (childWindow) {
+            patchWindow(childWindow);
+          }
+        }
+        return childDocument;
+      },
+    });
+
+    cleanups.push(() => {
+      for (const [signal, forwardAbort] of signalForwarders) {
+        signal.removeEventListener('abort', forwardAbort);
+      }
+      signalForwarders.clear();
+      eventTargetPrototype.addEventListener = originalAddEventListener;
+      Object.defineProperty(
+        iframePrototype,
+        'contentWindow',
+        contentWindowDescriptor,
+      );
+      Object.defineProperty(
+        iframePrototype,
+        'contentDocument',
+        contentDocumentDescriptor,
+      );
+    });
   };
 
+  patchWindow(rootWindow);
+
   return () => {
-    prototype.addEventListener = originalAddEventListener;
+    for (const cleanup of cleanups.reverse()) {
+      cleanup();
+    }
   };
 }
 

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -67,7 +67,7 @@ function patchAddEventListener(rootWindow: DOMWindow): () => void {
       options?: AddEventListenerOptions | boolean,
     ): void {
       if (typeof options === 'object' && options?.signal != null) {
-        const { signal, ...otherOptions } = options;
+        const { signal } = options;
         if (
           !Object.prototype.isPrototypeOf.call(
             JSDOMAbortSignal.prototype,
@@ -92,7 +92,9 @@ function patchAddEventListener(rootWindow: DOMWindow): () => void {
           }
 
           return originalAddEventListener.call(this, type, callback, {
-            ...otherOptions,
+            capture: options.capture,
+            once: options.once,
+            passive: options.passive,
             signal: jsdomAbortController.signal,
           });
         }
@@ -273,6 +275,7 @@ export const setupEnvironment = async (
     beforeParse,
     ...restOptions
   } = options as JSDOMOptions;
+  let cleanupAddEventListener = () => {};
   let cleanupObjectURLs = () => {};
   const virtualConsole =
     console && global.console ? new VirtualConsole() : undefined;
@@ -292,12 +295,12 @@ export const setupEnvironment = async (
     userAgent,
     ...restOptions,
     beforeParse(window) {
+      cleanupAddEventListener = patchAddEventListener(window);
       beforeParse?.(window);
       cleanupObjectURLs = installJSDOMObjectURL(window, context);
     },
   });
 
-  const cleanupAddEventListener = patchAddEventListener(dom.window);
   const cleanupGlobal = installGlobal(global, dom.window, {
     additionalKeys: ['URL', 'URLSearchParams'],
   });

--- a/packages/core/src/runtime/worker/env/jsdom.ts
+++ b/packages/core/src/runtime/worker/env/jsdom.ts
@@ -64,8 +64,20 @@ function patchAddEventListener(
     callback: EventListenerOrEventListenerObject | null,
     options?: AddEventListenerOptions | boolean,
   ): void {
-    if (typeof options === 'object' && options !== null) {
-      const signal = options.signal;
+    const optionsValue = options as unknown;
+    if (
+      optionsValue !== null &&
+      (typeof optionsValue === 'object' || typeof optionsValue === 'function')
+    ) {
+      const listenerOptions = optionsValue as AddEventListenerOptions;
+      // Web IDL converts inherited dictionary members first, then this
+      // dictionary's members in lexicographic order.
+      const capture = Boolean(listenerOptions.capture);
+      const once = Boolean(listenerOptions.once);
+      const passive = Boolean(listenerOptions.passive);
+      const signal = listenerOptions.signal;
+      let compatibleSignal = signal;
+
       if (
         signal != null &&
         !Object.prototype.isPrototypeOf.call(
@@ -81,23 +93,28 @@ function patchAddEventListener(
             controller.abort(signal.reason);
           } else {
             const forwardAbort = () => {
+              if (!signal.aborted) {
+                return;
+              }
+              signal.removeEventListener('abort', forwardAbort);
               signalForwarders?.delete(signal);
               controller.abort(signal.reason);
             };
-            signal.addEventListener('abort', forwardAbort, { once: true });
+            signal.addEventListener('abort', forwardAbort);
             signalForwarders?.set(signal, forwardAbort);
           }
           jsdomAbortController = controller;
           abortControllers.set(signal, jsdomAbortController);
         }
-
-        return originalAddEventListener.call(this, type, callback, {
-          capture: options.capture,
-          once: options.once,
-          passive: options.passive,
-          signal: jsdomAbortController.signal,
-        });
+        compatibleSignal = jsdomAbortController.signal;
       }
+
+      return originalAddEventListener.call(this, type, callback, {
+        capture,
+        once,
+        passive,
+        signal: compatibleSignal,
+      });
     }
 
     return originalAddEventListener.call(this, type, callback, options);

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -11,12 +11,60 @@ const createTestGlobal = (): typeof globalThis =>
     clearInterval: globalThis.clearInterval,
     clearTimeout: globalThis.clearTimeout,
     console: globalThis.console,
+    AbortController: globalThis.AbortController,
+    AbortSignal: globalThis.AbortSignal,
     fetch: globalThis.fetch,
     setInterval: globalThis.setInterval,
     setTimeout: globalThis.setTimeout,
     URL: globalThis.URL,
     URLSearchParams: globalThis.URLSearchParams,
   }) as typeof globalThis;
+
+test('bridges Node AbortSignal to jsdom event listeners', async () => {
+  const testGlobal = createTestGlobal();
+  let JSDOMAbortController!: typeof AbortController;
+  let eventTargetPrototype!: EventTarget;
+  let originalAddEventListener!: EventTarget['addEventListener'];
+  const { teardown } = await environment.setup(
+    testGlobal,
+    {
+      beforeParse(window: DOMWindow) {
+        JSDOMAbortController = window.AbortController;
+        eventTargetPrototype = window.EventTarget.prototype;
+        originalAddEventListener = eventTargetPrototype.addEventListener;
+      },
+    },
+    { scope: 'file' },
+  );
+
+  try {
+    expect(testGlobal.AbortController).toBe(globalThis.AbortController);
+    expect(eventTargetPrototype.addEventListener).not.toBe(
+      originalAddEventListener,
+    );
+
+    for (const controller of [
+      new testGlobal.AbortController(),
+      new JSDOMAbortController(),
+    ]) {
+      let calls = 0;
+      const type = 'rstest-abort-signal';
+      testGlobal.document.addEventListener(type, () => calls++, {
+        signal: controller.signal,
+      });
+      testGlobal.document.dispatchEvent(new testGlobal.Event(type));
+      expect(calls).toBe(1);
+
+      controller.abort();
+      testGlobal.document.dispatchEvent(new testGlobal.Event(type));
+      expect(calls).toBe(1);
+    }
+  } finally {
+    await teardown(testGlobal);
+  }
+
+  expect(eventTargetPrototype.addEventListener).toBe(originalAddEventListener);
+});
 
 test('forwards the console with the pre-v27 jsdom API', () => {
   const forwarded: Console[] = [];

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -1,3 +1,4 @@
+import { getEventListeners } from 'node:events';
 import { promisify } from 'node:util';
 import { expect, test } from '@rstest/core';
 import type { DOMWindow } from 'jsdom';
@@ -59,11 +60,58 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
       testGlobal.document.dispatchEvent(new testGlobal.Event(type));
       expect(calls).toBe(1);
     }
+
+    const abortedController = new testGlobal.AbortController();
+    abortedController.abort();
+    let calls = 0;
+    const type = 'rstest-aborted-signal';
+    testGlobal.document.addEventListener(type, () => calls++, {
+      signal: abortedController.signal,
+    });
+    testGlobal.document.dispatchEvent(new testGlobal.Event(type));
+    expect(calls).toBe(0);
   } finally {
     await teardown(testGlobal);
   }
 
   expect(eventTargetPrototype.addEventListener).toBe(originalAddEventListener);
+});
+
+test('removes Node AbortSignal forwarders', async () => {
+  const testGlobal = createTestGlobal();
+  const { teardown } = await environment.setup(
+    testGlobal,
+    {},
+    { scope: 'file' },
+  );
+  const abortedController = new testGlobal.AbortController();
+  const lingeringController = new testGlobal.AbortController();
+
+  try {
+    testGlobal.document.addEventListener('aborted', () => {}, {
+      signal: abortedController.signal,
+    });
+    expect(getEventListeners(abortedController.signal, 'abort')).toHaveLength(
+      1,
+    );
+    abortedController.abort();
+    expect(getEventListeners(abortedController.signal, 'abort')).toHaveLength(
+      0,
+    );
+
+    testGlobal.document.addEventListener('lingering', () => {}, {
+      signal: lingeringController.signal,
+    });
+    expect(getEventListeners(lingeringController.signal, 'abort')).toHaveLength(
+      1,
+    );
+  } finally {
+    await teardown(testGlobal);
+  }
+
+  expect(getEventListeners(lingeringController.signal, 'abort')).toHaveLength(
+    0,
+  );
 });
 
 test('forwards the console with the pre-v27 jsdom API', () => {

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -70,6 +70,22 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
     });
     testGlobal.document.dispatchEvent(new testGlobal.Event(type));
     expect(calls).toBe(0);
+
+    const syntheticController = new testGlobal.AbortController();
+    let syntheticCalls = 0;
+    const syntheticType = 'rstest-synthetic-abort-event';
+    testGlobal.document.addEventListener(
+      syntheticType,
+      () => syntheticCalls++,
+      { signal: syntheticController.signal },
+    );
+    syntheticController.signal.dispatchEvent(new Event('abort'));
+    testGlobal.document.dispatchEvent(new testGlobal.Event(syntheticType));
+    expect(syntheticCalls).toBe(1);
+
+    syntheticController.abort();
+    testGlobal.document.dispatchEvent(new testGlobal.Event(syntheticType));
+    expect(syntheticCalls).toBe(1);
   } finally {
     await teardown(testGlobal);
   }

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -25,14 +25,14 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
   const testGlobal = createTestGlobal();
   let JSDOMAbortController!: typeof AbortController;
   let eventTargetPrototype!: EventTarget;
-  let originalAddEventListener!: EventTarget['addEventListener'];
+  let patchedAddEventListener!: EventTarget['addEventListener'];
   const { teardown } = await environment.setup(
     testGlobal,
     {
       beforeParse(window: DOMWindow) {
         JSDOMAbortController = window.AbortController;
         eventTargetPrototype = window.EventTarget.prototype;
-        originalAddEventListener = eventTargetPrototype.addEventListener;
+        patchedAddEventListener = eventTargetPrototype.addEventListener;
       },
     },
     { scope: 'file' },
@@ -40,9 +40,7 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
 
   try {
     expect(testGlobal.AbortController).toBe(globalThis.AbortController);
-    expect(eventTargetPrototype.addEventListener).not.toBe(
-      originalAddEventListener,
-    );
+    expect(eventTargetPrototype.addEventListener).toBe(patchedAddEventListener);
 
     for (const controller of [
       new testGlobal.AbortController(),
@@ -74,7 +72,9 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
     await teardown(testGlobal);
   }
 
-  expect(eventTargetPrototype.addEventListener).toBe(originalAddEventListener);
+  expect(eventTargetPrototype.addEventListener).not.toBe(
+    patchedAddEventListener,
+  );
 });
 
 test('removes Node AbortSignal forwarders', async () => {
@@ -198,10 +198,20 @@ test('clears pending Node timers during jsdom teardown', async () => {
 test('should preserve URL customizations from beforeParse', async () => {
   const testGlobal = { console, URL, URLSearchParams } as typeof globalThis;
   const originalURL = testGlobal.URL;
+  const controller = new AbortController();
+  let beforeParseCalls = 0;
   const { teardown } = await environment.setup(
     testGlobal,
     {
       beforeParse(window: DOMWindow) {
+        const type = 'rstest-before-parse-abort-signal';
+        window.addEventListener(type, () => beforeParseCalls++, {
+          signal: controller.signal,
+        });
+        window.dispatchEvent(new window.Event(type));
+        controller.abort();
+        window.dispatchEvent(new window.Event(type));
+
         const OriginalURL = window.URL as typeof URL;
         class CustomURL extends OriginalURL {}
         Object.defineProperty(CustomURL, 'beforeParseMarker', { value: true });
@@ -212,6 +222,7 @@ test('should preserve URL customizations from beforeParse', async () => {
   );
 
   try {
+    expect(beforeParseCalls).toBe(1);
     expect(
       (testGlobal.URL as typeof URL & { beforeParseMarker: boolean })
         .beforeParseMarker,

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -1,4 +1,3 @@
-import { getEventListeners } from 'node:events';
 import { promisify } from 'node:util';
 import { expect, test } from '@rstest/core';
 import type { DOMWindow } from 'jsdom';
@@ -72,6 +71,9 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
     expect(calls).toBe(0);
 
     const syntheticController = new testGlobal.AbortController();
+    syntheticController.signal.addEventListener('abort', (event) =>
+      event.stopImmediatePropagation(),
+    );
     let syntheticCalls = 0;
     const syntheticType = 'rstest-synthetic-abort-event';
     testGlobal.document.addEventListener(
@@ -91,43 +93,6 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
   }
 
   expect(eventTargetPrototype.addEventListener).toBe(originalAddEventListener);
-});
-
-test('removes Node AbortSignal forwarders', async () => {
-  const testGlobal = createTestGlobal();
-  const { teardown } = await environment.setup(
-    testGlobal,
-    {},
-    { scope: 'file' },
-  );
-  const abortedController = new testGlobal.AbortController();
-  const lingeringController = new testGlobal.AbortController();
-
-  try {
-    testGlobal.document.addEventListener('aborted', () => {}, {
-      signal: abortedController.signal,
-    });
-    expect(getEventListeners(abortedController.signal, 'abort')).toHaveLength(
-      1,
-    );
-    abortedController.abort();
-    expect(getEventListeners(abortedController.signal, 'abort')).toHaveLength(
-      0,
-    );
-
-    testGlobal.document.addEventListener('lingering', () => {}, {
-      signal: lingeringController.signal,
-    });
-    expect(getEventListeners(lingeringController.signal, 'abort')).toHaveLength(
-      1,
-    );
-  } finally {
-    await teardown(testGlobal);
-  }
-
-  expect(getEventListeners(lingeringController.signal, 'abort')).toHaveLength(
-    0,
-  );
 });
 
 test('forwards the console with the pre-v27 jsdom API', () => {

--- a/packages/core/tests/runtime/worker/env/jsdom.test.ts
+++ b/packages/core/tests/runtime/worker/env/jsdom.test.ts
@@ -25,14 +25,14 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
   const testGlobal = createTestGlobal();
   let JSDOMAbortController!: typeof AbortController;
   let eventTargetPrototype!: EventTarget;
-  let patchedAddEventListener!: EventTarget['addEventListener'];
+  let originalAddEventListener!: EventTarget['addEventListener'];
   const { teardown } = await environment.setup(
     testGlobal,
     {
       beforeParse(window: DOMWindow) {
         JSDOMAbortController = window.AbortController;
         eventTargetPrototype = window.EventTarget.prototype;
-        patchedAddEventListener = eventTargetPrototype.addEventListener;
+        originalAddEventListener = eventTargetPrototype.addEventListener;
       },
     },
     { scope: 'file' },
@@ -40,7 +40,9 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
 
   try {
     expect(testGlobal.AbortController).toBe(globalThis.AbortController);
-    expect(eventTargetPrototype.addEventListener).toBe(patchedAddEventListener);
+    expect(eventTargetPrototype.addEventListener).not.toBe(
+      originalAddEventListener,
+    );
 
     for (const controller of [
       new testGlobal.AbortController(),
@@ -72,9 +74,7 @@ test('bridges Node AbortSignal to jsdom event listeners', async () => {
     await teardown(testGlobal);
   }
 
-  expect(eventTargetPrototype.addEventListener).not.toBe(
-    patchedAddEventListener,
-  );
+  expect(eventTargetPrototype.addEventListener).toBe(originalAddEventListener);
 });
 
 test('removes Node AbortSignal forwarders', async () => {
@@ -198,20 +198,10 @@ test('clears pending Node timers during jsdom teardown', async () => {
 test('should preserve URL customizations from beforeParse', async () => {
   const testGlobal = { console, URL, URLSearchParams } as typeof globalThis;
   const originalURL = testGlobal.URL;
-  const controller = new AbortController();
-  let beforeParseCalls = 0;
   const { teardown } = await environment.setup(
     testGlobal,
     {
       beforeParse(window: DOMWindow) {
-        const type = 'rstest-before-parse-abort-signal';
-        window.addEventListener(type, () => beforeParseCalls++, {
-          signal: controller.signal,
-        });
-        window.dispatchEvent(new window.Event(type));
-        controller.abort();
-        window.dispatchEvent(new window.Event(type));
-
         const OriginalURL = window.URL as typeof URL;
         class CustomURL extends OriginalURL {}
         Object.defineProperty(CustomURL, 'beforeParseMarker', { value: true });
@@ -222,7 +212,6 @@ test('should preserve URL customizations from beforeParse', async () => {
   );
 
   try {
-    expect(beforeParseCalls).toBe(1);
     expect(
       (testGlobal.URL as typeof URL & { beforeParseMarker: boolean })
         .beforeParseMarker,


### PR DESCRIPTION
## Summary

Rstest keeps Node's `AbortController` in jsdom so Node APIs such as `fetch` receive compatible signals, but jsdom `EventTarget` rejects those signals because they belong to another realm. This PR bridges foreign signals to jsdom-native controllers, forwards aborts, and restores the original listener implementation during teardown.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No public API or configuration changes.