### PR TITLE
docs: move LLMs UI to page outline

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
     ],
   },
   themeConfig: {
+    llmsUI: {
+      placement: 'outline',
+    },
     socialLinks: [
       {
         icon: 'github',


### PR DESCRIPTION
## Summary

This PR moves the LLMs UI actions into the documentation page outline so they stay accessible alongside page navigation. It ports the placement used by rstack-cli and sets `themeConfig.llmsUI.placement` to `outline`.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/414

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).