### PR TITLE
docs: remove unsupported extensions from Rslint guide

### DIFF
--- a/website/docs/en/integration/rslint.mdx
+++ b/website/docs/en/integration/rslint.mdx
@@ -14,7 +14,7 @@ import { PackageManagerTabs } from '@theme';
 
 ## Dedicated test files
 
-If your tests use filenames such as `*.test.ts` or `*.spec.ts`, scope the preset to test and spec files with extensions that Rslint can lint:
+If your tests use filenames such as `*.test.ts` or `*.spec.ts`, scope the preset to test and spec files:
 
 ```ts title="rslint.config.ts"
 import { defineConfig, rstestPlugin } from '@rslint/core';
@@ -27,7 +27,7 @@ export default defineConfig([
 ]);
 ```
 
-This pattern covers the `.js`, `.jsx`, `.ts`, `.tsx`, `.cjs`, `.cts`, `.mjs`, and `.mts` extensions supported by Rslint. The recommended preset does not declare a `files` pattern, so adding one keeps Rstest-specific rules focused on test files and leaves production files to your other Rslint configuration items.
+This pattern covers JavaScript and TypeScript files with `.js`, `.jsx`, `.ts`, `.tsx`, `.cjs`, `.cts`, `.mjs`, and `.mts` extensions. The recommended preset does not declare a `files` pattern, so adding one keeps Rstest-specific rules focused on test files and leaves production files to your other Rslint configuration items.
 
 ## In-source tests
 

--- a/website/docs/en/integration/rslint.mdx
+++ b/website/docs/en/integration/rslint.mdx
@@ -14,7 +14,7 @@ import { PackageManagerTabs } from '@theme';
 
 ## Dedicated test files
 
-If your tests use filenames such as `*.test.ts` or `*.spec.ts`, scope the preset to the same file pattern that Rstest discovers by default:
+If your tests use filenames such as `*.test.ts` or `*.spec.ts`, scope the preset to test and spec files with extensions that Rslint can lint:
 
 ```ts title="rslint.config.ts"
 import { defineConfig, rstestPlugin } from '@rslint/core';
@@ -22,14 +22,12 @@ import { defineConfig, rstestPlugin } from '@rslint/core';
 export default defineConfig([
   {
     ...rstestPlugin.configs.recommended,
-    files: [
-      '**/*.{test,spec}.{js,jsx,ts,tsx,cjs,cjsx,cts,ctsx,mjs,mjsx,mts,mtsx}',
-    ],
+    files: ['**/*.{test,spec}.{js,jsx,ts,tsx,cjs,cts,mjs,mts}'],
   },
 ]);
 ```
 
-This pattern covers JavaScript and TypeScript files with `.js`, `.jsx`, `.ts`, `.tsx`, `.cjs`, `.cjsx`, `.cts`, `.ctsx`, `.mjs`, `.mjsx`, `.mts`, and `.mtsx` extensions. The recommended preset does not declare a `files` pattern, so adding one keeps Rstest-specific rules focused on test files and leaves production files to your other Rslint configuration items.
+This pattern covers the `.js`, `.jsx`, `.ts`, `.tsx`, `.cjs`, `.cts`, `.mjs`, and `.mts` extensions supported by Rslint. The recommended preset does not declare a `files` pattern, so adding one keeps Rstest-specific rules focused on test files and leaves production files to your other Rslint configuration items.
 
 ## In-source tests
 

--- a/website/docs/zh/integration/rslint.mdx
+++ b/website/docs/zh/integration/rslint.mdx
@@ -14,7 +14,7 @@ import { PackageManagerTabs } from '@theme';
 
 ## 独立的测试文件
 
-如果测试文件使用 `*.test.ts` 或 `*.spec.ts` 这样的文件名，可以将 preset 限定到使用 Rslint 支持扩展名的 test 和 spec 文件：
+如果测试文件使用 `*.test.ts` 或 `*.spec.ts` 这样的文件名，可以将 preset 限定到 test 和 spec 文件：
 
 ```ts title="rslint.config.ts"
 import { defineConfig, rstestPlugin } from '@rslint/core';
@@ -27,7 +27,7 @@ export default defineConfig([
 ]);
 ```
 
