### PR TITLE
feat(vscode): add Rstack Editor migration notice and stand down when it is active

### DIFF
--- a/packages/vscode/AGENTS.md
+++ b/packages/vscode/AGENTS.md
@@ -4,6 +4,8 @@
 
 Two-process design: the extension (`src/extension.ts`, TestController + test tree) spawns a worker (`src/worker/`, spawn owned by `src/master.ts`) that runs tests and reports back over Node `child_process` IPC with `serialization: 'advanced'` (WebSocket was replaced by IPC in #691 — values must survive structured clone). The worker protocol types in `src/types.ts` are shared by both sides — a protocol change must land on both ends in the same commit.
 
+This extension is superseded by Rstack Editor (`rstack.rstack`), which ships the same Rstest integration. `activate` must stay gated on `rstackEditorTakesOver()` so the two never register a second Test Explorer controller in one window; new user-facing features belong in rstack-editor, not here.
+
 Tests are split by harness and the two patterns must not mix in one file: unit tests live in `tests/unit/` and run via rstest; E2E tests live in `tests/suite/` and run inside the VS Code Extension Host. For stable test-tree assertions in E2E, use `toLabelTree()` from `tests/suite/helpers.ts`.
 
 ## Commands

--- a/packages/vscode/AGENTS.md
+++ b/packages/vscode/AGENTS.md
@@ -4,7 +4,7 @@
 
 Two-process design: the extension (`src/extension.ts`, TestController + test tree) spawns a worker (`src/worker/`, spawn owned by `src/master.ts`) that runs tests and reports back over Node `child_process` IPC with `serialization: 'advanced'` (WebSocket was replaced by IPC in #691 — values must survive structured clone). The worker protocol types in `src/types.ts` are shared by both sides — a protocol change must land on both ends in the same commit.
 
-This extension is superseded by Rstack Editor (`rstack.rstack`), which ships the same Rstest integration. `activate` must stay gated on `rstackEditorTakesOver()` so the two never register a second Test Explorer controller in one window; new user-facing features belong in rstack-editor, not here.
+This extension is superseded by the Rstack extension (`rstack.rstack`), which ships the same Rstest integration. `activate` must stay gated on `rstackEditorTakesOver()` so the two never register a second Test Explorer controller in one window; new user-facing features belong in rstack-editor, not here.
 
 Tests are split by harness and the two patterns must not mix in one file: unit tests live in `tests/unit/` and run via rstest; E2E tests live in `tests/suite/` and run inside the VS Code Extension Host. For stable test-tree assertions in E2E, use `toLabelTree()` from `tests/suite/helpers.ts`.
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -2,9 +2,9 @@
 
 > [!IMPORTANT]
 >
-> **This extension is retired. Migrate to [Rstack Editor](https://github.com/rstackjs/rstack-editor).**
+> **This extension is retired. Migrate to the [Rstack](https://github.com/rstackjs/rstack-editor) extension.**
 >
-> New editor features land in the unified [Rstack](https://marketplace.visualstudio.com/items?itemName=rstack.rstack) extension (`rstack.rstack`), which covers Rstest testing, Rslint linting and `rs fmt` formatting in one install. It is also available on the [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) for Cursor, Trae, VSCodium and other VS Code forks. This standalone extension stays published and keeps working while the transition is underway, but receives no new features.
+> New editor features land in the unified [Rstack](https://marketplace.visualstudio.com/items?itemName=rstack.rstack) extension (`rstack.rstack`), which covers testing, linting and formatting in one install. It is also available on the [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) for Cursor, Trae, VSCodium and other VS Code forks. This standalone extension stays published and keeps working while the transition is underway, but receives no new features.
 >
 > To switch: install `rstack.rstack`, disable or uninstall `rstack.rstest` so only one copy of Rstest runs, then re-enter your settings under the `rstack.rstest.*` keys. Settings are not migrated automatically — see the [migration notes](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions).
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,5 +1,13 @@
 # Rstest VS Code extension
 
+> [!IMPORTANT]
+>
+> **This extension is retired. Migrate to [Rstack Editor](https://github.com/rstackjs/rstack-editor).**
+>
+> New editor features land in the unified [Rstack](https://marketplace.visualstudio.com/items?itemName=rstack.rstack) extension (`rstack.rstack`), which covers Rstest testing, Rslint linting and `rs fmt` formatting in one install. It is also available on the [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) for Cursor, Trae, VSCodium and other VS Code forks. This standalone extension stays published and keeps working while the transition is underway, but receives no new features.
+>
+> To switch: install `rstack.rstack`, disable or uninstall `rstack.rstest` so only one copy of Rstest runs, then re-enter your settings under the `rstack.rstest.*` keys. Settings are not migrated automatically — see the [migration notes](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions).
+
 Rstest is a VS Code extension that discovers, displays, and runs tests in your workspace. It builds a rich Test Explorer tree from your test files and keeps it up to date as files change.
 
 ## Features

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -62,6 +62,11 @@
         "title": "Run in Terminal",
         "category": "Rstest",
         "icon": "$(terminal)"
+      },
+      {
+        "command": "rstest.openRstackExtension",
+        "title": "Migrate to Rstack Editor",
+        "category": "Rstest"
       }
     ],
     "configuration": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -65,7 +65,7 @@
       },
       {
         "command": "rstest.openRstackExtension",
-        "title": "Migrate to Rstack Editor",
+        "title": "Migrate to Rstack",
         "category": "Rstest"
       }
     ],

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -3,6 +3,10 @@ import { RstestDiagnostics } from './diagnostics';
 import { TestErrorStore, testMessageText } from './errorStore';
 import { logger } from './logger';
 import { runningWorkers } from './master';
+import {
+  createMigrationNotice,
+  rstackEditorTakesOver,
+} from './migrationNotice';
 import { Project, WorkspaceManager } from './project';
 import { disposeTerminal } from './terminal';
 import { RstestFileCoverage } from './testRunReporter';
@@ -16,8 +20,13 @@ import {
 } from './testTree';
 
 export async function activate(context: vscode.ExtensionContext) {
-  const rstest = new Rstest(context);
-  return rstest;
+  context.subscriptions.push(logger);
+  const standingDown = rstackEditorTakesOver();
+  createMigrationNotice(context, standingDown);
+  if (standingDown) {
+    return;
+  }
+  return new Rstest(context);
 }
 
 export function deactivate() {
@@ -47,7 +56,6 @@ class Rstest {
     this.ctrl = vscode.tests.createTestController('rstest', 'Rstest');
     context.subscriptions.push(this.ctrl);
     context.subscriptions.push(this.diagnostics);
-    context.subscriptions.push(logger);
 
     this.startScanWorkspaces();
     this.setupTestController();

--- a/packages/vscode/src/migrationNotice.ts
+++ b/packages/vscode/src/migrationNotice.ts
@@ -1,0 +1,133 @@
+import vscode from 'vscode';
+import { logger } from './logger';
+
+const RSTACK_EXTENSION_ID = 'rstack.rstack';
+const OPEN_EXTENSION_COMMAND = 'rstest.openRstackExtension';
+
+const MIGRATION_NOTES_URL =
+  'https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions';
+
+/**
+ * Rstack Editor bundles the same Rstest integration as this extension. When
+ * it is installed, enabled, and has its Rstest stack switched on, this
+ * extension must stand down so only one Test Explorer controller runs.
+ * `extensions.getExtension` only sees enabled extensions, so a disabled
+ * Rstack Editor does not count.
+ */
+export function rstackEditorTakesOver(): boolean {
+  return (
+    vscode.extensions.getExtension(RSTACK_EXTENSION_ID) !== undefined &&
+    vscode.workspace.getConfiguration('rstack.rstest').get('enable', true)
+  );
+}
+
+type NoticeState = 'migrate' | 'off' | 'reload';
+
+const NOTICES: Record<
+  NoticeState,
+  { text: string; tooltip: vscode.MarkdownString; log: string }
+> = {
+  migrate: {
+    text: '$(sparkle-filled) Rstest → Rstack',
+    tooltip: new vscode.MarkdownString(
+      [
+        '**The standalone Rstest extension is retired.**',
+        '',
+        `New editor features land in the unified **Rstack** extension (\`${RSTACK_EXTENSION_ID}\`), which covers Rstest, Rslint and \`rs fmt\`. Click to open it in the Extensions view.`,
+        '',
+        `Settings move from \`rstest.*\` to \`rstack.rstest.*\` and are not migrated automatically — see the [migration notes](${MIGRATION_NOTES_URL}).`,
+      ].join('\n'),
+    ),
+    log: `The standalone Rstest extension is retired; new features land in ${RSTACK_EXTENSION_ID}. Migration notes: ${MIGRATION_NOTES_URL}`,
+  },
+  off: {
+    text: '$(sparkle-filled) Rstest: off',
+    tooltip: new vscode.MarkdownString(
+      [
+        `**Rstack Editor (\`${RSTACK_EXTENSION_ID}\`) is running Rstest, so this extension is inactive.**`,
+        '',
+        'Click to open this extension in the Extensions view and uninstall it.',
+      ].join('\n'),
+    ),
+    log: `${RSTACK_EXTENSION_ID} is active, so the standalone Rstest extension stands down. Uninstall it to remove this notice.`,
+  },
+  reload: {
+    text: '$(sparkle-filled) Rstest: reload window',
+    tooltip: new vscode.MarkdownString(
+      [
+        `**Rstack Editor (\`${RSTACK_EXTENSION_ID}\`) changed after this window started.**`,
+        '',
+        'Click to reload the window so exactly one copy of Rstest runs.',
+      ].join('\n'),
+    ),
+    log: `${RSTACK_EXTENSION_ID} changed after activation. Reload the window so exactly one copy of Rstest runs.`,
+  },
+};
+
+/**
+ * Non-modal status bar reminder that this extension is superseded by Rstack
+ * Editor. `standingDown` is the decision `activate` made; a live controller
+ * cannot be torn down (or created) afterwards, so whenever Rstack Editor's
+ * state no longer matches that decision the notice asks for a reload.
+ */
+export function createMigrationNotice(
+  context: vscode.ExtensionContext,
+  standingDown: boolean,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      OPEN_EXTENSION_COMMAND,
+      (extensionId: string = RSTACK_EXTENSION_ID) =>
+        vscode.commands.executeCommand(
+          'workbench.extensions.search',
+          `@id:${extensionId}`,
+        ),
+    ),
+  );
+
+  const item = vscode.window.createStatusBarItem(
+    'rstest.migrationNotice',
+    vscode.StatusBarAlignment.Right,
+  );
+  item.name = 'Rstest: Migrate to Rstack Editor';
+  item.backgroundColor = new vscode.ThemeColor(
+    'statusBarItem.warningBackground',
+  );
+  context.subscriptions.push(item);
+
+  const commands: Record<NoticeState, vscode.StatusBarItem['command']> = {
+    migrate: OPEN_EXTENSION_COMMAND,
+    off: {
+      command: OPEN_EXTENSION_COMMAND,
+      title: 'Uninstall the standalone Rstest extension',
+      arguments: [context.extension.id],
+    },
+    reload: 'workbench.action.reloadWindow',
+  };
+
+  let state: NoticeState | undefined;
+  const apply = (takesOver: boolean) => {
+    const next: NoticeState =
+      takesOver !== standingDown ? 'reload' : standingDown ? 'off' : 'migrate';
+    if (next === state) {
+      return;
+    }
+    state = next;
+    const notice = NOTICES[next];
+    item.text = notice.text;
+    item.tooltip = notice.tooltip;
+    item.command = commands[next];
+    item.show();
+    logger.warn(notice.log);
+  };
+
+  apply(standingDown);
+  context.subscriptions.push(
+    vscode.extensions.onDidChange(() => apply(rstackEditorTakesOver())),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('rstack.rstest.enable')) {
+        apply(rstackEditorTakesOver());
+      }
+    }),
+  );
+}

--- a/packages/vscode/src/migrationNotice.ts
+++ b/packages/vscode/src/migrationNotice.ts
@@ -8,11 +8,11 @@ const MIGRATION_NOTES_URL =
   'https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions';
 
 /**
- * Rstack Editor bundles the same Rstest integration as this extension. When
+ * The Rstack extension bundles the same Rstest integration as this extension. When
  * it is installed, enabled, and has its Rstest stack switched on, this
  * extension must stand down so only one Test Explorer controller runs.
  * `extensions.getExtension` only sees enabled extensions, so a disabled
- * Rstack Editor does not count.
+ * Rstack extension does not count.
  */
 export function rstackEditorTakesOver(): boolean {
   return (
@@ -33,7 +33,7 @@ const NOTICES: Record<
       [
         '**The standalone Rstest extension is retired.**',
         '',
-        `New editor features land in the unified **Rstack** extension (\`${RSTACK_EXTENSION_ID}\`), which covers Rstest, Rslint and \`rs fmt\`. Click to open it in the Extensions view.`,
+        `New editor features land in the unified **Rstack** extension (\`${RSTACK_EXTENSION_ID}\`), which covers testing, linting and formatting. Click to open it in the Extensions view.`,
         '',
         `Settings move from \`rstest.*\` to \`rstack.rstest.*\` and are not migrated automatically — see the [migration notes](${MIGRATION_NOTES_URL}).`,
       ].join('\n'),
@@ -44,7 +44,7 @@ const NOTICES: Record<
     text: '$(sparkle-filled) Rstest: off',
     tooltip: new vscode.MarkdownString(
       [
-        `**Rstack Editor (\`${RSTACK_EXTENSION_ID}\`) is running Rstest, so this extension is inactive.**`,
+        `**Rstack (\`${RSTACK_EXTENSION_ID}\`) is running Rstest, so this extension is inactive.**`,
         '',
         'Click to open this extension in the Extensions view and uninstall it.',
       ].join('\n'),
@@ -55,7 +55,7 @@ const NOTICES: Record<
     text: '$(sparkle-filled) Rstest: reload window',
     tooltip: new vscode.MarkdownString(
       [
-        `**Rstack Editor (\`${RSTACK_EXTENSION_ID}\`) changed after this window started.**`,
+        `**Rstack (\`${RSTACK_EXTENSION_ID}\`) changed after this window started.**`,
         '',
         'Click to reload the window so exactly one copy of Rstest runs.',
       ].join('\n'),
@@ -65,10 +65,11 @@ const NOTICES: Record<
 };
 
 /**
- * Non-modal status bar reminder that this extension is superseded by Rstack
- * Editor. `standingDown` is the decision `activate` made; a live controller
- * cannot be torn down (or created) afterwards, so whenever Rstack Editor's
- * state no longer matches that decision the notice asks for a reload.
+ * Non-modal status bar reminder that this extension is superseded by the
+ * Rstack extension. `standingDown` is the decision `activate` made; a live
+ * controller cannot be torn down (or created) afterwards, so whenever the
+ * Rstack extension's state no longer matches that decision the notice asks
+ * for a reload.
  */
 export function createMigrationNotice(
   context: vscode.ExtensionContext,
@@ -89,7 +90,7 @@ export function createMigrationNotice(
     'rstest.migrationNotice',
     vscode.StatusBarAlignment.Right,
   );
-  item.name = 'Rstest: Migrate to Rstack Editor';
+  item.name = 'Rstest: Migrate to Rstack';
   item.backgroundColor = new vscode.ThemeColor(
     'statusBarItem.warningBackground',
   );

--- a/packages/vscode/tests/suite/uxCommands.test.ts
+++ b/packages/vscode/tests/suite/uxCommands.test.ts
@@ -16,6 +16,10 @@ suite('Editor / Test Explorer UX commands', () => {
     // openOutput just reveals the channel — it must not throw.
     await vscode.commands.executeCommand('rstest.openOutput');
 
+    // openRstackExtension only opens the Extensions view search — it must
+    // not throw or need network access.
+    await vscode.commands.executeCommand('rstest.openRstackExtension');
+
     const fileItem = await waitFor(() =>
       getTestItemByLabels(controller.items, ['test', 'progress.test.ts']),
     );

--- a/packages/vscode/tests/unit/migrationNotice.test.ts
+++ b/packages/vscode/tests/unit/migrationNotice.test.ts
@@ -28,16 +28,16 @@ describe('rstackEditorTakesOver', () => {
     }
   });
 
-  it('keeps this extension active without Rstack Editor', () => {
+  it('keeps this extension active without the Rstack extension', () => {
     expect(rstackEditorTakesOver()).toBe(false);
   });
 
-  it('stands down when Rstack Editor is enabled', () => {
+  it('stands down when the Rstack extension is enabled', () => {
     installed = new Set(['rstack.rstack']);
     expect(rstackEditorTakesOver()).toBe(true);
   });
 
-  it('stays active when Rstack Editor has its Rstest stack switched off', () => {
+  it('stays active when the Rstack extension has its Rstest stack switched off', () => {
     installed = new Set(['rstack.rstack']);
     settings['rstack.rstest.enable'] = false;
     expect(rstackEditorTakesOver()).toBe(false);

--- a/packages/vscode/tests/unit/migrationNotice.test.ts
+++ b/packages/vscode/tests/unit/migrationNotice.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { rstackEditorTakesOver } from '../../src/migrationNotice';
+
+let installed = new Set<string>();
+const settings: Record<string, unknown> = {};
+
+rs.mock('vscode', () => ({
+  default: {
+    MarkdownString: class {},
+    extensions: {
+      getExtension: (id: string) => (installed.has(id) ? { id } : undefined),
+    },
+    workspace: {
+      getConfiguration: (section: string) => ({
+        get: (key: string, fallback: unknown) =>
+          settings[`${section}.${key}`] ?? fallback,
+      }),
+    },
+    window: { createOutputChannel: () => ({}) },
+  },
+}));
+
+describe('rstackEditorTakesOver', () => {
+  afterEach(() => {
+    installed = new Set();
+    for (const key of Object.keys(settings)) {
+      delete settings[key];
+    }
+  });
+
+  it('keeps this extension active without Rstack Editor', () => {
+    expect(rstackEditorTakesOver()).toBe(false);
+  });
+
+  it('stands down when Rstack Editor is enabled', () => {
+    installed = new Set(['rstack.rstack']);
+    expect(rstackEditorTakesOver()).toBe(true);
+  });
+
+  it('stays active when Rstack Editor has its Rstest stack switched off', () => {
+    installed = new Set(['rstack.rstack']);
+    settings['rstack.rstest.enable'] = false;
+    expect(rstackEditorTakesOver()).toBe(false);
+  });
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -189,6 +189,7 @@ tinyexec
 tinyglobby
 tinyrainbow
 tinyspy
+Trae
 transpiling
 treeshaking
 tsbuildinfo

--- a/website/docs/en/guide/basic/vscode-extension.mdx
+++ b/website/docs/en/guide/basic/vscode-extension.mdx
@@ -4,6 +4,18 @@ description: The Rstest VS Code extension keeps your project’s tests in sync i
 
 # VS Code extension
 
+:::tip Migrate to Rstack Editor
+
+New editor features now land in [Rstack Editor](https://github.com/rstackjs/rstack-editor), a single extension covering the whole Rstack toolchain: Rstest testing, Rslint linting, and `rs fmt` formatting. The standalone `rstack.rstest` extension is retired and receives no new features, though it stays published and keeps working while the transition is underway.
+
+We recommend switching now:
+
+1. Install the [Rstack](https://marketplace.visualstudio.com/items?itemName=rstack.rstack) extension from the VS Code Marketplace, or from the [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) for Cursor, Trae, VSCodium, and other VS Code forks.
+2. Disable or uninstall `rstack.rstest` so only one copy of Rstest runs.
+3. Re-enter your settings under the `rstack.rstest.*` keys and re-bind any keybindings to the new `rstack.rstest.*` command ids. Settings are not migrated automatically. See the [migration notes](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions) for details.
+
+:::
+
 The Rstest VS Code extension keeps your project’s tests in sync inside the editor so you can browse, run, and debug them in VS Code.
 
 <img

--- a/website/docs/en/guide/basic/vscode-extension.mdx
+++ b/website/docs/en/guide/basic/vscode-extension.mdx
@@ -4,7 +4,7 @@ description: The Rstack VS Code extension keeps your project’s tests in sync i
 
 # VS Code extension
 
-The [Rstack](https://github.com/rstackjs/rstack-editor) VS Code extension keeps your project’s tests in sync inside the editor so you can browse, run, and debug them in VS Code. It covers the whole Rstack toolchain in a single install: Rstest testing, Rslint linting, and `rs fmt` formatting.
+The [Rstack](https://github.com/rstackjs/rstack-editor) VS Code extension keeps your project’s tests in sync inside the editor so you can browse, run, and debug them in VS Code. It covers the whole Rstack toolchain in a single install: testing, linting, and formatting.
 
 <img
   src="https://assets.rspack.rs/rstest/assets/rstest-vscode-extension.gif"

--- a/website/docs/en/guide/basic/vscode-extension.mdx
+++ b/website/docs/en/guide/basic/vscode-extension.mdx
@@ -1,22 +1,10 @@
 ---
-description: The Rstest VS Code extension keeps your project’s tests in sync inside the editor so you can browse, run, and debug them in VS Code.
+description: The Rstack VS Code extension keeps your project’s tests in sync inside the editor so you can browse, run, and debug them in VS Code.
 ---
 
 # VS Code extension
 
-:::tip Migrate to Rstack Editor
-
-New editor features now land in [Rstack Editor](https://github.com/rstackjs/rstack-editor), a single extension covering the whole Rstack toolchain: Rstest testing, Rslint linting, and `rs fmt` formatting. The standalone `rstack.rstest` extension is retired and receives no new features, though it stays published and keeps working while the transition is underway.
-
-We recommend switching now:
-
-1. Install the [Rstack](https://marketplace.visualstudio.com/items?itemName=rstack.rstack) extension from the VS Code Marketplace, or from the [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) for Cursor, Trae, VSCodium, and other VS Code forks.
-2. Disable or uninstall `rstack.rstest` so only one copy of Rstest runs.
-3. Re-enter your settings under the `rstack.rstest.*` keys and re-bind any keybindings to the new `rstack.rstest.*` command ids. Settings are not migrated automatically. See the [migration notes](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions) for details.
-
-:::
-
-The Rstest VS Code extension keeps your project’s tests in sync inside the editor so you can browse, run, and debug them in VS Code.
+The [Rstack](https://github.com/rstackjs/rstack-editor) VS Code extension keeps your project’s tests in sync inside the editor so you can browse, run, and debug them in VS Code. It covers the whole Rstack toolchain in a single install: Rstest testing, Rslint linting, and `rs fmt` formatting.
 
 <img
   src="https://assets.rspack.rs/rstest/assets/rstest-vscode-extension.gif"
@@ -26,8 +14,20 @@ The Rstest VS Code extension keeps your project’s tests in sync inside the edi
 
 ## Installation
 
-You can visit the extension’s [Visual Studio Code Marketplace page](https://marketplace.visualstudio.com/items?itemName=rstack.rstest), or install it directly inside VS Code:
+You can visit the extension’s [Visual Studio Code Marketplace page](https://marketplace.visualstudio.com/items?itemName=rstack.rstack), or install it directly inside VS Code:
 
-- Open the _Extensions_ view (<kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd>) and search for `rstack.rstest`.
-- Open the _Quick Open_ panel (<kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd> + <kbd>P</kbd>), enter `ext install rstack.rstest`, and press Enter.
-- You can also run `code --install-extension rstack.rstest` in the terminal.
+- Open the _Extensions_ view (<kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd>) and search for `rstack.rstack`.
+- Open the _Quick Open_ panel (<kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd> + <kbd>P</kbd>), enter `ext install rstack.rstack`, and press Enter.
+- You can also run `code --install-extension rstack.rstack` in the terminal.
+
+For Cursor, Trae, VSCodium, and other VS Code forks, install it from the [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack).
+
+:::tip Coming from the standalone Rstest extension
+
+The standalone `rstack.rstest` extension is retired and receives no new features. It stays published and keeps working while the transition is underway, but we recommend switching now:
+
+1. Install `rstack.rstack` as described above.
+2. Disable or uninstall `rstack.rstest` so only one copy of Rstest runs.
+3. Re-enter your settings under the `rstack.rstest.*` keys and re-bind any keybindings to the new `rstack.rstest.*` command ids. Settings are not migrated automatically. See the [migration notes](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions) for details.
+
+:::

--- a/website/docs/zh/guide/basic/vscode-extension.mdx
+++ b/website/docs/zh/guide/basic/vscode-extension.mdx
@@ -4,6 +4,18 @@ description: Rstest VS Code 扩展能够在编辑器内同步项目测试，让�
 
 # VS Code 扩展
 
+:::tip 迁移到 Rstack Editor
+
+新的编辑器功能现在都在 [Rstack Editor](https://github.com/rstackjs/rstack-editor) 中开发。它是一个覆盖整个 Rstack 工具链的扩展，同时提供 Rstest 测试、Rslint 检查和 `rs fmt` 格式化。独立的 `rstack.rstest` 扩展已停止新功能开发，在过渡期间仍会保持发布并可正常使用。
+
+建议现在就切换：
+
+1. 从 VS Code Marketplace 安装 [Rstack](https://marketplace.visualstudio.com/items?itemName=rstack.rstack) 扩展；Cursor、Trae、VSCodium 等 VS Code 衍生编辑器可从 [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) 安装。
+2. 禁用或卸载 `rstack.rstest`，避免同时运行两份 Rstest。
+3. 在 `rstack.rstest.*` 下重新填写你的配置，并把快捷键重新绑定到新的 `rstack.rstest.*` 命令 id。配置不会自动迁移，详见[迁移说明](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions)。
+
+:::
+
 Rstest VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code 中浏览、运行和调试测试。
 
 <img

--- a/website/docs/zh/guide/basic/vscode-extension.mdx
+++ b/website/docs/zh/guide/basic/vscode-extension.mdx
@@ -1,22 +1,10 @@
 ---
-description: Rstest VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code 中浏览、运行和调试测试。
+description: Rstack VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code 中浏览、运行和调试测试。
 ---
 
 # VS Code 扩展
 
-:::tip 迁移到 Rstack Editor
-
-新的编辑器功能现在都在 [Rstack Editor](https://github.com/rstackjs/rstack-editor) 中开发。它是一个覆盖整个 Rstack 工具链的扩展，同时提供 Rstest 测试、Rslint 检查和 `rs fmt` 格式化。独立的 `rstack.rstest` 扩展已停止新功能开发，在过渡期间仍会保持发布并可正常使用。
-
-建议现在就切换：
-
-1. 从 VS Code Marketplace 安装 [Rstack](https://marketplace.visualstudio.com/items?itemName=rstack.rstack) 扩展；Cursor、Trae、VSCodium 等 VS Code 衍生编辑器可从 [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) 安装。
-2. 禁用或卸载 `rstack.rstest`，避免同时运行两份 Rstest。
-3. 在 `rstack.rstest.*` 下重新填写你的配置，并把快捷键重新绑定到新的 `rstack.rstest.*` 命令 id。配置不会自动迁移，详见[迁移说明](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions)。
-
-:::
-
-Rstest VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code 中浏览、运行和调试测试。
+[Rstack](https://github.com/rstackjs/rstack-editor) VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code 中浏览、运行和调试测试。它一次安装即覆盖整个 Rstack 工具链：Rstest 测试、Rslint 检查和 `rs fmt` 格式化。
 
 <img
   src="https://assets.rspack.rs/rstest/assets/rstest-vscode-extension.gif"
@@ -26,8 +14,20 @@ Rstest VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code
 
 ## 安装
 
-你可以访问扩展的 [Visual Studio Code Marketplace 页面](https://marketplace.visualstudio.com/items?itemName=rstack.rstest)，也可以直接在 VS Code 内安装：
+你可以访问扩展的 [Visual Studio Code Marketplace 页面](https://marketplace.visualstudio.com/items?itemName=rstack.rstack)，也可以直接在 VS Code 内安装：
 
-- 打开「扩展」视图（<kbd>^</kbd>/<kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>X</kbd>），搜索 `rstack.rstest`。
-- 打开「快速打开」面板（<kbd>^</kbd>/<kbd>⌘</kbd> + <kbd>P</kbd>），输入 `ext install rstack.rstest` 并按 Enter。
-- 也可以在终端执行 `code --install-extension rstack.rstest`。
+- 打开「扩展」视图（<kbd>^</kbd>/<kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>X</kbd>），搜索 `rstack.rstack`。
+- 打开「快速打开」面板（<kbd>^</kbd>/<kbd>⌘</kbd> + <kbd>P</kbd>），输入 `ext install rstack.rstack` 并按 Enter。
+- 也可以在终端执行 `code --install-extension rstack.rstack`。
+
+Cursor、Trae、VSCodium 等 VS Code 衍生编辑器可从 [Open VSX Registry](https://open-vsx.org/extension/rstack/rstack) 安装。
+
+:::tip 从独立的 Rstest 扩展迁移
+
+独立的 `rstack.rstest` 扩展已停止新功能开发。在过渡期间它仍会保持发布并可正常使用，但建议现在就切换：
+
+1. 按上述方式安装 `rstack.rstack`。
+2. 禁用或卸载 `rstack.rstest`，避免同时运行两份 Rstest。
+3. 在 `rstack.rstest.*` 下重新填写你的配置，并把快捷键重新绑定到新的 `rstack.rstest.*` 命令 id。配置不会自动迁移，详见[迁移说明](https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions)。
+
+:::

--- a/website/docs/zh/guide/basic/vscode-extension.mdx
+++ b/website/docs/zh/guide/basic/vscode-extension.mdx
@@ -4,7 +4,7 @@ description: Rstack VS Code 扩展能够在编辑器内同步项目测试，让�
 
 # VS Code 扩展
 
-[Rstack](https://github.com/rstackjs/rstack-editor) VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code 中浏览、运行和调试测试。它一次安装即覆盖整个 Rstack 工具链：Rstest 测试、Rslint 检查和 `rs fmt` 格式化。
+[Rstack](https://github.com/rstackjs/rstack-editor) VS Code 扩展能够在编辑器内同步项目测试，让你在 VS Code 中浏览、运行和调试测试。它一次安装即覆盖整个 Rstack 工具链：测试、检查和格式化。
 
 <img
   src="https://assets.rspack.rs/rstest/assets/rstest-vscode-extension.gif"


### PR DESCRIPTION
## Summary

<img width="195" height="59" alt="image" src="https://github.com/user-attachments/assets/cc2c4c15-9fe6-4ae8-af0f-673744b89291" />

<img width="466" height="93" alt="Code 2026-09-03 11 07 01" src="https://github.com/user-attachments/assets/5db08515-6fba-4c31-af45-0af7401f36d3" />

<img width="178" height="47" alt="Code 2026-09-03 11 06 33" src="https://github.com/user-attachments/assets/e1b0b697-dc92-4639-a2bd-6da058c15e0c" />

<img width="530" height="157" alt="Code 2026-09-03 11 06 27" src="https://github.com/user-attachments/assets/9ebc942a-542b-4280-a8b7-00c1718ec864" />


The standalone Rstest VS Code extension is superseded by the unified Rstack extension (`rstack.rstack`), which bundles the same Rstest integration. Installing both in one workspace currently registers two Test Explorer controllers. This PR starts the migration described in the Rstack extension's roadmap:

- `activate` skips creating the Rstest controller when `rstack.rstack` is enabled with `rstack.rstest.enable` on, so only one copy of Rstest runs.
- A warning-colored status bar item (no popups) nudges users to migrate, offers uninstall while standing down, and asks for a window reload when the Rstack extension's state changes after activation.
- The extension README (Marketplace listing) and the website docs point users to the Rstack extension and its migration notes.

## Related Links

- https://github.com/rstackjs/rstack-editor#roadmap

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

https://claude.ai/code/session_01HPCkT2PNcNmZ91nHS77kM9

