### PR TITLE
fix(browser): support Vue plugins in browser mode

### DIFF
--- a/e2e/vue/fixtures/package.json
+++ b/e2e/vue/fixtures/package.json
@@ -15,6 +15,7 @@
     "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@rsbuild/plugin-vue-jsx": "^2.0.1",
+    "@rstest/browser": "workspace:*",
     "@rstest/core": "workspace:*",
     "@vue/compiler-dom": "^3.5.42",
     "@vue/server-renderer": "^3.5.42",

--- a/e2e/vue/fixtures/rstest.browser.config.mts
+++ b/e2e/vue/fixtures/rstest.browser.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig, type RstestConfig } from '@rstest/core';
+import rsbuildConfig from './rsbuild.config';
+
+export default defineConfig({
+  ...(rsbuildConfig as RstestConfig),
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+    headless: true,
+  },
+});

--- a/e2e/vue/fixtures/rstest.browser.config.mts
+++ b/e2e/vue/fixtures/rstest.browser.config.mts
@@ -7,5 +7,8 @@ export default defineConfig({
     enabled: true,
     provider: 'playwright',
     headless: true,
+    providerOptions: {
+      launch: process.env.CI ? { channel: 'chrome' } : undefined,
+    },
   },
 });

--- a/e2e/vue/sfc.test.ts
+++ b/e2e/vue/sfc.test.ts
@@ -20,4 +20,18 @@ describe('vue sfc', () => {
 
     await expectExecSuccess();
   });
+
+  it('should run vue SFC test correctly in browser mode', async () => {
+    const { expectExecSuccess } = await runRstestCli({
+      command: 'rstest',
+      args: ['run', 'index', '--config=rstest.browser.config.mts'],
+      options: {
+        nodeOptions: {
+          cwd: join(__dirname, 'fixtures'),
+        },
+      },
+    });
+
+    await expectExecSuccess();
+  });
 });

--- a/packages/browser/src/browserRsbuild.ts
+++ b/packages/browser/src/browserRsbuild.ts
@@ -77,6 +77,8 @@ type BrowserProjectEntries = {
 };
 
 class RstestBrowserRuntimePlugin {
+  constructor(private readonly browserRuntimeDir: string) {}
+
   apply(compiler: Rspack.Compiler) {
     const { RuntimeModule } = compiler.webpack;
     class BrowserRuntimeModule extends RuntimeModule {
@@ -115,6 +117,20 @@ function __rstest_clean_browser_test_entry__(testEntryPath) {
         );
       },
     );
+
+    compiler.hooks.afterPlugins.tap('RstestBrowserSourceMapRule', () => {
+      compiler.options.module.rules.unshift({
+        test: /\.js$/,
+        include: this.browserRuntimeDir,
+        extractSourceMap: true,
+      });
+
+      if (isDebug()) {
+        logger.log(
+          `[rstest:browser] extractSourceMap rule added for: ${this.browserRuntimeDir}`,
+        );
+      }
+    });
   }
 }
 
@@ -1684,30 +1700,13 @@ export const createBrowserRuntime = async ({
                         : false;
                       rspackConfig.plugins = rspackConfig.plugins || [];
                       rspackConfig.plugins.push(
-                        new RstestBrowserRuntimePlugin(),
+                        new RstestBrowserRuntimePlugin(
+                          dirname(browserRuntimePath),
+                        ),
                       );
                       rspackConfig.plugins.push(virtualManifestPlugin);
 
                       applyDefaultWatchOptions(rspackConfig, isWatchMode);
-
-                      // Extract and merge sourcemaps from pre-built @rstest/core files
-                      // This preserves the sourcemap chain for inline snapshot support
-                      // See: https://rspack.rs/config/module-rules#rulesextractsourcemap
-                      const browserRuntimeDir = dirname(browserRuntimePath);
-                      rspackConfig.module = rspackConfig.module || {};
-                      rspackConfig.module.rules =
-                        rspackConfig.module.rules || [];
-                      rspackConfig.module.rules.unshift({
-                        test: /\.js$/,
-                        include: browserRuntimeDir,
-                        extractSourceMap: true,
-                      });
-
-                      if (isDebug()) {
-                        logger.log(
-                          `[rstest:browser] extractSourceMap rule added for: ${browserRuntimeDir}`,
-                        );
-                      }
                     },
                   },
                 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,9 @@ importers:
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
         version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
+      '@rstest/browser':
+        specifier: workspace:*
+        version: link:../../../packages/browser
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core


### PR DESCRIPTION
## Summary

This PR fixes browser-mode builds for Vue projects using `@rsbuild/plugin-vue`. The browser sourcemap rule injected by Rstest was being cloned by `VueLoaderPlugin`, and `rspack-vue-loader` rejected `extractSourceMap` during rule compilation. The rule is now injected from `RstestBrowserRuntimePlugin` after all plugins have initialized, preserving sourcemap handling while keeping the internal rule out of Vue's rule cloning. A Vue SFC browser-mode regression test covers the failure.

## Related Links

- https://rspack.rs/config/module-rules#rulesextractsourcemap

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).