### PR TITLE
refactor(core)!: express exact file filters with quotes

### DIFF
--- a/e2e/filter/fixtures-quoted/pkg/src/foo.test.ts
+++ b/e2e/filter/fixtures-quoted/pkg/src/foo.test.ts
@@ -1,0 +1,3 @@
+import { test } from '@rstest/core';
+
+test('works', () => {});

--- a/e2e/filter/fixtures-quoted/rstest.config.mjs
+++ b/e2e/filter/fixtures-quoted/rstest.config.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/e2e/filter/fixtures-quoted/src/foo.test.ts
+++ b/e2e/filter/fixtures-quoted/src/foo.test.ts
@@ -1,0 +1,3 @@
+import { test } from '@rstest/core';
+
+test('works', () => {});

--- a/e2e/filter/fixtures-quoted/src/foo.test.tsx
+++ b/e2e/filter/fixtures-quoted/src/foo.test.tsx
@@ -1,0 +1,3 @@
+import { test } from '@rstest/core';
+
+test('works', () => {});

--- a/e2e/filter/quoted.test.ts
+++ b/e2e/filter/quoted.test.ts
@@ -1,0 +1,22 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from '@rstest/core';
+import { runRstestCli } from '../scripts';
+
+const cwd = join(dirname(fileURLToPath(import.meta.url)), 'fixtures-quoted');
+
+it.each([
+  { filters: ['src/foo.test.ts'], count: 3 },
+  { filters: ['"src/foo.test.ts"'], count: 1 },
+  { filters: ["'src/foo.test.ts'"], count: 1 },
+  { filters: [`"${join(cwd, 'src/foo.test.ts')}"`], count: 1 },
+  { filters: ['"src/foo.test.ts"', 'pkg'], count: 2 },
+])('runs $count files for $filters', async ({ filters, count }) => {
+  const { cli, expectExecSuccess } = await runRstestCli({
+    command: 'rstest',
+    args: ['run', ...filters],
+    options: { nodeOptions: { cwd } },
+  });
+  await expectExecSuccess();
+  expect(cli.stdout).toContain(`Test Files ${count} passed`);
+});

