### PR TITLE
docs: add CSS guide

### DIFF
--- a/website/docs/en/guide/basic/_meta.json
+++ b/website/docs/en/guide/basic/_meta.json
@@ -1,6 +1,7 @@
 [
   "cli",
   "configure-rstest",
+  "css",
   "test-filter",
   "mock",
   "snapshot",

--- a/website/docs/en/guide/basic/css.mdx
+++ b/website/docs/en/guide/basic/css.mdx
@@ -84,6 +84,10 @@ export default {
 };
 ```
 
+:::warning
+If you use [`@rstest/adapter-rspack`](/guide/integration/rspack), this guide's Rsbuild plugin and `output.cssModules` examples do not apply. That adapter disables Rstest's built-in Rsbuild CSS plugins and uses the CSS rules from `rspack.config.ts` instead. Configure Less, Sass, and CSS Modules in your Rspack configuration.
+:::
+
 ## Optimizing CSS Modules performance
 
 Rstest's default CSS Modules processing aims to stay consistent with the Rsbuild build. As a result, importing `.module.less` or `.module.scss` files can still run the corresponding Less or Sass compiler.
@@ -99,7 +103,11 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   tools: {
-    rspack(config, { rspack }) {
+    rspack(config, { rspack, isServer }) {
+      if (!isServer) {
+        return;
+      }
+
       config.plugins.push(
         new rspack.NormalModuleReplacementPlugin(
           /\.module\.(css|less|sass|scss)$/,
@@ -117,6 +125,7 @@ This bypasses CSS Modules preprocessing and transformation, so it is usually fas
 
 - `styles.button` usually returns `button`, not the hashed class name from a real build.
 - Less, Sass, and CSS Modules syntax are not validated.
+- Missing or misspelled CSS Module files are not detected because the request is replaced before the original file is resolved. The application build can still fail even if the test build passes.
 - It is not suitable for testing `composes`, `:global`, real class names, emitted styles, or client/server class name consistency.
 
 Use this approach only when tests focus on component logic rather than style class names. Keep Rstest's default processing when you need to verify real CSS Modules behavior, and use Browser Mode when you need to verify browser rendering.

--- a/website/docs/en/guide/basic/css.mdx
+++ b/website/docs/en/guide/basic/css.mdx
@@ -12,7 +12,7 @@ Rstest is built on Rsbuild and Rspack, so you can import CSS files and CSS Modul
 
 In Node.js tests, Rstest does not emit CSS by default:
 
-- Regular CSS, Less, and Sass files do not produce style assets, which avoids unnecessary style processing.
+- Regular CSS files do not produce style assets. When the corresponding plugin is enabled, Less and Sass files still run through preprocessing so syntax and compilation errors are reported, but no style assets are emitted.
 - CSS Modules are still processed and export class name mappings for component tests.
 
 For example, the following imports work without additional CSS configuration:
@@ -95,18 +95,19 @@ If a test only needs to read properties such as `styles.button` and does not car
 Use `NormalModuleReplacementPlugin` to replace CSS Modules files:
 
 ```ts title="rstest.config.ts"
-import { rspack } from '@rspack/core';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   tools: {
-    rspack: {
-      plugins: [
+    rspack(config, { rspack }) {
+      config.plugins.push(
         new rspack.NormalModuleReplacementPlugin(
           /\.module\.(css|less|sass|scss)$/,
-          'identity-obj-proxy',
+          (resource) => {
+            resource.request = 'identity-obj-proxy';
+          },
         ),
-      ],
+      );
     },
   },
 });

