### PR TITLE
docs: split adapter integration references

### DIFF
--- a/website/docs/en/guide/integration/_meta.json
+++ b/website/docs/en/guide/integration/_meta.json
@@ -1,7 +1,25 @@
 [
   "playwright",
   "rslint",
-  { "type": "dir", "name": "rslib", "label": "Rslib" },
-  { "type": "dir", "name": "rsbuild", "label": "Rsbuild" },
-  { "type": "dir", "name": "rspack", "label": "Rspack" }
+  {
+    "type": "dir",
+    "name": "rslib",
+    "label": "Rslib",
+    "collapsible": true,
+    "collapsed": true
+  },
+  {
+    "type": "dir",
+    "name": "rsbuild",
+    "label": "Rsbuild",
+    "collapsible": true,
+    "collapsed": true
+  },
+  {
+    "type": "dir",
+    "name": "rspack",
+    "label": "Rspack",
+    "collapsible": true,
+    "collapsed": true
+  }
 ]

--- a/website/docs/en/guide/integration/_meta.json
+++ b/website/docs/en/guide/integration/_meta.json
@@ -1,1 +1,7 @@
-["playwright", "rslint", "rslib", "rsbuild", "rspack"]
+[
+  "playwright",
+  "rslint",
+  { "type": "dir", "name": "rslib", "label": "Rslib" },
+  { "type": "dir", "name": "rsbuild", "label": "Rsbuild" },
+  { "type": "dir", "name": "rspack", "label": "Rspack" }
+]

--- a/website/docs/en/guide/integration/rsbuild/_meta.json
+++ b/website/docs/en/guide/integration/rsbuild/_meta.json
@@ -1,0 +1,1 @@
+[{ "type": "file", "name": "reference", "label": "Configuration reference" }]

