### PR TITLE
fix(adapter-rslib): remove build-only plugins from tests

### DIFF
--- a/packages/adapter-rslib/src/index.ts
+++ b/packages/adapter-rslib/src/index.ts
@@ -133,7 +133,16 @@ export function withRslibConfig(
       root: finalLibConfig.root,
       name: libId,
       forceRerunTriggers: filePath ? [normalize(filePath)] : undefined,
-      plugins: finalLibConfig.plugins,
+      plugins: [
+        ...(finalLibConfig.plugins || []),
+        // Remove build-only plugins from the test environment.
+        // Rslib's declaration/type-check plugins are not needed for tests.
+        {
+          name: 'rslib-adapter:remove-useless-plugins',
+          remove: ['rsbuild:dts', 'rsbuild:type-check'],
+          setup: () => {},
+        },
+      ],
       source: {
         assetsInclude,
         decorators: {

--- a/packages/adapter-rslib/tests/index.test.ts
+++ b/packages/adapter-rslib/tests/index.test.ts
@@ -128,6 +128,33 @@ export default defineConfig({
     });
   });
 
+  it('should remove build-only plugins in the test environment', async () => {
+    const keepPlugin = {
+      name: 'custom-plugin',
+      setup: () => {},
+    };
+
+    const config = await withRslibConfig({
+      config: {
+        plugins: [
+          { name: 'rsbuild:dts', setup: () => {} },
+          { name: 'rsbuild:type-check', setup: () => {} },
+          { name: 'rsbuild:less', setup: () => {} },
+          keepPlugin,
+        ],
+      },
+    })({});
+
+    expect(config.plugins).toHaveLength(5);
+    expect(config.plugins?.[0]).toMatchObject({ name: 'rsbuild:dts' });
+    expect(config.plugins?.[2]).toMatchObject({ name: 'rsbuild:less' });
+    expect(config.plugins?.[3]).toBe(keepPlugin);
+    expect(config.plugins?.[4]).toMatchObject({
+      name: 'rslib-adapter:remove-useless-plugins',
+      remove: ['rsbuild:dts', 'rsbuild:type-check'],
+    });
+  });
+
   it('should use inline rslib config before configPath', async () => {
     const inlineConfigPath = join(__dirname, 'missing-inline-rslib.config.ts');
     const config = await withRslibConfig({


### PR DESCRIPTION
## Summary

Rstest's Rslib adapter should not run declaration generation or type-check plugins in the test environment. This PR appends the adapter removal plugin while preserving all other Rslib plugins, including `rsbuild:less`.

## Related Links

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).