--- a/website/docs/en/guide/basic/css.mdx
+++ b/website/docs/en/guide/basic/css.mdx
@@ -1,0 +1,121 @@
+---
+description: Learn how Rstest handles CSS, CSS Modules, Less, and Sass, and how to optimize style processing when needed.
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# CSS
+
+Rstest is built on Rsbuild and Rspack, so you can import CSS files and CSS Modules directly. Rstest chooses the appropriate processing behavior for the current test environment.
+
+## Default behavior
+
+In Node.js tests, Rstest does not emit CSS by default:
+
+- Regular CSS, Less, and Sass files do not produce style assets, which avoids unnecessary style processing.
+- CSS Modules are still processed and export class name mappings for component tests.
+
+For example, the following imports work without additional CSS configuration:
+
+```tsx title="Button.tsx"
+import styles from './Button.module.css';
+import './reset.css';
+
+export function Button() {
+  return <button className={styles.button}>Submit</button>;
+}
+```
+
+```ts title="Button.test.tsx"
+import { expect, test } from '@rstest/core';
+import styles from './Button.module.css';
+
+test('loads CSS Modules', () => {
+  expect(styles.button).toEqual(expect.any(String));
+});
+```
+
+CSS Modules commonly use filenames such as `.module.css`, `.module.less`, or `.module.scss`. You can customize class name generation and other CSS Modules options through [`output.cssModules`](/config/build/output#outputcssmodules).
+
+In Browser Mode, tests run in a real browser and styles participate in page rendering. Use [Browser Mode](/guide/browser-testing/) when you need to verify computed styles, layout, or visual behavior.
+
+## Using Less or Sass
+
+Rstest has built-in support for regular CSS and CSS Modules. Less, Sass, and other preprocessors require the corresponding Rsbuild plugin.
+
+### Less
+
+[@rsbuild/plugin-less](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-less) compiles Less files, including `.module.less` files.
+
+<PackageManagerTabs command="add @rsbuild/plugin-less -D" />
+
+```ts title="rstest.config.ts"
+import { pluginLess } from '@rsbuild/plugin-less';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  plugins: [pluginLess()],
+});
+```
+
+### Sass
+
+[@rsbuild/plugin-sass](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-sass) compiles Sass and SCSS files, including `.module.sass` and `.module.scss` files.
+
+<PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
+
+```ts title="rstest.config.ts"
+import { pluginSass } from '@rsbuild/plugin-sass';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  plugins: [pluginSass()],
+});
+```
+
+If your project already reuses an Rsbuild config through [`@rstest/adapter-rsbuild`](/guide/integration/rsbuild), configure these plugins in `rsbuild.config.ts` instead of duplicating them in `rstest.config.ts`.
+
+```ts title="rsbuild.config.ts"
+import { pluginLess } from '@rsbuild/plugin-less';
+import { pluginSass } from '@rsbuild/plugin-sass';
+
+export default {
+  plugins: [pluginLess(), pluginSass()],
+};
+```
+
+## Optimizing CSS Modules performance
+
+Rstest's default CSS Modules processing aims to stay consistent with the Rsbuild build. As a result, importing `.module.less` or `.module.scss` files can still run the corresponding Less or Sass compiler.
+
+If a test only needs to read properties such as `styles.button` and does not care about the generated class name, you can use [`identity-obj-proxy`](https://github.com/keyz/identity-obj-proxy) as a CSS Modules substitute:
+
+<PackageManagerTabs command="add identity-obj-proxy -D" />
+
+Use `NormalModuleReplacementPlugin` to replace CSS Modules files:
+
+```ts title="rstest.config.ts"
+import { rspack } from '@rspack/core';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      plugins: [
+        new rspack.NormalModuleReplacementPlugin(
+          /\.module\.(css|less|sass|scss)$/,
+          'identity-obj-proxy',
+        ),
+      ],
+    },
+  },
+});
+```
+
+This bypasses CSS Modules preprocessing and transformation, so it is usually faster, especially when many Sass files are imported. However, it is only a test substitute:
+
+- `styles.button` usually returns `button`, not the hashed class name from a real build.
+- Less, Sass, and CSS Modules syntax are not validated.
+- It is not suitable for testing `composes`, `:global`, real class names, emitted styles, or client/server class name consistency.
+
+Use this approach only when tests focus on component logic rather than style class names. Keep Rstest's default processing when you need to verify real CSS Modules behavior, and use Browser Mode when you need to verify browser rendering.

--- a/website/docs/zh/guide/basic/_meta.json
+++ b/website/docs/zh/guide/basic/_meta.json
@@ -1,6 +1,7 @@
 [
   "cli",
   "configure-rstest",
+  "css",
   "test-filter",
   "mock",
   "snapshot",

--- a/website/docs/zh/guide/basic/css.mdx
+++ b/website/docs/zh/guide/basic/css.mdx
@@ -12,7 +12,7 @@ Rstest 基于 Rsbuild 和 Rspack 构建，因此可以直接导入 CSS 文件和
 
 在 Node.js 测试中，Rstest 默认不输出 CSS：
 
-- 普通 CSS、Less 或 Sass 文件不会生成样式产物，避免执行不必要的样式处理。
+- 普通 CSS 文件不会生成样式产物。启用对应 plugin 后，Less 和 Sass 文件仍会执行预处理，以便发现语法和编译错误，但不会生成样式产物。
 - CSS Modules 仍会被处理，并导出 class name 映射，供组件测试使用。
 
 例如，下面的代码可以直接在测试中导入：
@@ -95,18 +95,19 @@ Rstest 的默认 CSS Modules 处理会尽量保持与 Rsbuild 构建结果一致
 然后通过 `NormalModuleReplacementPlugin` 替换 CSS Modules 文件：
 
 ```ts title="rstest.config.ts"
-import { rspack } from '@rspack/core';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   tools: {
-    rspack: {
-      plugins: [
+    rspack(config, { rspack }) {
+      config.plugins.push(
         new rspack.NormalModuleReplacementPlugin(
           /\.module\.(css|less|sass|scss)$/,
-          'identity-obj-proxy',
+          (resource) => {
+            resource.request = 'identity-obj-proxy';
+          },
         ),
-      ],
+      );
     },
   },
 });

--- a/website/docs/zh/guide/basic/css.mdx
+++ b/website/docs/zh/guide/basic/css.mdx
@@ -1,0 +1,121 @@
+---
+description: 介绍 Rstest 对 CSS、CSS Modules、Less 和 Sass 的处理方式，以及如何按需优化样式处理性能。
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# CSS
+
+Rstest 基于 Rsbuild 和 Rspack 构建，因此可以直接导入 CSS 文件和 CSS Modules。Rstest 会根据当前测试环境选择合适的处理方式。
+
+## 默认行为
+
+在 Node.js 测试中，Rstest 默认不输出 CSS：
+
+- 普通 CSS、Less 或 Sass 文件不会生成样式产物，避免执行不必要的样式处理。
+- CSS Modules 仍会被处理，并导出 class name 映射，供组件测试使用。
+
+例如，下面的代码可以直接在测试中导入：
+
+```tsx title="Button.tsx"
+import styles from './Button.module.css';
+import './reset.css';
+
+export function Button() {
+  return <button className={styles.button}>Submit</button>;
+}
+```
+
+```ts title="Button.test.tsx"
+import { expect, test } from '@rstest/core';
+import styles from './Button.module.css';
+
+test('loads CSS Modules', () => {
+  expect(styles.button).toEqual(expect.any(String));
+});
+```
+
+CSS Modules 通常使用 `.module.css`、`.module.less` 或 `.module.scss` 文件名。你可以通过 [`output.cssModules`](/config/build/output#outputcssmodules) 自定义 class name 生成规则和其他 CSS Modules 选项。
+
+在 Browser Mode 中，测试运行在真实浏览器中，样式会参与页面渲染。如果需要验证 computed styles、布局或视觉效果，请使用 [Browser Mode](/guide/browser-testing/)。
+
+## 使用 Less 或 Sass
+
+Rstest 内置支持普通 CSS 和 CSS Modules。Less、Sass 等预处理器需要安装并启用对应的 Rsbuild plugin。
+
+### Less
+
+[@rsbuild/plugin-less](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-less) 用于编译 Less 文件，包括 CSS Modules 中的 `.module.less` 文件。
+
+<PackageManagerTabs command="add @rsbuild/plugin-less -D" />
+
+```ts title="rstest.config.ts"
+import { pluginLess } from '@rsbuild/plugin-less';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  plugins: [pluginLess()],
+});
+```
+
+### Sass
+
+[@rsbuild/plugin-sass](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-sass) 用于编译 Sass 和 SCSS 文件，包括 `.module.sass` 和 `.module.scss` 文件。
+
+<PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
+
+```ts title="rstest.config.ts"
+import { pluginSass } from '@rsbuild/plugin-sass';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  plugins: [pluginSass()],
+});
+```
+
+如果项目已经通过 [`@rstest/adapter-rsbuild`](/guide/integration/rsbuild) 复用 Rsbuild 配置，请把这些 plugin 配置在 `rsbuild.config.ts` 中，而不是重复配置在 `rstest.config.ts` 中。
+
+```ts title="rsbuild.config.ts"
+import { pluginLess } from '@rsbuild/plugin-less';
+import { pluginSass } from '@rsbuild/plugin-sass';
+
+export default {
+  plugins: [pluginLess(), pluginSass()],
+};
+```
+
+## CSS Modules 的性能优化
+
+Rstest 的默认 CSS Modules 处理会尽量保持与 Rsbuild 构建结果一致。因此，导入 `.module.less` 或 `.module.scss` 时，仍可能执行对应的 Less 或 Sass 编译。
+
+如果测试只需要读取 `styles.button` 这样的属性，不关心真实生成的 class name，可以使用 [`identity-obj-proxy`](https://github.com/keyz/identity-obj-proxy) 替代 CSS Modules 模块：
+
+<PackageManagerTabs command="add identity-obj-proxy -D" />
+
+然后通过 `NormalModuleReplacementPlugin` 替换 CSS Modules 文件：
+
+```ts title="rstest.config.ts"
+import { rspack } from '@rspack/core';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      plugins: [
+        new rspack.NormalModuleReplacementPlugin(
+          /\.module\.(css|less|sass|scss)$/,
+          'identity-obj-proxy',
+        ),
+      ],
+    },
+  },
+});
+```
+
+这个方式可以绕过 CSS Modules 的预处理和转换，通常会更快，尤其是 Sass 文件较多时。但它只是一个测试替身：
+
+- `styles.button` 通常返回 `button`，不会返回真实构建中的 hash class name。
+- 不会验证 Less、Sass 或 CSS Modules 语法是否正确。
+- 不适合验证 `composes`、`:global`、真实 class name、样式产物或客户端与服务端 class name 是否一致。
+
+因此，建议只在测试关注组件逻辑、不关注样式 class name 时使用。需要验证真实 CSS Modules 行为的测试，应保留 Rstest 默认处理；需要验证浏览器渲染效果的测试，应使用 Browser Mode。

--- a/website/docs/zh/guide/basic/css.mdx
+++ b/website/docs/zh/guide/basic/css.mdx
@@ -84,6 +84,10 @@ export default {
 };
 ```
 