--- a/website/docs/en/guide/integration/rsbuild/index.mdx
+++ b/website/docs/en/guide/integration/rsbuild/index.mdx
@@ -1,0 +1,54 @@
+---
+description: This guide covers how to integrate Rstest with Rsbuild for seamless testing in your Rsbuild projects.
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rsbuild
+
+Use Rstest with [Rsbuild](https://rsbuild.rs) while reusing the configuration that already defines your application build.
+
+## Quick start
+
+### New project
+
+Create a new Rsbuild + Rstest project with the `--tools rstest` flag:
+
+```bash
+npm create rsbuild@latest -- --tools rstest
+```
+
+The scaffold includes Rstest and demo tests. Run them with `npm run test`.
+
+### Existing project
+
+To add Rstest to an existing project, follow the [Quick Start](/guide/start/quick-start) to install and set up test scripts.
+
+## Reuse Rsbuild config
+
+[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) loads your Rsbuild config and converts the test-relevant parts into Rstest configuration.
+
+### Install adapter
+
+<PackageManagerTabs command="add @rstest/adapter-rsbuild -D" />
+
+### Extend your config
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
+
+export default defineConfig({
+  extends: withRsbuildConfig(),
+});
+```
+
+The adapter loads `rsbuild.config.ts`, maps options used by test compilation, merges them with your Rstest config, and watches the loaded config through [`forceRerunTriggers`](/config/test/force-rerun-triggers). It also removes the `rsbuild:type-check` plugin because type checking does not run in the test pipeline.
+
+It does not copy build-only settings such as `dev`, `server`, or `html`. Use `cwd`, `config`, or `environmentName` when the default config location or environment does not match your project.
+
+If another tool already creates an Rsbuild config object in memory, use `toRstestConfig` instead of loading a config file. See the [configuration reference](./reference) for both entry points, options, mapping, and debug instructions.
+
+## Related documentation
+
+- [Rsbuild configuration overview](https://rsbuild.rs/config)

--- a/website/docs/en/guide/integration/rsbuild/index.mdx
+++ b/website/docs/en/guide/integration/rsbuild/index.mdx
@@ -43,7 +43,7 @@ export default defineConfig({
 });
 ```
 
-The adapter loads `rsbuild.config.ts`, maps options used by test compilation, merges them with your Rstest config, and watches the loaded config through [`forceRerunTriggers`](/config/test/force-rerun-triggers). It also removes the `rsbuild:type-check` plugin because type checking does not run in the test pipeline.
+The adapter loads `rsbuild.config.ts`, maps options used by test compilation, merges them with your Rstest config, and adds the loaded config file to [`forceRerunTriggers`](/config/test/force-rerun-triggers), so `--changed` runs the full test suite when that config changes. It also removes the `rsbuild:type-check` plugin because type checking does not run in the test pipeline.
 
 It does not copy build-only settings such as `dev`, `server`, or `html`. Use `cwd`, `config`, or `environmentName` when the default config location or environment does not match your project.
 

--- a/website/docs/en/guide/integration/rsbuild/reference.mdx
+++ b/website/docs/en/guide/integration/rsbuild/reference.mdx
@@ -1,63 +1,12 @@
 ---
-description: This guide covers how to integrate Rstest with Rsbuild for seamless testing in your Rsbuild projects.
+description: API and configuration mapping reference for the Rstest Rsbuild adapter.
 ---
 
 import { ApiMeta } from '@components/ApiMeta';
 
-# Rsbuild
+# Rsbuild adapter reference
 
-This guide covers how to integrate Rstest with [Rsbuild](https://rsbuild.rs) for seamless testing in your Rsbuild projects.
-
-## Quick start
-
-### New project
-
-Create a new Rsbuild + Rstest project. Add the `--tools rstest` flag when creating:
-
-```bash
-npm create rsbuild@latest -- --tools rstest
-```
-
-The scaffold includes Rstest and demo tests. Run them with `npm run test`.
-
-### Existing project
-
-To add Rstest to an existing project, follow the [Quick Start](/guide/start/quick-start) to install and set up test scripts.
-
-## Reuse Rsbuild config
-
-[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) is an official adapter that allows Rstest to automatically inherit test-relevant configuration from your existing Rsbuild config file. This keeps your test environment aligned with your build setup without carrying over options that only matter to dev servers or page output.
-
-### Install adapter
-
-import { PackageManagerTabs } from '@theme';
-
-<PackageManagerTabs command="add @rstest/adapter-rsbuild -D" />
-
-### Extend your config
-
-Using the `withRsbuildConfig` function from the adapter, you can extend your Rstest configuration from the Rsbuild config file.
-
-```typescript
-import { defineConfig } from '@rstest/core';
-import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
-
-export default defineConfig({
-  extends: withRsbuildConfig(),
-  // Additional Rstest-specific configuration
-});
-```
-
-This will automatically:
-
-- Load your `rsbuild.config.ts` file
-- Extract and map test-relevant Rsbuild options to Rstest configuration
-- Merge with any additional Rstest config you provide
-- Add the loaded Rsbuild config file to [`forceRerunTriggers`](/config/test/force-rerun-triggers), so `--changed` runs the full test suite when that config changes
-
-The adapter does not reuse the entire Rsbuild config as-is. It keeps the parts that matter for test execution, such as module resolution, transforms, CSS Modules, static asset handling, and `target`, and automatically drops options like `dev`, `server`, and `html` that are specific to the dev server, page entry, or production output.
-
-By default, the adapter uses `process.cwd()` to resolve the Rsbuild config. If your config lives elsewhere, you can use the `cwd` option. You can also pass an Rsbuild config object directly with the `config` option. See [API](#api) for more details.
+For setup, see the [Rsbuild integration overview](./). This page contains the complete adapter API, configuration mapping, and debugging workflow.
 
 ## API
 

--- a/website/docs/en/guide/integration/rslib/_meta.json
+++ b/website/docs/en/guide/integration/rslib/_meta.json
@@ -1,0 +1,1 @@
+[{ "type": "file", "name": "reference", "label": "Configuration reference" }]

--- a/website/docs/en/guide/integration/rslib/index.mdx
+++ b/website/docs/en/guide/integration/rslib/index.mdx
@@ -43,7 +43,7 @@ export default defineConfig({
 });
 ```
 
-The adapter loads `rslib.config.ts`, maps options used by test compilation, merges them with your Rstest config, and watches the loaded config through [`forceRerunTriggers`](/config/test/force-rerun-triggers).
+The adapter loads `rslib.config.ts`, maps options used by test compilation, merges them with your Rstest config, and adds the loaded config file to [`forceRerunTriggers`](/config/test/force-rerun-triggers), so `--changed` runs the full test suite when that config changes.
 
 It does not copy build-only settings such as `dev`, `server`, or `html`. Use `cwd`, `config`, or `libId` when the default config location or library selection does not match your project.
 

--- a/website/docs/en/guide/integration/rslib/index.mdx
+++ b/website/docs/en/guide/integration/rslib/index.mdx
@@ -1,0 +1,54 @@
+---
+description: This guide covers how to integrate Rstest with Rslib for seamless testing in your Rslib projects.
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rslib
+
+Use Rstest with [Rslib](https://rslib.rs) while reusing the configuration that already defines your library build.
+
+## Quick start
+
+### New project
+
+Create a new Rslib + Rstest project with the `--tools rstest` flag:
+
+```bash
+npx create-rslib --template react-ts --tools rstest --dir my-project
+```
+
+The scaffold includes Rstest and demo tests. Run them with `npm run test`.
+
+### Existing project
+
+To add Rstest to an existing project, follow the [Quick Start](/guide/start/quick-start) to install and set up test scripts.
+
+## Reuse Rslib config
+
+[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) loads your Rslib config and converts the test-relevant parts into Rstest configuration.
+
+### Install adapter
+
+<PackageManagerTabs command="add @rstest/adapter-rslib -D" />
+
+### Extend your config
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+
+export default defineConfig({
+  extends: withRslibConfig(),
+});
+```
+
+The adapter loads `rslib.config.ts`, maps options used by test compilation, merges them with your Rstest config, and watches the loaded config through [`forceRerunTriggers`](/config/test/force-rerun-triggers).
+
+It does not copy build-only settings such as `dev`, `server`, or `html`. Use `cwd`, `config`, or `libId` when the default config location or library selection does not match your project.
+
+For all options, configuration mapping, cache behavior, and debug instructions, see the [configuration reference](./reference).
+
+## Related documentation
+
+- [Rslib configuration overview](https://rslib.rs/config)

--- a/website/docs/en/guide/integration/rslib/reference.mdx
+++ b/website/docs/en/guide/integration/rslib/reference.mdx
@@ -1,79 +1,12 @@
 ---
-description: This guide covers how to integrate Rstest with Rslib for seamless testing in your Rslib projects.
+description: API and configuration mapping reference for the Rstest Rslib adapter.
 ---
 
 import { ApiMeta } from '@components/ApiMeta';
 
-# Rslib
+# Rslib adapter reference
 
-This guide covers how to integrate Rstest with [Rslib](https://rslib.rs) for seamless testing in your Rslib projects.
-
-## Quick start
-
-### New project
-
-Create a new Rslib + Rstest project. Add the `--tools rstest` flag when creating:
-
-```bash
-npx create-rslib --template react-ts --tools rstest --dir my-project
-```
-
-The scaffold includes Rstest and demo tests. Run them with `npm run test`.
-
-### Existing project
-
-To add Rstest to an existing project, follow the [Quick Start](/guide/start/quick-start) to install and set up test scripts.
-
-## Reuse Rslib config
-
-[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) is an official adapter that allows Rstest to automatically inherit test-relevant configuration from your existing Rslib config file. This keeps your test environment aligned with your build setup without carrying over options that only matter to build output.
-
-### Install adapter
-
-import { PackageManagerTabs } from '@theme';
-
-<PackageManagerTabs command="add @rstest/adapter-rslib -D" />
-
-### Extend your config
-
-Using the `withRslibConfig` function from the adapter, you can extend your Rstest configuration from the Rslib config file.
-
-```typescript
-import { defineConfig } from '@rstest/core';
-import { withRslibConfig } from '@rstest/adapter-rslib';
-
-export default defineConfig({
-  extends: withRslibConfig(),
-  // Additional Rstest-specific configuration
-});
-```
-
-This will automatically:
-
-- Load your `rslib.config.ts` file
-- Extract and map test-relevant Rslib options to Rstest configuration
-- Merge with any additional Rstest config you provide
-- Add the loaded Rslib config file to [`forceRerunTriggers`](/config/test/force-rerun-triggers), so `--changed` runs the full test suite when that config changes
-
-When `performance.buildCache` is enabled in your Rslib config, `withRslibConfig()` passes it through to Rstest and Rstest will still append its own cache defaults, such as runtime digest inputs and config-file-based invalidation.
-
-If your Rslib config does not enable `performance.buildCache`, Rstest keeps it disabled by default. Enable it explicitly in your Rstest config when you want persistent cache for test builds:
-
-```ts
-import { defineConfig } from '@rstest/core';
-import { withRslibConfig } from '@rstest/adapter-rslib';
-
-export default defineConfig({
-  extends: withRslibConfig(),
-  performance: {
-    buildCache: true,
-  },
-});
-```
-
-The adapter does not reuse the entire Rslib config as-is. It keeps the parts that matter for test execution, such as module resolution, transforms, CSS Modules, decorator-related settings, static asset handling, and `target`, and automatically drops unmapped fields like `dev`, `server`, and `html`, along with other options that only exist for dev server, page entry, or build output.
-
-By default, the adapter uses `process.cwd()` to resolve the Rslib config. If your config lives elsewhere, you can use the `cwd` option. You can also pass a Rslib config object directly with the `config` option. See [API](#api) for more details.
+For setup, see the [Rslib integration overview](./). This page contains the complete adapter API, configuration mapping, cache behavior, and debugging workflow.
 
 ## API
 
@@ -264,6 +197,5 @@ export default defineConfig({
 
 ## Related documentation
 
-- [`@rstest/adapter-rslib` documentation](https://www.npmjs.com/package/@rstest/adapter-rslib)
 - [Rslib configuration overview](https://rslib.rs/config)
 - [Rstest configuration overview](/config/)

--- a/website/docs/en/guide/integration/rslib/reference.mdx
+++ b/website/docs/en/guide/integration/rslib/reference.mdx
@@ -155,6 +155,24 @@ export default defineConfig({
 });
 ```
 
+## Cache behavior
+
+When `performance.buildCache` is enabled in your Rslib config, `withRslibConfig()` passes it through to Rstest and Rstest will still append its own cache defaults, such as runtime digest inputs and config-file-based invalidation.
+
+If your Rslib config does not enable `performance.buildCache`, Rstest keeps it disabled by default. Enable it explicitly in your Rstest config when you want persistent cache for test builds:
+
+```ts
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+
+export default defineConfig({
+  extends: withRslibConfig(),
+  performance: {
+    buildCache: true,
+  },
+});
+```
+
 ## Configuration mapping
 
 The adapter automatically maps these Rslib options to Rstest:

--- a/website/docs/en/guide/integration/rspack/_meta.json
+++ b/website/docs/en/guide/integration/rspack/_meta.json
@@ -1,0 +1,1 @@
+[{ "type": "file", "name": "reference", "label": "Configuration reference" }]

--- a/website/docs/en/guide/integration/rspack/index.mdx
+++ b/website/docs/en/guide/integration/rspack/index.mdx
@@ -1,0 +1,48 @@
+---
+description: This guide covers how to integrate Rstest with Rspack for seamless testing in your Rspack projects.
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rspack
+
+Use Rstest with [Rspack](https://rspack.rs) while reusing the configuration that already defines your application build.
+
+## Quick start
+
+To add Rstest to an existing Rspack project, follow the [Quick Start](/guide/start/quick-start) to install and set up test scripts.
+
+## Reuse Rspack config
+
+[@rstest/adapter-rspack](https://www.npmjs.com/package/@rstest/adapter-rspack) loads your Rspack config and maps compatible options into the Rstest test compiler.
+
+### Install adapter
+
+<PackageManagerTabs command="add @rstest/adapter-rspack -D" />
+
+### Extend your config
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withRspackConfig } from '@rstest/adapter-rspack';
+
+export default defineConfig({
+  extends: withRspackConfig(),
+});
+```
+
+The adapter loads `rspack.config.ts`, merges compatible compiler options with the generated test build, and watches the loaded config through [`forceRerunTriggers`](/config/test/force-rerun-triggers).
+
+:::warning
+Rstest uses Rsbuild internally, so the adapter keeps Rstest-owned test structure and disables its built-in CSS plugins when Rspack CSS configuration is applied. As a result, some Rsbuild-specific CSS options, such as `output.cssModules`, are unavailable.
+:::
+
+Use `cwd`, `configPath`, `configName`, or the environment options when the default Rspack config does not match your project. See the [configuration reference](./reference) for option details, mapping behavior, and debug instructions.
+
+## Example project
+
+See the [Rspack adapter example](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rspack-adapter) for a complete React project.
+
+## Related documentation
+
+- [Rspack configuration overview](https://rspack.rs/config)

--- a/website/docs/en/guide/integration/rspack/index.mdx
+++ b/website/docs/en/guide/integration/rspack/index.mdx
@@ -31,10 +31,10 @@ export default defineConfig({
 });
 ```
 
-The adapter loads `rspack.config.ts`, merges compatible compiler options with the generated test build, and watches the loaded config through [`forceRerunTriggers`](/config/test/force-rerun-triggers).
+The adapter loads `rspack.config.ts`, merges compatible compiler options with the generated test build, and adds the loaded config file to [`forceRerunTriggers`](/config/test/force-rerun-triggers), so `--changed` runs the full test suite when that config changes.
 
 :::warning
-Rstest uses Rsbuild internally, so the adapter keeps Rstest-owned test structure and disables its built-in CSS plugins when Rspack CSS configuration is applied. As a result, some Rsbuild-specific CSS options, such as `output.cssModules`, are unavailable.
+Rstest uses Rsbuild internally, so the adapter keeps Rstest-owned test structure and always removes the built-in CSS plugins `rsbuild:css`, `rsbuild:less`, and `rsbuild:sass`. As a result, some Rsbuild-specific CSS options, such as `output.cssModules`, are unavailable.
 :::
 
 Use `cwd`, `configPath`, `configName`, or the environment options when the default Rspack config does not match your project. See the [configuration reference](./reference) for option details, mapping behavior, and debug instructions.

--- a/website/docs/en/guide/integration/rspack/reference.mdx
+++ b/website/docs/en/guide/integration/rspack/reference.mdx
@@ -1,51 +1,10 @@
-# Rspack
+---
+description: API and configuration mapping reference for the Rstest Rspack adapter.
+---
 
-This guide covers how to integrate Rstest with [Rspack](https://rspack.rs) for seamless testing in your Rspack projects.
+# Rspack adapter reference
 
-## Quick start
-
-To add Rstest to an existing Rspack project, follow the [Quick Start](/guide/start/quick-start) to install and set up test scripts.
-
-## Reuse Rspack config
-
-[@rstest/adapter-rspack](https://www.npmjs.com/package/@rstest/adapter-rspack) is an official adapter that allows Rstest to automatically inherit configuration from your existing Rspack config file. This ensures your test environment matches your build configuration without duplication.
-
-### Install adapter
-
-import { PackageManagerTabs } from '@theme';
-
-<PackageManagerTabs command="add @rstest/adapter-rspack -D" />
-
-### Extend your config
-
-Using the `withRspackConfig` function from the adapter, you can extend your Rstest configuration from the Rspack config file.
-
-```typescript
-import { defineConfig } from '@rstest/core';
-import { withRspackConfig } from '@rstest/adapter-rspack';
-
-export default defineConfig({
-  extends: withRspackConfig(),
-  // Additional rstest-specific configuration
-});
-```
-
-This will automatically:
-
-- Load your `rspack.config.ts` file
-- Map compatible Rspack options to Rstest configuration
-- Merge with any additional Rstest config you provide
-- Add the loaded Rspack config file to [`forceRerunTriggers`](/config/test/force-rerun-triggers), so `--changed` runs the full test suite when that config changes
-
-By default, the adapter uses `process.cwd()` to resolve the Rspack config. If your config lives elsewhere, you can use the `cwd` option. See [API](#api) for more details.
-
-:::warning
-Since Rstest uses Rsbuild internally as its bundler, some Rstest built-in behaviors may differ from Rspack's defaults. For example, Rstest has its own CSS processing pipeline. To avoid conflicts, this adapter automatically disables Rstest (Rsbuild) built-in CSS plugins so that Rspack's CSS configuration takes effect. This means that some Rsbuild-specific CSS features and configurations (e.g., `output.cssModules` configuration) will not be available when using this adapter.
-:::
-
-## Example project
-
-See the [Rspack adapter example](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rspack-adapter) for a complete React project that inherits its Rspack configuration in Rstest.
+For setup and important caveats, see the [Rspack integration overview](./). This page contains the complete adapter API, compatibility mapping, and debugging workflow.
 
 ## API
 

--- a/website/docs/zh/guide/integration/_meta.json
+++ b/website/docs/zh/guide/integration/_meta.json
@@ -1,7 +1,25 @@
 [
   "playwright",
   "rslint",
-  { "type": "dir", "name": "rslib", "label": "Rslib" },
-  { "type": "dir", "name": "rsbuild", "label": "Rsbuild" },
-  { "type": "dir", "name": "rspack", "label": "Rspack" }
+  {
+    "type": "dir",
+    "name": "rslib",
+    "label": "Rslib",
+    "collapsible": true,
+    "collapsed": true
+  },
+  {
+    "type": "dir",
+    "name": "rsbuild",
+    "label": "Rsbuild",
+    "collapsible": true,
+    "collapsed": true
+  },
+  {
+    "type": "dir",
+    "name": "rspack",
+    "label": "Rspack",
+    "collapsible": true,
+    "collapsed": true
+  }
 ]

--- a/website/docs/zh/guide/integration/_meta.json
+++ b/website/docs/zh/guide/integration/_meta.json
@@ -1,1 +1,7 @@
-["playwright", "rslint", "rslib", "rsbuild", "rspack"]
+[
+  "playwright",
+  "rslint",
+  { "type": "dir", "name": "rslib", "label": "Rslib" },
+  { "type": "dir", "name": "rsbuild", "label": "Rsbuild" },
+  { "type": "dir", "name": "rspack", "label": "Rspack" }
+]

--- a/website/docs/zh/guide/integration/rsbuild/_meta.json
+++ b/website/docs/zh/guide/integration/rsbuild/_meta.json
@@ -1,0 +1,1 @@
+[{ "type": "file", "name": "reference", "label": "配置参考" }]

--- a/website/docs/zh/guide/integration/rsbuild/index.mdx
+++ b/website/docs/zh/guide/integration/rsbuild/index.mdx
@@ -1,0 +1,54 @@
+---
+description: 本指南介绍如何在 Rsbuild 项目中集成 Rstest，并复用已有的 Rsbuild 构建配置。
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rsbuild
+
+在 [Rsbuild](https://rsbuild.rs) 项目中使用 Rstest，并复用已有的应用构建配置。
+
+## 快速开始
+
+### 新项目
+
+创建 Rsbuild + Rstest 项目时，加上 `--tools rstest`：
+
+```bash
+npm create rsbuild@latest -- --tools rstest
+```
+
+脚手架会包含 Rstest 和示例测试。使用 `npm run test` 运行测试。
+
+### 已有项目
+
+已有项目可以参考[快速开始](/guide/start/quick-start)，完成 Rstest 的安装和测试脚本配置。
+
+## 复用 Rsbuild 配置
+
+[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) 会读取 Rsbuild 配置，并将测试编译需要的配置转换为 Rstest 配置。
+
+### 安装适配器
+
+<PackageManagerTabs command="add @rstest/adapter-rsbuild -D" />
+
+### 扩展配置
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
+
+export default defineConfig({
+  extends: withRsbuildConfig(),
+});
+```
+
+适配器会读取 `rsbuild.config.ts`，转换测试编译需要的选项，将结果与 Rstest 配置合并，并通过 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 监听已加载的配置文件。同时，它会移除 `rsbuild:type-check` plugin，因为测试流程不会执行类型检查。
+
+它不会复制 `dev`、`server`、`html` 等只用于构建的配置。如果默认配置位置或 environment 不适合当前项目，可以使用 `cwd`、`config` 或 `environmentName`。
+
+如果其他工具已经在内存中生成了 Rsbuild 配置对象，可以使用 `toRstestConfig` 直接转换，而不必重新读取配置文件。两种入口、options、配置映射和调试方法请查看[配置参考](./reference)。
+
+## 相关文档
+
+- [Rsbuild 配置概览](https://rsbuild.rs/config)

--- a/website/docs/zh/guide/integration/rsbuild/index.mdx
+++ b/website/docs/zh/guide/integration/rsbuild/index.mdx
@@ -43,7 +43,7 @@ export default defineConfig({
 });
 ```
 
-适配器会读取 `rsbuild.config.ts`，转换测试编译需要的选项，将结果与 Rstest 配置合并，并通过 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 监听已加载的配置文件。同时，它会移除 `rsbuild:type-check` plugin，因为测试流程不会执行类型检查。
+适配器会读取 `rsbuild.config.ts`，转换测试编译需要的选项，将结果与 Rstest 配置合并，并将已加载的配置文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，因此当该配置发生变化时，`--changed` 会运行完整测试套件。同时，它会移除 `rsbuild:type-check` plugin，因为测试流程不会执行类型检查。
 
 它不会复制 `dev`、`server`、`html` 等只用于构建的配置。如果默认配置位置或 environment 不适合当前项目，可以使用 `cwd`、`config` 或 `environmentName`。
 

--- a/website/docs/zh/guide/integration/rsbuild/reference.mdx
+++ b/website/docs/zh/guide/integration/rsbuild/reference.mdx
@@ -1,63 +1,12 @@
 ---
-description: 本指南介绍了如何将 Rstest 与 Rsbuild 集成，以便在你的 Rsbuild 项目中进行无缝测试。
+description: Rstest Rsbuild adapter 的 API 和配置映射参考。
 ---
 
 import { ApiMeta } from '@components/ApiMeta';
 
-# Rsbuild
+# Rsbuild adapter 配置参考
 
-本指南介绍了如何将 Rstest 与 [Rsbuild](https://rsbuild.rs) 集成，以便在你的 Rsbuild 项目中进行无缝测试。
-
-## 快速开始
-
-### 新建项目
-
-创建一个新的 Rsbuild + Rstest 项目。在创建时添加 `--tools rstest` 标志：
-
-```bash
-npm create rsbuild@latest -- --tools rstest
-```
-
-脚手架包含了 Rstest 和演示测试。使用 `npm run test` 来运行它们。
-
-### 现有项目
-
-要将 Rstest 添加到现有项目中，请遵循[快速入门](/guide/start/quick-start)来安装和设置测试脚本。
-
-## 复用 Rsbuild 配置
-
-[@rstest/adapter-rsbuild](https://www.npmjs.com/package/@rstest/adapter-rsbuild) 是一个官方适配器，它允许 Rstest 自动从你现有的 Rsbuild 配置文件中继承测试相关配置。这可以确保测试环境与构建配置尽量保持一致，同时避免把仅用于开发服务器或页面构建的选项带进测试流程。
-
-### 安装适配器
-
-import { PackageManagerTabs } from '@theme';
-
-<PackageManagerTabs command="add @rstest/adapter-rsbuild -D" />
-
-### 继承你的配置
-
-使用适配器中的 `withRsbuildConfig` 函数，你可以从 Rsbuild 配置文件中继承 Rstest 配置。
-
-```typescript
-import { defineConfig } from '@rstest/core';
-import { withRsbuildConfig } from '@rstest/adapter-rsbuild';
-
-export default defineConfig({
-  extends: withRsbuildConfig(),
-  // 额外的 Rstest 特定配置
-});
-```
-
-这将自动：
-
-- 加载你的 `rsbuild.config.ts` 文件
-- 提取并映射测试相关的 Rsbuild 选项到 Rstest 配置
-- 与你提供的任何其他 Rstest 配置合并
-- 将加载到的 Rsbuild 配置文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，因此该配置变更时 `--changed` 会运行完整测试套件
-
-适配器不会原样复用整份 Rsbuild 配置，而是只保留测试运行需要的部分，例如模块解析、代码转换、CSS Modules、静态资源处理和 `target`。像 `dev`、`server`、`html` 这类面向开发服务器、页面入口或产物输出的配置，会在转换时自动裁剪掉，避免把测试无关配置带入 Rstest。
-
-默认情况下，适配器使用 `process.cwd()` 来解析 Rsbuild 配置。如果配置文件在其他目录，可以使用 `cwd` 选项。你也可以通过 `config` 选项直接传入 Rsbuild 配置对象。更多详情请参阅 [API](#api)。
+安装与快速配置请查看 [Rsbuild 集成概览](./)。本页包含完整的 adapter API、配置映射和调试方法。
 
 ## API
 

--- a/website/docs/zh/guide/integration/rslib/_meta.json
+++ b/website/docs/zh/guide/integration/rslib/_meta.json
@@ -1,0 +1,1 @@
+[{ "type": "file", "name": "reference", "label": "配置参考" }]

--- a/website/docs/zh/guide/integration/rslib/index.mdx
+++ b/website/docs/zh/guide/integration/rslib/index.mdx
@@ -1,0 +1,54 @@
+---
+description: 本指南介绍如何在 Rslib 项目中集成 Rstest，并复用已有的 Rslib 构建配置。
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rslib
+
+在 [Rslib](https://rslib.rs) 项目中使用 Rstest，并复用已有的库构建配置。
+
+## 快速开始
+
+### 新项目
+
+创建 Rslib + Rstest 项目时，加上 `--tools rstest`：
+
+```bash
+npx create-rslib --template react-ts --tools rstest --dir my-project
+```
+
+脚手架会包含 Rstest 和示例测试。使用 `npm run test` 运行测试。
+
+### 已有项目
+
+已有项目可以参考[快速开始](/guide/start/quick-start)，完成 Rstest 的安装和测试脚本配置。
+
+## 复用 Rslib 配置
+
+[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) 会读取 Rslib 配置，并将测试编译需要的配置转换为 Rstest 配置。
+
+### 安装适配器
+
+<PackageManagerTabs command="add @rstest/adapter-rslib -D" />
+
+### 扩展配置
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+
+export default defineConfig({
+  extends: withRslibConfig(),
+});
+```
+
+适配器会读取 `rslib.config.ts`，转换测试编译需要的选项，将结果与 Rstest 配置合并，并通过 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 监听已加载的配置文件。
+
+它不会复制 `dev`、`server`、`html` 等只用于构建的配置。如果默认配置位置或 library 选择不适合当前项目，可以使用 `cwd`、`config` 或 `libId`。
+
+完整的 options、配置映射、cache 行为和调试方法请查看[配置参考](./reference)。
+
+## 相关文档
+
+- [Rslib 配置概览](https://rslib.rs/config)

--- a/website/docs/zh/guide/integration/rslib/index.mdx
+++ b/website/docs/zh/guide/integration/rslib/index.mdx
@@ -43,7 +43,7 @@ export default defineConfig({
 });
 ```
 
-适配器会读取 `rslib.config.ts`，转换测试编译需要的选项，将结果与 Rstest 配置合并，并通过 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 监听已加载的配置文件。
+适配器会读取 `rslib.config.ts`，转换测试编译需要的选项，将结果与 Rstest 配置合并，并将已加载的配置文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，因此当该配置发生变化时，`--changed` 会运行完整测试套件。
 
 它不会复制 `dev`、`server`、`html` 等只用于构建的配置。如果默认配置位置或 library 选择不适合当前项目，可以使用 `cwd`、`config` 或 `libId`。
 

--- a/website/docs/zh/guide/integration/rslib/reference.mdx
+++ b/website/docs/zh/guide/integration/rslib/reference.mdx
@@ -1,79 +1,12 @@
 ---
-description: 本指南介绍如何将 Rstest 集成到 Rslib 项目中，为你的 Rslib 项目提供无缝的测试体验。
+description: Rstest Rslib adapter 的 API 和配置映射参考。
 ---
 
 import { ApiMeta } from '@components/ApiMeta';
 
-# Rslib
+# Rslib adapter 配置参考
 
-本指南介绍如何将 Rstest 集成到 [Rslib](https://rslib.rs) 项目中，为你的 Rslib 项目提供无缝的测试体验。
-
-## 快速开始
-
-### 新项目
-
-通过在创建时添加 `--tools rstest` 参数，即可创建一个 Rslib + Rstest 项目：
-
-```bash
-npx create-rslib --template react-ts --tools rstest --dir my-project
-```
-
-脚手架已包含 Rstest 和示例测试，运行 `npm run test` 即可执行测试。
-
-### 已有项目
-
-如需为已有项目添加 Rstest，请参考[快速开始](/guide/start/quick-start)安装 Rstest 并配置测试脚本。
-
-## 复用 Rslib 配置
-
-[@rstest/adapter-rslib](https://www.npmjs.com/package/@rstest/adapter-rslib) 是 Rstest 官方提供的适配器，允许 Rstest 自动继承现有 Rslib 配置文件中的测试相关配置。这样可以确保测试环境与构建配置尽量保持一致，同时避免把只服务于构建产物的选项带进测试流程。
-
-### 安装适配器
-
-import { PackageManagerTabs } from '@theme';
-
-<PackageManagerTabs command="add @rstest/adapter-rslib -D" />
-
-### 扩展配置
-
-使用适配器中的 `withRslibConfig` 函数，可以从 Rslib 配置文件中扩展 Rstest 配置。
-
-```typescript
-import { defineConfig } from '@rstest/core';
-import { withRslibConfig } from '@rstest/adapter-rslib';
-
-export default defineConfig({
-  extends: withRslibConfig(),
-  // 额外的 Rstest 特定配置
-});
-```
-
-这将自动：
-
-- 加载你的 `rslib.config.ts` 文件
-- 提取并映射测试相关的 Rslib 选项到 Rstest 配置
-- 与你提供的其他 Rstest 配置合并
-- 将加载到的 Rslib 配置文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，因此该配置变更时 `--changed` 会运行完整测试套件
-
-如果你在 Rslib 配置里开启了 `performance.buildCache`，`withRslibConfig()` 会把这项配置传给 Rstest，Rstest 仍会继续补充自己的缓存默认值，例如运行时摘要项和基于配置文件的失效条件。
-
-如果你的 Rslib 配置没有开启 `performance.buildCache`，Rstest 默认也不会开启它。只有在你希望测试构建使用持久化缓存时，才需要在 Rstest 配置里显式设置 `performance.buildCache`：
-
-```ts
-import { defineConfig } from '@rstest/core';
-import { withRslibConfig } from '@rstest/adapter-rslib';
-
-export default defineConfig({
-  extends: withRslibConfig(),
-  performance: {
-    buildCache: true,
-  },
-});
-```
-
-适配器不会原样复用整份 Rslib 配置，而是只保留测试运行需要的部分，例如模块解析、代码转换、CSS Modules、装饰器相关配置、静态资源处理和 `target`。像 `dev`、`server`、`html` 等未映射字段，以及其他仅用于开发服务器、页面入口或构建产物的配置，会在转换时自动裁剪掉。
-
-默认情况下，适配器使用 `process.cwd()` 来解析 Rslib 配置。如果配置文件在其他目录，可以使用 `cwd` 选项。你也可以通过 `config` 选项直接传入 Rslib 配置对象。更多详情请参阅 [API](#api)。
+安装与快速配置请查看 [Rslib 集成概览](./)。本页包含完整的 adapter API、配置映射、cache 行为和调试方法。
 
 ## API
 
@@ -264,6 +197,5 @@ export default defineConfig({
 
 ## 相关文档
 
-- [`@rstest/adapter-rslib` 文档](https://www.npmjs.com/package/@rstest/adapter-rslib)
 - [Rslib 配置概览](https://rslib.rs/config)
 - [Rstest 配置概览](/config/)

--- a/website/docs/zh/guide/integration/rslib/reference.mdx
+++ b/website/docs/zh/guide/integration/rslib/reference.mdx
@@ -155,6 +155,24 @@ export default defineConfig({
 });
 ```
 
+## Cache 行为
+
+如果你在 Rslib 配置里开启了 `performance.buildCache`，`withRslibConfig()` 会把这项配置传给 Rstest，Rstest 仍会继续补充自己的缓存默认值，例如运行时摘要项和基于配置文件的失效条件。
+
+如果你的 Rslib 配置没有开启 `performance.buildCache`，Rstest 默认也不会开启它。只有在你希望测试构建使用持久化缓存时，才需要在 Rstest 配置里显式设置 `performance.buildCache`：
+
+```ts
+import { defineConfig } from '@rstest/core';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+
+export default defineConfig({
+  extends: withRslibConfig(),
+  performance: {
+    buildCache: true,
+  },
+});
+```
+
 ## 配置映射
 
 适配器会自动将以下 Rslib 选项映射到 Rstest：

--- a/website/docs/zh/guide/integration/rspack/_meta.json
+++ b/website/docs/zh/guide/integration/rspack/_meta.json
@@ -1,0 +1,1 @@
+[{ "type": "file", "name": "reference", "label": "配置参考" }]

--- a/website/docs/zh/guide/integration/rspack/index.mdx
+++ b/website/docs/zh/guide/integration/rspack/index.mdx
@@ -31,10 +31,10 @@ export default defineConfig({
 });
 ```
 
-适配器会读取 `rspack.config.ts`，将兼容的 compiler 选项与生成的测试构建合并，并通过 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 监听已加载的配置文件。
+适配器会读取 `rspack.config.ts`，将兼容的 compiler 选项与生成的测试构建合并，并将已加载的配置文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，因此当该配置发生变化时，`--changed` 会运行完整测试套件。
 
 :::warning
-Rstest 内部使用 Rsbuild，因此适配器会保留 Rstest 自己负责的测试结构；应用 Rspack CSS 配置时，还会禁用 Rstest 内置的 CSS plugin。这样会导致部分 Rsbuild 专属 CSS 选项（例如 `output.cssModules`）不可用。
+Rstest 内部使用 Rsbuild，因此适配器会保留 Rstest 自己负责的测试结构，并始终移除内置的 `rsbuild:css`、`rsbuild:less` 和 `rsbuild:sass` CSS plugin。这样会导致部分 Rsbuild 专属 CSS 选项（例如 `output.cssModules`）不可用。
 :::
 
 如果默认的 Rspack 配置不适合当前项目，可以使用 `cwd`、`configPath`、`configName` 或 environment 相关选项。选项详情、映射规则和调试方法请查看[配置参考](./reference)。

--- a/website/docs/zh/guide/integration/rspack/index.mdx
+++ b/website/docs/zh/guide/integration/rspack/index.mdx
@@ -1,0 +1,48 @@
+---
+description: 本指南介绍如何在 Rspack 项目中集成 Rstest，并复用已有的 Rspack 构建配置。
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rspack
+
+在 [Rspack](https://rspack.rs) 项目中使用 Rstest，并复用已有的应用构建配置。
+
+## 快速开始
+
+已有项目可以参考[快速开始](/guide/start/quick-start)，完成 Rstest 的安装和测试脚本配置。
+
+## 复用 Rspack 配置
+
+[@rstest/adapter-rspack](https://www.npmjs.com/package/@rstest/adapter-rspack) 会读取 Rspack 配置，并将兼容的选项转换到 Rstest test compiler。
+
+### 安装适配器
+
+<PackageManagerTabs command="add @rstest/adapter-rspack -D" />
+
+### 扩展配置
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withRspackConfig } from '@rstest/adapter-rspack';
+
+export default defineConfig({
+  extends: withRspackConfig(),
+});
+```
+
+适配器会读取 `rspack.config.ts`，将兼容的 compiler 选项与生成的测试构建合并，并通过 [`forceRerunTriggers`](/config/test/force-rerun-triggers) 监听已加载的配置文件。
+
+:::warning
+Rstest 内部使用 Rsbuild，因此适配器会保留 Rstest 自己负责的测试结构；应用 Rspack CSS 配置时，还会禁用 Rstest 内置的 CSS plugin。这样会导致部分 Rsbuild 专属 CSS 选项（例如 `output.cssModules`）不可用。
+:::
+
+如果默认的 Rspack 配置不适合当前项目，可以使用 `cwd`、`configPath`、`configName` 或 environment 相关选项。选项详情、映射规则和调试方法请查看[配置参考](./reference)。
+
+## 示例项目
+
+完整的 React 项目示例请查看 [Rspack adapter example](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rspack-adapter)。
+
+## 相关文档
+
+- [Rspack 配置概览](https://rspack.rs/config)

--- a/website/docs/zh/guide/integration/rspack/reference.mdx
+++ b/website/docs/zh/guide/integration/rspack/reference.mdx
@@ -1,51 +1,10 @@
-# Rspack
+---
+description: Rstest Rspack adapter 的 API 和配置映射参考。
+---
 
-本指南介绍了如何将 Rstest 与 [Rspack](https://rspack.rs) 集成，以便在你的 Rspack 项目中进行无缝测试。
+# Rspack adapter 配置参考
 
-## 快速开始
-
-要将 Rstest 添加到现有 Rspack 项目中，请遵循[快速入门](/guide/start/quick-start)来安装和设置测试脚本。
-
-## 复用 Rspack 配置
-
-[@rstest/adapter-rspack](https://www.npmjs.com/package/@rstest/adapter-rspack) 是一个官方适配器，它允许 Rstest 自动从你现有的 Rspack 配置文件中继承配置。这可以确保你的测试环境与构建配置相匹配，而无需重复配置。
-
-### 安装适配器
-
-import { PackageManagerTabs } from '@theme';
-
-<PackageManagerTabs command="add @rstest/adapter-rspack -D" />
-
-### 继承你的配置
-
-使用适配器中的 `withRspackConfig` 函数，你可以从 Rspack 配置文件中继承 Rstest 配置。
-
-```typescript
-import { defineConfig } from '@rstest/core';
-import { withRspackConfig } from '@rstest/adapter-rspack';
-
-export default defineConfig({
-  extends: withRspackConfig(),
-  // 额外的 rstest 特定配置
-});
-```
-
-这将自动：
-
-- 加载你的 `rspack.config.ts` 文件
-- 将兼容的 Rspack 选项映射到 Rstest 配置
-- 与你提供的任何其他 Rstest 配置合并
-- 将加载到的 Rspack 配置文件加入 [`forceRerunTriggers`](/config/test/force-rerun-triggers)，因此该配置变更时 `--changed` 会运行完整测试套件
-
-默认情况下，适配器使用 `process.cwd()` 来解析 Rspack 配置。如果你的配置文件在其他地方，你可以使用 `cwd` 选项。更多详情请参阅 [API](#api) 部分。
-
-:::warning
-由于 Rstest 内部使用 Rsbuild 作为打包工具，一些 Rstest 的内置行为可能与 Rspack 的默认行为不同。例如，Rstest 有自己的 CSS 处理流程。为了避免冲突，此适配器会自动禁用 Rstest（Rsbuild） 内置的 CSS 插件，使 Rspack 的 CSS 配置生效。这意味着使用此适配器时，一些 Rsbuild 特有的 CSS 功能和配置（如 `output.cssModules` 配置）将不可用。
-:::
-
-## 示例项目
-
-你可以参考 [Rspack adapter 示例](https://github.com/rstackjs/rstack-examples/tree/main/rstest/rspack-adapter)，了解如何在完整的 React 项目中让 Rstest 继承 Rspack 配置。
+安装、快速配置和重要注意事项请查看 [Rspack 集成概览](./)。本页包含完整的 adapter API、兼容性映射和调试方法。
 
 ## API
 


### PR DESCRIPTION
## Summary

The Rslib, Rsbuild, and Rspack integration guides repeated Quick start and adapter setup content, making the configuration references harder to scan.

- Splits each adapter guide into a concise overview and a configuration reference.
- Removes duplicated Quick start/setup sections and redundant npm adapter documentation links.
- Updates the English and Chinese navigation to expose each overview and reference.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).