### PR TITLE
chore(deps): update Rslib to 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ fixtures-test-*/
 .rstest-reports/
 .rstest-playwright/
 .rslib/
+**/.rstack/declarations/
 !packages/core/src/coverage
 !packages/core/tests/coverage
 tests-dist/

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ fixtures-test-*/
 .rstest-reports/
 .rstest-playwright/
 .rslib/
+.rstack/
 !packages/core/src/coverage
 !packages/core/tests/coverage
 tests-dist/

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ fixtures-test-*/
 .rstest-reports/
 .rstest-playwright/
 .rslib/
-**/.rstack/declarations/
 !packages/core/src/coverage
 !packages/core/tests/coverage
 tests-dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,6 @@
 dist
 compiled
 doc_build
-**/.rstack/declarations
 
 # Per-package third-party license bundles are generated and prettier-formatted by
 # each package's own build (`rslib build && prettier ./LICENSE.md --write`), so the

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 dist
 compiled
 doc_build
+**/.rstack/declarations
 
 # Per-package third-party license bundles are generated and prettier-formatted by
 # each package's own build (`rslib build && prettier ./LICENSE.md --write`), so the

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
     "@module-federation/rstest": "2.9.0",
     "@rsbuild/core": "~2.2.2",
     "@rsbuild/plugin-react": "^2.1.0",
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/browser": "workspace:*",
     "@rstest/browser-react": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
     "@module-federation/rstest": "2.9.0",
     "@rsbuild/core": "~2.2.2",
     "@rsbuild/plugin-react": "^2.1.0",
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/browser": "workspace:*",
     "@rstest/browser-react": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*"
   },

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*"
   },

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -36,7 +36,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "get-tsconfig": "5.0.0-beta.6",

--- a/packages/adapter-rslib/package.json
+++ b/packages/adapter-rslib/package.json
@@ -36,7 +36,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "get-tsconfig": "5.0.0-beta.6",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -36,7 +36,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rspack/cli": "~2.2.2",
     "@rspack/core": "~2.2.2",
     "@rstest/core": "workspace:*",

--- a/packages/adapter-rspack/package.json
+++ b/packages/adapter-rspack/package.json
@@ -36,7 +36,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rspack/cli": "~2.2.2",
     "@rspack/core": "~2.2.2",
     "@rstest/core": "workspace:*",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -44,7 +44,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/react": "^19.2.18",

--- a/packages/browser-react/package.json
+++ b/packages/browser-react/package.json
@@ -44,7 +44,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/react": "^19.2.18",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -53,7 +53,7 @@
     "ws": "^8.21.3"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/browser-ui": "workspace:*",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -53,7 +53,7 @@
     "ws": "^8.21.3"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/browser-ui": "workspace:*",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,7 @@
     "@rsbuild/plugin-less": "^2.0.1",
     "@rsbuild/plugin-node-polyfill": "^1.4.6",
     "@rsbuild/plugin-sass": "^2.0.1",
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/tsconfig": "workspace:*",
     "@sinonjs/fake-timers": "^15.4.0",
     "@types/babel__code-frame": "^7.27.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,7 @@
     "@rsbuild/plugin-less": "^2.0.1",
     "@rsbuild/plugin-node-polyfill": "^1.4.6",
     "@rsbuild/plugin-sass": "^2.0.1",
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/tsconfig": "workspace:*",
     "@sinonjs/fake-timers": "^15.4.0",
     "@types/babel__code-frame": "^7.27.0",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/istanbul-lib-coverage": "^2.0.6",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/istanbul-lib-coverage": "^2.0.6",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/istanbul-lib-coverage": "^2.0.6",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "@types/istanbul-lib-coverage": "^2.0.6",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -39,7 +39,7 @@
     "test": "pnpm run build && rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "playwright": "^1.62.1",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -39,7 +39,7 @@
     "test": "pnpm run build && rstest"
   },
   "devDependencies": {
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",
     "playwright": "^1.62.1",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -270,7 +270,7 @@
   ],
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0-rc.2",
+    "@rslib/core": "1.0.0",
     "@rstest/core": "workspace:*",
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/mocha": "^10.0.10",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -270,7 +270,7 @@
   ],
   "devDependencies": {
     "@rsbuild/core": "~2.2.2",
-    "@rslib/core": "1.0.0",
+    "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/mocha": "^10.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/browser':
         specifier: workspace:*
@@ -976,7 +976,7 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
@@ -988,7 +988,7 @@ importers:
   packages/adapter-rslib:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
@@ -1006,7 +1006,7 @@ importers:
   packages/adapter-rspack:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rspack/cli':
         specifier: ~2.2.2
@@ -1043,7 +1043,7 @@ importers:
         version: 8.21.3
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/browser-ui':
         specifier: workspace:*
@@ -1079,7 +1079,7 @@ importers:
   packages/browser-react:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
@@ -1180,7 +1180,7 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0))
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/tsconfig':
         specifier: workspace:*
