### PR TITLE
refactor(core): match runCLI argv to the process.argv shape

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -5,21 +5,18 @@ import { prepareCli } from './prepare';
 /** @experimental Subject to change until 1.0.0. */
 export type RunCLIOptions = {
   /**
-   * The command, filters, and flags to parse, exactly as written after `rstest`
-   * on the command line.
-   * @default process.argv.slice(2)
+   * The command-line arguments to parse, matching the shape of Node.js `process.argv`
+   * @default process.argv
    */
   argv?: string[];
 };
 
 /** @experimental Subject to change until 1.0.0. */
-export function runCLI({
-  argv = process.argv.slice(2),
-}: RunCLIOptions = {}): void {
+export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
   prepareCli();
 
   try {
-    setupCommands(['node', 'rstest', ...argv]);
+    setupCommands(argv);
   } catch (err) {
     logger.error('Failed to start Rstest CLI.');
     logger.error(err);

--- a/packages/core/tests/cli/index.test.ts
+++ b/packages/core/tests/cli/index.test.ts
@@ -20,20 +20,21 @@ afterEach(() => {
 });
 
 describe('runCLI', () => {
-  it('accepts arguments written after the rstest command', () => {
-    runCLI({ argv: ['run', 'sum.test.ts', '--watch'] });
-
-    expect(prepareCliSpy).toHaveBeenCalledOnce();
-    expect(setupCommandsSpy).toHaveBeenCalledWith([
-      'node',
-      'rstest',
+  it('passes caller-supplied full-shape argv through unchanged', () => {
+    const argv = [
+      '/usr/local/bin/node',
+      '/project/node_modules/.bin/rstest',
       'run',
       'sum.test.ts',
       '--watch',
-    ]);
+    ];
+    runCLI({ argv });
+
+    expect(prepareCliSpy).toHaveBeenCalledOnce();
+    expect(setupCommandsSpy).toHaveBeenCalledWith(argv);
   });
 
-  it('defaults to the arguments after the executable and script', () => {
+  it('passes process.argv through unchanged by default', () => {
     process.argv = [
       '/usr/local/bin/node',
       '/project/node_modules/.bin/rstest',
@@ -43,11 +44,6 @@ describe('runCLI', () => {
 
     runCLI();
 
-    expect(setupCommandsSpy).toHaveBeenCalledWith([
-      'node',
-      'rstest',
-      'run',
-      'sum.test.ts',
-    ]);
+    expect(setupCommandsSpy).toHaveBeenCalledWith(process.argv);
   });
 });

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -434,11 +434,12 @@ interface RstestInstance {
 import { runCLI } from '@rstest/core/api';
 
 runCLI({
-  argv: ['run', 'src/foo.test.ts', '--update'],
+  argv: [...process.argv.slice(0, 2), 'run', 'src/foo.test.ts', '--update'],
 });
 ```
 
-`argv` contains the command, filters, and flags exactly as you would type them after `rstest` on the command line. It defaults to `process.argv.slice(2)`.
+`argv` matches the shape of Node.js `process.argv` and defaults to `process.argv`: the first two entries are the executable and script paths and are ignored, while the command, filters, and flags start at index 2.
+This is the same shape used by Rsbuild's and Rspress's `runCLI`.
 
 See the [CLI documentation](/guide/basic/cli) for all available commands and flags.
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -434,11 +434,12 @@ interface RstestInstance {
 import { runCLI } from '@rstest/core/api';
 
 runCLI({
-  argv: ['run', 'src/foo.test.ts', '--update'],
+  argv: [...process.argv.slice(0, 2), 'run', 'src/foo.test.ts', '--update'],
 });
 ```
 
-`argv` 包含在命令行中写在 `rstest` 之后的命令、过滤条件和选项。默认值为 `process.argv.slice(2)`。
+`argv` 的结构与 Node.js 的 `process.argv` 一致，默认值为 `process.argv`：前两项是 executable 和 script 的路径，会被忽略，命令、filters 和 flags 从索引 2 开始。
+这与 Rsbuild 和 Rspress 的 `runCLI` 使用的结构相同。
 
 所有可用的命令和选项，请参阅 [CLI 文档](/guide/basic/cli)。
 


### PR DESCRIPTION
## Summary

`runCLI` from `@rstest/core/api` currently takes `argv` as the arguments written after `rstest` (default `process.argv.slice(2)`) and prepends placeholder `node` / `rstest` entries before parsing. Rsbuild and Rspress expose the same option with the full Node.js `process.argv` shape (default `process.argv`), and so did Rstest before #1729. A caller that passes `process.argv` to every Rstack CLI therefore gets the executable and script paths treated as test filters on Rstest only.

This PR makes `argv` match the `process.argv` shape again: the first two entries are ignored by the parser, and the command, filters, and flags start at index 2. The default is `process.argv`. This is a breaking change to the `@experimental` `runCLI` option relative to the unreleased #1729; the shape is the one that shipped in 0.11. `bin/rstest.js` calls `runCLI()` without arguments, so the CLI itself is unaffected. Docs and the JSDoc are updated to describe the shape.

## Related Links

- #1729

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
