### PR TITLE
perf(core): skip environment bundle sourcemap scans

### DIFF
--- a/packages/core/src/core/testEnvironmentModule.ts
+++ b/packages/core/src/core/testEnvironmentModule.ts
@@ -2,6 +2,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rm,
   stat,
   writeFile,
@@ -359,7 +360,11 @@ const buildTestEnvironmentModule = async ({
 
   const result = await rsbuild.build();
   await result.close();
-  return join(outputPath, 'environment.mjs');
+  const bundlePath = join(outputPath, 'environment.mjs');
+  // The OS temp path can contain an alias (macOS exposes /var as /private/var),
+  // while Node's ESM stack uses the canonical path. Resolve it once here so
+  // workers and source-map-support identify the generated file consistently.
+  return realpath(bundlePath);
 };
 
 const shouldPrebundle = async ({

--- a/packages/core/src/runtime/worker/runInPool.ts
+++ b/packages/core/src/runtime/worker/runInPool.ts
@@ -1,4 +1,5 @@
 import type { FileCoverageData } from 'istanbul-lib-coverage';
+import { pathToFileURL } from 'node:url';
 import { isMainThread, threadId } from 'node:worker_threads';
 import { normalize } from 'pathe';
 import { install } from 'source-map-support';
@@ -35,6 +36,7 @@ import { createNodeTaskContext } from './taskContext.node';
 import type { TaskContext } from './taskContext';
 
 let sourceMaps: Record<string, string> = {};
+let currentEnvironmentBundle: { path: string; url: string } | undefined;
 
 // Threads-pool workers all share `process.pid` with the host, and each
 // worker_thread has its own JS context, so PhaseTracker's `nextThreadId`
@@ -53,6 +55,19 @@ install({
       return {
         url: source,
         map: JSON.parse(sourceMaps[source]),
+      };
+    }
+    // Stack frames may identify the same ESM file as either a filesystem path
+    // or a file URL, and source-map-support passes that value through unchanged.
+    if (
+      source === currentEnvironmentBundle?.path ||
+      source === currentEnvironmentBundle?.url
+    ) {
+      // Environment bundles are built without sourcemaps. Returning null would
+      // let source-map-support read and scan the entire bundle on first use.
+      return {
+        url: source,
+        map: { version: 3, sources: [], names: [], mappings: '' },
       };
     }
     return null;
@@ -171,6 +186,14 @@ const preparePool = async (
   tracker?: PhaseTracker,
   onTestEnvironmentFallback?: (fallback: TestEnvironmentModuleFallback) => void,
 ) => {
+  const environmentBundlePath = context.testEnvironmentModule?.bundlePath;
+  currentEnvironmentBundle = environmentBundlePath
+    ? {
+        path: environmentBundlePath,
+        url: pathToFileURL(environmentBundlePath).href,
+      }
+    : undefined;
+
   // Reset globalCleanups only when preparePool is called again (running without isolation)
   globalCleanups.forEach((fn) => {
     fn();

--- a/packages/core/tests/core/testEnvironmentModule.test.ts
+++ b/packages/core/tests/core/testEnvironmentModule.test.ts
@@ -110,6 +110,9 @@ exports.canvasToken = canvas.token;
         if (!moduleReference?.bundlePath) {
           throw new Error('Expected jsdom to be bundled.');
         }
+        expect(moduleReference.bundlePath).toBe(
+          fs.realpathSync(moduleReference.bundlePath),
+        );
         expect(fs.existsSync(moduleReference.bundlePath)).toBe(true);
 
         const bundled = await import(


### PR DESCRIPTION
## Summary

Rstest builds environment bundles without sourcemaps. When jsdom formats an error stack, `source-map-support` still reads and scans the 12.3 MB bundle for a sourcemap. This unnecessary work can happen for every test file.

This PR returns an empty sourcemap for the environment bundle, which stops the fallback scan. It resolves the real path once and supports both file paths and file URLs because stack frames may use either form. Sourcemaps for other files are unchanged.

## Benchmark

Design system benchmark: 80 files, 240 tests, jsdom, 8 forks, 6 paired runs on an Apple M3 Max.

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Full run | 5,781 ms | 5,477 ms | 304 ms (5.3%) |
| Bundle scan per file | 15.8 ms | 0 ms | Removed |

The optimized version was faster in 5 of 6 pairs, with a typical saving of 218 ms.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).