### PR TITLE
fix(vscode): make icon setup cross-platform

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "rslib build && npx prettier ./LICENSE.md --write",
     "build:local": "cross-env SOURCEMAP=true rslib build",
-    "preinstall": "[ -f icon.png ] || curl https://assets.rspack.rs/rstest/rstest-logo-512x512.png --output icon.png",
+    "preinstall": "node ./scripts/ensureIcon.cjs",
     "lint": "rslint .",
     "package:vsce": "npm run build && vsce package",
     "test": "npm run test:unit && npm run test:e2e",

--- a/packages/vscode/scripts/ensureIcon.cjs
+++ b/packages/vscode/scripts/ensureIcon.cjs
@@ -1,0 +1,35 @@
+const { existsSync } = require('node:fs');
+const { writeFile } = require('node:fs/promises');
+const { join } = require('node:path');
+
+const iconPath = join(__dirname, '..', 'icon.png');
+const iconUrl = 'https://assets.rspack.rs/rstest/rstest-logo-512x512.png';
+
+async function ensureIcon({
+  path = iconPath,
+  url = iconUrl,
+  fetchIcon = globalThis.fetch,
+} = {}) {
+  if (existsSync(path)) {
+    return false;
+  }
+
+  const response = await fetchIcon(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download the VS Code icon: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  await writeFile(path, Buffer.from(await response.arrayBuffer()));
+  return true;
+}
+
+if (require.main === module) {
+  ensureIcon().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { ensureIcon };

--- a/packages/vscode/tests/unit/ensureIcon.test.ts
+++ b/packages/vscode/tests/unit/ensureIcon.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
+
+// This helper must stay dependency-free CommonJS so Node can run it before install.
+const { ensureIcon } = require('../../scripts/ensureIcon.cjs') as {
+  ensureIcon(options: {
+    path: string;
+    url: string;
+    fetchIcon: () => Promise<{
+      ok: boolean;
+      status: number;
+      statusText: string;
+      arrayBuffer: () => Promise<ArrayBuffer>;
+    }>;
+  }): Promise<boolean>;
+};
+
+describe('ensureIcon', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'rstest-vscode-icon-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { force: true, recursive: true });
+  });
+
+  it('does not download an existing icon', async () => {
+    const path = join(tempDir, 'icon.png');
+    await writeFile(path, 'existing icon');
+
+    const downloaded = await ensureIcon({
+      path,
+      url: 'https://example.com/icon.png',
+      fetchIcon: () => {
+        throw new Error('unexpected download');
+      },
+    });
+
+    expect(downloaded).toBe(false);
+    await expect(readFile(path, 'utf8')).resolves.toBe('existing icon');
+  });
+
+  it('downloads a missing icon', async () => {
+    const path = join(tempDir, 'icon.png');
+    const content = new TextEncoder().encode('downloaded icon');
+
+    const downloaded = await ensureIcon({
+      path,
+      url: 'https://example.com/icon.png',
+      fetchIcon: async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () => content.buffer,
+      }),
+    });
+
+    expect(downloaded).toBe(true);
+    await expect(readFile(path, 'utf8')).resolves.toBe('downloaded icon');
+  });
+});


### PR DESCRIPTION
## Summary

- Windows runs the VS Code package lifecycle through `cmd.exe`, so the POSIX icon guard fails and redownloads an existing icon.
- Replace the shell expression with a dependency-free Node helper and cover both the existing-icon and missing-icon paths.
- This only affects VS Code extension asset setup; browser mode, adapters, public APIs, and documentation are unaffected.

## Related Links

- Fixes #1756

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).