-这个模式覆盖 Rslint 支持的 `.js`、`.jsx`、`.ts`、`.tsx`、`.cjs`、`.cts`、`.mjs` 和 `.mts` 扩展名。recommended preset 本身没有声明 `files` 匹配模式。加上这个模式后，Rstest 专用 rules 只会检查测试文件，生产代码仍然可以由其他 Rslint 配置项负责。
+这个模式覆盖 `.js`、`.jsx`、`.ts`、`.tsx`、`.cjs`、`.cts`、`.mjs` 和 `.mts` 文件。recommended preset 本身没有声明 `files` 匹配模式。加上这个模式后，Rstest 专用 rules 只会检查测试文件，生产代码仍然可以由其他 Rslint 配置项负责。
 
 ## In-source tests
 

--- a/website/docs/zh/integration/rslint.mdx
+++ b/website/docs/zh/integration/rslint.mdx
@@ -14,7 +14,7 @@ import { PackageManagerTabs } from '@theme';
 
 ## 独立的测试文件
 
-如果测试文件使用 `*.test.ts` 或 `*.spec.ts` 这样的文件名，可以将 preset 限定到与 Rstest 默认发现范围一致的文件模式：
+如果测试文件使用 `*.test.ts` 或 `*.spec.ts` 这样的文件名，可以将 preset 限定到使用 Rslint 支持扩展名的 test 和 spec 文件：
 
 ```ts title="rslint.config.ts"
 import { defineConfig, rstestPlugin } from '@rslint/core';
@@ -22,14 +22,12 @@ import { defineConfig, rstestPlugin } from '@rslint/core';
 export default defineConfig([
   {
     ...rstestPlugin.configs.recommended,
-    files: [
-      '**/*.{test,spec}.{js,jsx,ts,tsx,cjs,cjsx,cts,ctsx,mjs,mjsx,mts,mtsx}',
-    ],
+    files: ['**/*.{test,spec}.{js,jsx,ts,tsx,cjs,cts,mjs,mts}'],
   },
 ]);
 ```
 
-这个模式覆盖 `.js`、`.jsx`、`.ts`、`.tsx`、`.cjs`、`.cjsx`、`.cts`、`.ctsx`、`.mjs`、`.mjsx`、`.mts` 和 `.mtsx` 文件。recommended preset 本身没有声明 `files` 匹配模式。加上这个模式后，Rstest 专用 rules 只会检查测试文件，生产代码仍然可以由其他 Rslint 配置项负责。
+这个模式覆盖 Rslint 支持的 `.js`、`.jsx`、`.ts`、`.tsx`、`.cjs`、`.cts`、`.mjs` 和 `.mts` 扩展名。recommended preset 本身没有声明 `files` 匹配模式。加上这个模式后，Rstest 专用 rules 只会检查测试文件，生产代码仍然可以由其他 Rslint 配置项负责。
 
 ## In-source tests
 


### PR DESCRIPTION
## Summary

Rslint only lints `.js`, `.jsx`, `.ts`, `.tsx`, `.cjs`, `.cts`, `.mjs`, and `.mts` source files. The previously documented `.cjsx`, `.ctsx`, `.mjsx`, and `.mtsx` entries are artifacts of expanding Rstest's default `?(c|m)[jt]s?(x)` glob rather than recognized Node.js or TypeScript source file extensions: Node.js defines `.cjs` and `.mjs` for CommonJS and ES modules, while TypeScript defines `.cts` and `.mts` for the corresponding TypeScript module formats and uses `.tsx` for TypeScript files containing JSX. Since Rslint does not lint those four expanded combinations even when they are explicitly matched by `files`, this change removes them from the English and Chinese Rslint integration guides.

## Related Links

This is a follow-up to #1795.

| Reference | Documentation |
| --- | --- |
| Node.js module extensions | [Determining module system](https://nodejs.org/api/packages.html#determining-module-system) |
| TypeScript module extensions | [New file extensions in TypeScript 4.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#new-file-extensions) |
| TypeScript JSX extension | [JSX basic usage](https://www.typescriptlang.org/docs/handbook/jsx.html#basic-usage) |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
