### PR TITLE
test(browser): prevent suite hook timeout e2e flake

### DIFF
--- a/e2e/browser-mode/error.test.ts
+++ b/e2e/browser-mode/error.test.ts
@@ -40,7 +40,11 @@ describe('browser mode - error handling', () => {
 
   it('reports suite hook element mismatches before hook timeouts', async () => {
     const { cli, expectExecFailed } = await runBrowserCli('error', {
-      args: ['tests/elementAssertionTimeout.test.ts'],
+      args: [
+        'tests/elementAssertionTimeout.test.ts',
+        '--testNamePattern',
+        'runs suite hooks',
+      ],
     });
 
     await expectExecFailed();


### PR DESCRIPTION
## Summary

This PR isolates the suite-hook assertion timeout e2e case to the selected suite. The previous command ran all seven timeout scenarios from the same fixture, allowing unrelated fixture/test timeout races under full-suite load to make the negative assertions flaky.

## Related Links

https://github.com/web-infra-dev/rstest/pull/1798

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).