--- a/e2e/programmatic/fixtures/run-list.mjs
+++ b/e2e/programmatic/fixtures/run-list.mjs
@@ -38,7 +38,7 @@ try {
   const listed = await rstest.listTests({
     includeSuites: true,
     includeLocation: true,
-    shard: { index: 1, count: 2 },
+    shard: '1/2',
   });
   const files = await rstest.listTests({
     filesOnly: true,
@@ -46,8 +46,7 @@ try {
   });
   const filtered = await rstest.listTests({
     filesOnly: true,
-    filters: ['alpha/alpha.test.ts'],
-    filterMode: 'exact',
+    filters: ['"alpha/alpha.test.ts"'],
   });
   const skippedRoot = join(root, 'skipped');
   await mkdir(skippedRoot);

--- a/e2e/programmatic/fixtures/run-watch.mjs
+++ b/e2e/programmatic/fixtures/run-watch.mjs
@@ -74,23 +74,19 @@ try {
     cwd: emptyFilterRoot,
     config: { include: ['*.test.ts'], reporters: [] },
   });
-  const emptyFilterCycles = {};
-  for (const filterMode of ['fuzzy', 'exact']) {
-    let firstResult;
-    const emptyFilterWatcher = await emptyFilterRstest.watch({
-      filters: [],
-      filterMode,
-      onResult(result) {
-        firstResult ??= result;
-      },
-    });
-    openWatchers.add(emptyFilterWatcher);
-    emptyFilterCycles[filterMode] = firstResult.files.map((file) =>
-      file.testPath.split('/').pop(),
-    );
-    await emptyFilterWatcher.close();
-    openWatchers.delete(emptyFilterWatcher);
-  }
+  let firstResult;
+  const emptyFilterWatcher = await emptyFilterRstest.watch({
+    filters: [],
+    onResult(result) {
+      firstResult ??= result;
+    },
+  });
+  openWatchers.add(emptyFilterWatcher);
+  const emptyFilterFiles = firstResult.files.map((file) =>
+    file.testPath.split('/').pop(),
+  );
+  await emptyFilterWatcher.close();
+  openWatchers.delete(emptyFilterWatcher);
 
   await mkdir(zeroMatchRoot, { recursive: true });
   const zeroMatchCycles = [];
@@ -103,8 +99,7 @@ try {
     config: { include: ['*.test.ts'], reporters: [] },
   });
   const zeroMatchWatcher = await zeroMatchRstest.watch({
-    filters: ['added.test.ts'],
-    filterMode: 'exact',
+    filters: ['"added.test.ts"'],
     onResult(result) {
       const files = result.files.map((file) => file.testPath.split('/').pop());
       zeroMatchCycles.push(files);
@@ -283,7 +278,7 @@ it('does not create a snapshot', () => {
   console.log(
     `__RSTEST_API_RESULT__${JSON.stringify({
       cycles,
-      emptyFilterCycles,
+      emptyFilterFiles,
       zeroMatchCycles,
       emptyProjectCycles,
       updateOptions: {

--- a/e2e/programmatic/index.test.ts
+++ b/e2e/programmatic/index.test.ts
@@ -361,7 +361,7 @@ describe('programmatic createRstest', () => {
       files: ['first.test.ts'],
       tests: 1,
     });
-    expect(result.emptyFilterCycles).toEqual({ fuzzy: [], exact: [] });
+    expect(result.emptyFilterFiles).toEqual([]);
     expect(result.zeroMatchCycles[0]).toEqual([]);
     expect(result.zeroMatchCycles.at(-1)).toEqual(['added.test.ts']);
     expect(result.emptyProjectCycles[0]).toEqual([]);

--- a/packages/browser/src/browserRsbuild.ts
+++ b/packages/browser/src/browserRsbuild.ts
@@ -892,7 +892,6 @@ export const collectProjectEntries = async (
         rootPath: context.rootPath,
         projectRoot: project.rootPath,
         fileFilters: context.fileFilters,
-        fileFilterMode: context.fileFilterMode,
       });
 
       const setup = materializeVirtualSetupFiles(

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -42,6 +42,7 @@ Contracts between modules or processes — not readable from any single file.
 ### Run cycle (`src/core`)
 
 - Exit codes never downgrade: a later zero must not clear a prior non-zero.
+- File filters are plain strings everywhere: a filter wrapped in matching quotes is an exact path, and `--related`/`--changed` express their resolved paths that way.
 - `stateManager` reset is core-owned (top of a non-watch run, or `prepareWatchCycleState` ahead of every watch cycle, a session's first included) — executors never reset it, so bail reads stay cycle-scoped even where two executors' first cycles bracket one startup. The snapshot summary is the one half a first cycle keeps, because the update-snapshot shortcut reads whatever the last cycle produced and the browser's first cycle would otherwise clear what the node's just left.
 - `@rstest/browser` is version-locked to core and loaded through the core-owned `BrowserHostModule` contract; the browser package constrains its exports against it via `satisfies`.
 - Reporter output is sorted by `testPath`, deliberately decoupled from the perf-first execution order (failed-first, then longest-processing-time). Don't "fix" one by changing the other.

--- a/packages/core/src/api/createRstest.ts
+++ b/packages/core/src/api/createRstest.ts
@@ -45,22 +45,10 @@ export type HostRuntime = {
   onExitCodeChange?: (code: number) => void;
 };
 
-const toShardOption = (shard: RunOptions['shard']): string | undefined =>
-  typeof shard === 'string'
-    ? shard
-    : shard
-      ? `${shard.index}/${shard.count}`
-      : undefined;
-
 const toCommonOptions = ({
   filters: _filters,
-  filterMode: _filterMode,
-  shard,
   ...common
-}: RunOptions = {}): CommonOptions => ({
-  ...common,
-  shard: toShardOption(shard),
-});
+}: RunOptions = {}): CommonOptions => common;
 
 const listedRunModes = {
   run: undefined,
@@ -192,7 +180,6 @@ export async function createRstestInstance(
       options: { ...commonOptions, trace: runtime.trace },
       command,
       filters: runOptions.filters,
-      filterMode: runOptions.filterMode,
       createRstestContext: createHostContext,
       embedded: runtime.embedded,
     });

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -2,7 +2,6 @@ import type { LoadConfigOptions } from '@rsbuild/core';
 import type {
   BrowserName,
   CoverageMapData,
-  FileFilterMode,
   FormattedError,
   Location as TestLocation,
   NormalizedConfig,
@@ -17,7 +16,6 @@ import type { LoadedRstestConfig } from '../config';
 /** @experimental Subject to change until 1.0.0. */
 export type {
   CoverageMapData,
-  FileFilterMode,
   NormalizedConfig,
   RstestConfig,
   SnapshotSummary,
@@ -56,10 +54,9 @@ export interface RstestContext {
 /** @experimental Subject to change until 1.0.0. */
 export interface RunOptions {
   filters?: string[];
-  filterMode?: FileFilterMode;
   related?: boolean;
   changed?: boolean | string;
-  shard?: string | { index: number; count: number };
+  shard?: string;
   project?: string[];
   testNamePattern?: RegExp | string;
   update?: boolean;

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -15,15 +15,11 @@ import {
   logger,
 } from '../utils';
 
-export type CommonOptions = Omit<
-  RunOptions,
-  'filters' | 'filterMode' | 'shard'
-> & {
+export type CommonOptions = Omit<RunOptions, 'filters'> & {
   root?: string;
   config?: string;
   configLoader?: LoadConfigOptions['loader'];
   trace?: boolean;
-  shard?: string;
 };
 
 export const loadCliConfig = (

--- a/packages/core/src/core/browser/globalSetupStage.ts
+++ b/packages/core/src/core/browser/globalSetupStage.ts
@@ -112,7 +112,6 @@ export async function runBrowserGlobalSetupStage(
               context,
               project,
               fileFilters: context.fileFilters,
-              fileFilterMode: context.fileFilterMode,
             });
         const entryCount = Object.keys(entries).length;
         return entryCount > 0 ? { project, entryCount } : undefined;

--- a/packages/core/src/core/browser/runPlanner.ts
+++ b/packages/core/src/core/browser/runPlanner.ts
@@ -77,18 +77,15 @@ export function createBrowserRunPlanner({
   const { rootPath } = context;
   const { shard } = context.normalizedConfig;
 
-  const isFuzzyFilter = (filter: string) =>
-    isFuzzyBasenameFilter(filter, context.fileFilterMode);
-
   const isInsideProject = (filter: string, project: InternalProjectContext) =>
     isFilterInsideProject(filter, project.rootPath, rootPath);
 
   const isBrowserProjectPathFilter = (filter: string) =>
-    !isFuzzyFilter(filter) &&
+    !isFuzzyBasenameFilter(filter) &&
     browserProjects.some((project) => isInsideProject(filter, project));
 
   const isNodeProjectPathFilter = (filter: string) =>
-    !isFuzzyFilter(filter) &&
+    !isFuzzyBasenameFilter(filter) &&
     nodeProjects.some((project) => isInsideProject(filter, project));
 
   const browserConfigHookProjects =
@@ -113,7 +110,7 @@ export function createBrowserRunPlanner({
 
     return context.fileFilters.some(
       (filter) =>
-        isFuzzyFilter(filter) ||
+        isFuzzyBasenameFilter(filter) ||
         browserConfigHookProjects.some((project) =>
           isInsideProject(filter, project),
         ) ||
@@ -132,7 +129,7 @@ export function createBrowserRunPlanner({
       return browserConfigHookProjects;
     }
 
-    if (context.fileFilters.some(isFuzzyFilter)) {
+    if (context.fileFilters.some(isFuzzyBasenameFilter)) {
       return browserConfigHookProjects;
     }
 

--- a/packages/core/src/core/buildRunner.ts
+++ b/packages/core/src/core/buildRunner.ts
@@ -3,13 +3,12 @@ import picomatch from 'picomatch';
 import type { CommonOptions } from '../cli/init';
 import { exitReporters } from '../reporter';
 import type {
-  FileFilterMode,
   Project,
   RstestCommand,
   RstestConfig,
   RstestInstance,
 } from '../types';
-import { logger } from '../utils';
+import { logger, quoteFilter } from '../utils';
 import type { ResolvedRunnerInputs } from './resolveConfig';
 
 export type CreateRstestContextFn<
@@ -25,7 +24,6 @@ export type CreateRstestContextFn<
   },
   command: RstestCommand,
   fileFilters?: string[],
-  fileFilterMode?: FileFilterMode,
 ) => Instance;
 
 export const normalizeRunnerFilters = (
@@ -191,14 +189,12 @@ const getCoverageChangedOption = (options: CommonOptions) =>
 const resolveEffectiveFilters = async ({
   options,
   filters,
-  filterMode,
   createRstestContext,
   inputs,
   embedded,
 }: {
   options: CommonOptions;
   filters?: ReadonlyArray<string | number>;
-  filterMode?: FileFilterMode;
   createRstestContext: CreateRstestContextFn;
   inputs: ResolvedRunnerInputs;
   embedded: boolean;
@@ -207,7 +203,6 @@ const resolveEffectiveFilters = async ({
   if (!isRelatedRun(options)) {
     return {
       effectiveFilters: normalizedFilters,
-      fileFilterMode: filterMode ?? ('fuzzy' as const),
     };
   }
 
@@ -245,7 +240,6 @@ const resolveEffectiveFilters = async ({
   if (forceRerunFiles.length) {
     return {
       effectiveFilters: undefined,
-      fileFilterMode: undefined,
       relatedFilters: sourceFilters,
       relatedMode: 'changed' as const,
       relatedResolutionEmpty: false,
@@ -264,8 +258,8 @@ const resolveEffectiveFilters = async ({
   });
 
   return {
-    effectiveFilters: relatedFiles,
-    fileFilterMode: 'exact' as const,
+    // Fuzzy absolute paths also match .tsx siblings and same-suffix paths in other packages.
+    effectiveFilters: relatedFiles.map(quoteFilter),
     relatedFilters: sourceFilters,
     relatedMode: changedRun ? ('changed' as const) : ('related' as const),
     relatedResolutionEmpty: relatedFiles.length === 0,
@@ -306,7 +300,6 @@ export async function buildResolvedRunner<Instance extends RstestInstance>({
   options,
   command,
   filters,
-  filterMode,
   createRstestContext,
   embedded = false,
 }: {
@@ -314,7 +307,6 @@ export async function buildResolvedRunner<Instance extends RstestInstance>({
   options: CommonOptions;
   command: RstestCommand;
   filters?: ReadonlyArray<string | number>;
-  filterMode?: FileFilterMode;
   createRstestContext: CreateRstestContextFn<Instance>;
   embedded?: boolean;
 }): Promise<Instance> {
@@ -338,7 +330,6 @@ ${conflictProjects.map((p) => `- ${p.configFilePath || p.config.root}`).join('\n
   const selection = await resolveEffectiveFilters({
     options,
     filters,
-    filterMode,
     createRstestContext,
     inputs,
     embedded,
@@ -354,7 +345,6 @@ ${conflictProjects.map((p) => `- ${p.configFilePath || p.config.root}`).join('\n
     },
     command,
     selection.effectiveFilters,
-    selection.fileFilterMode,
   );
 
   try {

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1,5 +1,4 @@
 import type {
-  FileFilterMode,
   ListCommandCollectOptions,
   Project,
   RstestCommand,
@@ -42,14 +41,12 @@ export function createRstest(
   },
   command: RstestCommand,
   fileFilters?: string[],
-  fileFilterMode?: FileFilterMode,
 ): CoreRstestInstance {
   const context = new Rstest(
     {
       cwd,
       command,
       fileFilters,
-      fileFilterMode,
       configFilePath,
       projects,
       trace,

--- a/packages/core/src/core/planner.ts
+++ b/packages/core/src/core/planner.ts
@@ -192,9 +192,7 @@ export async function createTestPlanner(
         getPlan().entriesCache.get(project.environmentName)?.entries || {},
       ),
     );
-    return filters
-      ? filterFiles(entries, filters, context.rootPath, context.fileFilterMode)
-      : entries;
+    return filters ? filterFiles(entries, filters, context.rootPath) : entries;
   };
 
   return {

--- a/packages/core/src/core/projectPlan.ts
+++ b/packages/core/src/core/projectPlan.ts
@@ -1,5 +1,4 @@
 import type {
-  FileFilterMode,
   InternalContext,
   InternalProjectContext,
   ProjectEntries,
@@ -18,12 +17,10 @@ export const getProjectEntries = async ({
   context,
   project,
   fileFilters,
-  fileFilterMode,
 }: {
   context: InternalContext;
   project: InternalProjectContext;
   fileFilters?: string[];
-  fileFilterMode?: FileFilterMode;
 }): Promise<Record<string, string>> => {
   const { include, exclude, includeSource, root } = project.normalizedConfig;
 
@@ -34,7 +31,6 @@ export const getProjectEntries = async ({
     rootPath: context.rootPath,
     projectRoot: root,
     fileFilters,
-    fileFilterMode,
   });
 };
 
@@ -109,16 +105,8 @@ export const createProjectPlanState = ({
   // executor cycles instead.
   const getProjectEntryFilter = (
     project: InternalProjectContext,
-  ): {
-    fileFilters: string[] | undefined;
-    fileFilterMode: FileFilterMode | undefined;
-  } =>
-    isWatchMode && isNodeProject(project)
-      ? { fileFilters: undefined, fileFilterMode: undefined }
-      : {
-          fileFilters: context.fileFilters,
-          fileFilterMode: context.fileFilterMode,
-        };
+  ): string[] | undefined =>
+    isWatchMode && isNodeProject(project) ? undefined : context.fileFilters;
 
   const refreshEnvironmentPartitions = (): Promise<void> => {
     environmentPartitionRefresh ??= (async () => {
@@ -129,7 +117,7 @@ export const createProjectPlanState = ({
           getProjectEntries({
             context,
             project,
-            ...getProjectEntryFilter(project),
+            fileFilters: getProjectEntryFilter(project),
           }),
       });
       allProjects = refreshed.projects;
@@ -173,12 +161,11 @@ export const createProjectPlanState = ({
     // A watch compiler re-evaluates its dynamic entry on every rebuild. Re-glob
     // here instead of serving the planning snapshot so newly created matching
     // tests become entries and deleted tests leave the compilation.
-    const { fileFilters, fileFilterMode } = getProjectEntryFilter(project);
+    const fileFilters = getProjectEntryFilter(project);
     const entries = await getProjectEntries({
       context,
       project,
       fileFilters,
-      fileFilterMode,
     });
     entriesCache.set(name, {
       entries,
@@ -199,10 +186,7 @@ export const createProjectPlanState = ({
     } else if (context.normalizedConfig.shard) {
       entriesCache =
         (await resolveShardedEntries(context, {
-          getFileFilters: (project) =>
-            getProjectEntryFilter(project).fileFilters,
-          getFileFilterMode: (project) =>
-            getProjectEntryFilter(project).fileFilterMode,
+          getFileFilters: getProjectEntryFilter,
           onShardCounts: (counts) => {
             lastShardCounts = counts;
           },

--- a/packages/core/src/core/related.ts
+++ b/packages/core/src/core/related.ts
@@ -6,7 +6,7 @@ import type {
   InternalProjectContext,
   NormalizedProjectConfig,
 } from '../types';
-import { getTestEntries } from '../utils';
+import { getTestEntries, normalizeExactPathMatch } from '../utils';
 import { createSetupFileState } from './setupFileState';
 import { prepareRsbuild } from './rsbuild';
 
@@ -315,14 +315,6 @@ const createRelatedBuildSafeguardsPlugin = (): RsbuildPlugin => ({
     });
   },
 });
-
-const normalizeExactPathMatch = (filePath: string): string => {
-  const normalizedPath = normalize(filePath);
-
-  return process.platform === 'win32'
-    ? normalizedPath.toLocaleLowerCase()
-    : normalizedPath;
-};
 
 const collectDirectlyMatchedFiles = ({
   files,

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -13,7 +13,6 @@ import { MdReporter } from '../reporter/md';
 import { VerboseReporter } from '../reporter/verbose';
 import type {
   BuiltInReporterNames,
-  FileFilterMode,
   InternalContext,
   InternalProjectContext,
   NormalizedConfig,
@@ -95,7 +94,6 @@ type Options = {
   cwd: string;
   command: RstestCommand;
   fileFilters?: string[];
-  fileFilterMode?: FileFilterMode;
   configFilePath?: string;
   projects: Project[];
   trace?: boolean;
@@ -108,7 +106,6 @@ export class Rstest implements InternalContext {
   public cwd: string;
   public command: RstestCommand;
   public fileFilters?: string[];
-  public fileFilterMode?: FileFilterMode;
   public relatedFilters?: string[];
   public relatedMode?: 'related' | 'changed';
   public relatedResolutionEmpty?: boolean;
@@ -160,7 +157,6 @@ export class Rstest implements InternalContext {
       cwd = process.cwd(),
       command,
       fileFilters,
-      fileFilterMode,
       configFilePath,
       projects,
       trace = false,
@@ -173,7 +169,6 @@ export class Rstest implements InternalContext {
     this.command = command;
     this.trace = trace;
     this.fileFilters = fileFilters;
-    this.fileFilterMode = fileFilterMode;
     this.configFilePath = configFilePath;
     this.embedded = embedded;
 

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -23,7 +23,6 @@ export type ProjectEntries = {
 };
 
 export type RstestCommand = 'watch' | 'run' | 'list' | 'merge-reports';
-export type FileFilterMode = 'fuzzy' | 'exact';
 
 export type Project = { config: RstestConfig; configFilePath?: string };
 
@@ -75,10 +74,8 @@ export type InternalContext = {
   originalConfig: Readonly<RstestConfig>;
   /** The normalized Rstest config. */
   normalizedConfig: NormalizedConfig;
-  /** filter by a filename regex pattern */
+  /** CLI filter patterns: substring by default, exact paths when wrapped in matching quotes (see isQuotedFilter). */
   fileFilters?: string[];
-  /** How file filters should match discovered test files. */
-  fileFilterMode?: FileFilterMode;
   /** Original source filters passed to `--related` or resolved from `--changed`. */
   relatedFilters?: string[];
   /** CLI option that produced related source filters. */

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -13,6 +13,23 @@ import { TEST_DELIMITER } from './constants';
 import { color } from './logger';
 import { wrapRegex } from './regexpWireFormat';
 
+export const isQuotedFilter = (filter: string): boolean =>
+  filter.length >= 2 &&
+  (filter[0] === '"' || filter[0] === "'") &&
+  filter.at(-1) === filter[0];
+
+export const quoteFilter = (path: string): string => `"${path}"`;
+
+export const unquoteFilter = (filter: string): string =>
+  isQuotedFilter(filter) ? filter.slice(1, -1) : filter;
+
+export const normalizeExactPathMatch = (filePath: string): string => {
+  const normalizedPath = normalize(filePath);
+  return process.platform === 'win32'
+    ? normalizedPath.toLocaleLowerCase()
+    : normalizedPath;
+};
+
 /**
  * Generate a stable hash for a file path.
  * Uses FNV-1a to produce a 10-char hex string.

--- a/packages/core/src/utils/shard.ts
+++ b/packages/core/src/utils/shard.ts
@@ -1,9 +1,4 @@
-import type {
-  FileFilterMode,
-  InternalContext,
-  ProjectEntries,
-  ShardConfig,
-} from '../types';
+import type { InternalContext, ProjectEntries, ShardConfig } from '../types';
 import { color, logger } from './logger';
 import { getTestEntries } from './testFiles';
 
@@ -57,15 +52,11 @@ export async function resolveShardedEntries(
   {
     onShardCounts,
     getFileFilters = () => context.fileFilters,
-    getFileFilterMode = () => context.fileFilterMode,
   }: {
     onShardCounts?: (counts: ShardCounts) => void;
     getFileFilters?: (
       project: InternalContext['projects'][number],
     ) => string[] | undefined;
-    getFileFilterMode?: (
-      project: InternalContext['projects'][number],
-    ) => FileFilterMode | undefined;
   } = {},
 ): Promise<Map<string, ProjectEntries> | undefined> {
   const { normalizedConfig, projects: allProjects, rootPath } = context;
@@ -87,7 +78,6 @@ export async function resolveShardedEntries(
           rootPath,
           projectRoot: root,
           fileFilters,
-          fileFilterMode: getFileFilterMode(p),
         });
         return Object.entries(entries).map(([alias, testPath]) => ({
           project: p.environmentName,

--- a/packages/core/src/utils/testFiles.ts
+++ b/packages/core/src/utils/testFiles.ts
@@ -2,8 +2,14 @@ import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import pathe from 'pathe';
 import { glob, isDynamicPattern } from 'tinyglobby';
-import type { FileFilterMode, Project } from '../types';
-import { castArray, parsePosix } from './helper';
+import type { Project } from '../types';
+import {
+  castArray,
+  isQuotedFilter,
+  normalizeExactPathMatch,
+  parsePosix,
+  unquoteFilter,
+} from './helper';
 import { color } from './logger';
 
 /**
@@ -16,8 +22,9 @@ export const isFilterInsideProject = (
   projectRootPath: string,
   rootPath: string,
 ): boolean => {
+  const path = unquoteFilter(filter);
   const absoluteFilter = pathe.normalize(
-    pathe.isAbsolute(filter) ? filter : pathe.resolve(rootPath, filter),
+    pathe.isAbsolute(path) ? path : pathe.resolve(rootPath, path),
   );
   const relativeFilter = pathe.normalize(
     pathe.relative(projectRootPath, absoluteFilter),
@@ -30,14 +37,11 @@ export const isFilterInsideProject = (
 };
 
 /**
- * Whether a CLI file filter is a bare basename fragment (no path separator, no
- * leading `.`) that `fuzzy` mode matches against every project.
+ * Whether a CLI file filter is an unquoted basename fragment (no path separator,
+ * no leading `.`) that substring matching applies to every project.
  */
-export const isFuzzyBasenameFilter = (
-  filter: string,
-  mode: FileFilterMode | undefined,
-): boolean => {
-  if (mode === 'exact' || pathe.isAbsolute(filter)) {
+export const isFuzzyBasenameFilter = (filter: string): boolean => {
+  if (isQuotedFilter(filter) || pathe.isAbsolute(filter)) {
     return false;
   }
 
@@ -53,7 +57,6 @@ export const filterFiles = (
   testFiles: string[],
   filters: string[],
   dir: string,
-  mode: FileFilterMode = 'fuzzy',
 ): string[] => {
   if (!filters.length) {
     return [];
@@ -64,31 +67,30 @@ export const filterFiles = (
       ? filters.map((f) => f.split(pathe.sep).join('/'))
       : filters;
 
-  if (mode === 'exact') {
-    const normalizeExactMatchPath = (filePath: string) => {
-      const normalizedPath = pathe.normalize(filePath);
-      return process.platform === 'win32'
-        ? normalizedPath.toLocaleLowerCase()
-        : normalizedPath;
-    };
-
-    const exactFilters = new Set(
-      fileFilters.map((filter) => normalizeExactMatchPath(filter)),
-    );
-
-    return testFiles.filter((testFilePath) => {
-      const absolutePath = normalizeExactMatchPath(testFilePath);
-      const relativePath = normalizeExactMatchPath(
-        pathe.relative(dir, testFilePath),
-      );
-
-      return exactFilters.has(absolutePath) || exactFilters.has(relativePath);
-    });
+  const exactFilters = new Set<string>();
+  const fuzzyFilters: string[] = [];
+  for (const filter of fileFilters) {
+    if (isQuotedFilter(filter)) {
+      exactFilters.add(normalizeExactPathMatch(unquoteFilter(filter)));
+    } else {
+      fuzzyFilters.push(filter);
+    }
   }
 
   return testFiles.filter((t) => {
-    const testFile = pathe.relative(dir, t).toLocaleLowerCase();
-    return fileFilters.some((f) => {
+    const relativePath = pathe.relative(dir, t);
+    if (
+      exactFilters.size > 0 &&
+      (exactFilters.has(normalizeExactPathMatch(t)) ||
+        exactFilters.has(normalizeExactPathMatch(relativePath)))
+    ) {
+      return true;
+    }
+    if (fuzzyFilters.length === 0) {
+      return false;
+    }
+    const testFile = relativePath.toLocaleLowerCase();
+    return fuzzyFilters.some((f) => {
       // if filter is a full file path, we should include it if it's in the same folder
       if (pathe.isAbsolute(f) && t.startsWith(f)) {
         return true;
@@ -144,7 +146,6 @@ export const getTestEntries = async ({
   rootPath,
   projectRoot,
   fileFilters,
-  fileFilterMode,
   includeSource,
 }: {
   rootPath: string;
@@ -152,7 +153,6 @@ export const getTestEntries = async ({
   exclude: string[];
   includeSource: string[];
   fileFilters?: string[];
-  fileFilterMode?: FileFilterMode;
   projectRoot: string;
 }): Promise<Record<string, string>> => {
   const globOptions = {
@@ -207,7 +207,7 @@ export const getTestEntries = async ({
   return Object.fromEntries(
     (fileFilters === undefined
       ? testFiles
-      : filterFiles(testFiles, fileFilters, rootPath, fileFilterMode)
+      : filterFiles(testFiles, fileFilters, rootPath)
     ).map((entry) => {
       const relativePath = pathe.relative(rootPath, entry);
       return [formatTestEntryName(relativePath), entry];

--- a/packages/core/tests/api/index.test.ts
+++ b/packages/core/tests/api/index.test.ts
@@ -207,9 +207,9 @@ describe('createRstest', () => {
         config: { reporters: [] },
       });
 
-      await expect(
-        rstest.run({ shard: { index: 1.5, count: 2 } }),
-      ).rejects.toThrow('Invalid shard option: 1.5/2');
+      await expect(rstest.run({ shard: '1.5/2' })).rejects.toThrow(
+        'Invalid shard option: 1.5/2',
+      );
     });
   });
 

--- a/packages/core/tests/api/publicTypes.ts
+++ b/packages/core/tests/api/publicTypes.ts
@@ -12,7 +12,6 @@ import {
 } from '@rstest/core/api';
 export type {
   CoverageMapData,
-  FileFilterMode,
   NormalizedConfig,
   ProjectContext,
   RstestContext,

--- a/packages/core/tests/core/related.test.ts
+++ b/packages/core/tests/core/related.test.ts
@@ -55,9 +55,8 @@ describe('filterFiles', () => {
     expect(
       filterFiles(
         ['/repo/tests/index.test.ts', '/repo/tests/index.test.tsx'],
-        ['/repo/tests/index.test.ts'],
+        ['"/repo/tests/index.test.ts"'],
         '/repo',
-        'exact',
       ),
     ).toEqual(['/repo/tests/index.test.ts']);
   });
@@ -67,9 +66,8 @@ describe('filterFiles', () => {
       expect(
         filterFiles(
           ['/repo/tests/Foo.test.ts', '/repo/tests/foo.test.ts'],
-          ['/repo/tests/Foo.test.ts'],
+          ['"/repo/tests/Foo.test.ts"'],
           '/repo',
-          'exact',
         ),
       ).toEqual(['/repo/tests/Foo.test.ts']);
     });
@@ -80,9 +78,8 @@ describe('filterFiles', () => {
       expect(
         filterFiles(
           ['/repo/tests/Foo.test.ts', '/repo/tests/foo.test.ts'],
-          ['/repo/tests/Foo.test.ts'],
+          ['"/repo/tests/Foo.test.ts"'],
           '/repo',
-          'exact',
         ),
       ).toEqual(['/repo/tests/Foo.test.ts', '/repo/tests/foo.test.ts']);
     });

--- a/packages/core/tests/utils/testFiles.test.ts
+++ b/packages/core/tests/utils/testFiles.test.ts
@@ -33,8 +33,7 @@ describe('test filterFiles', () => {
   it('treats an explicit empty filter list as matching no files', () => {
     const testFiles = [path.join(__dirname, 'index.test.ts')];
 
-    expect(filterFiles(testFiles, [], __dirname, 'fuzzy')).toEqual([]);
-    expect(filterFiles(testFiles, [], __dirname, 'exact')).toEqual([]);
+    expect(filterFiles(testFiles, [], __dirname)).toEqual([]);
   });
 });
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import vscode from 'vscode';
+import { quoteFilter } from '../../core/src/utils/helper';
 import { RstestDiagnostics } from './diagnostics';
 import { TestErrorStore, testMessageText } from './errorStore';
 import { logger } from './logger';
@@ -346,14 +347,15 @@ class Rstest {
         } else if (data instanceof TestFile || data instanceof TestFolder) {
           await data.api.runTest({
             ...commonOptions,
-            fileFilter: data.uri.fsPath,
-            fileFilterMode: data instanceof TestFolder ? 'fuzzy' : 'exact',
+            fileFilter:
+              data instanceof TestFolder
+                ? data.uri.fsPath
+                : quoteFilter(data.uri.fsPath),
           });
         } else if (data instanceof TestCase) {
           await data.api.runTest({
             ...commonOptions,
-            fileFilter: data.uri.fsPath,
-            fileFilterMode: 'exact',
+            fileFilter: quoteFilter(data.uri.fsPath),
             testCaseNamePath: data.parentNames.concat(test.label),
             isSuite: data.type === 'suite',
           });

--- a/packages/vscode/src/master.ts
+++ b/packages/vscode/src/master.ts
@@ -2,10 +2,10 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import net from 'node:net';
 import path, { dirname } from 'node:path';
-import type { FileFilterMode } from '@rstest/core/api';
 import { type BirpcReturn, createBirpc } from 'birpc';
 import regexpEscape from 'core-js-pure/actual/regexp/escape';
 import vscode from 'vscode';
+import { quoteFilter } from '../../core/src/utils/helper';
 import { getConfigValue } from './config';
 import {
   formatConfiguredCoreNotFoundMessage,
@@ -331,9 +331,7 @@ export class RstestApi {
       return await worker.listTests({
         ...paths,
         configFilePath: this.configFilePath,
-        // Runtime discovery filters always target concrete files.
-        fileFilterMode: fileFilters ? 'exact' : undefined,
-        fileFilters,
+        fileFilters: fileFilters?.map(quoteFilter),
         includeTaskLocation: true,
       });
     } catch (error) {
@@ -349,7 +347,6 @@ export class RstestApi {
     token,
     updateSnapshot,
     fileFilter,
-    fileFilterMode,
     testCaseNamePath,
     isSuite,
     kind,
@@ -362,7 +359,6 @@ export class RstestApi {
     token: vscode.CancellationToken;
     updateSnapshot?: boolean;
     fileFilter?: string;
-    fileFilterMode?: FileFilterMode;
     testCaseNamePath?: string[];
     isSuite?: boolean;
     kind?: vscode.TestRunProfileKind;
@@ -416,7 +412,6 @@ export class RstestApi {
     try {
       workerRun = worker.runTest({
         command: continuous ? 'watch' : 'run',
-        fileFilterMode,
         fileFilters: fileFilter ? [fileFilter] : undefined,
         testNamePattern: testCaseNamePath
           ? new RegExp(this.buildTestNamePattern(testCaseNamePath, isSuite))

--- a/packages/vscode/src/types.ts
+++ b/packages/vscode/src/types.ts
@@ -1,12 +1,10 @@
 import type { RstestConfig } from '@rstest/core';
-import type { FileFilterMode } from '@rstest/core/api';
 
 //#region master -> worker
 export type WorkerInitOptions = RstestConfig & {
   apiPath: string;
   configFilePath: string;
   coreVersion?: string;
-  fileFilterMode?: FileFilterMode;
   fileFilters?: string[];
   rstestPath: string;
   command?: 'run' | 'list' | 'watch';

--- a/packages/vscode/src/worker/index.ts
+++ b/packages/vscode/src/worker/index.ts
@@ -26,7 +26,6 @@ export class Worker {
     apiPath,
     configFilePath,
     coreVersion,
-    fileFilterMode,
     fileFilters,
     rstestPath,
     command = 'run',
@@ -64,7 +63,7 @@ export class Worker {
       },
     });
 
-    return { rstest, fileFilterMode, fileFilters, command };
+    return { rstest, fileFilters, command };
   }
 
   public async getNormalizedConfig(options: WorkerInitOptions) {
@@ -106,7 +105,7 @@ export class Worker {
   private async executeTestRun(data: WorkerInitOptions): Promise<void> {
     logger.debug('Received runTest request', JSON.stringify(data, null, 2));
     try {
-      const { rstest, fileFilterMode, fileFilters, command } = await this.init({
+      const { rstest, fileFilters, command } = await this.init({
         ...data,
         coverage: data.coverage?.enabled
           ? {
@@ -117,7 +116,6 @@ export class Worker {
       });
       const runOptions = {
         filters: fileFilters,
-        filterMode: fileFilterMode,
       } satisfies NonNullable<Parameters<typeof rstest.run>[0]>;
       // TODO: Browser and mixed continuous runs intentionally fail through the
       // public watch() guard until browser watch support lands in RFC PR4. Keep
@@ -190,13 +188,12 @@ export class Worker {
   }
 
   public async listTests(data: WorkerInitOptions) {
-    const { rstest, fileFilterMode, fileFilters } = await this.init({
+    const { rstest, fileFilters } = await this.init({
       ...data,
       command: 'list',
     });
     const filterOptions = {
       filters: fileFilters,
-      filterMode: fileFilterMode,
     };
     const declarations = await rstest.listTests({
       ...filterOptions,

--- a/packages/vscode/tests/unit/master.test.ts
+++ b/packages/vscode/tests/unit/master.test.ts
@@ -358,7 +358,7 @@ describe('RstestApi test listing', () => {
     rs.restoreAllMocks();
   });
 
-  it('uses exact filters for targeted runtime discovery', async () => {
+  it('quotes file paths for targeted runtime discovery', async () => {
     const api = createApi();
     const worker = mockWorker(api);
 
@@ -366,8 +366,7 @@ describe('RstestApi test listing', () => {
 
     expect(worker.listTests).toHaveBeenCalledWith(
       expect.objectContaining({
-        fileFilterMode: 'exact',
-        fileFilters: ['/x/file.test.ts'],
+        fileFilters: ['"/x/file.test.ts"'],
       }),
     );
   });
@@ -388,7 +387,6 @@ describe('RstestApi test listing', () => {
     );
     const worker = new Worker();
     rs.spyOn(worker as any, 'init').mockResolvedValue({
-      fileFilterMode: undefined,
       fileFilters: undefined,
       rstest: { listTests },
     });
@@ -399,7 +397,6 @@ describe('RstestApi test listing', () => {
     ]);
     expect(listTests).toHaveBeenCalledWith({
       filesOnly: true,
-      filterMode: undefined,
       filters: undefined,
     });
   });
@@ -417,8 +414,7 @@ describe('RstestApi test listing', () => {
     const listTests = rs.fn(async () => [declaration]);
     const worker = new Worker();
     rs.spyOn(worker as any, 'init').mockResolvedValue({
-      fileFilterMode: 'exact',
-      fileFilters: [testPath],
+      fileFilters: [`"${testPath}"`],
       rstest: { listTests },
     });
 
@@ -427,8 +423,7 @@ describe('RstestApi test listing', () => {
     ]);
     expect(listTests).toHaveBeenCalledTimes(1);
     expect(listTests).toHaveBeenCalledWith({
-      filterMode: 'exact',
-      filters: [testPath],
+      filters: [`"${testPath}"`],
       includeLocation: true,
       includeSuites: true,
     });
@@ -554,9 +549,9 @@ describe('RstestApi test-run completion', () => {
   };
 
   it.each([
-    { filterMode: 'fuzzy' as const, kind: 'folder' },
-    { filterMode: 'exact' as const, kind: 'file' },
-  ])('forwards a $kind filter in $filterMode mode', async ({ filterMode }) => {
+    { filter: '/x/tests', kind: 'folder' },
+    { filter: '"/x/tests/file.test.ts"', kind: 'file' },
+  ])('forwards the $kind path without a filter mode', async ({ filter }) => {
     const api = createApi();
     const engineRun = rs.fn(async () => ({
       status: 'pass',
@@ -565,29 +560,25 @@ describe('RstestApi test-run completion', () => {
     const coreWorker = new Worker();
     rs.spyOn(coreWorker as any, 'init').mockResolvedValue({
       command: 'run',
-      fileFilterMode: filterMode,
-      fileFilters: ['/x/tests'],
+      fileFilters: [filter],
       rstest: { run: engineRun },
     });
     const worker = mockWorker(api, (data) => coreWorker.runTest(data));
     const { run, token } = createRunContext();
 
     await api.runTest({
-      fileFilter: '/x/tests',
-      fileFilterMode: filterMode,
+      fileFilter: filter,
       run,
       token,
     });
 
     expect(worker.runTest).toHaveBeenCalledWith(
       expect.objectContaining({
-        fileFilterMode: filterMode,
-        fileFilters: ['/x/tests'],
+        fileFilters: [filter],
       }),
     );
     expect(engineRun).toHaveBeenCalledWith({
-      filterMode,
-      filters: ['/x/tests'],
+      filters: [filter],
     });
   });
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -161,50 +161,24 @@ const rstest = await createRstest({
 });
 
 const result = await rstest.run({
-  filters: ['src/foo.test.ts'],
-  filterMode: 'exact',
+  filters: ['"src/foo.test.ts"'],
 });
 
 console.log(result.status);
 console.log(result.summary.tests);
 ```
 
-### Select test files
-
-The following options select test files:
-
-- `filters` uses case-insensitive substring matching by default. Omit `filters` to select all files; an explicit empty array selects none in either mode.
-- `filterMode` uses normalized path equality when set to `'exact'`.
-- `related` interprets `filters` as source files and selects their related tests.
-- `changed` selects tests related to working tree changes, optionally since a Git ref. `changed: false` disables changed-file selection.
-- `shard` accepts the CLI-style `"1/3"` form or `{ index: 1, count: 3 }`.
-- `project` supports project names, `*` wildcards, and `!` exclusions.
-
-The remaining options control execution behavior for this run:
-
-- `testNamePattern` selects tests by name using a `RegExp` or string pattern.
-- `update` controls the snapshot update mode. `update: false` explicitly disables snapshot updates; omitting `update` keeps the configured or default mode.
-- `bail` is the number of test failures allowed before stopping this run; boolean `true` means one.
-- `passWithNoTests` controls whether this run succeeds when no tests match.
-
 ### RunOptions
 
 `RunOptions` accepts every `rstest run` flag except `config`, `configLoader`, `root` and `trace`. See [CLI options](/guide/basic/cli#cli-options) for the full flag list and [`packages/core/src/api/types.ts`](https://github.com/web-infra-dev/rstest/blob/main/packages/core/src/api/types.ts) for the exact types.
+
+`filters` is API-only; the CLI passes filters as positional arguments. It uses case-insensitive substring matching by default. Wrap a filter in matching single or double quotes to match an exact absolute or root-relative path, for example `filters: ['"src/foo.test.ts"', 'utils']`; quoted and unquoted filters can be mixed. Omit `filters` to select all files; an explicit empty array selects none.
 
 - **Type:**
 
 ```ts
 interface RunOptions {
   filters?: string[];
-  filterMode?: FileFilterMode;
-  related?: boolean;
-  changed?: boolean | string;
-  shard?: string | { index: number; count: number };
-  project?: string[];
-  testNamePattern?: RegExp | string;
-  update?: boolean;
-  bail?: number | boolean;
-  passWithNoTests?: boolean;
   // ...plus every other `rstest run` flag as an override of the config option
   // of the same name, e.g. `testTimeout`, `coverage`, `reporters`.
 }

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -51,6 +51,12 @@ $ npx rstest
     Duration 189 ms (build 22 ms, tests 167 ms)
 ```
 
+Wrap a filter in matching single or double quotes to match an exact absolute or root-relative path; the shell removes one layer of quotes, so use two layers:
+
+```bash
+rstest run '"src/foo.test.ts"'
+```
+
 ### Watch mode
 
 If you want to automatically rerun the test when the file changes, you can use the `--watch` flag or `rstest watch` command:

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -161,50 +161,24 @@ const rstest = await createRstest({
 });
 
 const result = await rstest.run({
-  filters: ['src/foo.test.ts'],
-  filterMode: 'exact',
+  filters: ['"src/foo.test.ts"'],
 });
 
 console.log(result.status);
 console.log(result.summary.tests);
 ```
 
-### 选择测试文件
-
-以下选项用于选择测试文件：
-
-- `filters` 默认使用不区分大小写的子字符串匹配。省略 `filters` 时选择所有文件；显式传入空数组时，两种模式都不会选择任何文件。
-- `filterMode` 设为 `'exact'` 后会使用规范化路径全等匹配。
-- `related` 将 `filters` 作为源文件输入，并选择与其关联的测试。
-- `changed` 选择与工作区变更相关的测试，也可以指定一个起始 Git 引用。`changed: false` 会禁用 `changed` 文件选择。
-- `shard` 接受 CLI 风格的 `"1/3"` 或 `{ index: 1, count: 3 }`。
-- `project` 支持项目名称、`*` 通配符和 `!` 排除项。
-
-其余选项控制本次运行的执行行为：
-
-- `testNamePattern` 使用 `RegExp` 或字符串模式按测试名称选择测试。
-- `update` 控制快照更新模式。`update: false` 会显式禁用快照更新；省略 `update` 时会保留配置或默认模式。
-- `bail` 表示停止本次运行前允许的测试失败数；布尔值 `true` 表示 1。
-- `passWithNoTests` 控制没有匹配测试时本次运行是否成功。
-
 ### RunOptions
 
 `RunOptions` 接受除 `config`、`configLoader`、`root` 和 `trace` 之外的所有 `rstest run` flag。完整 flag 列表见 [CLI 选项](/guide/basic/cli#cli-选项)，精确类型见 [`packages/core/src/api/types.ts`](https://github.com/web-infra-dev/rstest/blob/main/packages/core/src/api/types.ts)。
+
+`filters` 仅用于 API；CLI 通过位置参数传入 filter。它默认使用不区分大小写的子字符串匹配。用成对的单引号或双引号包裹 filter，可精确匹配绝对路径或相对于 root 的路径，例如 `filters: ['"src/foo.test.ts"', 'utils']`；带引号和不带引号的 filter 可以混用。省略 `filters` 时选择所有文件；显式传入空数组时不会选择任何文件。
 
 - **类型：**
 
 ```ts
 interface RunOptions {
   filters?: string[];
-  filterMode?: FileFilterMode;
-  related?: boolean;
-  changed?: boolean | string;
-  shard?: string | { index: number; count: number };
-  project?: string[];
-  testNamePattern?: RegExp | string;
-  update?: boolean;
-  bail?: number | boolean;
-  passWithNoTests?: boolean;
   // ……以及其余所有 `rstest run` flag，用于覆盖同名配置项，
   // 例如 `testTimeout`、`coverage`、`reporters`。
 }

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -51,6 +51,12 @@ $ npx rstest
     Duration 189 ms (build 22 ms, tests 167 ms)
 ```
 
+用成对的单引号或双引号包裹 filter，可精确匹配绝对路径或相对于 root 的路径；shell 会去掉一层引号，因此需要两层：
+
+```bash
+rstest run '"src/foo.test.ts"'
+```
+
 ### Watch 模式
 
 如果你希望在文件更改时自动重新运行测试，可以使用 `--watch` 或 `rstest watch` 命令：


### PR DESCRIPTION
## Summary

`RunOptions` is meant to equal the `rstest run` flags, with `filters` standing in for positional arguments. Two fields still had API-only shapes: `filterMode: 'fuzzy' | 'exact'` (no CLI equivalent) and `shard` accepting `{ index, count }` (the engine's resolved form, not what the CLI takes). This PR removes both as breaking changes to the `@experimental` API before 0.12.0.

- **Exact file selection is now expressed in the filter string itself.** A filter wrapped in matching single or double quotes matches an exact absolute or root-relative path; unquoted filters keep today's case-insensitive substring matching, and the two can be mixed. This works identically on the CLI (`rstest run '"src/foo.test.ts"'`, two quote layers because the shell strips one) and through `run()` / `listTests()` / `watch()` (`filters: ['"src/foo.test.ts"']`). The internal `FileFilterMode` and its `fileFilterMode` plumbing are gone; `--related` / `--changed` quote the paths they resolve.
- **`shard` is `string` only** (`"1/3"`), matching the CLI and the config option.
- **VS Code extension** quotes the path for file and test-case runs and for runtime discovery; folder runs stay substring-based. Older cores that do not understand quotes fall back to substring matching, so the extension expects a core that ships this change.

Docs: the `RunOptions` section on the instance page now states the rule and explains only `filters`; everything else is documented on the CLI options page. The CLI guide gains the quoting example.

## Related Links

- #1803

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
