### PR TITLE
perf(core): reuse successful jsdom compatibility probes

### DIFF
--- a/packages/core/src/runtime/worker/env/testEnvironmentModule.ts
+++ b/packages/core/src/runtime/worker/env/testEnvironmentModule.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import type { TestEnvironmentModuleFallback } from '../../../pool/protocol';
 import type { TestEnvironmentModuleReference } from '../../../types';
@@ -68,8 +69,18 @@ const validateBuiltinDependency = (
   );
 };
 
-const probeBundledDependency = (loaded: LoadedTestEnvironmentModule): void => {
+const probeBundledDependency = (
+  loaded: LoadedTestEnvironmentModule,
+  bundlePath: string,
+): void => {
   if (loaded.name !== 'jsdom') {
+    return;
+  }
+
+  // Share successful probes through a marker.
+  const markerPath = `${bundlePath}.probe-ok`;
+  if (fs.existsSync(markerPath)) {
+    logger.debug('Reusing successful bundled jsdom compatibility probe');
     return;
   }
 
@@ -81,6 +92,12 @@ const probeBundledDependency = (loaded: LoadedTestEnvironmentModule): void => {
     dom.window.getComputedStyle(dom.window.document.documentElement);
   } finally {
     dom.window.close();
+  }
+
+  try {
+    fs.writeFileSync(markerPath, '');
+  } catch (error) {
+    logger.debug(`Failed to share bundled jsdom compatibility probe: ${error}`);
   }
 };
 
@@ -95,7 +112,7 @@ const loadModule = async (
         reference.bundlePath,
         await importModule(reference.bundlePath),
       );
-      probeBundledDependency(loaded);
+      probeBundledDependency(loaded, reference.bundlePath);
       logger.debug(`loaded bundled test environment ${reference.packageName}`);
       return loaded;
     } catch (error) {

--- a/packages/core/tests/runtime/worker/env/testEnvironmentModule.test.ts
+++ b/packages/core/tests/runtime/worker/env/testEnvironmentModule.test.ts
@@ -52,6 +52,7 @@ describe('loadTestEnvironmentModule', () => {
       expect(
         (loaded.module.JSDOM as unknown as { source: string }).source,
       ).toBe('bundle');
+      expect(fs.existsSync(`${bundlePath}.probe-ok`)).toBe(true);
       expect(
         await loadTestEnvironmentModule({
           name: 'jsdom',
@@ -96,6 +97,7 @@ describe('loadTestEnvironmentModule', () => {
       expect(
         (loaded.module.JSDOM as unknown as { source: string }).source,
       ).toBe('resolved');
+      expect(fs.existsSync(`${bundlePath}.probe-ok`)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Previously, each isolated worker repeated the bundled jsdom compatibility check by creating a temporary JSDOM instance, computing styles, and closing it.

This PR records a successful check so subsequent workers loading the same bundle can skip that repeated work. Workers that start before the success marker is written still check independently, and failed checks retain the existing native jsdom fallback.

## Performance

enterprise-monolith (150 files / 195 tests), M3 Max, Node 24.19.0, 8 isolated forks; dependencies external, build/compile caches disabled.

| Ordering cache | Baseline ms | PR ms | Median saving | Faster pairs |
| --- | ---: | ---: | ---: | ---: |
| Historical | 3316.9 | 3236.8 | 67.4 ms | 15/20 |
| Empty | 3308.1 | 3230.5 | 85.6 ms | 15/20 |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
