### PR TITLE
perf(core): use code unit ordering for reporter paths

### DIFF
--- a/e2e/browser-mode/reporterOutput.test.ts
+++ b/e2e/browser-mode/reporterOutput.test.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from '@rstest/core';
+import { describe, expect, it, onTestFinished } from '@rstest/core';
+import { prepareFixtures } from '../scripts';
 import { runBrowserCliWithCwd } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,6 +17,62 @@ const xmlPath = join(fixtureDir, '.tmp', 'report.xml');
 // reporter — so file-writing reporters produce complete output (verified: zero
 // `flushOutputStreams` references existed in `packages/browser/src`).
 describe('browser mode - browser-only reporter output', () => {
+  it.each(['node', 'browser'])(
+    'orders %s report paths by code units and preserves in-file test order',
+    async (mode) => {
+      const target = join(
+        __dirname,
+        'fixtures',
+        `fixtures-test-report-order-${mode}`,
+      );
+      const { fs: fixtureFs } = await prepareFixtures({
+        fixturesPath: fixtureDir,
+        fixturesTargetPath: target,
+      });
+      onTestFinished(() => fixtureFs.delete(target));
+      fixtureFs.delete(join(target, 'tests/browser.test.ts'));
+      const paths = ['ä.test.ts', 'z.test.ts', 'a.test.ts', 'B.test.ts'];
+      for (const path of paths) {
+        fs.copyFileSync(
+          join(__dirname, '../reporter/fixtures/agent-md-pass/many.test.ts'),
+          join(target, 'tests', path),
+        );
+      }
+
+      const { expectExecSuccess } = await runBrowserCliWithCwd(target, {
+        args: mode === 'node' ? ['--browser.enabled=false'] : [],
+        env: { LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8' },
+      });
+      await expectExecSuccess();
+
+      const report = JSON.parse(
+        fs.readFileSync(join(target, '.tmp/report.json'), 'utf8'),
+      );
+      const orderedPaths = [
+        'tests/B.test.ts',
+        'tests/a.test.ts',
+        'tests/z.test.ts',
+        'tests/ä.test.ts',
+      ];
+      expect(
+        report.files.map((file: { testPath: string }) => file.testPath),
+      ).toEqual(orderedPaths);
+      expect(
+        report.tests.map((test: { testPath: string; fullName: string }) => [
+          test.testPath,
+          test.fullName,
+        ]),
+      ).toEqual(
+        orderedPaths.flatMap((path) =>
+          Array.from({ length: 12 }, (_, i) => [
+            path,
+            `agent-md-pass > case ${i + 1}`,
+          ]),
+        ),
+      );
+    },
+  );
+
   it('writes complete junit and json reporter files', async ({
     onTestFinished,
   }) => {

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -376,7 +376,7 @@ export class Rstest implements InternalContext {
     // would shift run-to-run with the sequencer's scheduling. Sort is stable,
     // so individual test cases keep their in-file declaration order.
     const byTestPath = (a: { testPath: string }, b: { testPath: string }) =>
-      a.testPath.localeCompare(b.testPath);
+      a.testPath === b.testPath ? 0 : a.testPath.localeCompare(b.testPath);
     this.reporterResults.results.sort(byTestPath);
     this.reporterResultIndex.clear();
     this.reporterResults.results.forEach((result, index) => {

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -370,13 +370,14 @@ export class Rstest implements InternalContext {
         );
     }
 
+    // Compare code units so report order does not depend on the host locale.
     // Reporter *presentation* order is deterministic by test path, decoupled
     // from *execution* order (which is perf-first and cache/timing dependent —
     // see testSequencer.ts). Without this, the order files appear in reports
     // would shift run-to-run with the sequencer's scheduling. Sort is stable,
     // so individual test cases keep their in-file declaration order.
     const byTestPath = (a: { testPath: string }, b: { testPath: string }) =>
-      a.testPath === b.testPath ? 0 : a.testPath.localeCompare(b.testPath);
+      a.testPath < b.testPath ? -1 : a.testPath > b.testPath ? 1 : 0;
     this.reporterResults.results.sort(byTestPath);
     this.reporterResultIndex.clear();
     this.reporterResults.results.forEach((result, index) => {

--- a/packages/core/tests/core/rstest.test.ts
+++ b/packages/core/tests/core/rstest.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'pathe';
 import { Rstest } from '../../src/core/rstest';
+import type { TestResult } from '../../src/types';
 
 // Mock std-env to ensure consistent snapshot across environments
 rs.mock('std-env', () => ({
@@ -11,6 +12,39 @@ process.env.DEBUG = 'false';
 const rootPath = join(__dirname, '../..');
 
 describe('rstest context', () => {
+  it('sorts reporter paths by code units and preserves in-file test order', () => {
+    const context = new Rstest(
+      { cwd: rootPath, command: 'run', projects: [] },
+      {},
+    );
+    const paths = ['ä.test.ts', 'z.test.ts', 'a.test.ts', 'B.test.ts'];
+    const tests: TestResult[] = paths.flatMap((testPath) =>
+      ['second', 'first'].map((name) => ({
+        testId: `${testPath}:${name}`,
+        testPath,
+        name,
+        status: 'pass',
+        project: '',
+      })),
+    );
+    context.updateReporterResultState(
+      tests
+        .filter((test) => test.name === 'second')
+        .map((test) => ({ ...test, results: [] })),
+      tests,
+    );
+
+    const orderedPaths = ['B.test.ts', 'a.test.ts', 'z.test.ts', 'ä.test.ts'];
+    expect(
+      context.reporterResults.results.map((file) => file.testPath),
+    ).toEqual(orderedPaths);
+    expect(
+      context.reporterResults.testResults.map((test) => test.testId),
+    ).toEqual(
+      orderedPaths.flatMap((path) => [`${path}:second`, `${path}:first`]),
+    );
+  });
+
   it('uses a longer default test timeout for browser projects', () => {
     const browserContext = new Rstest(
       {

--- a/website/docs/en/api/javascript-api/reporter.mdx
+++ b/website/docs/en/api/javascript-api/reporter.mdx
@@ -57,6 +57,8 @@ The `Reporter` interface provides lifecycle hooks for test execution. Each hook 
 - **Case-level hooks**: `onTestCaseStart`, `onTestCaseResult`
 - **Run-level hooks**: `onTestRunStart`, `onTestRunEnd`, `onUserConsoleLog`, `onExit`
 
+The `results` and `testResults` arrays passed to `onTestRunEnd` are sorted by `testPath` in UTF-16 code unit order, independent of the system locale. Entries with the same path retain their relative order. This report ordering does not affect test execution order.
+
 ### Basic interface structure
 
 ```ts

--- a/website/docs/zh/api/javascript-api/reporter.mdx
+++ b/website/docs/zh/api/javascript-api/reporter.mdx
@@ -57,6 +57,8 @@ export default defineConfig({
 - **用例级钩子**：`onTestCaseStart`、`onTestCaseResult`
 - **运行级钩子**：`onTestRunStart`、`onTestRunEnd`、`onUserConsoleLog`、`onExit`
 
+传入 `onTestRunEnd` 的 `results` 和 `testResults` 数组按 `testPath` 的 UTF-16 编码单元顺序排序，不受系统 locale 影响。路径相同的条目保留原有相对顺序。报告排序不会影响测试执行顺序。
+
 ### 基本接口结构
 
 ```ts


### PR DESCRIPTION
## Summary

Sort final reporter results by UTF-16 code units to avoid locale comparison and make report order independent of the host locale. Case and accent ordering can change; test execution order and the relative order of tests sharing a path are preserved. Includes Node/browser report-order tests and bilingual documentation.

Bundled `deps-heavy` CLI wall time on Node 24.19.0 / Apple M3 Max, based on `1fe4c6954`: 31 interleaved rounds after 2 warmups per variant, fresh processes, warm filesystem/compile cache, build cache disabled, forks with isolation and piped output.

| Case | Original median | Equal-path guard median | `<` / `>` median |
| --- | ---: | ---: | ---: |
| Single file / 2 tests, 1 worker | 286.90 ms | 282.69 ms | 278.65 ms |
| 25 files / 50 tests, 8 workers | 611.96 ms | 617.02 ms | 617.96 ms |

Against the original comparator, the paired median reduction is **5.30 ms** for the single file (95% bootstrap CI: 2.63–8.64 ms) and **−2.36 ms** for the full suite (CI: −8.85–7.17 ms; no significant improvement). Paired reductions use per-round differences, rather than differences between the table medians.

No significant additional gain over the equal-path guard was measured. A separate full-suite trace found 39 `localeCompare` calls in the sequencer before reporting, so replacing the reporter comparator cannot eliminate that initialization cost.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
