### PR TITLE
refactor(core): run merge-reports through the public API

### DIFF
--- a/e2e/programmatic/fixtures/run-inline.mjs
+++ b/e2e/programmatic/fixtures/run-inline.mjs
@@ -42,7 +42,12 @@ try {
       },
     },
   });
-  const buildFailureResult = await buildFailure.run();
+  let buildFailureResult;
+  try {
+    buildFailureResult = await buildFailure.run();
+  } catch (error) {
+    buildFailureResult = { status: 'rejected', message: error.message };
+  }
 
   console.log(
     `__RSTEST_API_RESULT__${JSON.stringify({
@@ -62,10 +67,7 @@ try {
       unhandledErrors: result.unhandledErrors,
       duration: { hasTotal: typeof result.duration.total === 'number' },
       snapshotPresent: typeof result.snapshot === 'object',
-      buildFailure: {
-        status: buildFailureResult.status,
-        message: buildFailureResult.unhandledErrors[0]?.message,
-      },
+      buildFailure: buildFailureResult,
     })}__END__`,
   );
 } finally {

--- a/e2e/programmatic/fixtures/run-missing-dependencies.mjs
+++ b/e2e/programmatic/fixtures/run-missing-dependencies.mjs
@@ -52,7 +52,12 @@ try {
     reporters: [],
   };
   const rstest = await createRstest({ cwd: root, config });
-  const runResult = await rstest.run();
+  let runResult;
+  try {
+    runResult = await rstest.run();
+  } catch (error) {
+    runResult = { status: 'rejected', message: error.message };
+  }
 
   let watchError;
   let watcher;
@@ -65,19 +70,18 @@ try {
     await watcher.close();
   }
 
-  const mergeResult = await rstest.mergeReports();
+  let mergeResult;
+  try {
+    mergeResult = await rstest.mergeReports();
+  } catch (error) {
+    mergeResult = { status: 'rejected', message: error.message };
+  }
 
   console.log(
     `__RSTEST_API_RESULT__${JSON.stringify({
-      run: {
-        status: runResult.status,
-        message: runResult.unhandledErrors[0]?.message,
-      },
+      run: runResult,
       watch: { message: watchError },
-      mergeReports: {
-        status: mergeResult.status,
-        message: mergeResult.unhandledErrors[0]?.message,
-      },
+      mergeReports: mergeResult,
     })}__END__`,
   );
 } finally {

--- a/e2e/programmatic/index.test.ts
+++ b/e2e/programmatic/index.test.ts
@@ -11,7 +11,7 @@ const parsePayload = (stdout: string) =>
   parseMarkerPayload<Record<string, any>>(stdout, '__RSTEST_API_RESULT__');
 
 describe('programmatic createRstest', () => {
-  it('uses inline config and contains build failures in run results', async ({
+  it('uses inline config and rejects build failures', async ({
     onTestFinished,
   }) => {
     const { cli } = await runRstestCli({
@@ -44,7 +44,7 @@ describe('programmatic createRstest', () => {
     expect(result.unhandledErrors).toEqual([]);
     expect(result.duration.hasTotal).toBe(true);
     expect(result.snapshotPresent).toBe(true);
-    expect(result.buildFailure.status).toBe('error');
+    expect(result.buildFailure.status).toBe('rejected');
     expect(result.buildFailure.message).toContain(
       'programmatic build exploded',
     );
@@ -180,10 +180,10 @@ describe('programmatic createRstest', () => {
       'Failed to load coverage provider module: @rstest/coverage-istanbul';
 
     expect(execution.exitCode).toBe(0);
-    expect(result.run).toMatchObject({ status: 'error' });
+    expect(result.run).toMatchObject({ status: 'rejected' });
     expect(result.run.message).toContain(dependencyMessage);
     expect(result.watch.message).toContain(dependencyMessage);
-    expect(result.mergeReports).toMatchObject({ status: 'error' });
+    expect(result.mergeReports).toMatchObject({ status: 'rejected' });
     expect(result.mergeReports.message).toContain(dependencyMessage);
     expect(cli.log).not.toContain('Install it now?');
     expect(cli.log).not.toContain('Installing ');

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -19,6 +19,8 @@ Core testing framework for Rstest.
 
 `resolveRunnerInputs` owns configuration-source resolution and `buildResolvedRunner` owns selection plus context construction. The public instance API is the CLI's target driver; commands not migrated yet may call this shared chain directly. Every change must narrow the gap between those drivers: expose new CLI needs as public observations or capabilities rather than adding CLI-only execution paths.
 
+When a CLI command migrates to the public `createRstest` (as `merge-reports` already has), config discovery, the CLI → config merge, the agent reporter default, host exit code, and error printing stay in `src/cli`; never add them to the engine or the public API to make a migration easier.
+
 `NormalizedConfig` is exported from `@rstest/core/api` as the type of `RstestContext.config`, so changing its shape is a public API change.
 
 ## Executor contract (node + browser isomorphism)

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -28,11 +28,7 @@ import {
   getTaskNameWithPrefix,
   ROOT_SUITE_NAME,
 } from '../utils';
-import {
-  createErrorResult,
-  createResultReporter,
-  type ResultReporter,
-} from './result';
+import { createResultReporter, type ResultReporter } from './result';
 import type {
   CreateRstestOptions,
   ListedTest,
@@ -155,7 +151,7 @@ export async function createRstest(
           ? getAbsolutePath(cwd, config.filePath)
           : undefined,
     },
-    options: {},
+    options: { configLoader: options.configLoader },
     cwd,
   });
   const initialContext = createRstestContext(
@@ -222,26 +218,13 @@ export async function createRstest(
     commonOptions: CommonOptions | undefined,
     operation: (engine: Engine) => Promise<void>,
   ): Promise<TestRunResult> => {
-    try {
-      return await withEngine(
-        command,
-        runOptions,
-        commonOptions,
-        async (engine) => {
-          const capture: ResultReporter = createResultReporter(engine.context);
-          engine.context.reporters.push(capture.reporter);
-          const result = capture.nextResult();
-          try {
-            await operation(engine);
-            return await result;
-          } catch (error) {
-            return capture.errorResult(error);
-          }
-        },
-      );
-    } catch (error) {
-      return createErrorResult(error);
-    }
+    return withEngine(command, runOptions, commonOptions, async (engine) => {
+      const capture = createResultReporter(engine.context);
+      engine.context.reporters.push(capture.reporter);
+      const result = capture.nextResult();
+      await operation(engine);
+      return await result;
+    });
   };
 
   return {

--- a/packages/core/src/api/result.ts
+++ b/packages/core/src/api/result.ts
@@ -134,7 +134,6 @@ const createResult = (
 export type ResultReporter = {
   reporter: Reporter;
   nextResult(): Promise<TestRunResult>;
-  errorResult(error: unknown): TestRunResult;
 };
 
 export function createResultReporter(
@@ -194,25 +193,5 @@ export function createResultReporter(
       new Promise<TestRunResult>((resolve) => {
         resolveResult = resolve;
       }),
-    errorResult(error) {
-      const failedCycle: CapturedCycle = captured ?? {
-        files: cycleFiles,
-        unhandledErrors: [],
-        duration: { total: 0 },
-        snapshot: context.snapshotManager.summary,
-      };
-      failedCycle.unhandledErrors.unshift(toSerializedError(error));
-      return createResult(context, failedCycle);
-    },
-  };
-}
-
-export function createErrorResult(error: unknown): TestRunResult {
-  return {
-    status: 'error',
-    files: [],
-    summary: computeSummary([]),
-    unhandledErrors: [toSerializedError(error)],
-    duration: { total: 0 },
   };
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,3 +1,4 @@
+import type { LoadConfigOptions } from '@rsbuild/core';
 import type {
   CoverageMapData,
   FileFilterMode,
@@ -30,6 +31,8 @@ export interface CreateRstestOptions {
   cwd?: string;
   /** Inline or loaded configuration. */
   config?: RstestConfig | LoadedRstestConfig;
+  /** The loader used for config files discovered through `projects`; defaults to `auto`. */
+  configLoader?: LoadConfigOptions['loader'];
 }
 
 /** @experimental Subject to change until 1.0.0. */

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,10 +1,17 @@
 import cac, { type CAC, type Command } from 'cac';
 import type { RstestCommand, RstestInstance } from '../types';
-import { color, determineAgent, formatError, isTTY, logger } from '../utils';
+import {
+  color,
+  determineAgent,
+  formatError,
+  getAbsolutePath,
+  isTTY,
+  logger,
+} from '../utils';
 import { buildResolvedRunner, isRelatedRun } from '../core/buildRunner';
 import { exitReporters } from '../reporter';
 import type { PackageInstallerConfirm } from '../utils/packageInstaller';
-import { mirrorExitCode } from './exitCode';
+import { mirrorExitCode, setHostExitCode } from './exitCode';
 import type { CommonOptions } from './init';
 import { renderListTests, type ListCommandOptions } from './listRenderer';
 import { showRstest } from './prepare';
@@ -771,19 +778,35 @@ export function createCli(): CAC {
         showRstest();
       }
       try {
-        const { inputs, createRstest } = await resolveCliRuntime(options);
-        const rstest = await buildResolvedRunner({
-          inputs,
-          options,
-          command: 'merge-reports',
-          filters: undefined,
-          createRstestContext: createRstest,
+        const [
+          { loadConfig },
+          { applyAgentReporterDefault, mergeWithCLIOptions },
+          { createRstest },
+        ] = await Promise.all([
+          import('../config'),
+          import('./init'),
+          import('../api'),
+        ]);
+        const cwd = process.cwd();
+        const loaded = await loadConfig({
+          cwd: options.root ? getAbsolutePath(cwd, options.root) : cwd,
+          path: options.config,
+          configLoader: options.configLoader,
+        });
+        mergeWithCLIOptions(loaded.content, options);
+        applyAgentReporterDefault(loaded.content, options);
+        const rstest = await createRstest({
+          cwd,
+          config: loaded,
+          configLoader: options.configLoader,
         });
 
-        try {
-          await rstest.mergeReports({ path, cleanup: options.cleanup });
-        } finally {
-          await exitReporters(rstest.context);
+        const result = await rstest.mergeReports({
+          path,
+          cleanup: options.cleanup,
+        });
+        if (result.status !== 'pass') {
+          setHostExitCode(1);
         }
       } catch (err) {
         logger.error('Failed to merge reports.');

--- a/packages/core/src/cli/exitCode.ts
+++ b/packages/core/src/cli/exitCode.ts
@@ -1,11 +1,13 @@
 import type { InternalContext } from '../types';
 
 export function mirrorExitCode(context: InternalContext): void {
-  context.exitCode.onChange((code) => {
-    const hostCode = process.exitCode;
-    if (hostCode !== undefined && hostCode !== 0 && hostCode !== '0') {
-      return;
-    }
-    process.exitCode = code;
-  });
+  context.exitCode.onChange(setHostExitCode);
+}
+
+export function setHostExitCode(code: number): void {
+  const hostCode = process.exitCode;
+  if (hostCode !== undefined && hostCode !== 0 && hostCode !== '0') {
+    return;
+  }
+  process.exitCode = code;
 }

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -625,6 +625,19 @@ ${conflictProjects.map((p) => `- ${p.configFilePath || p.config.root}`).join('\n
   return projects;
 }
 
+export function applyAgentReporterDefault(
+  config: RstestConfig,
+  options: CommonOptions,
+): void {
+  if (
+    determineAgent().isAgent &&
+    !options.reporters &&
+    config.reporters == null
+  ) {
+    config.reporters = ['md'];
+  }
+}
+
 export async function initCli(options: CommonOptions): Promise<{
   config: RstestConfig;
   configFilePath?: string;
@@ -637,15 +650,7 @@ export async function initCli(options: CommonOptions): Promise<{
     source: { type: 'discover' },
     options,
     cwd,
-    tweakConfig: (config) => {
-      if (
-        determineAgent().isAgent &&
-        !options.reporters &&
-        config.reporters == null
-      ) {
-        config.reporters = ['md'];
-      }
-    },
+    tweakConfig: (config) => applyAgentReporterDefault(config, options),
   });
 
   return {

--- a/packages/core/tests/api/index.test.ts
+++ b/packages/core/tests/api/index.test.ts
@@ -111,11 +111,13 @@ describe('createRstest', () => {
       const project = ['missing'];
       const message = 'No projects found';
 
-      const result = await rstest.run({ project });
-      expect(result.status).toBe('error');
-      expect(result.unhandledErrors).toHaveLength(1);
-      const [error] = result.unhandledErrors;
-      const errorMessage = stripAnsi(error?.message ?? '');
+      const error: Error = await rstest.run({ project }).then(
+        () => {
+          throw new Error('run() resolved');
+        },
+        (reason) => reason,
+      );
+      const errorMessage = stripAnsi(error.message);
       expect(errorMessage).toMatch(/^No projects found,/);
       expect(errorMessage).toContain('projectName filter: [\n  "missing"\n]');
       await expect(rstest.watch({ project })).rejects.toThrow(message);
@@ -205,15 +207,9 @@ describe('createRstest', () => {
         config: { reporters: [] },
       });
 
-      const result = await rstest.run({
-        shard: { index: 1.5, count: 2 },
-      });
-
-      expect(result.status).toBe('error');
-      expect(result.unhandledErrors).toHaveLength(1);
-      expect(result.unhandledErrors[0]?.message).toContain(
-        'Invalid shard option: 1.5/2',
-      );
+      await expect(
+        rstest.run({ shard: { index: 1.5, count: 2 } }),
+      ).rejects.toThrow('Invalid shard option: 1.5/2');
     });
   });
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -68,6 +68,7 @@ interface LoadedRstestConfig {
 interface CreateRstestOptions {
   cwd?: string;
   config?: RstestConfig | LoadedRstestConfig;
+  configLoader?: 'auto' | 'jiti' | 'native'; // Loader for configs discovered through `projects`; defaults to `auto`.
 }
 
 function createRstest(options?: CreateRstestOptions): Promise<RstestInstance>;
@@ -146,7 +147,7 @@ The resolved project contexts. Without an explicit `projects` config, the array 
 
 ## rstest.run
 
-`rstest.run()` runs one test cycle and returns a `TestRunResult`. Failures are reported through `status` and never reject the promise; see [TestRunResult](#testrunresult).
+`rstest.run()` runs one test cycle and returns a `TestRunResult`. It rejects when the run cannot start due to invalid options, configuration or compiler errors; test failures are reported through `status` without rejecting the promise; see [TestRunResult](#testrunresult).
 
 ### Example
 
@@ -391,6 +392,8 @@ interface RstestInstance {
 ## rstest.mergeReports
 
 `rstest.mergeReports()` merges blob reports and returns the same result model as `rstest.run()`.
+
+It rejects when the operation cannot produce a run result; failures in the merged tests are reported through `status` without rejecting the promise.
 
 ### Example
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -68,6 +68,7 @@ interface LoadedRstestConfig {
 interface CreateRstestOptions {
   cwd?: string;
   config?: RstestConfig | LoadedRstestConfig;
+  configLoader?: 'auto' | 'jiti' | 'native'; // 通过 `projects` 发现的配置文件所使用的 loader；默认为 `auto`。
 }
 
 function createRstest(options?: CreateRstestOptions): Promise<RstestInstance>;
@@ -146,7 +147,7 @@ Rstest 实例规范化后的配置。
 
 ## rstest.run
 
-`rstest.run()` 会运行一个测试轮次，并返回 `TestRunResult`。失败会通过 `status` 报告，不会导致 Promise 被拒绝；具体规则见 [TestRunResult](#testrunresult)。
+`rstest.run()` 会运行一个测试轮次，并返回 `TestRunResult`。当无效选项、配置或 compiler 错误导致运行无法启动时，Promise 会被拒绝；测试失败仍通过 `status` 报告，不会导致 Promise 被拒绝，具体规则见 [TestRunResult](#testrunresult)。
 
 ### 示例
 
@@ -391,6 +392,8 @@ interface RstestInstance {
 ## rstest.mergeReports
 
 `rstest.mergeReports()` 用于合并 blob 报告，并返回与 `rstest.run()` 相同的结果模型。
+
+当本次操作无法产生运行结果时，Promise 会被拒绝；合并的测试结果中若有测试失败，仍通过 `status` 报告，不会导致 Promise 被拒绝。
 
 ### 示例
 


### PR DESCRIPTION
## Summary

`rstest merge-reports` now builds its engine through the public `createRstest()` from `@rstest/core/api` instead of the internal `resolveCliRuntime` + `buildResolvedRunner` chain. This is the first of the three one-shot command switches planned after #1784 and #1787; `run`, `list`, and `watch` stay on the internal path for now. The command's output, exit codes, and the existing `e2e/reporter/mergeReports` cases are unchanged.

Making the CLI a consumer of the public API exposed two gaps, both fixed here as breaking changes to the `@experimental` API before 0.12.0:

- **`run()` and `mergeReports()` reject when the operation cannot produce a run** (invalid options, configuration or compiler errors, missing or mismatched blob reports), matching `listTests()`, `watch()`, and `createRstest()`. Previously such errors were folded into `TestRunResult` as `status: 'error'` with the thrown error prepended to `unhandledErrors`, so a caller could not tell an aborted operation from a completed run with unhandled errors. `unhandledErrors` now holds only the run-level errors reporters received through `onTestRunEnd`; `status` is `'error'` exactly when that list is non-empty.
- **`CreateRstestOptions.configLoader`** selects the loader for config files discovered through `projects` (default `auto`). This restores the `--config-loader` channel to per-project config loading, which the internal path had and the public API lacked.

Two accepted differences on `merge-reports`: the interactive coverage-provider install prompt is not reachable through the public API, so a TTY run with a missing provider fails with the same error a non-TTY run already gets; `--root` is resolved on the root config against `cwd` and no longer replayed onto file-based project configs at creation time.

CLI-only concerns stay in `src/cli`: config discovery, the CLI → config merge, the agent reporter default, host exit code (`setHostExitCode`, shared with `mirrorExitCode`), and error printing.

## Related Links

- #1784
- #1787

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
