### PR TITLE
fix(core): decide `each` row spreading per table, not per row

### DIFF
--- a/e2e/describe/each.test.ts
+++ b/e2e/describe/each.test.ts
@@ -2,8 +2,13 @@ import { afterAll, describe, expect, it } from '@rstest/core';
 
 const logs: string[] = [];
 
+// Not every row is an array, so each row must arrive whole — the array row too.
+const mixedTable = [null, 42, ['a']];
+const mixedReceived: unknown[] = [];
+
 afterAll(() => {
   expect(logs.length).toBe(9);
+  expect(mixedReceived).toEqual(mixedTable);
 });
 
 describe.each([
@@ -55,5 +60,11 @@ describe.each<{ a: number; b: number; expected: number }>`
   it(`should return ${expected}`, () => {
     expect(a + b).toBe(expected);
     logs.push('executed');
+  });
+});
+
+describe.each(mixedTable)('mixed table case %#', (value) => {
+  it('should receive the row itself', () => {
+    mixedReceived.push(value);
   });
 });

--- a/e2e/test-api/each.test.ts
+++ b/e2e/test-api/each.test.ts
@@ -2,8 +2,13 @@ import { afterAll, expect, it } from '@rstest/core';
 
 const logs: string[] = [];
 
+// Not every row is an array, so each row must arrive whole — the array row too.
+const mixedTable = [null, 42, ['a']];
+const mixedReceived: unknown[] = [];
+
 afterAll(() => {
   expect(logs.length).toBe(13);
+  expect(mixedReceived).toEqual(mixedTable);
 });
 
 it.each([
@@ -55,4 +60,8 @@ it.each`
 `('template single column $value', ({ value }) => {
   expect(typeof value).toBe('boolean');
   logs.push('executed');
+});
+
+it.each(mixedTable)('mixed table case %#', (value) => {
+  mixedReceived.push(value);
 });

--- a/packages/core/src/runtime/runner/runtime.ts
+++ b/packages/core/src/runtime/runner/runtime.ts
@@ -31,16 +31,13 @@ import {
   ROOT_SUITE_NAME,
   SYNTHETIC_STACK_ERROR_MESSAGE,
 } from '../../utils/constants';
-import {
-  castArray,
-  generateFilePathHash,
-  isPlainObject,
-} from '../../utils/helper';
+import { generateFilePathHash, isPlainObject } from '../../utils/helper';
 import { fileContext } from '../fileContext';
 import {
   formatName,
   isTemplateStringsArray,
   parseTemplateTable,
+  resolveEachArgs,
   resolveTestArgs,
   TestRegisterError,
 } from '../util';
@@ -504,9 +501,10 @@ export class RunnerRuntime {
     return (name, arg2, arg3) => {
       const { fn, options: suiteOptions } = resolveTestArgs(arg2, arg3);
       const { timeout, retry, repeats, meta } = suiteOptions;
+      const argsByRow = resolveEachArgs(cases);
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
-        const params = castArray(param) as any[];
+        const params = argsByRow[i]!;
 
         this.describe({
           name: formatName(name, param, i),
@@ -574,9 +572,10 @@ export class RunnerRuntime {
     return (name, arg2, arg3) => {
       const { fn, options: testOptions } = resolveTestArgs(arg2, arg3);
       const { timeout, retry, repeats, meta } = testOptions;
+      const argsByRow = resolveEachArgs(cases);
       for (let i = 0; i < cases.length; i++) {
         const param = cases[i]!;
-        const params = castArray(param) as any[];
+        const params = argsByRow[i]!;
 
         const shouldPassContext =
           typeof fn === 'function' && TEST_EACH_CONTEXT_SYMBOL in fn;

--- a/packages/core/src/runtime/util.ts
+++ b/packages/core/src/runtime/util.ts
@@ -198,6 +198,18 @@ const formatTemplate = (template: string, values: any[]): string => {
   });
 };
 
+/**
+ * The callback arguments for each row of an `each` table. Whether rows are
+ * spread is decided by the whole table, as Jest and Vitest do: only when every
+ * row is an array, so an array row of a mixed table reaches the callback as the
+ * array itself. `Array.from` densifies a sparse table, so a hole becomes one
+ * `undefined` argument instead of a failed spread.
+ */
+export const resolveEachArgs = (cases: readonly unknown[]): unknown[][] => {
+  const rows = Array.from(cases);
+  return rows.every(Array.isArray) ? rows : rows.map((row) => [row]);
+};
+
 export const formatName = (
   template: string,
   param: any[] | Record<string, any>,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -104,7 +104,10 @@ export interface TestEachFn {
   <T extends readonly [unknown, ...unknown[]]>(
     cases: readonly T[],
   ): TestCall<(...args: [...T]) => MaybePromise<void>>;
-  <T>(cases: readonly T[]): TestCall<(...args: T[]) => MaybePromise<void>>;
+  <T extends readonly unknown[]>(
+    cases: readonly T[],
+  ): TestCall<(...args: [...T]) => MaybePromise<void>>;
+  <T>(cases: readonly T[]): TestCall<(param: T) => MaybePromise<void>>;
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
     ...expressions: unknown[]
@@ -143,6 +146,9 @@ export interface DescribeEachFn {
     cases: readonly T[],
   ): DescribeCall<(param: T) => MaybePromise<void>>;
   <T extends readonly [unknown, ...unknown[]]>(
+    cases: readonly T[],
+  ): DescribeCall<(...args: [...T]) => MaybePromise<void>>;
+  <T extends readonly unknown[]>(
     cases: readonly T[],
   ): DescribeCall<(...args: [...T]) => MaybePromise<void>>;
   <T>(cases: readonly T[]): DescribeCall<(param: T) => MaybePromise<void>>;

--- a/packages/core/tests/runner/util.test.ts
+++ b/packages/core/tests/runner/util.test.ts
@@ -1,4 +1,41 @@
-import { formatName, formatTestError } from '../../src/runtime/util';
+import {
+  formatName,
+  formatTestError,
+  resolveEachArgs,
+} from '../../src/runtime/util';
+
+describe('resolveEachArgs', () => {
+  it('spreads every row when the whole table is arrays', () => {
+    expect(
+      resolveEachArgs([
+        [1, 2],
+        [3, 4],
+      ]),
+    ).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('passes each row whole once any row is not an array', () => {
+    expect(resolveEachArgs([null, 42, ['a']])).toEqual([[null], [42], [['a']]]);
+    expect(resolveEachArgs([{ a: 1 }, { a: 2 }])).toEqual([
+      [{ a: 1 }],
+      [{ a: 2 }],
+    ]);
+  });
+
+  it('treats a hole as a single undefined argument', () => {
+    const sparse: (number[] | undefined)[] = [];
+    sparse[0] = [1];
+    sparse[2] = [2];
+    expect(resolveEachArgs(sparse)).toEqual([[[1]], [undefined], [[2]]]);
+  });
+
+  it('returns no rows for an empty table', () => {
+    expect(resolveEachArgs([])).toEqual([]);
+  });
+});
 
 it('test formatName', () => {
   expect(formatName('test index %#', [1, 2, 3], 1)).toBe('test index 1');

--- a/website/docs/en/api/runtime-api/test-api/describe.mdx
+++ b/website/docs/en/api/runtime-api/test-api/describe.mdx
@@ -158,8 +158,12 @@ describe.todo('should implement this suite');
 - **Type:**
 
 ```ts
-describe.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
-describe.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+// Every row is an array: the row is spread into the arguments
+describe.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, fn?: (...args: [...T]) => void | Promise<void>, timeout?: number): void;
+describe.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (...args: [...T]) => void | Promise<void>): void;
+// Otherwise: the row is passed as a single argument
+describe.each<T>(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+describe.each<T>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
 ```
 
 Creates a describe block for each item in the provided array. Like `describe`, it accepts an optional [`TestOptions`](#testoptions) object as its second argument and applies it to every generated suite.
@@ -174,6 +178,8 @@ describe.each([
   });
 });
 ```
+
+Rows are spread into the suite function arguments only when every row of the table is an array. Once any row is not an array, every row is passed whole, so an array row of a mixed table arrives as the array itself.
 
 You can also use a tagged template literal table syntax:
 

--- a/website/docs/en/api/runtime-api/test-api/test.mdx
+++ b/website/docs/en/api/runtime-api/test-api/test.mdx
@@ -135,8 +135,12 @@ test.todo('should implement this test');
 - **Type:**
 
 ```ts
-test.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
-test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+// Every row is an array: the row is spread into the arguments
+test.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, fn?: (...args: [...T]) => void | Promise<void>, timeout?: number): void;
+test.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (...args: [...T]) => void | Promise<void>): void;
+// Otherwise: the row is passed as a single argument
+test.each<T>(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+test.each<T>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
 ```
 
 Runs the same test logic for each item in the provided array.
@@ -199,6 +203,15 @@ test.each([
 // this will return
 // adds 1 + 2 to equal 3
 // adds 2 + 2 to equal 4
+```
+
+Rows are spread into the test function arguments only when every row of the table is an array. Once any row is not an array, every row is passed whole, so an array row of a mixed table arrives as the array itself:
+
+```ts
+test.each([null, 42, ['a']])('rejects %o', (value) => {
+  // The third case receives ['a'], not 'a'.
+  expect(isValid(value)).toBe(false);
+});
 ```
 
 You can also access object properties with `$` prefix:

--- a/website/docs/zh/api/runtime-api/test-api/describe.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/describe.mdx
@@ -158,8 +158,12 @@ describe.todo('should implement this suite');
 - **类型：**
 
 ```ts
-describe.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
-describe.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+// Every row is an array: the row is spread into the arguments
+describe.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, fn?: (...args: [...T]) => void | Promise<void>, timeout?: number): void;
+describe.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (...args: [...T]) => void | Promise<void>): void;
+// Otherwise: the row is passed as a single argument
+describe.each<T>(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+describe.each<T>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
 ```
 
 为数组中的每一项生成一个 describe 块。与 `describe` 一样，它的第二个参数可选地接受一个 [`TestOptions`](#testoptions) 对象，并作用于生成的每个套件。
@@ -174,6 +178,8 @@ describe.each([
   });
 });
 ```
+
+只有当表格的每一行都是数组时，行才会展开成套件函数的多个参数。只要有一行不是数组，每一行都会整体作为单个参数传入，混合表中的数组行会原样传给套件函数。
 
 你也可以使用标签模板字面量的表格语法：
 

--- a/website/docs/zh/api/runtime-api/test-api/test.mdx
+++ b/website/docs/zh/api/runtime-api/test-api/test.mdx
@@ -135,8 +135,12 @@ test.todo('should implement this test');
 - **类型：**
 
 ```ts
-test.each(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
-test.each(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
+// Every row is an array: the row is spread into the arguments
+test.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, fn?: (...args: [...T]) => void | Promise<void>, timeout?: number): void;
+test.each<T extends readonly unknown[]>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (...args: [...T]) => void | Promise<void>): void;
+// Otherwise: the row is passed as a single argument
+test.each<T>(cases: ReadonlyArray<T>)(name: string, fn?: (param: T) => void | Promise<void>, timeout?: number): void;
+test.each<T>(cases: ReadonlyArray<T>)(name: string, options: TestOptions, fn?: (param: T) => void | Promise<void>): void;
 ```
 
 对提供的数组中的每一项运行相同的测试逻辑。
@@ -199,6 +203,15 @@ test.each([
 // 此时将返回：
 // adds 1 + 2 to equal 3
 // adds 2 + 2 to equal 4
+```
+
+只有当表格的每一行都是数组时，行才会展开成测试函数的多个参数。只要有一行不是数组，每一行都会整体作为单个参数传入，混合表中的数组行会原样传给测试函数：
+
+```ts
+test.each([null, 42, ['a']])('rejects %o', (value) => {
+  // The third case receives ['a'], not 'a'.
+  expect(isValid(value)).toBe(false);
+});
 ```
 
 你也可以使用 `$` 前缀访问对象属性：


### PR DESCRIPTION
## Summary

`test.each` / `describe.each` decided per row whether to spread it into the callback arguments: any row that was an array got spread, even when the table also contained non-array rows. In a mixed table such as `[null, 42, ['a']]`, the third case received `'a'` instead of `['a']` — a silent change of test input rather than an error, which makes a table listing "an array" among several single values impossible to express.

The decision is now made once per table, as Jest and Vitest do: `resolveEachArgs` turns the table into per-row argument lists, spreading rows only when **every** row is an array. A mixed table passes each row whole; a hole in a sparse table becomes one `undefined` argument rather than a failed spread. Homogeneous array tables and object/template tables are unaffected.

Type changes, so the exported overloads follow the same table-wide rule:

- The fallback `TestEachFn` overload narrows from `(...args: T[])` to `(param: T)`, matching both the runtime and the equivalent `DescribeEachFn` overload. A callback that declared a second parameter on a non-tuple table now fails to type-check — that parameter was always `undefined` at runtime.
- A `<T extends readonly unknown[]>` spread overload is added to both `TestEachFn` and `DescribeEachFn`, so an all-array table held in a plain variable (inferred as `number[][]`, not a tuple type) still types its callback as spread.

Test names are unchanged — they still format from the per-row value, as Vitest does, so `%o` on an array row keeps printing its elements.

## Related Links

- Closes #1768

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
