### PR TITLE
feat(core): enable automatic prebundle by default

### DIFF
--- a/e2e/dom/fixtures/prebundle/rstest.native.config.mts
+++ b/e2e/dom/fixtures/prebundle/rstest.native.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testEnvironment: {
+    name: 'jsdom',
+    prebundle: false,
+  },
+});

--- a/e2e/dom/index.test.ts
+++ b/e2e/dom/index.test.ts
@@ -60,7 +60,7 @@ describe('jsdom', () => {
     await expectExecSuccess();
   });
 
-  it('should only prebundle when explicitly enabled', async ({
+  it('should prebundle by default and allow opting out', async ({
     onTestFinished,
   }) => {
     const cwd = fileURLToPath(new URL('./fixtures/prebundle', import.meta.url));
@@ -77,13 +77,19 @@ describe('jsdom', () => {
         },
       });
 
-    const native = await run();
+    const defaultConfig = await run();
+    await defaultConfig.expectExecSuccess();
+    expect(defaultConfig.cli.stdout).toContain(
+      'bundled test environment jsdom',
+    );
+
+    const native = await run('rstest.native.config.mts');
     await native.expectExecSuccess();
     expect(native.cli.stdout).not.toContain('bundled test environment jsdom');
 
-    const prebundled = await run('rstest.prebundle.config.mts');
-    await prebundled.expectExecSuccess();
-    expect(prebundled.cli.stdout).toContain('bundled test environment jsdom');
+    const explicitAuto = await run('rstest.prebundle.config.mts');
+    await explicitAuto.expectExecSuccess();
+    expect(explicitAuto.cli.stdout).toContain('bundled test environment jsdom');
   });
 
   it('should run test correctly with custom externals', async () => {

--- a/packages/core/src/core/testEnvironmentModule.ts
+++ b/packages/core/src/core/testEnvironmentModule.ts
@@ -373,7 +373,7 @@ const shouldPrebundle = async ({
   project: InternalProjectContext;
   resolvedPath: string;
 }): Promise<boolean> => {
-  const option = project.normalizedConfig.testEnvironment.prebundle ?? false;
+  const option = project.normalizedConfig.testEnvironment.prebundle ?? 'auto';
   if (option === true) {
     return true;
   }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -298,8 +298,8 @@ export type EnvironmentWithOptions = {
    *
    * - `'auto'`: prebundle supported built-in environments.
    * - `true`: always prebundle the selected built-in environment.
-   * - `false` (default): load the environment natively.
-   * @default false
+   * - `false`: load the environment natively.
+   * @default 'auto'
    */
   prebundle?: TestEnvironmentPrebundle;
 };

--- a/packages/core/tests/core/testEnvironmentModule.test.ts
+++ b/packages/core/tests/core/testEnvironmentModule.test.ts
@@ -578,8 +578,8 @@ exports.canvasInstalled = canvasInstalled;
     });
   });
 
-  it('does not prebundle by default', async () => {
-    await withTempDir('rstest-env-default-native-', async (root) => {
+  it('uses automatic prebundle by default', async () => {
+    await withTempDir('rstest-env-default-auto-', async (root) => {
       createPackage(root, 'export class JSDOM {}');
 
       const result = await prepareTestEnvironmentModules({
@@ -591,7 +591,7 @@ exports.canvasInstalled = canvasInstalled;
         expect(result.modules.get('jsdom')).toMatchObject({
           name: 'jsdom',
         });
-        expect(result.modules.get('jsdom')?.bundlePath).toBeUndefined();
+        expect(result.modules.get('jsdom')?.bundlePath).toBeTruthy();
       } finally {
         await result.cleanup();
       }

--- a/website/docs/en/config/test/test-environment.mdx
+++ b/website/docs/en/config/test/test-environment.mdx
@@ -95,13 +95,13 @@ The `options` object is passed directly to the environment's constructor.
 
 <ApiMeta addedVersion="0.11.6" />
 
-Rstest can prebundle a test environment before workers load it. This reduces repeated module resolution and initialization work when many test files use the same DOM environment. This optimization is disabled by default and must be explicitly enabled.
+Rstest can prebundle a test environment before workers load it. This reduces repeated module resolution and initialization work when many test files use the same DOM environment. Since 0.12.0, this optimization is enabled by default in `auto` mode.
 
 The `prebundle` option accepts:
 
 - `'auto'`: prebundle Rstest-tested versions of the built-in `jsdom` and `happy-dom` environments. Unknown versions use native loading.
 - `true`: always prebundle the selected built-in environment.
-- `false` (default): disable the prebundle and load the environment natively.
+- `false`: disable the prebundle and load the environment natively.
 
 The current automatic compatibility matrix covers jsdom 15–26 and 29–30, and happy-dom 20. Other major versions stay on the native path unless `prebundle: true` is set explicitly.
 

--- a/website/docs/zh/config/test/test-environment.mdx
+++ b/website/docs/zh/config/test/test-environment.mdx
@@ -95,13 +95,13 @@ export default defineConfig({
 
 <ApiMeta addedVersion="0.11.6" />
 
-Rstest 可以在 worker 加载测试环境前对其进行预打包。当大量测试文件使用相同的 DOM 环境时，这可以减少重复的模块解析和初始化开销。这项优化默认关闭，需要显式启用。
+Rstest 可以在 worker 加载测试环境前对其进行预打包。当大量测试文件使用相同的 DOM 环境时，这可以减少重复的模块解析和初始化开销。从 0.12.0 开始，这项优化默认以 `auto` 模式开启。
 
 `prebundle` 支持以下值：
 
 - `'auto'`：预打包经过 Rstest 验证的内置 `jsdom` 和 `happy-dom` 版本。未知版本使用原生加载。
 - `true`：强制预打包选中的内置环境。
-- `false`（默认值）：关闭预打包，原生加载环境。
+- `false`：关闭预打包，原生加载环境。
 
 当前自动兼容矩阵覆盖 jsdom 15–26、29–30 和 happy-dom 20。其他大版本默认保留原生加载路径，除非显式设置 `prebundle: true`。
 


### PR DESCRIPTION
## Summary

Since 0.12.0, supported DOM test environments use `prebundle: 'auto'` by default. Users can still opt out with `prebundle: false`; unsupported environment versions continue to use native loading.

- Updates the core default and public config documentation.
- Adds unit and DOM e2e coverage for default, explicit opt-out, and explicit `auto` behavior.
- Browser mode and adapters are unaffected because this behavior is owned by core's test-environment module preparation.

## Related Links

- [feat(core): support prebundle test environments #1663](https://github.com/web-infra-dev/rstest/pull/1663) — includes the original prebundle implementation and performance comparison.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).