@@ -1309,7 +1309,7 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
@@ -1364,7 +1364,7 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
@@ -1394,7 +1394,7 @@ importers:
   packages/playwright:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
@@ -1415,7 +1415,7 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0
+        specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/browser':
         specifier: workspace:*
         version: link:../packages/browser
@@ -976,8 +976,8 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -988,8 +988,8 @@ importers:
   packages/adapter-rslib:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1006,8 +1006,8 @@ importers:
   packages/adapter-rspack:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rspack/cli':
         specifier: ~2.2.2
         version: 2.2.2(@rspack/core@2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rspack/dev-server@2.2.1(@rspack/core@2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)))
@@ -1043,8 +1043,8 @@ importers:
         version: 8.21.3
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/browser-ui':
         specifier: workspace:*
         version: link:../browser-ui
@@ -1079,8 +1079,8 @@ importers:
   packages/browser-react:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1180,8 +1180,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0))
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -1309,8 +1309,8 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1364,8 +1364,8 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1394,8 +1394,8 @@ importers:
   packages/playwright:
     devDependencies:
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1415,8 +1415,8 @@ importers:
         specifier: ~2.2.2
         version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: workspace:*
         version: link:../core
@@ -1640,66 +1640,66 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@ast-grep/napi-darwin-arm64@0.45.1':
-    resolution: {integrity: sha512-CthYcA0H3z5A2EHKH4rhSuFzpYUtxqUMnohmejxtMS6wiAgriKhOCopxN8XKclspYMtQyX2GC/PbvcU3dIbQHw==}
+  '@ast-grep/napi-darwin-arm64@0.45.2':
+    resolution: {integrity: sha512-29+sfXTJ7xxqgTuWAHA89gDAQIiJyAZ1ZiHoupjKIqyn0mhXrktO1WOghlDzyYs++hITEPOeXftxy48Y0tDGDQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@ast-grep/napi-darwin-x64@0.45.1':
-    resolution: {integrity: sha512-PhlXMDEEH5fMjXjYcrbeNgGqrojj4zN8C7eMQC6M4pVkuW74uPhrblD4KUbNunp5I2LkWCdKOs36jhBaZe1iPw==}
+  '@ast-grep/napi-darwin-x64@0.45.2':
+    resolution: {integrity: sha512-PUjh7Zf4dKNzYLOYhX5wU6O4BgRPdJnD9zkS1n+/5SeK0U1L5YL486RjNgFt9Xyff0PGtP/wDeoHMF5PhKEwsw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@ast-grep/napi-linux-arm64-gnu@0.45.1':
-    resolution: {integrity: sha512-XScjs95/SrsV6kLl9MnF2qbqwKU79bcBA3JHi6xUu+hf0uZ0lc6MsZ595cEy5yw9PYRhgqwrT3wta9p4qU4jpg==}
+  '@ast-grep/napi-linux-arm64-gnu@0.45.2':
+    resolution: {integrity: sha512-bnGKLLHWO13pjPChOFq7Ifqj3HJdOAxMQAGDCUC2JSJhO2YL8/xBZrpN0cHIWNuoUNSAXjCtr5AsCnPz/3jlFg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ast-grep/napi-linux-arm64-musl@0.45.1':
-    resolution: {integrity: sha512-qjH5CN5KIUdJW2dHfp8W57QsP6H0mA6E/rboKEzAxw6Ant1q2ZKqE3bLHUZMDoZXOBGdCODSZm0bTDcctiP49g==}
+  '@ast-grep/napi-linux-arm64-musl@0.45.2':
+    resolution: {integrity: sha512-FXVb4/V55THjhKxi5zWVrAO8JQj+/DiYP7JLsqenkm5V3UNuC8p2opGOyQpUvNpvcqJiZA9Hl+Onj/yfwSVr/A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@ast-grep/napi-linux-x64-gnu@0.45.1':
-    resolution: {integrity: sha512-nPP0y5EnehCgmYqvVDKSvH4vHbEFdAi8L+Kq2Sz94vK32yv4eOWf9vWhgoPscWpw76GWuwhpDvME8SZARnS3DQ==}
+  '@ast-grep/napi-linux-x64-gnu@0.45.2':
+    resolution: {integrity: sha512-mtEIPLV9MW2PBswFcp3ydM4T5Ub73s89SRd0QMT2+DfA9XBLCLhnC+r/Yt4eRgnf8FyNx49bFTPxXvFKscr9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ast-grep/napi-linux-x64-musl@0.45.1':
-    resolution: {integrity: sha512-sg50LKH7TskWd/boWVFp9gwKc3Jd8sg0f8P6T2VQemX/EOj+OFaMJ2+y7Ok17WI/dODkrZgAPUwq7RAvMzLtqg==}
+  '@ast-grep/napi-linux-x64-musl@0.45.2':
+    resolution: {integrity: sha512-WLLHxDmuXkb/e3mz/xDCrB2dZPzv1ntsepuRTtpaIGczxnQTgFSzX/CXPD0e1MfsU/QL1AiXxxni8w+NGy/ZpQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@ast-grep/napi-win32-arm64-msvc@0.45.1':
-    resolution: {integrity: sha512-wnTmD34OD9bUpdBVTb58P0y+YPb/2C2g07zj96LSk5R4pdcEMrCFsrWZlaNwtEV4q7L9BfLgrxq3MBGI8c6doA==}
+  '@ast-grep/napi-win32-arm64-msvc@0.45.2':
+    resolution: {integrity: sha512-04iOFaMzD2nf8CKw3nURWN42900wqPtUTQaMo1I2KRk3qbgtHSJjJoVJGAWUXkCq4LhPg3Xlk1s+ssWf4rNm2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@ast-grep/napi-win32-ia32-msvc@0.45.1':
-    resolution: {integrity: sha512-gRyJwRPY1mWRtnJ6AMncV2pNU+B2indjLCb9z/+aZrUN5u/gOxYryEzvRatyC9rVUMeQGJD+k0htpsqIwgXVbA==}
+  '@ast-grep/napi-win32-ia32-msvc@0.45.2':
+    resolution: {integrity: sha512-tE3y0RQcajocKwpYLbgHKd4lzGGAx1wGMA0bGPsWdoFK8VSob6ZDuYdSlSdnaRs8jAc4F3axToNRKn15p+0/Dg==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@ast-grep/napi-win32-x64-msvc@0.45.1':
-    resolution: {integrity: sha512-mzfMmCO7tSNks+NGkGkSnDBKxBjHoOLAMJt2IbAkMYATxHC0RqfBoN7Qtd02VGhHWEfwWLPv/wU6MrvweZ3jdQ==}
+  '@ast-grep/napi-win32-x64-msvc@0.45.2':
+    resolution: {integrity: sha512-o8Z5Z42TAJe0fPnb11rrjtte58wlw/MuR4KpVMHl8IhJLBBR7gHR0E8wfMz88TxzsQz0U2KYev0k0a2fV4i0sQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@ast-grep/napi@0.45.1':
-    resolution: {integrity: sha512-4cmGQEHoP9GLHEhGvd1vgSzO3Y6KF7FczDk4+q/VfXV9/9sNxNVgNHC8t3BglhIADDcoHrCMc9aw4lHG+M240A==}
+  '@ast-grep/napi@0.45.2':
+    resolution: {integrity: sha512-hBA5c7JV6OM7zFWoLjUNZhsDpxEIEIeew5S3z1giwK5tPQqobuFfM2OhS45bN3E0+yQtgCX/o8/AEHKbGD3ykg==}
     engines: {node: '>= 10'}
 
   '@azu/format-text@1.0.2':
@@ -3520,8 +3520,8 @@ packages:
   '@rsdoctor/utils@1.6.3':
     resolution: {integrity: sha512-xuZalAwSE8r/8Ro+N9RxyA+0OXvaSGXOaggmbmF89YGrYhQ4R3h05XvgZKQLtd//w8DxR6znUqb1xKp8a4NYDw==}
 
-  '@rslib/core@1.0.0-rc.2':
-    resolution: {integrity: sha512-6Bex+f8THioCRtfVg8cswHWR4T1xwY+VxRXoOXIgGBROTMlCuoS2/TzcLwYHmU1q1FXfXM8zAs0XuEnUAoDXzQ==}
+  '@rslib/core@1.0.0':
+    resolution: {integrity: sha512-eZNXCWU1v5oti4+DKCunc76DkNnYqMgRtks9UyZRRFlmaK4pKAxhejeCUS+XkbMurGIAa+aDyVynQD7DXEgK1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -7661,8 +7661,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsbuild-plugin-dts@1.0.0-rc.2:
-    resolution: {integrity: sha512-Mqalmu3j7UcDLUl3O5Y502V5Id6cbKyNn/nUxQIxar7gK2KjdPyw58WRfMQ7/4r4oHmeBeIgeSCb50M648ysoA==}
+  rsbuild-plugin-dts@1.0.0:
+    resolution: {integrity: sha512-FVoTsiTfSc0LPeSjrVhpvFOBRig0YXJq3Hp+bVxzh9/bzFvODzLRWOEux8q1Phe1oVCIIVSc2+Nb7kDcxIhosw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -8969,44 +8969,44 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@ast-grep/napi-darwin-arm64@0.45.1':
+  '@ast-grep/napi-darwin-arm64@0.45.2':
     optional: true
 
-  '@ast-grep/napi-darwin-x64@0.45.1':
+  '@ast-grep/napi-darwin-x64@0.45.2':
     optional: true
 
-  '@ast-grep/napi-linux-arm64-gnu@0.45.1':
+  '@ast-grep/napi-linux-arm64-gnu@0.45.2':
     optional: true
 
-  '@ast-grep/napi-linux-arm64-musl@0.45.1':
+  '@ast-grep/napi-linux-arm64-musl@0.45.2':
     optional: true
 
-  '@ast-grep/napi-linux-x64-gnu@0.45.1':
+  '@ast-grep/napi-linux-x64-gnu@0.45.2':
     optional: true
 
-  '@ast-grep/napi-linux-x64-musl@0.45.1':
+  '@ast-grep/napi-linux-x64-musl@0.45.2':
     optional: true
 
-  '@ast-grep/napi-win32-arm64-msvc@0.45.1':
+  '@ast-grep/napi-win32-arm64-msvc@0.45.2':
     optional: true
 
-  '@ast-grep/napi-win32-ia32-msvc@0.45.1':
+  '@ast-grep/napi-win32-ia32-msvc@0.45.2':
     optional: true
 
-  '@ast-grep/napi-win32-x64-msvc@0.45.1':
+  '@ast-grep/napi-win32-x64-msvc@0.45.2':
     optional: true
 
-  '@ast-grep/napi@0.45.1':
+  '@ast-grep/napi@0.45.2':
     optionalDependencies:
-      '@ast-grep/napi-darwin-arm64': 0.45.1
-      '@ast-grep/napi-darwin-x64': 0.45.1
-      '@ast-grep/napi-linux-arm64-gnu': 0.45.1
-      '@ast-grep/napi-linux-arm64-musl': 0.45.1
-      '@ast-grep/napi-linux-x64-gnu': 0.45.1
-      '@ast-grep/napi-linux-x64-musl': 0.45.1
-      '@ast-grep/napi-win32-arm64-msvc': 0.45.1
-      '@ast-grep/napi-win32-ia32-msvc': 0.45.1
-      '@ast-grep/napi-win32-x64-msvc': 0.45.1
+      '@ast-grep/napi-darwin-arm64': 0.45.2
+      '@ast-grep/napi-darwin-x64': 0.45.2
+      '@ast-grep/napi-linux-arm64-gnu': 0.45.2
+      '@ast-grep/napi-linux-arm64-musl': 0.45.2
+      '@ast-grep/napi-linux-x64-gnu': 0.45.2
+      '@ast-grep/napi-linux-x64-musl': 0.45.2
+      '@ast-grep/napi-win32-arm64-msvc': 0.45.2
+      '@ast-grep/napi-win32-ia32-msvc': 0.45.2
+      '@ast-grep/napi-win32-x64-msvc': 0.45.2
 
   '@azu/format-text@1.0.2': {}
 
@@ -11000,10 +11000,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)':
+  '@rslib/core@1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
-      rsbuild-plugin-dts: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.2)(typescript@6.0.3)
+      rsbuild-plugin-dts: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.2)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@22.18.6)
       typescript: 6.0.3
@@ -15835,9 +15835,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-dts@1.0.0-rc.2(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.2)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.2)(typescript@6.0.3):
     dependencies:
-      '@ast-grep/napi': 0.45.1
+      '@ast-grep/napi': 0.45.2
       '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@22.18.6)


### PR DESCRIPTION
## Summary

- Update `@rslib/core` from `1.0.0-rc.2` to the `~1.0.0` range across all workspaces.
- Ignore Rslib's generated `.rstack/` build artifacts so CI lint does not scan declaration intermediates.
- Confirm the before/after build artifacts are byte-identical across 10 Rslib-built packages (181 files).

## Related Links

- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).