### PR TITLE
fix(playwright): preserve assertion errors at timeout

### DIFF
--- a/packages/playwright/src/expect.ts
+++ b/packages/playwright/src/expect.ts
@@ -301,16 +301,19 @@ const createPlaywrightMatcher =
       message,
     );
 
-const runWithTimeout = async (check: () => Promise<void>, timeout: number) => {
+const runWithTimeout = async (
+  check: () => Promise<void>,
+  timeout: number,
+): Promise<Error | undefined> => {
   const timers = getRealTimers();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   try {
-    await Promise.race([
-      check(),
-      new Promise<never>((_, reject) => {
+    return await Promise.race([
+      check().then(() => undefined),
+      new Promise<Error>((resolve) => {
         timeoutId = timers.setTimeout(() => {
-          reject(
+          resolve(
             new Error(`Playwright assertion timed out after ${timeout}ms.`),
           );
         }, timeout);
@@ -340,23 +343,26 @@ const waitForExpectation = async (
 
     firstAttempt = false;
     try {
-      await runWithTimeout(
+      const timeoutError = await runWithTimeout(
         check,
         Number.isFinite(remaining) ? Math.max(remaining, 0) : 0,
       );
-      return;
-    } catch (error) {
-      lastError = error;
 
-      const remainingAfterCheck = deadline - getRealNow();
-      if (!Number.isFinite(remainingAfterCheck) || remainingAfterCheck <= 0) {
-        break;
+      if (!timeoutError) {
+        return;
       }
 
-      await waitForRealTime(
-        Math.min(EXPECT_POLL_INTERVAL, remainingAfterCheck),
-      );
+      lastError ??= timeoutError;
+    } catch (error) {
+      lastError = error;
     }
+
+    const remainingAfterCheck = deadline - getRealNow();
+    if (!Number.isFinite(remainingAfterCheck) || remainingAfterCheck <= 0) {
+      break;
+    }
+
+    await waitForRealTime(Math.min(EXPECT_POLL_INTERVAL, remainingAfterCheck));
   }
 
   if (lastError instanceof Error) {

--- a/packages/playwright/tests/expect.test.ts
+++ b/packages/playwright/tests/expect.test.ts
@@ -302,6 +302,24 @@ describe('@rstest/playwright expect', () => {
     expect(Date.now() - start).toBeLessThan(1000);
   });
 
+  it('preserves the last assertion error when the final polling attempt times out', async () => {
+    let attempts = 0;
+    const locator = {
+      ...createLocator({ texts: ['Hello'] }),
+      isVisible: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return false;
+        }
+        return new Promise<boolean>(() => {});
+      },
+    } as unknown as Locator;
+
+    await rstestExpect(
+      expect(locator).toBeVisible({ timeout: 100 }),
+    ).rejects.toThrow('Expected locator to be visible.');
+  });
+
   test('uses real timers for Playwright assertion retries', async () => {
     try {
       rstest.useFakeTimers({ now: 0 });


### PR DESCRIPTION
## Summary

This PR fixes a race in `@rstest/playwright` where a local polling timeout could overwrite the latest Playwright assertion error at the deadline. It preserves the assertion message while keeping hung polling attempts bounded, and adds regression coverage.

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required; internal behavior fix).