### PR TITLE
fix(core): restore defineConfig completions

### DIFF
--- a/e2e/types/projectConfig.ts
+++ b/e2e/types/projectConfig.ts
@@ -1,4 +1,12 @@
-import { defineConfig, defineInlineProject, defineProject } from '@rstest/core';
+import {
+  defineConfig,
+  defineInlineProject,
+  defineProject,
+  type RstestConfig,
+  type RstestConfigAsyncFn,
+  type RstestConfigExport,
+  type RstestConfigSyncFn,
+} from '@rstest/core';
 
 export const inlineNodeProject = defineInlineProject({
   name: 'runtime-utils-node',
@@ -88,9 +96,35 @@ export const exportedConfigFactory = defineConfig(() => ({
   testEnvironment: 'node',
 }));
 
+export const exportedSyncConfig: RstestConfigSyncFn = defineConfig(() => ({
+  testEnvironment: 'node',
+}));
+
 export const exportedAsyncConfigFactory = defineConfig(async () => ({
   testEnvironment: 'jsdom',
 }));
+
+export const exportedAsyncConfig: RstestConfigAsyncFn = defineConfig(
+  async () => ({
+    testEnvironment: 'jsdom',
+  }),
+);
+
+export const exportedObjectConfig: RstestConfig = defineConfig({
+  testEnvironment: 'jsdom',
+});
+
+export const exportedExplicitConfig: RstestConfigSyncFn =
+  defineConfig<RstestConfig>(() => ({
+    testEnvironment: 'node',
+  }));
+
+export const exportedAnyConfig: RstestConfigSyncFn = defineConfig(() =>
+  JSON.parse('{}'),
+);
+
+declare const dynamicConfig: RstestConfigExport;
+defineConfig(dynamicConfig);
 
 // @ts-expect-error unknown config property
 defineConfig({ testEnvironment: 'node', testEnvironmnt: 'node' });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,22 @@ export type RstestConfigExport =
  * This function helps you to autocomplete configuration types.
  * It accepts a Rstest config object, or a function that returns a config.
  */
+export function defineConfig<
+  const Config extends RstestConfig,
+  const Definition extends Config | (() => Config) | (() => Promise<Config>),
+>(
+  config: Definition &
+    (Definition extends (...args: never[]) => infer CallbackResult
+      ? [Awaited<CallbackResult>] extends [RstestConfig]
+        ? unknown
+        : never
+      : RstestConfig &
+          Record<Exclude<keyof Definition, keyof RstestConfig>, never>),
+): Definition extends (...args: never[]) => infer CallbackResult
+  ? [CallbackResult] extends [RstestConfig]
+    ? RstestConfigSyncFn
+    : RstestConfigAsyncFn
+  : RstestConfig;
 export function defineConfig<const Config extends RstestConfig>(
   config: () => Config,
 ): RstestConfigSyncFn;


### PR DESCRIPTION
## Summary

This PR restores TypeScript config-key completions for object literals passed to `defineConfig`. It adds a const-generic conditional overload while retaining existing sync/async factory compatibility, explicit generic calls, `any`-returning callbacks, and dynamic config definitions.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1841

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).