### PR TITLE
chore(deps): migrate to @rstackjs/doc-ui v1.14.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1521,9 +1521,9 @@ importers:
       '@rspress/plugin-client-redirects':
         specifier: 2.0.19
         version: 2.0.19(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
-      '@rstack-dev/doc-ui':
-        specifier: 1.14.8
-        version: 1.14.8(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
+      '@rstackjs/doc-ui':
+        specifier: 1.14.9
+        version: 1.14.9(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -3906,8 +3906,8 @@ packages:
   '@rspress/shared@2.0.19':
     resolution: {integrity: sha512-INrETllWuR49lksqCz+xeLSO6rKtHA+5Ix2YQWcP9nerCuTSyGYwH8eBC0HrIacJkGHxB8wkkbV99tyzGtY8Wg==}
 
-  '@rstack-dev/doc-ui@1.14.8':
-    resolution: {integrity: sha512-CAibkpvCnJEcxsypu3ZE9JjtQw+1+iJGv9X09Yg4//9FevHpfaHW+b2onFG+Z/xOlUXGg83rJTb7CO6YbToP0w==}
+  '@rstackjs/doc-ui@1.14.9':
+    resolution: {integrity: sha512-Te7Wx4K9JuvluP7HsH/Dpdju5QhClUe17/9YBzHlul+x2wg63jOkngv79DlMXyYDJgHQ+11vZfz18B+bnPhttw==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
@@ -11626,7 +11626,7 @@ snapshots:
       - core-js
       - supports-color
 
-  '@rstack-dev/doc-ui@1.14.8(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))':
+  '@rstackjs/doc-ui@1.14.9(@rspress/core@2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))':
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
-  - '@rstack-dev/doc-ui'
+  - '@rstackjs/doc-ui'
   - rsbuild-plugin-dts
   # Renovate security update: svelte@5.55.7
   - svelte@5.55.7

--- a/website/docs/en/blog/announcing-0-10.mdx
+++ b/website/docs/en/blog/announcing-0-10.mdx
@@ -11,7 +11,7 @@ authors:
     github: 'fi3ework'
 ---
 
-import { BlogAuthors } from '@rstack-dev/doc-ui/blog-authors';
+import { BlogAuthors } from '@rstackjs/doc-ui/blog-authors';
 
 # Announcing Rstest 0.10
 

--- a/website/docs/en/blog/announcing-0-11.mdx
+++ b/website/docs/en/blog/announcing-0-11.mdx
@@ -11,7 +11,7 @@ authors:
     github: 'fi3ework'
 ---
 
-import { BlogAuthors } from '@rstack-dev/doc-ui/blog-authors';
+import { BlogAuthors } from '@rstackjs/doc-ui/blog-authors';
 
 # Announcing Rstest 0.11
 

--- a/website/docs/zh/blog/announcing-0-10.mdx
+++ b/website/docs/zh/blog/announcing-0-10.mdx
@@ -11,7 +11,7 @@ authors:
     github: 'fi3ework'
 ---
 
-import { BlogAuthors } from '@rstack-dev/doc-ui/blog-authors';
+import { BlogAuthors } from '@rstackjs/doc-ui/blog-authors';
 
 # Rstest 0.10 发布
 

--- a/website/docs/zh/blog/announcing-0-11.mdx
+++ b/website/docs/zh/blog/announcing-0-11.mdx
@@ -11,7 +11,7 @@ authors:
     github: 'fi3ework'
 ---
 
-import { BlogAuthors } from '@rstack-dev/doc-ui/blog-authors';
+import { BlogAuthors } from '@rstackjs/doc-ui/blog-authors';
 
 # Rstest 0.11 发布
 

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "@rspress/core": "2.0.19",
     "@rspress/plugin-algolia": "2.0.19",
     "@rspress/plugin-client-redirects": "2.0.19",
-    "@rstack-dev/doc-ui": "1.14.8",
+    "@rstackjs/doc-ui": "1.14.9",
     "@rstest/tsconfig": "workspace:*",
     "@types/node": "^22.16.5",
     "@types/react": "^19.2.18",

--- a/website/theme/components/BlogList.tsx
+++ b/website/theme/components/BlogList.tsx
@@ -1,7 +1,7 @@
 import { useLang } from '@rspress/core/runtime';
 import { Link, renderInlineMarkdown } from '@rspress/core/theme';
-import { BlogBackground } from '@rstack-dev/doc-ui/blog-background';
-import { BlogList as BaseBlogList } from '@rstack-dev/doc-ui/blog-list';
+import { BlogBackground } from '@rstackjs/doc-ui/blog-background';
+import { BlogList as BaseBlogList } from '@rstackjs/doc-ui/blog-list';
 import { useBlogPages } from './useBlogPages';
 
 export function BlogList() {

--- a/website/theme/components/Features.tsx
+++ b/website/theme/components/Features.tsx
@@ -2,7 +2,7 @@ import { useI18n } from '@rspress/core/runtime';
 import {
   containerStyle,
   innerContainerStyle,
-} from '@rstack-dev/doc-ui/section-style';
+} from '@rstackjs/doc-ui/section-style';
 import { HomeFeature } from '@theme';
 import './Features.module.scss';
 

--- a/website/theme/components/Hero.tsx
+++ b/website/theme/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { useI18n, useNavigate } from '@rspress/core/runtime';
-import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
+import { Hero as BaseHero } from '@rstackjs/doc-ui/hero';
 import { useI18nUrl } from './utils';
 import './Hero.module.scss';
 

--- a/website/theme/components/ToolStack.tsx
+++ b/website/theme/components/ToolStack.tsx
@@ -1,6 +1,6 @@
 import { useLang } from '@rspress/core/runtime';
-import { containerStyle } from '@rstack-dev/doc-ui/section-style';
-import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
+import { containerStyle } from '@rstackjs/doc-ui/section-style';
+import { ToolStack as BaseToolStack } from '@rstackjs/doc-ui/tool-stack';
 
 export function ToolStack() {
   const lang = useLang();

--- a/website/theme/components/useBlogPages.tsx
+++ b/website/theme/components/useBlogPages.tsx
@@ -1,5 +1,5 @@
-import type { BlogAvatarAuthor } from '@rstack-dev/doc-ui/blog-avatar';
-import type { BlogListItem } from '@rstack-dev/doc-ui/blog-list';
+import type { BlogAvatarAuthor } from '@rstackjs/doc-ui/blog-avatar';
+import type { BlogListItem } from '@rstackjs/doc-ui/blog-list';
 import { useLang, usePages } from '@rspress/core/runtime';
 
 const DEFAULT_AUTHOR: BlogAvatarAuthor = {

--- a/website/theme/index.scss
+++ b/website/theme/index.scss
@@ -1,13 +1,3 @@
 :root {
-  --rp-c-brand: #ff5e00;
-  --rp-c-brand-dark: #ff704d;
-  --rp-c-brand-darker: #ff704d;
-  --rp-c-brand-light: #ff7524;
-  --rp-c-brand-lighter: #ff7524;
   --rp-c-link: var(--rp-c-brand);
-  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
-}
-
-.dark {
-  --rp-c-link: var(--rp-c-brand-light);
 }

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -9,10 +9,11 @@ import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
-import { BlogBackButton } from '@rstack-dev/doc-ui/blog-back-button';
-import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
+import { BlogBackButton } from '@rstackjs/doc-ui/blog-back-button';
+import { NavIcon } from '@rstackjs/doc-ui/nav-icon';
 
 import { HomeLayout } from './pages';
+import '@rstackjs/doc-ui/theme.css';
 import './index.scss';
 
 const Search = () => {

--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -1,4 +1,4 @@
-import { BackgroundImage } from '@rstack-dev/doc-ui/background-image';
+import { BackgroundImage } from '@rstackjs/doc-ui/background-image';
 import { CopyRight } from '../components/Copyright';
 import { Features } from '../components/Features';
 import { Hero } from '../components/Hero';


### PR DESCRIPTION
## Summary

`@rstackjs/doc-ui` replaces the old `@rstack-dev/doc-ui` package and now exposes shared Rspress theme styles. This PR ports the migration from Rsbuild to Rstest, updates all website imports to v1.14.9, loads the shared `theme.css`, and keeps only the Rstest-specific link override locally.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8382
- https://github.com/rstackjs/rstack-doc-ui/releases/tag/v1.14.9

## Checklist

- [x] Tests updated (not required; website production build passes).
- [x] Documentation updated.