### PR TITLE
fix(vscode): generate current license file

### DIFF
--- a/packages/core/licensePlugin.ts
+++ b/packages/core/licensePlugin.ts
@@ -10,7 +10,11 @@ type PackageLicenseMeta =
     ? Meta
     : never;
 
-export async function licensePlugin() {
+export async function licensePlugin(
+  packageName = '@rstest/core',
+  includeCodeReferences = true,
+  excludedPackages: readonly string[] = [],
+) {
   const { default: WebpackLicensePlugin } =
     await import('webpack-license-plugin');
 
@@ -28,7 +32,11 @@ export async function licensePlugin() {
       return '';
     }
 
-    return licenseText
+    const relevantLicenseText = includeCodeReferences
+      ? licenseText
+      : licenseText.split('\n## Code references', 1)[0].trimEnd();
+
+    return relevantLicenseText
       .split('\n')
       .map((line) => `> ${line}`)
       .join('\n');
@@ -57,7 +65,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## Code references
+${
+  includeCodeReferences
+    ? `## Code references
 
 This project references and adapts code from the following projects:
 
@@ -315,11 +325,14 @@ Licensed under Apache license in the repository at https://github.com/microsoft/
 > See the License for the specific language governing permissions and
 > limitations under the License.
 
-## Third-party licenses
+`
+    : ''
+}## Third-party licenses
 
-The following third-party packages are bundled into @rstest/core.
+The following third-party packages are bundled into ${packageName}.
 
 ${packages
+  .filter(({ name }) => !excludedPackages.includes(name))
   .sort((left, right) => {
     return left.name < right.name ? -1 : 1;
   })

--- a/packages/core/licensePlugin.ts
+++ b/packages/core/licensePlugin.ts
@@ -338,7 +338,6 @@ Licensed under Apache license in the repository at https://github.com/microsoft/
 The following third-party packages are bundled into ${packageName}.
 
 ${packages
-  .filter(({ name }) => !excludedPackages.includes(name))
   .sort((left, right) => {
     return left.name < right.name ? -1 : 1;
   })
@@ -359,7 +358,10 @@ ${packages
     additionalFiles: {
       '../LICENSE.md': (packages) => {
         const uniquePackages = new Map<string, PackageLicenseMeta>();
-        for (const pkg of [...packages, ...additionalPackages]) {
+        for (const pkg of [
+          ...packages.filter(({ name }) => !excludedPackages.includes(name)),
+          ...additionalPackages,
+        ]) {
           if (!uniquePackages.has(pkg.name)) {
             uniquePackages.set(pkg.name, pkg);
           }

--- a/packages/core/licensePlugin.ts
+++ b/packages/core/licensePlugin.ts
@@ -10,10 +10,16 @@ type PackageLicenseMeta =
     ? Meta
     : never;
 
+type AdditionalPackageLicenseMeta = Pick<
+  PackageLicenseMeta,
+  'name' | 'license' | 'licenseText' | 'repository'
+>;
+
 export async function licensePlugin(
   packageName = '@rstest/core',
   includeCodeReferences = true,
   excludedPackages: readonly string[] = [],
+  additionalPackages: readonly AdditionalPackageLicenseMeta[] = [],
 ) {
   const { default: WebpackLicensePlugin } =
     await import('webpack-license-plugin');
@@ -353,7 +359,7 @@ ${packages
     additionalFiles: {
       '../LICENSE.md': (packages) => {
         const uniquePackages = new Map<string, PackageLicenseMeta>();
-        for (const pkg of packages) {
+        for (const pkg of [...packages, ...additionalPackages]) {
           if (!uniquePackages.has(pkg.name)) {
             uniquePackages.set(pkg.name, pkg);
           }

--- a/packages/vscode/LICENSE.md
+++ b/packages/vscode/LICENSE.md
@@ -426,3 +426,25 @@ Licensed under MIT license in the repository at https://github.com/open-circle/v
 ### yuku-parser
 
 Licensed under MIT license in the repository at https://github.com/yuku-toolchain/yuku.
+
+> MIT License
+>
+> Copyright (c) 2026 Yuku
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.

--- a/packages/vscode/LICENSE.md
+++ b/packages/vscode/LICENSE.md
@@ -150,6 +150,10 @@ Licensed under MIT license in the repository at git+https://github.com/jridgewel
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
+### @yuku-parser/binding-darwin-arm64
+
+Licensed under MIT license in the repository at https://github.com/yuku-toolchain/yuku.
+
 ### birpc
 
 Licensed under MIT license in the repository at git+https://github.com/antfu-collective/birpc.git.

--- a/packages/vscode/LICENSE.md
+++ b/packages/vscode/LICENSE.md
@@ -154,6 +154,28 @@ Licensed under MIT license in the repository at git+https://github.com/jridgewel
 
 Licensed under MIT license in the repository at https://github.com/yuku-toolchain/yuku.
 
+> MIT License
+>
+> Copyright (c) 2026 Yuku
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
 ### birpc
 
 Licensed under MIT license in the repository at git+https://github.com/antfu-collective/birpc.git.

--- a/packages/vscode/LICENSE.md
+++ b/packages/vscode/LICENSE.md
@@ -20,267 +20,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-## Code references
-
-This project references and adapts code from the following projects:
-
-### Vitest
-
-Licensed under MIT license in the repository at git+https://github.com/vitest-dev/vitest.git.
-
-> MIT License
->
-> Copyright (c) 2021-Present VoidZero Inc. and Vitest contributors
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### Jest
-
-Licensed under MIT license in the repository at https://github.com/jestjs/jest.git.
-
-> MIT License
->
-> Copyright (c) Meta Platforms, Inc. and affiliates.
-> Copyright Contributors to the Jest project.
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### Playwright
-
-Licensed under Apache license in the repository at https://github.com/microsoft/playwright.git.
-
-> Apache License
-> Version 2.0, January 2004
-> http://www.apache.org/licenses/
->
-> TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
->
-> 1. Definitions.
->
-> "License" shall mean the terms and conditions for use, reproduction,
-> and distribution as defined by Sections 1 through 9 of this document.
->
-> "Licensor" shall mean the copyright owner or entity authorized by
-> the copyright owner that is granting the License.
->
-> "Legal Entity" shall mean the union of the acting entity and all
-> other entities that control, are controlled by, or are under common
-> control with that entity. For the purposes of this definition,
-> "control" means (i) the power, direct or indirect, to cause the
-> direction or management of such entity, whether by contract or
-> otherwise, or (ii) ownership of fifty percent (50%) or more of the
-> outstanding shares, or (iii) beneficial ownership of such entity.
->
-> "You" (or "Your") shall mean an individual or Legal Entity
-> exercising permissions granted by this License.
->
-> "Source" form shall mean the preferred form for making modifications,
-> including but not limited to software source code, documentation
-> source, and configuration files.
->
-> "Object" form shall mean any form resulting from mechanical
-> transformation or translation of a Source form, including but
-> not limited to compiled object code, generated documentation,
-> and conversions to other media types.
->
-> "Work" shall mean the work of authorship, whether in Source or
-> Object form, made available under the License, as indicated by a
-> copyright notice that is included in or attached to the work
-> (an example is provided in the Appendix below).
->
-> "Derivative Works" shall mean any work, whether in Source or Object
-> form, that is based on (or derived from) the Work and for which the
-> editorial revisions, annotations, elaborations, or other modifications
-> represent, as a whole, an original work of authorship. For the purposes
-> of this License, Derivative Works shall not include works that remain
-> separable from, or merely link (or bind by name) to the interfaces of,
-> the Work and Derivative Works thereof.
->
-> "Contribution" shall mean any work of authorship, including
-> the original version of the Work and any modifications or additions
-> to that Work or Derivative Works thereof, that is intentionally
-> submitted to Licensor for inclusion in the Work by the copyright owner
-> or by an individual or Legal Entity authorized to submit on behalf of
-> the copyright owner. For the purposes of this definition, "submitted"
-> means any form of electronic, verbal, or written communication sent
-> to the Licensor or its representatives, including but not limited to
-> communication on electronic mailing lists, source code control systems,
-> and issue tracking systems that are managed by, or on behalf of, the
-> Licensor for the purpose of discussing and improving the Work, but
-> excluding communication that is conspicuously marked or otherwise
-> designated in writing by the copyright owner as "Not a Contribution."
->
-> "Contributor" shall mean Licensor and any individual or Legal Entity
-> on behalf of whom a Contribution has been received by Licensor and
-> subsequently incorporated within the Work.
-
-> 2. Grant of Copyright License. Subject to the terms and conditions of
->    this License, each Contributor hereby grants to You a perpetual,
->    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
->    copyright license to reproduce, prepare Derivative Works of,
->    publicly display, publicly perform, sublicense, and distribute the
->    Work and such Derivative Works in Source or Object form.
-> 3. Grant of Patent License. Subject to the terms and conditions of
->    this License, each Contributor hereby grants to You a perpetual,
->    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
->    (except as stated in this section) patent license to make, have made,
->    use, offer to sell, sell, import, and otherwise transfer the Work,
->    where such license applies only to those patent claims licensable
->    by such Contributor that are necessarily infringed by their
->    Contribution(s) alone or by combination of their Contribution(s)
->    with the Work to which such Contribution(s) was submitted. If You
->    institute patent litigation against any entity (including a
->    cross-claim or counterclaim in a lawsuit) alleging that the Work
->    or a Contribution incorporated within the Work constitutes direct
->    or contributory patent infringement, then any patent licenses
->    granted to You under this License for that Work shall terminate
->    as of the date such litigation is filed.
-> 4. Redistribution. You may reproduce and distribute copies of the
->    Work or Derivative Works thereof in any medium, with or without
->    modifications, and in Source or Object form, provided that You
->    meet the following conditions:
->
-> (a) You must give any other recipients of the Work or
-> Derivative Works a copy of this License; and
->
-> (b) You must cause any modified files to carry prominent notices
-> stating that You changed the files; and
->
-> (c) You must retain, in the Source form of any Derivative Works
-> that You distribute, all copyright, patent, trademark, and
-> attribution notices from the Source form of the Work,
-> excluding those notices that do not pertain to any part of
-> the Derivative Works; and
-
-> (d) If the Work includes a "NOTICE" text file as part of its
-> distribution, then any Derivative Works that You distribute must
-> include a readable copy of the attribution notices contained
-> within such NOTICE file, excluding those notices that do not
-> pertain to any part of the Derivative Works, in at least one
-> of the following places: within a NOTICE text file distributed
-> as part of the Derivative Works; within the Source form or
-> documentation, if provided along with the Derivative Works; or,
-> within a display generated by the Derivative Works, if and
-> wherever such third-party notices normally appear. The contents
-> of the NOTICE file are for informational purposes only and
-> do not modify the License. You may add Your own attribution
-> notices within Derivative Works that You distribute, alongside
-> or as an addendum to the NOTICE text from the Work, provided
-> that such additional attribution notices cannot be construed
-> as modifying the License.
->
-> You may add Your own copyright statement to Your modifications and
-> may provide additional or different license terms and conditions
-> for use, reproduction, or distribution of Your modifications, or
-> for any such Derivative Works as a whole, provided Your use,
-> reproduction, and distribution of the Work otherwise complies with
-> the conditions stated in this License.
->
-> 5. Submission of Contributions. Unless You explicitly state otherwise,
->    any Contribution intentionally submitted for inclusion in the Work
->    by You to the Licensor shall be under the terms and conditions of
->    this License, without any additional terms or conditions.
->    Notwithstanding the above, nothing herein shall supersede or modify
->    the terms of any separate license agreement you may have executed
->    with Licensor regarding such Contributions.
-> 6. Trademarks. This License does not grant permission to use the trade
->    names, trademarks, service marks, or product names of the Licensor,
->    except as required for reasonable and customary use in describing the
->    origin of the Work and reproducing the content of the NOTICE file.
-> 7. Disclaimer of Warranty. Unless required by applicable law or
->    agreed to in writing, Licensor provides the Work (and each
->    Contributor provides its Contributions) on an "AS IS" BASIS,
->    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
->    implied, including, without limitation, any warranties or conditions
->    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
->    PARTICULAR PURPOSE. You are solely responsible for determining the
->    appropriateness of using or redistributing the Work and assume any
->    risks associated with Your exercise of permissions under this License.
-> 8. Limitation of Liability. In no event and under no legal theory,
->    whether in tort (including negligence), contract, or otherwise,
->    unless required by applicable law (such as deliberate and grossly
->    negligent acts) or agreed to in writing, shall any Contributor be
->    liable to You for damages, including any direct, indirect, special,
->    incidental, or consequential damages of any character arising as a
->    result of this License or out of the use or inability to use the
->    Work (including but not limited to damages for loss of goodwill,
->    work stoppage, computer failure or malfunction, or any and all
->    other commercial damages or losses), even if such Contributor
->    has been advised of the possibility of such damages.
-> 9. Accepting Warranty or Additional Liability. While redistributing
->    the Work or Derivative Works thereof, You may choose to offer,
->    and charge a fee for, acceptance of support, warranty, indemnity,
->    or other liability obligations and/or rights consistent with this
->    License. However, in accepting such obligations, You may act only
->    on Your own behalf and on Your sole responsibility, not on behalf
->    of any other Contributor, and only if You agree to indemnify,
->    defend, and hold each Contributor harmless for any liability
->    incurred by, or claims asserted against, such Contributor by reason
->    of your accepting any such warranty or additional liability.
->
-> END OF TERMS AND CONDITIONS
->
-> APPENDIX: How to apply the Apache License to your work.
->
-> To apply the Apache License to your work, attach the following
-> boilerplate notice, with the fields enclosed by brackets "[]"
-> replaced with your own identifying information. (Don't include
-> the brackets!) The text should be enclosed in the appropriate
-> comment syntax for the file format. We also recommend that a
-> file or class name and description of purpose be included on the
-> same "printed page" as the copyright notice for easier
-> identification within third-party archives.
->
-> Portions Copyright (c) Microsoft Corporation.
-> Portions Copyright 2017 Google Inc.
->
-> Licensed under the Apache License, Version 2.0 (the "License");
-> you may not use this file except in compliance with the License.
-> You may obtain a copy of the License at
->
->     http://www.apache.org/licenses/LICENSE-2.0
->
-> Unless required by applicable law or agreed to in writing, software
-> distributed under the License is distributed on an "AS IS" BASIS,
-> WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-> See the License for the specific language governing permissions and
-> limitations under the License.
-
 ## Third-party licenses
 
-The following third-party packages are bundled into @rstest/core.
+The following third-party packages are bundled into rstest VS Code extension.
 
 ### @babel/code-frame
 
@@ -336,248 +78,14 @@ Licensed under MIT license in the repository at https://github.com/babel/babel.g
 > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-### @jest/diff-sequences
+### @jridgewell/resolve-uri
 
-Licensed under MIT license in the repository at https://github.com/jestjs/jest.git.
+Licensed under MIT license in the repository at https://github.com/jridgewell/resolve-uri.
 
-> MIT License
->
-> Copyright (c) Meta Platforms, Inc. and affiliates.
-> Copyright Contributors to the Jest project.
+> Copyright 2019 Justin Ridgewell <jridgewell@google.com>
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### @jest/get-type
-
-Licensed under MIT license in the repository at https://github.com/jestjs/jest.git.
-
-> MIT License
->
-> Copyright (c) Meta Platforms, Inc. and affiliates.
-> Copyright Contributors to the Jest project.
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### @sinonjs/commons
-
-Licensed under BSD-3-Clause license in the repository at git+https://github.com/sinonjs/commons.git.
-
-> BSD 3-Clause License
->
-> Copyright (c) 2018, Sinon.JS
-> All rights reserved.
->
-> Redistribution and use in source and binary forms, with or without
-> modification, are permitted provided that the following conditions are met:
->
-> - Redistributions of source code must retain the above copyright notice, this
->   list of conditions and the following disclaimer.
-> - Redistributions in binary form must reproduce the above copyright notice,
->   this list of conditions and the following disclaimer in the documentation
->   and/or other materials provided with the distribution.
-> - Neither the name of the copyright holder nor the names of its
->   contributors may be used to endorse or promote products derived from
->   this software without specific prior written permission.
->
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-> AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-> DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-> FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-> DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-> SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-> CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-> OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-> OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### @sinonjs/fake-timers
-
-Licensed under BSD-3-Clause license in the repository at git+https://github.com/sinonjs/fake-timers.git.
-
-> Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no. All rights reserved.
->
-> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
->
-> 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-> 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-> 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
->
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### @vitest/expect
-
-Licensed under MIT license in the repository at git+https://github.com/vitest-dev/vitest.git.
-
-> MIT License
->
-> Copyright (c) 2021-Present Vitest Team
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### @vitest/pretty-format
-
-Licensed under MIT license in the repository at git+https://github.com/vitest-dev/vitest.git.
-
-> MIT License
->
-> Copyright (c) 2021-Present Vitest Team
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### @vitest/snapshot
-
-Licensed under MIT license in the repository at git+https://github.com/vitest-dev/vitest.git.
-
-> MIT License
->
-> Copyright (c) 2021-Present Vitest Team
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### ansi-styles
-
-Licensed under MIT license.
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### buffer-from
-
-Licensed under MIT license.
-
-> MIT License
->
-> Copyright (c) 2016, 2018 Linus Unnebäck
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### chalk
-
-Licensed under MIT license.
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### chokidar
-
-Licensed under MIT license in the repository at git+https://github.com/paulmillr/chokidar.git.
-
-> The MIT License (MIT)
->
-> Copyright (c) 2012 Paul Miller (https://paulmillr.com), Elan Shanker
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the “Software”), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
@@ -586,51 +94,112 @@ Licensed under MIT license in the repository at git+https://github.com/paulmillr
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
 >
-> THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+### @jridgewell/sourcemap-codec
+
+Licensed under MIT license in the repository at git+https://github.com/jridgewell/sourcemaps.git.
+
+> Copyright 2024 Justin Ridgewell <justin@ridgewell.name>
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+### @jridgewell/trace-mapping
+
+Licensed under MIT license in the repository at git+https://github.com/jridgewell/sourcemaps.git.
+
+> Copyright 2024 Justin Ridgewell <justin@ridgewell.name>
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+### birpc
+
+Licensed under MIT license in the repository at git+https://github.com/antfu-collective/birpc.git.
+
+> MIT License
+>
+> Copyright (c) 2021 Anthony Fu <https://github.com/antfu>
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+### core-js-pure
+
+Licensed under MIT license in the repository at git+https://github.com/zloirock/core-js.git.
+
+> Copyright (c) 2013–2025 Denis Pushkarev (zloirock.ru)
+> Copyright (c) 2025–2026 CoreJS Company (core-js.io)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
-
-### color-convert
-
-Licensed under MIT license.
-
-> Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### color-name
-
-Licensed under MIT license in the repository at git@github.com:colorjs/color-name.git.
-
-> The MIT License (MIT)
-> Copyright (c) 2015 Dmitry Ivanov
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### fdir
 
@@ -644,50 +213,9 @@ Licensed under MIT license in the repository at git+https://github.com/thecodrr/
 >
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-### has-flag
-
-Licensed under MIT license.
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### jest-diff
-
-Licensed under MIT license in the repository at https://github.com/jestjs/jest.git.
-
-> MIT License
->
-> Copyright (c) Meta Platforms, Inc. and affiliates.
-> Copyright Contributors to the Jest project.
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
 ### js-tokens
 
-Licensed under MIT license.
+Licensed under MIT license in the repository at lydell/js-tokens.
 
 > The MIT License (MIT)
 >
@@ -711,21 +239,9 @@ Licensed under MIT license.
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
 
-### magic-string
-
-Licensed under MIT license.
-
-> Copyright 2018 Rich Harris
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 ### picocolors
 
-Licensed under ISC license.
+Licensed under ISC license in the repository at alexeyraspopov/picocolors.
 
 > ISC License
 >
@@ -745,7 +261,7 @@ Licensed under ISC license.
 
 ### picomatch
 
-Licensed under MIT license.
+Licensed under MIT license in the repository at micromatch/picomatch.
 
 > The MIT License (MIT)
 >
@@ -769,40 +285,13 @@ Licensed under MIT license.
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
 
-### pretty-format
+### rslog
 
-Licensed under MIT license in the repository at https://github.com/jestjs/jest.git.
-
-> MIT License
->
-> Copyright (c) Meta Platforms, Inc. and affiliates.
-> Copyright Contributors to the Jest project.
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### react-is
-
-Licensed under MIT license in the repository at https://github.com/facebook/react.git.
+Licensed under MIT license in the repository at git+https://github.com/rstackjs/rslog.git.
 
 > MIT License
 >
-> Copyright (c) Facebook, Inc. and its affiliates.
+> Copyright (c) 2023-present Bytedance, Inc. and its affiliates.
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
@@ -822,61 +311,25 @@ Licensed under MIT license in the repository at https://github.com/facebook/reac
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
-### source-map
+### semver
 
-Licensed under BSD-3-Clause license in the repository at http://github.com/mozilla/source-map.git.
+Licensed under ISC license in the repository at git+https://github.com/npm/node-semver.git.
 
-> Copyright (c) 2009-2011, Mozilla Foundation and contributors
-> All rights reserved.
+> The ISC License
 >
-> Redistribution and use in source and binary forms, with or without
-> modification, are permitted provided that the following conditions are met:
+> Copyright (c) Isaac Z. Schlueter and Contributors
 >
-> - Redistributions of source code must retain the above copyright notice, this
->   list of conditions and the following disclaimer.
-> - Redistributions in binary form must reproduce the above copyright notice,
->   this list of conditions and the following disclaimer in the documentation
->   and/or other materials provided with the distribution.
-> - Neither the names of the Mozilla Foundation nor the names of project
->   contributors may be used to endorse or promote products derived from this
->   software without specific prior written permission.
+> Permission to use, copy, modify, and/or distribute this software for any
+> purpose with or without fee is hereby granted, provided that the above
+> copyright notice and this permission notice appear in all copies.
 >
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-> ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-> WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-> DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-> FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-> DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-> SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-> CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-> OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-> OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### source-map-support
-
-Licensed under MIT license in the repository at https://github.com/evanw/node-source-map-support.
-
-> The MIT License (MIT)
->
-> Copyright (c) 2014 Evan Wallace
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+> MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+> ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+> WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+> ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+> IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ### stacktrace-parser
 
@@ -904,20 +357,6 @@ Licensed under MIT license in the repository at git+https://github.com/errwischt
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
-### supports-color
-
-Licensed under MIT license.
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 ### tinyglobby
 
 Licensed under MIT license in the repository at git+https://github.com/SuperchupuDev/tinyglobby.git.
@@ -944,78 +383,20 @@ Licensed under MIT license in the repository at git+https://github.com/Superchup
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
-### tinyrainbow
+### valibot
 
-Licensed under MIT license in the repository at git+https://github.com/tinylibs/tinyrainbow.git.
-
-> MIT License
->
-> Copyright (c) 2022 Tinylibs
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
-### tinyspy
-
-Licensed under MIT license in the repository at git+https://github.com/tinylibs/tinyspy.git.
+Licensed under MIT license in the repository at https://github.com/open-circle/valibot.
 
 > MIT License
 >
-> Copyright (c) 2022 Tinylibs
+> Copyright (c) Fabian Hiller
 >
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 >
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 >
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-### type-detect
+### yuku-parser
 
-Licensed under MIT license in the repository at git+ssh://git@github.com/chaijs/type-detect.git.
-
-> Copyright (c) 2013 Jake Luer <jake@alogicalparadox.com> (http://alogicalparadox.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
+Licensed under MIT license in the repository at https://github.com/yuku-toolchain/yuku.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -16,7 +16,7 @@
   "publisher": "rstack",
   "main": "./dist/extension.js",
   "scripts": {
-    "build": "rslib build",
+    "build": "rslib build && npx prettier ./LICENSE.md --write",
     "build:local": "cross-env SOURCEMAP=true rslib build",
     "preinstall": "[ -f icon.png ] || curl https://assets.rspack.rs/rstest/rstest-logo-512x512.png --output icon.png",
     "lint": "rslint .",

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -20,6 +20,30 @@ const yukuBindingPath = yukuRequire.resolve(
 const yukuBindingPackage = yukuRequire(
   `${dirname(yukuBindingPath)}/package.json`,
 );
+// The binding package omits its LICENSE file; keep the upstream notice in the
+// generated VSIX license: https://github.com/yuku-toolchain/yuku/blob/main/LICENSE
+const yukuLicenseText = `MIT License
+
+Copyright (c) 2026 Yuku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
 
 export default defineConfig({
   lib: [
@@ -62,7 +86,7 @@ export default defineConfig({
                     {
                       name: yukuBindingPackage.name,
                       license: yukuBindingPackage.license,
-                      licenseText: '',
+                      licenseText: yukuLicenseText,
                       repository: yukuBindingPackage.repository.url,
                     },
                   ],

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { defineConfig, rspack } from '@rslib/core';
+import { licensePlugin } from '../core/licensePlugin';
 import { rslibRspackConfig } from '../../scripts/rslibConfig';
 import { rsdoctorCIPlugin } from '../../scripts/rsdoctorPlugin';
 
@@ -46,6 +47,12 @@ export default defineConfig({
                 },
               ],
             }),
+            // only load & apply licensePlugin in lib build
+            process.argv.includes('--watch') || !process.argv.includes('build')
+              ? null
+              : await licensePlugin('rstest VS Code extension', false, [
+                  '@rstest/core',
+                ]),
             rsdoctorCIPlugin({ reportDir: '.rsdoctor/extension' }),
           ].filter(Boolean),
         },

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
 import { defineConfig, rspack } from '@rslib/core';
 import { licensePlugin } from '../core/licensePlugin';
 import { rslibRspackConfig } from '../../scripts/rslibConfig';
@@ -15,6 +16,9 @@ const yukuRequire = createRequire(require.resolve('yuku-parser'));
 // Yuku computes this package name at runtime, so Rspack cannot discover it.
 const yukuBindingPath = yukuRequire.resolve(
   `@yuku-parser/binding-${yukuBindingSuffix}`,
+);
+const yukuBindingPackage = yukuRequire(
+  `${dirname(yukuBindingPath)}/package.json`,
 );
 
 export default defineConfig({
@@ -50,9 +54,19 @@ export default defineConfig({
             // only load & apply licensePlugin in lib build
             process.argv.includes('--watch') || !process.argv.includes('build')
               ? null
-              : await licensePlugin('rstest VS Code extension', false, [
-                  '@rstest/core',
-                ]),
+              : await licensePlugin(
+                  'rstest VS Code extension',
+                  false,
+                  ['@rstest/core'],
+                  [
+                    {
+                      name: yukuBindingPackage.name,
+                      license: yukuBindingPackage.license,
+                      licenseText: '',
+                      repository: yukuBindingPackage.repository.url,
+                    },
+                  ],
+                ),
             rsdoctorCIPlugin({ reportDir: '.rsdoctor/extension' }),
           ].filter(Boolean),
         },

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -12,7 +12,11 @@ const vsceTarget =
 const yukuBindingSuffix = vsceTarget.startsWith('linux-')
   ? `${vsceTarget}-gnu`
   : vsceTarget;
-const yukuRequire = createRequire(require.resolve('yuku-parser'));
+const yukuParserPath = require.resolve('yuku-parser');
+const yukuRequire = createRequire(yukuParserPath);
+const yukuParserPackage = yukuRequire(
+  `${dirname(yukuParserPath)}/package.json`,
+);
 // Yuku computes this package name at runtime, so Rspack cannot discover it.
 const yukuBindingPath = yukuRequire.resolve(
   `@yuku-parser/binding-${yukuBindingSuffix}`,
@@ -20,7 +24,7 @@ const yukuBindingPath = yukuRequire.resolve(
 const yukuBindingPackage = yukuRequire(
   `${dirname(yukuBindingPath)}/package.json`,
 );
-// The binding package omits its LICENSE file; keep the upstream notice in the
+// Yuku packages omit their LICENSE files; keep the upstream notice in the
 // generated VSIX license: https://github.com/yuku-toolchain/yuku/blob/main/LICENSE
 const yukuLicenseText = `MIT License
 
@@ -81,13 +85,19 @@ export default defineConfig({
               : await licensePlugin(
                   'rstest VS Code extension',
                   false,
-                  ['@rstest/core'],
+                  ['@rstest/core', 'yuku-parser'],
                   [
                     {
                       name: yukuBindingPackage.name,
                       license: yukuBindingPackage.license,
                       licenseText: yukuLicenseText,
                       repository: yukuBindingPackage.repository.url,
+                    },
+                    {
+                      name: yukuParserPackage.name,
+                      license: yukuParserPackage.license,
+                      licenseText: yukuLicenseText,
+                      repository: yukuParserPackage.repository.url,
                     },
                   ],
                 ),


### PR DESCRIPTION
## Summary

This PR replaces the manually maintained VS Code extension license file with build-time generation from the actual bundle. It reuses the core license plugin, keeps core-only code references out of the extension license, and excludes the same-repository `@rstest/core` package from the extension's third-party list while retaining actual bundled dependencies.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).