+:::warning
+如果项目使用 [`@rstest/adapter-rspack`](/guide/integration/rspack)，本指南中的 Rsbuild plugin 和 `output.cssModules` 示例不适用。该 adapter 会禁用 Rstest 内置的 Rsbuild CSS plugin，并改用 `rspack.config.ts` 中继承的 CSS 规则。请在 Rspack 配置中设置 Less、Sass 和 CSS Modules。
+:::
+
 ## CSS Modules 的性能优化
 
 Rstest 的默认 CSS Modules 处理会尽量保持与 Rsbuild 构建结果一致。因此，导入 `.module.less` 或 `.module.scss` 时，仍可能执行对应的 Less 或 Sass 编译。
@@ -99,7 +103,11 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   tools: {
-    rspack(config, { rspack }) {
+    rspack(config, { rspack, isServer }) {
+      if (!isServer) {
+        return;
+      }
+
       config.plugins.push(
         new rspack.NormalModuleReplacementPlugin(
           /\.module\.(css|less|sass|scss)$/,
@@ -117,6 +125,7 @@ export default defineConfig({
 
 - `styles.button` 通常返回 `button`，不会返回真实构建中的 hash class name。
 - 不会验证 Less、Sass 或 CSS Modules 语法是否正确。
+- CSS Module 文件不存在或路径写错时不会被发现，因为请求会在解析原文件之前被替换。这样测试构建可能通过，但应用构建仍会失败。
 - 不适合验证 `composes`、`:global`、真实 class name、样式产物或客户端与服务端 class name 是否一致。
 
 因此，建议只在测试关注组件逻辑、不关注样式 class name 时使用。需要验证真实 CSS Modules 行为的测试，应保留 Rstest 默认处理；需要验证浏览器渲染效果的测试，应使用 Browser Mode。


### PR DESCRIPTION
## Summary

This PR adds a CSS guide that explains how Rstest handles regular CSS, CSS Modules, Less, and Sass across Node.js tests and Browser Mode. It also documents the corresponding Rsbuild plugin setup and the performance trade-offs of using `identity-obj-proxy` as a CSS Modules test substitute.

## Related Links

- https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-less
- https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-sass
- https://github.com/keyz/identity-obj-proxy

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated.