### PR TITLE
fix(vscode): mirror workspace trust in the Rstack stand-down check

### DIFF
--- a/packages/vscode/src/migrationNotice.ts
+++ b/packages/vscode/src/migrationNotice.ts
@@ -8,15 +8,18 @@ const MIGRATION_NOTES_URL =
   'https://github.com/rstackjs/rstack-editor/blob/main/packages/vscode/README.md#coming-from-the-standalone-extensions';
 
 /**
- * The Rstack extension bundles the same Rstest integration as this extension. When
- * it is installed, enabled, and has its Rstest stack switched on, this
- * extension must stand down so only one Test Explorer controller runs.
+ * The Rstack extension bundles the same Rstest integration as this extension.
+ * This predicate mirrors its VS Code-level gates (workspace trust and
+ * `rstack.rstest.enable`), not project detection.
  * `extensions.getExtension` only sees enabled extensions, so a disabled
- * Rstack extension does not count.
+ * Rstack extension does not count. Trust needs no change listener: VS Code
+ * does not activate this extension in Restricted Mode, and granted trust
+ * cannot be revoked without a reload.
  */
 export function rstackEditorTakesOver(): boolean {
   return (
     vscode.extensions.getExtension(RSTACK_EXTENSION_ID) !== undefined &&
+    vscode.workspace.isTrusted &&
     vscode.workspace.getConfiguration('rstack.rstest').get('enable', true)
   );
 }

--- a/packages/vscode/tests/unit/migrationNotice.test.ts
+++ b/packages/vscode/tests/unit/migrationNotice.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { rstackEditorTakesOver } from '../../src/migrationNotice';
 
 let installed = new Set<string>();
+let isTrusted = true;
 const settings: Record<string, unknown> = {};
 
 rs.mock('vscode', () => ({
@@ -11,6 +12,9 @@ rs.mock('vscode', () => ({
       getExtension: (id: string) => (installed.has(id) ? { id } : undefined),
     },
     workspace: {
+      get isTrusted() {
+        return isTrusted;
+      },
       getConfiguration: (section: string) => ({
         get: (key: string, fallback: unknown) =>
           settings[`${section}.${key}`] ?? fallback,
@@ -23,6 +27,7 @@ rs.mock('vscode', () => ({
 describe('rstackEditorTakesOver', () => {
   afterEach(() => {
     installed = new Set();
+    isTrusted = true;
     for (const key of Object.keys(settings)) {
       delete settings[key];
     }
@@ -32,9 +37,15 @@ describe('rstackEditorTakesOver', () => {
     expect(rstackEditorTakesOver()).toBe(false);
   });
 
-  it('stands down when the Rstack extension is enabled', () => {
+  it('stands down when the setting is default and the workspace is trusted', () => {
     installed = new Set(['rstack.rstack']);
     expect(rstackEditorTakesOver()).toBe(true);
+  });
+
+  it('stays active when the workspace is untrusted', () => {
+    installed = new Set(['rstack.rstack']);
+    isTrusted = false;
+    expect(rstackEditorTakesOver()).toBe(false);
   });
 
   it('stays active when the Rstack extension has its Rstest stack switched off', () => {


### PR DESCRIPTION
## Summary

The unified Rstack extension gates its Rstest controller on workspace trust before it looks at `rstack.rstest.enable`, but the stand-down check in this extension only looked at the setting. This PR adds the `workspace.isTrusted` gate to `rstackEditorTakesOver()` so the predicate mirrors the unified extension's VS Code-level gates.

No change listener is added for trust: VS Code does not activate this extension in Restricted Mode, and granted trust cannot be revoked without a reload, so the value read at activation stays correct for the window's lifetime.

## Related Links

- https://github.com/web-infra-dev/rstest/issues/1777

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

