### PR TITLE
docs: simplify pool configuration and selection guidance

### DIFF
--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -89,6 +89,8 @@ Reuses Node.js worker threads while creating a fresh `vm.Context` for every test
 
 ## Choose a pool type
 
+If performance does not meet your expectations, use the `rstest-debugging` skill to identify the bottleneck before adjusting the pool. See [Profiling](/guide/debug/profiling) for installation and troubleshooting guidance.
+
 Keep `forks` unless measured performance gives you a reason to switch. Try `threads` when worker startup is expensive. Try a VM pool when repeatedly starting workers or loading and compiling test and setup dependencies accounts for a substantial part of runtime.
 
 VM pools reuse workers and immutable compilation resources while preserving a fresh environment for each file. They can help suites with many small files or large setup dependencies, but setup files, environment creation, and module evaluation still run for each file. Expensive setup work such as database initialization or network requests is not eliminated; compare performance on your own suite.

--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -1,5 +1,5 @@
 ---
-description: Options of pool used to run tests in.
+description: Configure the worker pool used to run tests.
 overviewHeaders: []
 ---
 
@@ -13,7 +13,7 @@ import { ApiMeta } from '@components/ApiMeta';
 export type RstestPoolType = 'forks' | 'threads' | 'vmForks' | 'vmThreads';
 
 export type RstestPoolOptions = {
-  /** Pool used to run tests in. */
+  /** Worker pool used to run tests. */
   type?: RstestPoolType;
   /** Maximum number or percentage of workers to run tests in. */
   maxWorkers?: number | string;
@@ -26,12 +26,12 @@ export type RstestPoolOptions = {
    * @default undefined (`system memory / maxWorkers` for VM pools)
    */
   memoryLimit?: number | string;
-  /** Pass additional arguments to node process in the child processes. */
+  /** Pass additional Node.js arguments to workers. */
   execArgv?: string[];
 };
 
 export type RstestConfig = {
-  /** Pool used to run tests in. */
+  /** Worker pool used to run tests. */
   pool?: RstestPoolType | RstestPoolOptions;
 };
 ```
@@ -47,103 +47,78 @@ const defaultPool = {
 
 - **CLI:** `--pool <type>`, `--pool.type <type>`, `--pool.maxWorkers <value>`, `--pool.memoryLimit <limit>`, `--pool.execArgv <arg>`
 
-Options of pool used to run tests in.
+Configure how Rstest creates workers, isolates test files, and controls worker concurrency and memory.
 
 ## Pool types
 
-Rstest supports the following pool types. All share the same scheduler, RPC, and result-aggregation logic — they differ in how workers are spawned and isolated.
+Rstest supports four pool types. They differ in worker transport and file isolation.
 
 ### forks
 
-Each test file runs in a separate Node.js child process spawned via `child_process.fork`. Every worker has its own V8 heap, so process-wide state (`process.chdir`, signal handlers, environment mutations, native module bindings) cannot leak between files.
+The default pool. With the default [`isolate: true`](/config/test/isolate), each test file runs in a new Node.js child process created with `child_process.fork`. Set `isolate: false` to reuse child processes across files.
 
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
 
-Each test file runs in a Node.js worker thread spawned via `node:worker_threads`. Every worker has its own V8 isolate and heap, while all workers share one operating-system process and its aggregate RSS. Rstest pipes each worker's stdout and stderr back to the host.
+Runs test files in `node:worker_threads`. Each worker has its own V8 isolate and heap, but all workers share one operating-system process and its aggregate RSS. Node.js does not support `process.chdir()` inside a worker thread.
 
 ### vmForks
 
 <ApiMeta addedVersion="0.12.0" />
 
-`vmForks` uses `child_process.fork` to create isolated worker processes and a fresh `vm.Context` for every test file. The child process is reused across files assigned to it, so process-level state is not reset per file; use `forks` when that is required. It has the same VM module loading and cross-realm behavior as `vmThreads`, while keeping process APIs such as `process.chdir()` available inside the worker. Worker recycling is handled by letting the child process exit.
+Reuses child processes created with `child_process.fork`, while creating a fresh `vm.Context` for every test file. It supports process APIs such as `process.chdir()`, but process-level state can persist between files assigned to the same worker.
 
 ### vmThreads
 
 <ApiMeta addedVersion="0.12.0" />
 
-`vmThreads` reuses Node.js worker threads while creating a fresh `vm.Context` for every test file. This keeps file-level JavaScript globals, DOM objects, and the bundled module graph isolated without paying for a new worker thread for every file. It is intended for DOM-heavy suites where environment setup is expensive but worker startup is also measurable. `vmForks` provides the same VM isolation with separate child processes.
+Reuses Node.js worker threads while creating a fresh `vm.Context` for every test file. It avoids child-process startup and keeps file-level JavaScript state isolated, but retains worker-thread restrictions such as the lack of `process.chdir()`.
 
-Its core guarantee is file-level VM isolation with reusable compilation resources, not complete equivalence with a separate Node.js process or a replacement for Node's module loader. Support is limited to the loading paths and cross-realm behavior described below.
+## VM pool behavior
 
-#### Isolation and cross-realm limits
+`vmForks` and `vmThreads` provide file-level VM isolation, not process-level isolation or complete compatibility with Node.js module loading.
 
-The [`isolate`](/config/test/isolate) option has no effect on `vmForks` or `vmThreads`. Passing `isolate: false` is accepted for configuration compatibility, but every file still receives a fresh VM context, module graph, test environment, and worker-scoped fixture lifecycle.
+### Isolation and cleanup
 
-Async runtime helpers such as `rs.waitFor()`, `rs.waitUntil()`, and `rs.runAllTimersAsync()` execute in the worker realm. Their returned Promises and internally created errors are not guaranteed to pass `instanceof Promise` or `instanceof Error` against VM constructors. Use `await` and assertions on values or error messages. User callback values and errors are passed through without realm conversion; the stable API references still resolve the current file's state at call time.
+Both VM pools reuse workers, but create a fresh VM context, module graph, test environment, and worker-scoped fixture lifecycle for every file. The [`isolate`](/config/test/isolate) option therefore has no effect on them.
 
-Always await `rs.waitFor()` and `rs.waitUntil()`. If either is still pending at VM file teardown, Rstest clears its internal timers and leaves its Promise pending rather than resolving or rejecting it, so disposal does not trigger its user continuations. This does not cancel work already started inside a user callback.
+State outside the VM context can remain in a reused worker, including changes to `process.env`, signal handlers, native addons, and shared constructors such as `Buffer`. Await or cancel asynchronous work before a file finishes: teardown clears tracked timers, but does not cancel arbitrary Promise chains, native I/O, or background tasks.
 
-At file teardown, Rstest clears pending timers created through its file-scoped timer wrappers, including `util.promisify(setTimeout)` and `util.promisify(setImmediate)`. Pending operations from these promisified timers are cancelled with `AbortError`, as are the wrapped `node:timers/promises` timeout and immediate operations. Tests must still await or explicitly cancel their asynchronous work: VM teardown does not cancel arbitrary Promise chains, native I/O, or background tasks. Cancellation can itself run user `catch` or `finally` handlers; it does not guarantee that no user code runs after teardown.
+Pool transports serialize [`testEnvironment.options`](/config/test/test-environment#environment-options) before dispatch. See that option for structured-clone and Bun JSON IPC restrictions.
 
-The VM context does not isolate worker-level state. Changes to `process.env`, signal handlers, native addons, and other state outside the VM context may persist when the same worker runs another file. Compatibility globals copied from the worker realm, such as `Buffer`, are shared constructors, so mutating those constructors may persist between files. Context-native globals such as `ArrayBuffer` and `Uint8Array` are recreated for each file. Node.js does not support `process.chdir()` inside any worker thread, so neither `threads` nor `vmThreads` can run tests or setup files that call it. VM contexts also have cross-realm identity, so values created in one file may not pass `instanceof` checks against constructors from another file. In the `happy-dom` environment, DOM implementation objects are created by `happy-dom`'s provider realm; use the environment's DOM constructors instead of assuming every DOM value passes `instanceof Object` or `instanceof Array` against VM intrinsics.
+### Cross-realm values
 
-Node worker pools send `testEnvironment.options` through an IPC structured-clone boundary. The options therefore must be structured-cloneable; function-valued options such as `beforeParse`, custom callback hooks, or instances that contain functions are rejected before dispatch. Use cloneable options or move equivalent callback setup into a setup file. This applies to `forks`, `threads`, `vmForks`, and `vmThreads`.
+Values can retain constructors from the worker, Node.js, or DOM-provider realm. Do not rely on `instanceof` against VM constructors for Promises, errors, Node.js native objects, or DOM objects. Prefer `await` and assert on values or stable fields such as an error's `name`, `code`, or `message`.
 
-On Bun, `forks` and `vmForks` use JSON IPC, so their environment options must also be JSON-compatible. Values such as `Map`, `Set`, `Date`, class instances, and `BigInt` are rejected because JSON IPC would change their shape or fail to serialize them.
+Rstest adapts plain objects, arrays, Promise fulfillment values, and ordinary Error rejections returned directly by Node.js builtins. Callback arguments, synchronous native errors, Buffers, streams, typed arrays, native handles, `DOMException`, and methods on returned native objects keep their original prototypes.
 
-Each VM worker also keeps a bounded cache of immutable bundle bytes, source maps, external source text, resolution results, and V8 compilation data between files. After the first file, unchanged assets are referenced from that worker instead of being transferred again, and unchanged modules can skip part of the resolution, parse, and compile work. These entries share one cache budget: at most 64 MiB or one quarter of the worker's `memoryLimit`, whichever is smaller. Rstest disables V8's unbounded isolate-wide compilation cache for these workers; the bounded cache supplies the reusable compilation resources instead. The cache is cleared on rebuild or worker recycle. Evaluated module instances, context-bound scripts, and setup execution state are not cached across VM contexts.
+### Supported module loading
 
-Under memory pressure or high concurrency, `vmForks` is usually easier to bound than `vmThreads`. Each fork worker reports its own RSS, so Rstest can use the fork-based `MemoryGate` to defer new workers when free memory is low. `vmThreads` workers share the host process RSS, so applying the same per-worker RSS gate would incorrectly treat the aggregate process memory as each worker's usage and collapse parallelism. This does not mean `vmForks` always uses less memory: child processes have additional startup overhead, and `memoryLimit` remains a worker heap recycling threshold for both VM pools.
+| Loading path                         | Support and limits                                                                                                                                                             |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Built test and setup bundles         | Run in the file VM. Setup and evaluated module state are recreated for every file.                                                                                             |
+| External JavaScript ESM and CommonJS | Static and dynamic imports are supported. CommonJS named exports are snapshots, and `interopDefault` still applies.                                                            |
+| External JSON and WebAssembly        | JSON ESM imports require `type: 'json'`. Asynchronous WebAssembly and JavaScript, JSON, or base64 WebAssembly `data:` URLs are supported; synchronous Wasm `require()` is not. |
+| Synchronous `require(esm)`           | Requires Node.js 24.9+, VM graph support, and no top-level await. Otherwise use dynamic `import()`.                                                                            |
+| Native addons                        | Direct CommonJS `require()` is supported, but addon state is outside VM isolation. VM ESM imports of `.node` files are unsupported.                                            |
 
-Across the Node builtin boundary, Rstest adapts plain objects, arrays, Promise fulfillment values, and Error rejection reasons from the direct and Promise result paths to the current VM. Callback arguments and errors thrown synchronously by native builtins are not converted. This is not a general conversion of every value between realms: Node-native objects such as Buffers, streams, typed arrays, and native handles retain their native backing and prototypes. DOM objects created by jsdom and happy-dom likewise retain the prototype of their provider realm. Do not rely on constructor identity when passing values across realms.
+Resolution and export-condition selection use Node.js `require.resolve()`. Rstest does not switch package entries when the selected entry uses an unsupported VM operation. `Module._cache` exposes the file's CommonJS and JSON cache, but synchronous `require(esm)` does not create CommonJS cache records or `module.children` links.
 
-In the Node environment, `fetch()` returns a VM Promise but preserves the native `Response`. Its body methods, such as `json()` and `text()`, keep native Promises, results, and errors; conversion does not extend to methods on returned native objects. Error conversion applies to ordinary errors, not native `DOMException` objects: aborting `fetch()` with the default signal reason preserves that same `DOMException` (`name: 'AbortError'`, `code: 20`). A failing `structuredClone()` also preserves Node's native `DOMException` (`name: 'DataCloneError'`, `code: 25`). Use `await` and assertions on content or error `name`/`code`, rather than `instanceof Promise`, `Object`, or `Error` against VM constructors for these values.
+Custom Node.js loaders and external TypeScript execution are unsupported; compile or bundle those files first.
 
-#### Supported module loading
-
-| Loading path                         | Supported behavior                                                                                                                      | Boundary                                                                                                                                                                  |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Built test and setup bundles         | Execute in the file VM; setup executes for each file.                                                                                   | Only immutable compilation resources are reused, not setup or dependency execution state.                                                                                 |
-| External JavaScript ESM and CommonJS | Execute in the file VM, including static and dynamic JavaScript imports.                                                                | This is not support for arbitrary Node loader hooks or runtime source transforms.                                                                                         |
-| CommonJS named exports               | Statically detected own exports are read from the original `module.exports` receiver, including non-enumerable properties and getters.  | Named exports are snapshots, not live bindings. The existing `interopDefault` option still applies; do not assume every CJS namespace is identical to native ESM interop. |
-| External JSON and WebAssembly        | JSON and asynchronously loaded WebAssembly execute in the file VM. JavaScript, JSON, and base64 WebAssembly `data:` URLs are supported. | JSON ESM imports require `type: 'json'`; synchronous `require()` of WebAssembly is not supported.                                                                         |
-| Synchronous `require(esm)`           | Supported on Node.js 24.9+ when the VM graph API is available and the graph has no top-level await.                                     | Async graphs throw `ERR_REQUIRE_ASYNC_MODULE`; older VM implementations reject ESM require with `ERR_REQUIRE_ESM`. Use dynamic `import()` instead.                        |
-| Native addons                        | Direct CommonJS `require()` delegates loading to Node.                                                                                  | Addon state is outside VM isolation; importing `.node` files through the VM ESM graph is not supported.                                                                   |
-
-CommonJS path and export-condition selection are delegated to Node's native `require.resolve()`, including its handling of startup flags. VM execution support is checked **after** resolution: Rstest does not select a different package entry to work around an unsupported VM operation.
-
-For example, on Node.js 22 a package's `module-sync` condition may select an ESM entry that the VM cannot require synchronously. This throws `ERR_REQUIRE_ESM` rather than selecting the package's CommonJS fallback. Use dynamic `import()` or bundle the dependency instead.
-
-`Module._cache` exposes the file's `require.cache` for CommonJS and JSON entry inspection and deletion; replacing or deleting the `_cache` property itself is unsupported. Synchronous `require(esm)` uses the VM's ESM cache and does not currently publish CommonJS cache records or `module.children` links. Do not rely on those APIs to traverse or invalidate an ESM graph.
-
-Custom Node loaders and external TypeScript execution are outside this scope; compile or bundle those files first. The supported loading paths do not imply complete Node loader-internal metadata compatibility, universal cross-realm value conversion, or cancellation of arbitrary asynchronous work. Failures within the supported execution paths remain compatibility bugs.
+Each VM worker caches immutable bundle bytes, source maps, external source, resolution results, and V8 compilation data. The cache is cleared on rebuild or worker recycle and is limited to the smaller of 64 MiB and one quarter of `memoryLimit`. Evaluated modules and setup state are never shared between VM contexts.
 
 ## Choose a pool type
 
-`forks` is the default — most existing test code relies on per-file process isolation. If you're not sure, keep using `forks`.
+If you are unsure, use the default `forks` pool.
 
-Consider switching to `threads` when:
-
-- Your suite is dominated by small, fast test files and worker startup eats a noticeable share of total runtime — `worker_threads` spawns roughly 10× faster than `child_process.fork`, making watch-mode reruns feel instant.
-- Worker startup is the bottleneck and your suite can use a shared operating-system process. Worker heaps are still separate, and their memory contributes to the same process RSS.
-- Your tests don't call `process.chdir()`, mutate worker-level state, or rely on that state being reset between files.
-
-Consider switching to `vmThreads` or `vmForks` when:
-
-- Each file needs a fresh global or DOM environment, but creating a worker thread per file dominates runtime.
-- Your tests are compatible with cross-realm values and do not depend on process-level isolation.
-- A shared configuration sets `isolate: false`, but this suite must retain file-level JavaScript isolation.
-
-Consider `vmForks` when the suite needs VM isolation, relies on process APIs, and can tolerate process-level state being shared by files assigned to the same child. Consider `vmThreads` when avoiding child-process startup is more important and the suite is compatible with worker-thread limitations.
-
-Stick with `forks` when:
-
-- Your tests call `process.chdir()`, mutate worker-level state, or rely on per-file process isolation.
-- Your project uses native addons (e.g. `better-sqlite3`, `sharp`, `canvas`) — one not built for worker threads can abort the whole run under `threads` (`SIGSEGV` / `SIGABRT`, not a catchable error).
-- You want a hard crash in one test file contained inside its own worker, without risking the parent process or sibling tests.
-- You need strict process-level isolation for every test file. Use `forks` with `isolate: true`; `forks` also reuses child processes when `isolate: false`, while `vmForks` always reuses child processes and only creates a fresh VM context for each file.
+| Pool        | Choose it when                                                                        | Important trade-off                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `forks`     | You need process-level isolation, native-addon compatibility, or crash containment.   | Highest worker startup cost. Use `isolate: true` for a new process per file.                          |
+| `threads`   | Worker startup is the bottleneck and the suite supports worker threads.               | No `process.chdir()`; workers share process RSS and must not depend on process state resetting.       |
+| `vmForks`   | You need a fresh VM per file plus process APIs or independently measured fork memory. | Reused files share process state, cross-realm limits apply, and child processes add startup overhead. |
+| `vmThreads` | You need a fresh VM per file with lower worker startup overhead.                      | Cross-realm and worker-thread limits apply; memory is aggregated in the host process RSS.             |
 
 ## Configure worker concurrency and memory
 
@@ -184,6 +159,8 @@ Common values:
 Sets the V8 heap threshold for recycling a `vmForks` or `vmThreads` worker. After a test file finishes, Rstest reads the worker's `heapUsed`; if it reaches the threshold, the worker is recycled before another file is assigned to it. This is a worker-recycling threshold, not a hard process RSS or OOM limit.
 
 This option currently applies only to `vmForks` and `vmThreads`. It is ignored by `forks` and `threads`. Numbers in `(0, 1]` are treated as a fraction of system memory, larger numbers are bytes, and strings may use `%`, `KB`, `KiB`, `MB`, `MiB`, `GB`, or `GiB`. When omitted, each VM worker uses an equal share of system memory (`system memory / maxWorkers`).
+
+`vmForks` can also defer creating workers based on each child process's RSS, which makes memory pressure easier to control than with the aggregate RSS of `vmThreads`. This does not mean it always uses less memory: child processes have additional overhead, and `memoryLimit` is not a hard memory cap for either pool.
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';

--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -47,27 +47,41 @@ const defaultPool = {
 
 - **CLI:** `--pool <type>`, `--pool.type <type>`, `--pool.maxWorkers <value>`, `--pool.memoryLimit <limit>`, `--pool.execArgv <arg>`
 
-Configure how Rstest creates workers, isolates test files, and controls worker concurrency and memory.
+Configure the worker pool Rstest uses to run tests, including isolation, concurrency, and memory recycling thresholds.
 
-Start with the default `forks` pool: it offers the broadest Node.js compatibility and per-file process isolation. If performance does not meet your needs, measure worker startup, module loading, and setup costs before choosing another pool.
+## Choose a pool type
+
+Start with the default `forks` pool. It introduces the fewest execution restrictions of the four pools and offers broader compatibility with Node.js APIs and native addons. The default [`isolate: true`](/config/test/isolate) also gives each test file a separate process, preventing process-level state from persisting between files and containing native crashes within the child process.
+
+If performance does not meet your expectations, first identify where the time is spent. The `rstest-debugging` skill can help; see [Profiling](/guide/debug/profiling) for installation and analysis guidance. If worker startup or module loading is the bottleneck, consider these options:
+
+| Scenario                                                                                    | Pool to try | Check before switching                                                               |
+| ------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------ |
+| Short test files spend a large share of their time starting workers                         | `threads`   | Tests and dependencies support worker-thread API and native-addon restrictions       |
+| Many files repeatedly start workers and load and compile dependencies                       | `vmThreads` | Tests support worker-thread and cross-realm restrictions                             |
+| Worker reuse is desirable, but you also need process APIs or easier memory-pressure control | `vmForks`   | Tests tolerate process state persisting within a worker and cross-realm restrictions |
+
+VM pools reuse workers and compilation resources, which can benefit suites with many files or large setup dependencies. Setup files, test environment creation, and module evaluation still run for every file, however. Switching to a VM pool will not eliminate database initialization or network requests performed in setup. Use your project's runtime and memory measurements to make the final choice.
 
 ## Pool types
 
-Rstest supports four pool types. They differ in worker transport and file isolation.
+`forks` and `threads` run tests in child processes and worker threads, respectively. `vmForks` and `vmThreads` reuse those workers while creating a fresh `vm.Context` for each file.
+
+All pools serialize environment options before sending them to workers, so functions are not supported in those options. See [`testEnvironment.options`](/config/test/test-environment#environment-options) for the requirements, including Bun's JSON IPC restrictions.
 
 ### forks
 
-The default pool. With the default [`isolate: true`](/config/test/isolate), each test file runs in a new Node.js child process created with `child_process.fork`. Set `isolate: false` to reuse child processes across files.
+Creates Node.js child processes with `child_process.fork`. Each worker has separate process memory and process-level state. By default, every file gets a new process; with [`isolate: false`](/config/test/isolate), multiple files can reuse the same child process.
 
-Of the four pools, `forks` introduces the fewest execution restrictions: it avoids worker-thread API restrictions and VM cross-realm limits, and is generally the most compatible with native addons. A native crash stays within the child process, and a fresh process resets process-level state between files. The trade-off is the cost of starting and initializing a process for each file.
+With the default isolation setting, each file incurs process startup and initialization costs.
 
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
 
-Runs test files in `node:worker_threads`. Each worker has its own V8 isolate and heap, but all workers share one operating-system process and its aggregate RSS.
+Runs tests through `node:worker_threads`. Each worker has its own V8 isolate and heap, but all threads share one operating-system process. RSS therefore measures memory usage across the entire process.
 
-The following Node.js restrictions apply to both `threads` and `vmThreads`:
+Threads generally start faster than child processes, but have some Node.js API restrictions. The following differences apply to both `threads` and `vmThreads`:
 
 - `process.chdir()`, `process.abort()`, and methods that change user or group IDs are unavailable; `process.title` cannot be changed.
 - OS signals are not delivered through `process.on()`, and `process.exit()` terminates only the worker thread.
@@ -79,34 +93,21 @@ See the [Node.js Worker documentation](https://nodejs.org/api/worker_threads.htm
 
 <ApiMeta addedVersion="0.12.0" />
 
-Reuses child processes created with `child_process.fork`, while creating a fresh `vm.Context` for every test file. It supports process APIs such as `process.chdir()`, but process-level state can persist between files assigned to the same worker.
+Reuses child processes and creates a fresh `vm.Context` for each test file, reducing repeated process startup. Process APIs such as `process.chdir()` remain available, but files in the same child process can share process-level state.
 
 ### vmThreads
 
 <ApiMeta addedVersion="0.12.0" />
 
-Reuses Node.js worker threads while creating a fresh `vm.Context` for every test file. It avoids child-process startup and keeps file-level JavaScript state isolated, but retains worker-thread restrictions such as the lack of `process.chdir()`.
+Reuses worker threads and creates a fresh `vm.Context` for each test file, reducing repeated thread startup. It provides the same VM isolation as `vmForks`, with the worker-thread restrictions described above.
 
-## Choose a pool type
-
-If performance does not meet your expectations, use the `rstest-debugging` skill to identify the bottleneck before adjusting the pool. See [Profiling](/guide/debug/profiling) for installation and troubleshooting guidance.
-
-Keep `forks` unless measured performance gives you a reason to switch. Try `threads` when worker startup is expensive. Try a VM pool when repeatedly starting workers or loading and compiling test and setup dependencies accounts for a substantial part of runtime.
-
-VM pools reuse workers and immutable compilation resources while preserving a fresh environment for each file. They can help suites with many small files or large setup dependencies, but setup files, environment creation, and module evaluation still run for each file. Expensive setup work such as database initialization or network requests is not eliminated; compare performance on your own suite.
-
-| Pool        | Choose it when                                                                            | Important trade-off                                                                                   |
-| ----------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `forks`     | Default choice for broad Node.js compatibility, process isolation, and crash containment. | Starting and initializing a new process per file has overhead with `isolate: true`.                   |
-| `threads`   | Worker startup is the bottleneck and the suite supports worker threads.                   | Worker-thread API and native-addon restrictions apply; all workers share one process.                 |
-| `vmForks`   | You need a fresh VM per file plus process APIs or independently measured fork memory.     | Reused files share process state, cross-realm limits apply, and child processes add startup overhead. |
-| `vmThreads` | You need a fresh VM per file with lower worker startup overhead.                          | Cross-realm and worker-thread limits apply; memory is aggregated in the host process RSS.             |
+For the isolation scope and compatibility requirements of both VM pools, see [VM pool behavior](#vm-pool-behavior) at the end of this page.
 
 ## Configure worker concurrency and memory
 
 ### `pool.maxWorkers`
 
-Controls how many test files can run at the same time. Use it when tests compete for the same database, port, fixture directory, or other external resource.
+`pool.maxWorkers` controls how many test files run at the same time. Lower it to reduce resource conflicts when tests share a database, port, or fixture directory.
 
 The default is computed from the CPU count and the command mode. You can provide a positive integer or a percentage of the available CPU count.
 
@@ -130,7 +131,7 @@ Common values:
 
 - `1`: run test files one at a time. This is the Rstest equivalent of Vitest's `fileParallelism: false` and Jest's `--runInBand`.
 - `50%`: keep parallelism proportional to the available CPU count, which is useful on CI machines with shared capacity.
-- A fixed number such as `4`: cap resource usage to a known safe level regardless of machine size.
+- A fixed number such as `4`: run at most 4 workers, regardless of the machine's CPU count.
 
 `maxWorkers` is about file-level parallelism. It does not limit `test.concurrent` cases inside a single test file — use [`maxConcurrency`](/config/test/max-concurrency) for that.
 
@@ -138,11 +139,14 @@ Common values:
 
 <ApiMeta addedVersion="0.12.0" />
 
-Sets the V8 heap threshold for recycling a `vmForks` or `vmThreads` worker. After a test file finishes, Rstest reads the worker's `heapUsed`; if it reaches the threshold, the worker is recycled before another file is assigned to it. This is a worker-recycling threshold, not a hard process RSS or OOM limit.
+As a VM worker runs successive files, its memory usage can grow. `pool.memoryLimit` controls when to recycle it: after each file, Rstest checks the worker's V8 `heapUsed`. If it reaches the threshold, Rstest recycles the worker and runs subsequent files in a new one.
 
-This option currently applies only to `vmForks` and `vmThreads`. It is ignored by `forks` and `threads`. Numbers in `(0, 1]` are treated as a fraction of system memory, larger numbers are bytes, and strings may use `%`, `KB`, `KiB`, `MB`, `MiB`, `GB`, or `GiB`. When omitted, each VM worker uses an equal share of system memory (`system memory / maxWorkers`).
+This option applies only to `vmForks` and `vmThreads`; `forks` and `threads` ignore it. The default threshold is `system memory / maxWorkers`. To override it, use one of these formats:
 
-`vmForks` can also defer creating workers based on each child process's RSS, which makes memory pressure easier to control than with the aggregate RSS of `vmThreads`. This does not mean it always uses less memory: child processes have additional overhead, and `memoryLimit` is not a hard memory cap for either pool.
+- A number: values in `(0, 1]` are fractions of system memory; values greater than `1` are bytes.
+- A string: supports `%`, `KB`, `KiB`, `MB`, `MiB`, `GB`, and `GiB`, such as `'25%'` or `'256MB'`.
+
+For example, this configuration runs up to 4 VM workers. After each file, a worker whose heap usage reaches `256MB` is recycled:
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -162,9 +166,13 @@ You can also set it from the CLI:
 npx rstest --pool vmThreads --pool.memoryLimit 256MB
 ```
 
+`memoryLimit` triggers recycling only between files. It is not a hard process RSS limit and cannot guarantee that a run avoids OOM.
+
+Separately, `vmForks` can use each child process's RSS to defer worker creation under memory pressure. This makes memory pressure easier to control than with the shared process RSS of `vmThreads`. This scheduling mechanism operates independently of `memoryLimit`; child processes still have additional overhead, so actual memory usage is not necessarily lower.
+
 ## Pass Node.js flags to workers
 
-Use `pool.execArgv` when the code running inside workers needs specific Node.js flags, such as custom conditions, warnings, or debugging flags.
+Use `pool.execArgv` to pass Node.js startup flags to workers. For example, this configuration enables the `development` condition:
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -176,7 +184,7 @@ export default defineConfig({
 });
 ```
 
-For debugging a single worker, combine `execArgv` with `maxWorkers: 1` so only one test file attaches to the debugger at a time:
+When debugging, combine it with `maxWorkers: 1` to run files one at a time and make execution easier to follow:
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -191,23 +199,25 @@ export default defineConfig({
 
 ## VM pool behavior
 
-`vmForks` and `vmThreads` provide file-level VM isolation, not process-level isolation or complete compatibility with Node.js module loading.
+The following applies to both `vmForks` and `vmThreads`. Before switching, check your tests' requirements for isolation, cross-realm values, and module loading.
 
 ### Isolation and cleanup
 
-Both VM pools reuse workers, but create a fresh VM context, module graph, test environment, and worker-scoped fixture lifecycle for every file. The [`isolate`](/config/test/isolate) option therefore has no effect on them.
+Each test file gets a fresh VM context, module graph, and test environment. Worker-scoped fixtures are also created and cleaned up per file. These behaviors apply regardless of the [`isolate`](/config/test/isolate) setting.
 
-State outside the VM context can remain in a reused worker, including changes to `process.env`, signal handlers, native addons, and shared constructors such as `Buffer`. Await or cancel asynchronous work before a file finishes: teardown clears tracked timers, but does not cancel arbitrary Promise chains, native I/O, or background tasks.
+The worker itself is reused, so state outside the VM context may persist across files. This includes changes to `process.env`, signal handlers, native addons, and shared constructors such as `Buffer`.
 
-Pool transports serialize [`testEnvironment.options`](/config/test/test-environment#environment-options) before dispatch. See that option for structured-clone and Bun JSON IPC restrictions.
+Tests must also manage their own asynchronous work. Await or cancel it before the file finishes. Teardown clears timers managed by Rstest, but cannot cancel arbitrary Promise chains, native I/O, or background tasks.
 
 ### Cross-realm values
 
-Values can retain constructors from the worker, Node.js, or DOM-provider realm. Do not rely on `instanceof` against VM constructors for Promises, errors, Node.js native objects, or DOM objects. Prefer `await` and assert on values or stable fields such as an error's `name`, `code`, or `message`.
+Each realm has its own constructors, so values from the worker, Node.js, or a DOM provider may fail `instanceof` checks in the current VM. Use `await` and content assertions when handling these Promises, errors, or objects. For errors, check fields such as `name`, `code`, or `message`.
 
-Rstest adapts plain objects, arrays, Promise fulfillment values, and ordinary Error rejections returned directly by Node.js builtins. Callback arguments, synchronous native errors, Buffers, streams, typed arrays, native handles, `DOMException`, and methods on returned native objects keep their original prototypes.
+Rstest adapts plain objects and arrays returned by Node.js builtins, either directly or through Promises, along with ordinary Error rejection reasons, to the current VM. This conversion does not cover callback arguments, synchronous native errors, or methods on returned native objects. Buffers, streams, typed arrays, native handles, `DOMException`, and DOM objects retain their original prototypes.
 
 ### Supported module loading
+
+VM pools support the loading paths below, with some differences from Node.js loaders. Custom Node.js loaders and direct execution of external TypeScript are unsupported; compile or bundle those files first.
 
 | Loading path                         | Support and limits                                                                                                                                                             |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -217,8 +227,8 @@ Rstest adapts plain objects, arrays, Promise fulfillment values, and ordinary Er
 | Synchronous `require(esm)`           | Requires Node.js 24.9+, VM graph support, and no top-level await. Otherwise use dynamic `import()`.                                                                            |
 | Native addons                        | Direct CommonJS `require()` is supported, but addon state is outside VM isolation. VM ESM imports of `.node` files are unsupported.                                            |
 
-Resolution and export-condition selection use Node.js `require.resolve()`. Rstest does not switch package entries when the selected entry uses an unsupported VM operation. `Module._cache` exposes the file's CommonJS and JSON cache, but synchronous `require(esm)` does not create CommonJS cache records or `module.children` links.
+CommonJS paths and export conditions are resolved by Node.js `require.resolve()`. If the selected entry cannot run in the VM, Rstest does not automatically select another entry.
 
-Custom Node.js loaders and external TypeScript execution are unsupported; compile or bundle those files first.
+`Module._cache` exposes the current file's CommonJS and JSON cache. Synchronous `require(esm)` uses a separate VM ESM cache and does not create CommonJS cache records or `module.children` links.
 
-Each VM worker caches immutable bundle bytes, source maps, external source, resolution results, and V8 compilation data. The cache is cleared on rebuild or worker recycle and is limited to the smaller of 64 MiB and one quarter of `memoryLimit`. Evaluated modules and setup state are never shared between VM contexts.
+To reduce repeated loading and compilation, each VM worker caches immutable bundle bytes, source maps, external source, resolution results, and V8 compilation data. The cache is limited to the smaller of 64 MiB and one quarter of `memoryLimit`, and is cleared on rebuild or worker recycle. Evaluated module instances and setup state are not reused across VM contexts.

--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -168,6 +168,8 @@ npx rstest --pool vmThreads --pool.memoryLimit 256MB
 
 `memoryLimit` triggers recycling only between files. It is not a hard process RSS limit and cannot guarantee that a run avoids OOM.
 
+It also bounds each VM worker's shared cache of immutable assets, external source, resolution results, and compilation data to the smaller of 64 MiB and one quarter of `memoryLimit`. Lowering the threshold can shrink this cache and increase loading and compilation work.
+
 Separately, `vmForks` can use each child process's RSS to defer worker creation under memory pressure. This makes memory pressure easier to control than with the shared process RSS of `vmThreads`. This scheduling mechanism operates independently of `memoryLimit`; child processes still have additional overhead, so actual memory usage is not necessarily lower.
 
 ## Pass Node.js flags to workers
@@ -207,6 +209,8 @@ Each file gets a fresh VM context, module graph, and test environment. Worker-sc
 
 Tests must still await or cancel asynchronous work before the file finishes. Teardown clears timers managed by Rstest, but does not cancel arbitrary Promise chains, native I/O, or background tasks.
 
+Pending wrapped `node:timers/promises` and promisified timeout/immediate operations are cancelled with `AbortError`. Cancellation may run user `catch` or `finally` handlers, so teardown does not guarantee that no user code runs afterward.
+
 ### Cross-realm assertions
 
 Values from Node.js, workers, or DOM environments may use different constructors and fail `instanceof` checks in the current VM. Use `await` and content assertions, and check an error's `name`, `code`, or `message`.
@@ -216,3 +220,20 @@ Values from Node.js, workers, or DOM environments may use different constructors
 Test and setup bundles, external JavaScript ESM, and CommonJS can run in the VM. Custom Node.js loaders and external TypeScript execution are unsupported; compile or bundle those files first.
 
 Synchronous `require(esm)` requires Node.js 24.9+, VM graph support, and a dependency graph without top-level await. Otherwise, use dynamic `import()`. Native addons can only be loaded through direct CommonJS `require()`, and their state is outside VM isolation.
+
+<details>
+<summary>Module loading compatibility</summary>
+
+VM loading differs from the native Node.js loader in the following ways:
+
+| Loading path                               | Support and limits                                                                                                                                                                                                                                      |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Test/setup bundles and external JavaScript | Execute in the file VM, including static and dynamic imports. Setup and evaluated module state are recreated per file.                                                                                                                                  |
+| CommonJS named exports                     | Statically detected own exports, including non-enumerable properties and getters, are read from the original `module.exports` receiver. They are snapshots, not live bindings; `interopDefault` still applies.                                          |
+| JSON, WebAssembly, and `data:` URLs        | JSON ESM imports require `type: 'json'`. Asynchronous WebAssembly and JavaScript, JSON, and base64 WebAssembly `data:` URLs are supported. Synchronous Wasm `require()` is unsupported.                                                                 |
+| Synchronous `require(esm)`                 | Requires Node.js 24.9+ and VM graph support. Async graphs throw `ERR_REQUIRE_ASYNC_MODULE`; older VM implementations reject ESM require with `ERR_REQUIRE_ESM`.                                                                                         |
+| Native addons                              | Direct CommonJS `require()` delegates to Node.js. VM ESM imports of `.node` files are unsupported, and addon state is not VM-isolated.                                                                                                                  |
+| CommonJS resolution                        | Node.js `require.resolve()` selects paths and export conditions. Rstest does not choose a fallback entry if the selected entry cannot run in the VM.                                                                                                    |
+| `Module._cache`                            | Exposes the file's `require.cache` for inspecting and deleting CommonJS/JSON entries. Replacing or deleting `_cache` itself is unsupported. Synchronous `require(esm)` uses the VM ESM cache without CommonJS cache records or `module.children` links. |
+
+</details>

--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -49,6 +49,8 @@ const defaultPool = {
 
 Configure how Rstest creates workers, isolates test files, and controls worker concurrency and memory.
 
+Start with the default `forks` pool: it offers the broadest Node.js compatibility and per-file process isolation. If performance does not meet your needs, measure worker startup, module loading, and setup costs before choosing another pool.
+
 ## Pool types
 
 Rstest supports four pool types. They differ in worker transport and file isolation.
@@ -57,11 +59,21 @@ Rstest supports four pool types. They differ in worker transport and file isolat
 
 The default pool. With the default [`isolate: true`](/config/test/isolate), each test file runs in a new Node.js child process created with `child_process.fork`. Set `isolate: false` to reuse child processes across files.
 
+Of the four pools, `forks` introduces the fewest execution restrictions: it avoids worker-thread API restrictions and VM cross-realm limits, and is generally the most compatible with native addons. A native crash stays within the child process, and a fresh process resets process-level state between files. The trade-off is the cost of starting and initializing a process for each file.
+
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
 
-Runs test files in `node:worker_threads`. Each worker has its own V8 isolate and heap, but all workers share one operating-system process and its aggregate RSS. Node.js does not support `process.chdir()` inside a worker thread.
+Runs test files in `node:worker_threads`. Each worker has its own V8 isolate and heap, but all workers share one operating-system process and its aggregate RSS.
+
+The following Node.js restrictions apply to both `threads` and `vmThreads`:
+
+- `process.chdir()`, `process.abort()`, and methods that change user or group IDs are unavailable; `process.title` cannot be changed.
+- OS signals are not delivered through `process.on()`, and `process.exit()` terminates only the worker thread.
+- Native addons must support use in worker threads. A native crash can affect the entire process.
+
+See the [Node.js Worker documentation](https://nodejs.org/api/worker_threads.html#class-worker) for the full list of differences.
 
 ### vmForks
 
@@ -75,50 +87,18 @@ Reuses child processes created with `child_process.fork`, while creating a fresh
 
 Reuses Node.js worker threads while creating a fresh `vm.Context` for every test file. It avoids child-process startup and keeps file-level JavaScript state isolated, but retains worker-thread restrictions such as the lack of `process.chdir()`.
 
-## VM pool behavior
-
-`vmForks` and `vmThreads` provide file-level VM isolation, not process-level isolation or complete compatibility with Node.js module loading.
-
-### Isolation and cleanup
-
-Both VM pools reuse workers, but create a fresh VM context, module graph, test environment, and worker-scoped fixture lifecycle for every file. The [`isolate`](/config/test/isolate) option therefore has no effect on them.
-
-State outside the VM context can remain in a reused worker, including changes to `process.env`, signal handlers, native addons, and shared constructors such as `Buffer`. Await or cancel asynchronous work before a file finishes: teardown clears tracked timers, but does not cancel arbitrary Promise chains, native I/O, or background tasks.
-
-Pool transports serialize [`testEnvironment.options`](/config/test/test-environment#environment-options) before dispatch. See that option for structured-clone and Bun JSON IPC restrictions.
-
-### Cross-realm values
-
-Values can retain constructors from the worker, Node.js, or DOM-provider realm. Do not rely on `instanceof` against VM constructors for Promises, errors, Node.js native objects, or DOM objects. Prefer `await` and assert on values or stable fields such as an error's `name`, `code`, or `message`.
-
-Rstest adapts plain objects, arrays, Promise fulfillment values, and ordinary Error rejections returned directly by Node.js builtins. Callback arguments, synchronous native errors, Buffers, streams, typed arrays, native handles, `DOMException`, and methods on returned native objects keep their original prototypes.
-
-### Supported module loading
-
-| Loading path                         | Support and limits                                                                                                                                                             |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Built test and setup bundles         | Run in the file VM. Setup and evaluated module state are recreated for every file.                                                                                             |
-| External JavaScript ESM and CommonJS | Static and dynamic imports are supported. CommonJS named exports are snapshots, and `interopDefault` still applies.                                                            |
-| External JSON and WebAssembly        | JSON ESM imports require `type: 'json'`. Asynchronous WebAssembly and JavaScript, JSON, or base64 WebAssembly `data:` URLs are supported; synchronous Wasm `require()` is not. |
-| Synchronous `require(esm)`           | Requires Node.js 24.9+, VM graph support, and no top-level await. Otherwise use dynamic `import()`.                                                                            |
-| Native addons                        | Direct CommonJS `require()` is supported, but addon state is outside VM isolation. VM ESM imports of `.node` files are unsupported.                                            |
-
-Resolution and export-condition selection use Node.js `require.resolve()`. Rstest does not switch package entries when the selected entry uses an unsupported VM operation. `Module._cache` exposes the file's CommonJS and JSON cache, but synchronous `require(esm)` does not create CommonJS cache records or `module.children` links.
-
-Custom Node.js loaders and external TypeScript execution are unsupported; compile or bundle those files first.
-
-Each VM worker caches immutable bundle bytes, source maps, external source, resolution results, and V8 compilation data. The cache is cleared on rebuild or worker recycle and is limited to the smaller of 64 MiB and one quarter of `memoryLimit`. Evaluated modules and setup state are never shared between VM contexts.
-
 ## Choose a pool type
 
-If you are unsure, use the default `forks` pool.
+Keep `forks` unless measured performance gives you a reason to switch. Try `threads` when worker startup is expensive. Try a VM pool when repeatedly starting workers or loading and compiling test and setup dependencies accounts for a substantial part of runtime.
 
-| Pool        | Choose it when                                                                        | Important trade-off                                                                                   |
-| ----------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `forks`     | You need process-level isolation, native-addon compatibility, or crash containment.   | Highest worker startup cost. Use `isolate: true` for a new process per file.                          |
-| `threads`   | Worker startup is the bottleneck and the suite supports worker threads.               | No `process.chdir()`; workers share process RSS and must not depend on process state resetting.       |
-| `vmForks`   | You need a fresh VM per file plus process APIs or independently measured fork memory. | Reused files share process state, cross-realm limits apply, and child processes add startup overhead. |
-| `vmThreads` | You need a fresh VM per file with lower worker startup overhead.                      | Cross-realm and worker-thread limits apply; memory is aggregated in the host process RSS.             |
+VM pools reuse workers and immutable compilation resources while preserving a fresh environment for each file. They can help suites with many small files or large setup dependencies, but setup files, environment creation, and module evaluation still run for each file. Expensive setup work such as database initialization or network requests is not eliminated; compare performance on your own suite.
+
+| Pool        | Choose it when                                                                            | Important trade-off                                                                                   |
+| ----------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `forks`     | Default choice for broad Node.js compatibility, process isolation, and crash containment. | Starting and initializing a new process per file has overhead with `isolate: true`.                   |
+| `threads`   | Worker startup is the bottleneck and the suite supports worker threads.                   | Worker-thread API and native-addon restrictions apply; all workers share one process.                 |
+| `vmForks`   | You need a fresh VM per file plus process APIs or independently measured fork memory.     | Reused files share process state, cross-realm limits apply, and child processes add startup overhead. |
+| `vmThreads` | You need a fresh VM per file with lower worker startup overhead.                          | Cross-realm and worker-thread limits apply; memory is aggregated in the host process RSS.             |
 
 ## Configure worker concurrency and memory
 
@@ -206,3 +186,37 @@ export default defineConfig({
   },
 });
 ```
+
+## VM pool behavior
+
+`vmForks` and `vmThreads` provide file-level VM isolation, not process-level isolation or complete compatibility with Node.js module loading.
+
+### Isolation and cleanup
+
+Both VM pools reuse workers, but create a fresh VM context, module graph, test environment, and worker-scoped fixture lifecycle for every file. The [`isolate`](/config/test/isolate) option therefore has no effect on them.
+
+State outside the VM context can remain in a reused worker, including changes to `process.env`, signal handlers, native addons, and shared constructors such as `Buffer`. Await or cancel asynchronous work before a file finishes: teardown clears tracked timers, but does not cancel arbitrary Promise chains, native I/O, or background tasks.
+
+Pool transports serialize [`testEnvironment.options`](/config/test/test-environment#environment-options) before dispatch. See that option for structured-clone and Bun JSON IPC restrictions.
+
+### Cross-realm values
+
+Values can retain constructors from the worker, Node.js, or DOM-provider realm. Do not rely on `instanceof` against VM constructors for Promises, errors, Node.js native objects, or DOM objects. Prefer `await` and assert on values or stable fields such as an error's `name`, `code`, or `message`.
+
+Rstest adapts plain objects, arrays, Promise fulfillment values, and ordinary Error rejections returned directly by Node.js builtins. Callback arguments, synchronous native errors, Buffers, streams, typed arrays, native handles, `DOMException`, and methods on returned native objects keep their original prototypes.
+
+### Supported module loading
+
+| Loading path                         | Support and limits                                                                                                                                                             |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Built test and setup bundles         | Run in the file VM. Setup and evaluated module state are recreated for every file.                                                                                             |
+| External JavaScript ESM and CommonJS | Static and dynamic imports are supported. CommonJS named exports are snapshots, and `interopDefault` still applies.                                                            |
+| External JSON and WebAssembly        | JSON ESM imports require `type: 'json'`. Asynchronous WebAssembly and JavaScript, JSON, or base64 WebAssembly `data:` URLs are supported; synchronous Wasm `require()` is not. |
+| Synchronous `require(esm)`           | Requires Node.js 24.9+, VM graph support, and no top-level await. Otherwise use dynamic `import()`.                                                                            |
+| Native addons                        | Direct CommonJS `require()` is supported, but addon state is outside VM isolation. VM ESM imports of `.node` files are unsupported.                                            |
+
+Resolution and export-condition selection use Node.js `require.resolve()`. Rstest does not switch package entries when the selected entry uses an unsupported VM operation. `Module._cache` exposes the file's CommonJS and JSON cache, but synchronous `require(esm)` does not create CommonJS cache records or `module.children` links.
+
+Custom Node.js loaders and external TypeScript execution are unsupported; compile or bundle those files first.
+
+Each VM worker caches immutable bundle bytes, source maps, external source, resolution results, and V8 compilation data. The cache is cleared on rebuild or worker recycle and is limited to the smaller of 64 MiB and one quarter of `memoryLimit`. Evaluated modules and setup state are never shared between VM contexts.

--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -67,7 +67,7 @@ VM pools reuse workers and compilation resources, which can benefit suites with 
 
 `forks` and `threads` run tests in child processes and worker threads, respectively. `vmForks` and `vmThreads` reuse those workers while creating a fresh `vm.Context` for each file.
 
-All pools serialize environment options before sending them to workers, so functions are not supported in those options. See [`testEnvironment.options`](/config/test/test-environment#environment-options) for the requirements, including Bun's JSON IPC restrictions.
+All pools serialize environment options before sending them to workers, so functions are not supported in those options. See [`testEnvironment.options`](/config/test/test-environment#environment-options) for the requirements.
 
 ### forks
 
@@ -199,36 +199,20 @@ export default defineConfig({
 
 ## VM pool behavior
 
-The following applies to both `vmForks` and `vmThreads`. Before switching, check your tests' requirements for isolation, cross-realm values, and module loading.
+These restrictions apply to both `vmForks` and `vmThreads`.
 
 ### Isolation and cleanup
 
-Each test file gets a fresh VM context, module graph, and test environment. Worker-scoped fixtures are also created and cleaned up per file. These behaviors apply regardless of the [`isolate`](/config/test/isolate) setting.
+Each file gets a fresh VM context, module graph, and test environment. Worker-scoped fixtures are also created and cleaned up per file, regardless of [`isolate`](/config/test/isolate). Workers are reused, however, so state outside the VM, such as `process.env` and native-addon state, may persist across files.
 
-The worker itself is reused, so state outside the VM context may persist across files. This includes changes to `process.env`, signal handlers, native addons, and shared constructors such as `Buffer`.
+Tests must still await or cancel asynchronous work before the file finishes. Teardown clears timers managed by Rstest, but does not cancel arbitrary Promise chains, native I/O, or background tasks.
 
-Tests must also manage their own asynchronous work. Await or cancel it before the file finishes. Teardown clears timers managed by Rstest, but cannot cancel arbitrary Promise chains, native I/O, or background tasks.
+### Cross-realm assertions
 
-### Cross-realm values
+Values from Node.js, workers, or DOM environments may use different constructors and fail `instanceof` checks in the current VM. Use `await` and content assertions, and check an error's `name`, `code`, or `message`.
 
-Each realm has its own constructors, so values from the worker, Node.js, or a DOM provider may fail `instanceof` checks in the current VM. Use `await` and content assertions when handling these Promises, errors, or objects. For errors, check fields such as `name`, `code`, or `message`.
+### Module loading
 
-Rstest adapts plain objects and arrays returned by Node.js builtins, either directly or through Promises, along with ordinary Error rejection reasons, to the current VM. This conversion does not cover callback arguments, synchronous native errors, or methods on returned native objects. Buffers, streams, typed arrays, native handles, `DOMException`, and DOM objects retain their original prototypes.
+Test and setup bundles, external JavaScript ESM, and CommonJS can run in the VM. Custom Node.js loaders and external TypeScript execution are unsupported; compile or bundle those files first.
 
-### Supported module loading
-
-VM pools support the loading paths below, with some differences from Node.js loaders. Custom Node.js loaders and direct execution of external TypeScript are unsupported; compile or bundle those files first.
-
-| Loading path                         | Support and limits                                                                                                                                                             |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Built test and setup bundles         | Run in the file VM. Setup and evaluated module state are recreated for every file.                                                                                             |
-| External JavaScript ESM and CommonJS | Static and dynamic imports are supported. CommonJS named exports are snapshots, and `interopDefault` still applies.                                                            |
-| External JSON and WebAssembly        | JSON ESM imports require `type: 'json'`. Asynchronous WebAssembly and JavaScript, JSON, or base64 WebAssembly `data:` URLs are supported; synchronous Wasm `require()` is not. |
-| Synchronous `require(esm)`           | Requires Node.js 24.9+, VM graph support, and no top-level await. Otherwise use dynamic `import()`.                                                                            |
-| Native addons                        | Direct CommonJS `require()` is supported, but addon state is outside VM isolation. VM ESM imports of `.node` files are unsupported.                                            |
-
-CommonJS paths and export conditions are resolved by Node.js `require.resolve()`. If the selected entry cannot run in the VM, Rstest does not automatically select another entry.
-
-`Module._cache` exposes the current file's CommonJS and JSON cache. Synchronous `require(esm)` uses a separate VM ESM cache and does not create CommonJS cache records or `module.children` links.
-
-To reduce repeated loading and compilation, each VM worker caches immutable bundle bytes, source maps, external source, resolution results, and V8 compilation data. The cache is limited to the smaller of 64 MiB and one quarter of `memoryLimit`, and is cleared on rebuild or worker recycle. Evaluated module instances and setup state are not reused across VM contexts.
+Synchronous `require(esm)` requires Node.js 24.9+, VM graph support, and a dependency graph without top-level await. Otherwise, use dynamic `import()`. Native addons can only be loaded through direct CommonJS `require()`, and their state is outside VM isolation.

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -46,66 +46,67 @@ const defaultPool = {
 
 - **CLI：** `--pool <type>`、`--pool.type <type>`、`--pool.maxWorkers <value>`、`--pool.memoryLimit <limit>`、`--pool.execArgv <arg>`
 
-配置 Rstest 如何创建 worker、隔离测试文件，以及控制并行度和内存。
+配置 Rstest 运行测试所用的 worker pool，包括隔离方式、并行度和内存回收阈值。
 
-建议先使用默认的 `forks`，它的 Node.js 兼容性最好，并提供文件级进程隔离。性能不符合预期时，再根据 worker 启动、模块加载和 setup 的实际耗时选择其他 pool。
+## 如何选择 pool 类型
+
+建议先使用默认的 `forks`。它在四种 pool 中引入的执行限制最少，对 Node.js API 和 native addon 的兼容性更好。默认的 [`isolate: true`](/config/test/isolate) 还会为每个测试文件创建独立进程，避免进程级状态在文件之间残留，并将原生崩溃的影响限制在子进程内。
+
+性能不符合预期时，先确认耗时集中在哪个阶段。可以使用 `rstest-debugging` skill 辅助排查，安装方式和分析方法见[性能分析](/guide/debug/profiling)。如果瓶颈确实在 worker 启动或模块加载，再考虑下面的选择：
+
+| 场景                                                   | 可以尝试    | 切换前需要确认                                            |
+| ------------------------------------------------------ | ----------- | --------------------------------------------------------- |
+| 单文件测试较短，worker 启动占用较多时间                | `threads`   | 测试及依赖兼容 worker thread 的 API 和 native addon 限制  |
+| 文件较多，重复启动 worker、加载和编译依赖的成本较高    | `vmThreads` | 测试兼容 worker thread 和跨 realm 限制                    |
+| 希望复用 worker，同时需要进程 API 或更容易控制内存压力 | `vmForks`   | 测试能接受同一 worker 内的进程状态残留，以及跨 realm 限制 |
+
+VM pool 会复用 worker 和编译资源，因此测试文件多、setup 依赖较大时可能受益。不过，setup 文件、测试环境创建和模块求值仍会逐文件执行。如果主要耗时来自 setup 中的数据库初始化或网络请求，切换 VM pool 并不会省去这些工作。最终应以项目自身的耗时和内存测量结果为准。
 
 ## Pool 类型
 
-Rstest 支持四种 pool，主要区别是 worker 的创建方式和文件隔离方式。
+`forks` 和 `threads` 分别使用子进程和线程运行测试；`vmForks` 和 `vmThreads` 则在复用这些 worker 的同时，为每个文件创建新的 `vm.Context`。
+
+所有 pool 都需要将环境选项序列化后传给 worker，不支持在这些选项中传入函数。具体要求见 [`testEnvironment.options`](/config/test/test-environment#环境选项)，其中也说明了 Bun 下的 JSON IPC 限制。
 
 ### forks
 
-默认 pool。使用默认的 [`isolate: true`](/config/test/isolate) 时，每个测试文件都会在 `child_process.fork` 创建的新 Node.js 子进程中运行。设置 `isolate: false` 后，子进程会在文件之间复用。
+通过 `child_process.fork` 创建 Node.js 子进程，每个 worker 都有独立的进程内存和进程级状态。默认每个文件使用新进程；设置 [`isolate: false`](/config/test/isolate) 后，多个文件可以复用同一个子进程。
 
-四种 pool 中，`forks` 引入的执行限制最少：没有 worker thread 的 API 限制和 VM 的跨 realm 限制，对 native addon 通常也最兼容。原生崩溃的影响限于子进程，新进程还能在文件之间重置进程级状态。代价是每个文件都需要承担进程启动和初始化成本。
+默认隔离模式下，每个文件都需要承担进程启动和初始化成本。
 
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
 
-通过 `node:worker_threads` 运行测试文件。每个 worker 都有独立的 V8 isolate 和 heap，但共享同一个操作系统进程，内存也会计入同一份 RSS。
+通过 `node:worker_threads` 运行测试。每个 worker 都有独立的 V8 isolate 和 heap，但所有线程共享同一个操作系统进程，RSS 反映的是整个进程的内存占用。
 
-以下 Node.js 限制同时适用于 `threads` 和 `vmThreads`：
+相比子进程，线程通常启动更快，但有一些 Node.js API 限制。以下差异同时适用于 `threads` 和 `vmThreads`：
 
 - 不支持 `process.chdir()`、`process.abort()` 和修改用户或用户组 ID 的方法，也不能修改 `process.title`。
 - `process.on()` 不会收到操作系统信号；`process.exit()` 只结束当前 worker thread。
 - native addon 必须支持在 worker thread 中使用，原生崩溃可能影响整个进程。
 
-完整差异请参阅 [Node.js Worker 文档](https://nodejs.org/api/worker_threads.html#class-worker)。
+完整差异见 [Node.js Worker 文档](https://nodejs.org/api/worker_threads.html#class-worker)。
 
 ### vmForks
 
 <ApiMeta addedVersion="0.12.0" />
 
-复用 `child_process.fork` 创建的子进程，同时为每个测试文件创建新的 `vm.Context`。它支持 `process.chdir()` 等进程 API，但分配到同一个 worker 的文件可能共享进程级状态。
+复用子进程，并为每个测试文件创建新的 `vm.Context`，减少反复启动进程的开销。`process.chdir()` 等进程 API 仍然可用，但同一子进程中的文件可能共享进程级状态。
 
 ### vmThreads
 
 <ApiMeta addedVersion="0.12.0" />
 
-复用 Node.js worker thread，同时为每个测试文件创建新的 `vm.Context`。它省去了子进程启动开销，并保持文件级 JavaScript 状态隔离，但仍受 worker thread 限制，例如不能调用 `process.chdir()`。
+复用 worker thread，并为每个测试文件创建新的 `vm.Context`，减少反复启动线程的开销。它与 `vmForks` 提供相同的 VM 隔离，同时受上述 worker thread 限制。
 
-## 如何选择 pool 类型
-
-性能不符合预期时，可以使用 `rstest-debugging` skill 辅助定位瓶颈，再决定是否调整 pool。安装方式和排查方法请参阅[性能分析](/guide/debug/profiling)。
-
-默认使用 `forks`，测量后再决定是否切换。worker 启动耗时较高时，可以尝试 `threads`；反复启动 worker，或加载、编译测试与 setup 依赖的成本较高时，可以尝试 VM pool。
-
-VM pool 会复用 worker 和不可变的编译资源，同时为每个文件创建新环境，可能更适合文件多、单文件测试短或 setup 依赖较大的套件。但 setup 文件、环境创建和模块求值仍会逐文件执行，数据库初始化、网络请求等 setup 工作不会因此省掉，收益需要用自己的测试套件验证。
-
-| Pool        | 适用场景                                                              | 主要取舍                                                              |
-| ----------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `forks`     | 默认选择，适合需要 Node.js 兼容性、进程隔离和限制崩溃影响范围的套件。 | `isolate: true` 时，每个文件都有新进程的启动和初始化成本。            |
-| `threads`   | worker 启动是主要瓶颈，而且测试套件兼容 worker thread。               | 受 worker thread API 和 native addon 限制，所有 worker 共享进程。     |
-| `vmForks`   | 每个文件需要新 VM，同时依赖进程 API 或需要分别观测各子进程的内存。    | 文件之间可能共享进程状态，受跨 realm 限制，而且子进程有额外启动成本。 |
-| `vmThreads` | 每个文件需要新 VM，同时希望减少 worker 启动成本。                     | 受跨 realm 和 worker thread 限制；内存统一计入宿主进程 RSS。          |
+两种 VM pool 的隔离范围和兼容性要求见文末的 [VM pool 的行为边界](#vm-pool-的行为边界)。
 
 ## 配置 worker 并行度和内存
 
 ### `pool.maxWorkers`
 
-控制同时运行的测试文件数量。当测试会竞争同一个数据库、端口、fixture 目录或其他外部资源时，可以用它限制并行度。
+`pool.maxWorkers` 决定同时运行多少个测试文件。测试会竞争同一个数据库、端口或 fixture 目录时，可以调低这个值，减少资源冲突。
 
 默认值会根据 CPU 数量和运行模式自动计算。你可以传入正整数，或传入可用 CPU 数量的百分比。
 
@@ -129,7 +130,7 @@ npx rstest --pool.maxWorkers 1
 
 - `1`：让测试文件逐个运行。这等价于 Vitest 的 `fileParallelism: false` 和 Jest 的 `--runInBand`。
 - `50%`：根据可用 CPU 数量按比例控制并行度，适合容量共享的 CI 机器。
-- 固定数字，如 `4`：无论机器规模如何，都把资源占用限制在已知安全的范围内。
+- 固定数字，如 `4`：将同时运行的 worker 数量限制为 4，不随机器的 CPU 数量变化。
 
 `maxWorkers` 控制的是文件级并行度。它不会限制单个测试文件内的 `test.concurrent` 用例；如需限制这类用例，请使用 [`maxConcurrency`](/config/test/max-concurrency)。
 
@@ -137,11 +138,14 @@ npx rstest --pool.maxWorkers 1
 
 <ApiMeta addedVersion="0.12.0" />
 
-设置 `vmForks` 或 `vmThreads` worker 的 V8 heap 回收阈值。每个测试文件运行结束后，Rstest 会读取 worker 的 `heapUsed`；达到阈值时，会在分配下一个文件前回收 worker。这是 worker 回收阈值，不是进程 RSS 或 OOM 的硬上限。
+VM worker 会连续运行多个文件，内存也可能随之增长。`pool.memoryLimit` 用于控制何时回收 worker：每个文件结束后，Rstest 会检查其 V8 `heapUsed`，达到阈值便回收，在新的 worker 中运行后续文件。
 
-该配置当前仅作用于 `vmForks` 和 `vmThreads`，传给 `forks` 或 `threads` 时会被忽略。`(0, 1]` 的数字表示系统内存比例，更大的数字表示字节数；字符串支持 `%`、`KB`、`KiB`、`MB`、`MiB`、`GB` 和 `GiB`。未设置时，每个 VM worker 默认使用等额的系统内存（`系统内存 / maxWorkers`）。
+此选项仅适用于 `vmForks` 和 `vmThreads`，在 `forks` 和 `threads` 中会被忽略。默认阈值为 `系统内存 / maxWorkers`，也可以使用以下格式指定：
 
-`vmForks` 还能根据每个子进程的 RSS 延后创建 worker。相比只能看到进程总 RSS 的 `vmThreads`，它更容易控制内存压力。但这不表示 `vmForks` 一定更省内存：子进程本身也有额外开销，而且两种 pool 的 `memoryLimit` 都不是内存硬上限。
+- 数字：`(0, 1]` 表示系统内存的比例，大于 `1` 表示字节数。
+- 字符串：支持 `%`、`KB`、`KiB`、`MB`、`MiB`、`GB` 和 `GiB`，例如 `'25%'` 或 `'256MB'`。
+
+例如，下面的配置最多运行 4 个 VM worker。每个文件结束后，heap 使用量达到 `256MB` 的 worker 会被回收：
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -161,9 +165,13 @@ export default defineConfig({
 npx rstest --pool vmThreads --pool.memoryLimit 256MB
 ```
 
+`memoryLimit` 只在文件之间触发回收，不是进程 RSS 的硬上限，也不能保证避免 OOM。
+
+此外，`vmForks` 能根据各子进程的 RSS，在内存紧张时延后创建 worker，因此比共享进程 RSS 的 `vmThreads` 更容易控制内存压力。这项调度机制与 `memoryLimit` 分开工作；子进程本身仍有额外开销，实际内存占用不一定更低。
+
 ## 向 worker 传递 Node.js flags
 
-当 worker 内运行的代码需要特定 Node.js flags（例如自定义 conditions、warnings 或调试参数）时，可以使用 `pool.execArgv`。
+使用 `pool.execArgv` 向 worker 传递 Node.js 启动参数。例如，下面的配置启用 `development` condition：
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -175,7 +183,7 @@ export default defineConfig({
 });
 ```
 
-如果要调试单个 worker，可以把 `execArgv` 和 `maxWorkers: 1` 组合使用，确保同一时间只有一个测试文件连接到 debugger：
+调试时可以配合 `maxWorkers: 1` 使用，让测试文件逐个运行，便于跟踪执行过程：
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -190,23 +198,25 @@ export default defineConfig({
 
 ## VM pool 的行为边界
 
-`vmForks` 和 `vmThreads` 提供文件级 VM 隔离，但不等同于进程级隔离，也不完全兼容 Node.js 模块加载机制。
+以下说明同时适用于 `vmForks` 和 `vmThreads`。切换前需要确认测试对隔离范围、跨 realm 的值和模块加载方式的要求。
 
 ### 隔离与清理
 
-两种 VM pool 都会复用 worker，但每个文件都有新的 VM context、module graph、test environment 和 worker scope fixture 生命周期。因此，[`isolate`](/config/test/isolate) 对它们不生效。
+每个测试文件都会获得新的 VM context、模块图和测试环境，worker scope fixture 也按文件创建和清理。无论 [`isolate`](/config/test/isolate) 如何设置，这些行为都不变。
 
-VM context 之外的状态可能留在复用的 worker 中，包括对 `process.env`、signal handler、native addon 和 `Buffer` 等共享 constructor 的修改。测试文件结束前，请 await 或主动取消异步任务。teardown 会清理受 Rstest 管理的 timer，但不会取消任意 Promise 链、原生 I/O 或后台任务。
+worker 本身仍会复用，所以 VM context 之外的状态可能跨文件保留，例如对 `process.env`、signal handler、native addon 和 `Buffer` 等共享 constructor 的修改。
 
-Pool 会先序列化 [`testEnvironment.options`](/config/test/test-environment#环境选项)，再把任务发给 worker。structured clone 和 Bun JSON IPC 的限制请参阅该配置项。
+异步任务也需要测试自行管理。请在文件结束前 `await` 或主动取消这些任务；teardown 会清理受 Rstest 管理的定时器，但无法取消任意 Promise 链、原生 I/O 或后台任务。
 
 ### 跨 realm 的值
 
-值可能保留 worker、Node.js 或 DOM provider realm 的 constructor。对于 Promise、错误、Node.js 原生对象和 DOM 对象，不要依赖它们能通过 VM constructor 的 `instanceof` 检查。请使用 `await`，并断言具体值或错误的 `name`、`code`、`message` 等稳定字段。
+不同 realm 有各自的 constructor，因此来自 worker、Node.js 或 DOM provider 的值，可能无法通过当前 VM 中的 `instanceof` 检查。处理这些 Promise、错误或对象时，优先使用 `await` 和内容断言；判断错误则可以检查 `name`、`code` 或 `message`。
 
-Rstest 会适配 Node.js builtin 直接返回或通过 Promise 返回的普通对象、数组和普通 Error。callback 参数、原生同步错误、Buffer、stream、typed array、native handle、`DOMException`，以及原生对象的方法返回值，仍保留原来的 prototype。
+Rstest 会将 Node.js builtin 直接返回或通过 Promise 返回的普通对象、数组，以及 Promise 拒绝时的普通 Error 适配到当前 VM。这种转换不覆盖 callback 参数、原生同步异常或返回的原生对象的方法。Buffer、stream、typed array、native handle、`DOMException` 和 DOM 对象仍保留原来的 prototype。
 
 ### 支持的模块加载方式
+
+VM pool 支持以下加载方式，但不完全兼容 Node.js loader。自定义 Node.js loader 和直接执行 external TypeScript 不在支持范围内，请先编译或 bundle。
 
 | 加载方式                            | 支持范围与限制                                                                                                                                               |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -216,8 +226,8 @@ Rstest 会适配 Node.js builtin 直接返回或通过 Promise 返回的普通�
 | 同步 `require(esm)`                 | 需要 Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await，否则请使用动态 `import()`。                                                               |
 | Native addon                        | 支持通过 CommonJS `require()` 直接加载，但 addon 状态不受 VM 隔离；不支持通过 VM ESM graph import `.node` 文件。                                             |
 
-路径和 export condition 由 Node.js 的 `require.resolve()` 决定。若选中的入口使用了 VM 不支持的操作，Rstest 不会自动改选其他入口。`Module._cache` 可以访问当前文件的 CommonJS 和 JSON 缓存，但同步 `require(esm)` 不会生成 CommonJS cache record 或 `module.children` 关联。
+CommonJS 路径和 export condition 由 Node.js 的 `require.resolve()` 决定。如果选中的入口无法在 VM 中执行，Rstest 不会自动改选其他入口。
 
-不支持自定义 Node.js loader 和直接运行 external TypeScript，请先编译或 bundle。
+`Module._cache` 用于访问当前文件的 CommonJS 和 JSON 缓存。同步 `require(esm)` 使用独立的 VM ESM 缓存，不会生成 CommonJS 缓存记录或 `module.children` 关联。
 
-每个 VM worker 会缓存不可变的 bundle、source map、external source、解析结果和 V8 compilation data。缓存会在 rebuild 或 worker 回收时清空，上限取 64 MiB 与 `memoryLimit` 四分之一中的较小值。执行后的 module 和 setup 状态不会在 VM context 之间共享。
+为减少重复加载和编译，每个 VM worker 会缓存不可变的 bundle、source map、external source、解析结果和 V8 compilation data。缓存上限为 64 MiB 与 `memoryLimit` 四分之一中的较小值，并在 rebuild 或 worker 回收时清空。执行后的模块实例和 setup 状态不会跨 VM context 复用。

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -1,5 +1,5 @@
 ---
-description: 用于运行测试的线程池的选项。
+description: 配置运行测试所用的 worker pool。
 overviewHeaders: []
 ---
 
@@ -13,9 +13,9 @@ import { ApiMeta } from '@components/ApiMeta';
 export type RstestPoolType = 'forks' | 'threads' | 'vmForks' | 'vmThreads';
 
 export type RstestPoolOptions = {
-  /** 用于运行测试的线程池 */
+  /** 运行测试所用的 worker pool */
   type?: RstestPoolType;
-  /** 最大运行的线程池的数量或百分比 */
+  /** worker 数量上限或可用 CPU 的百分比 */
   maxWorkers?: number | string;
   /**
    * `vmForks` 或 `vmThreads` worker 完成一个测试文件后，如果报告的 V8 `heapUsed` 达到该阈值，
@@ -25,12 +25,12 @@ export type RstestPoolOptions = {
    * @default undefined（VM pool 使用 `系统内存 / maxWorkers`）
    */
   memoryLimit?: number | string;
-  /** 向子进程中的 node 进程传递附加参数。 */
+  /** 向 worker 传递额外的 Node.js 参数。 */
   execArgv?: string[];
 };
 
 export type RstestConfig = {
-  /** 用于运行测试的线程池 */
+  /** 运行测试所用的 worker pool */
   pool?: RstestPoolType | RstestPoolOptions;
 };
 ```
@@ -46,103 +46,78 @@ const defaultPool = {
 
 - **CLI：** `--pool <type>`、`--pool.type <type>`、`--pool.maxWorkers <value>`、`--pool.memoryLimit <limit>`、`--pool.execArgv <arg>`
 
-用于运行测试的线程池的选项。
+配置 Rstest 如何创建 worker、隔离测试文件，以及控制并行度和内存。
 
 ## Pool 类型
 
-Rstest 支持以下 pool 类型，它们共享同一套 scheduler、RPC 和结果聚合逻辑，差异在于 worker 的创建方式和隔离方式。
+Rstest 支持四种 pool，主要区别是 worker 的创建方式和文件隔离方式。
 
 ### forks
 
-每个测试文件运行在通过 `child_process.fork` 启动的独立 Node.js 子进程中。每个 worker 拥有独立的 V8 heap，因此进程级状态（`process.chdir`、signal handler、env 修改、native module 绑定）不会在文件之间泄漏。
+默认 pool。使用默认的 [`isolate: true`](/config/test/isolate) 时，每个测试文件都会在 `child_process.fork` 创建的新 Node.js 子进程中运行。设置 `isolate: false` 后，子进程会在文件之间复用。
 
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
 
-每个测试文件运行在通过 `node:worker_threads` 创建的 worker thread 中。每个 worker 都拥有独立的 V8 isolate 和 heap，但所有 worker 共享同一个操作系统进程，内存会汇总到该进程的 RSS。Rstest 会将各 worker 的 stdout 和 stderr 传回主进程。
+通过 `node:worker_threads` 运行测试文件。每个 worker 都有独立的 V8 isolate 和 heap，但共享同一个操作系统进程，内存也会计入同一份 RSS。Node.js 不支持在 worker thread 中调用 `process.chdir()`。
 
 ### vmForks
 
 <ApiMeta addedVersion="0.12.0" />
 
-`vmForks` 使用 `child_process.fork` 创建相互隔离的 worker 进程，并为每个测试文件创建新的 `vm.Context`。分配给同一个 worker 的文件会复用子进程，因此进程级状态不会按文件重置；如果需要按文件重置进程状态，请使用 `forks`。它与 `vmThreads` 具有相同的 VM 模块加载和 cross realm 行为，同时保留 worker 内的 `process.chdir()` 等进程 API。worker 回收通过退出子进程完成。
+复用 `child_process.fork` 创建的子进程，同时为每个测试文件创建新的 `vm.Context`。它支持 `process.chdir()` 等进程 API，但分配到同一个 worker 的文件可能共享进程级状态。
 
 ### vmThreads
 
 <ApiMeta addedVersion="0.12.0" />
 
-`vmThreads` 复用 Node.js worker thread，同时为每个测试文件创建新的 `vm.Context`。这样可以隔离文件级 JavaScript global、DOM 对象和 bundle module graph，又不需要为每个文件重新创建 worker thread。它适合 DOM 测试较多、环境初始化成本高，同时 worker 启动成本也比较明显的测试套件。`vmForks` 使用独立子进程提供相同的 VM 隔离。
+复用 Node.js worker thread，同时为每个测试文件创建新的 `vm.Context`。它省去了子进程启动开销，并保持文件级 JavaScript 状态隔离，但仍受 worker thread 限制，例如不能调用 `process.chdir()`。
 
-核心保证是文件级 VM 隔离和编译资源复用，不是与独立 Node.js 进程完全等价，也不是替代 Node module loader。支持范围以下文列出的加载方式和跨 realm 行为为准。
+## VM pool 的行为边界
 
-#### 隔离与跨 realm 限制
+`vmForks` 和 `vmThreads` 提供文件级 VM 隔离，但不等同于进程级隔离，也不完全兼容 Node.js 模块加载机制。
 
-[`isolate`](/config/test/isolate) 选项对 `vmForks` 和 `vmThreads` 不生效。为了保持配置兼容性，Rstest 会接受 `isolate: false`，但每个文件仍会获得新的 VM context、module graph、test environment 和 worker scope fixture 生命周期。
+### 隔离与清理
 
-`rs.waitFor()`、`rs.waitUntil()`、`rs.runAllTimersAsync()` 等异步 runtime helper 在 worker realm 执行。它们返回的 Promise 和内部创建的错误，不保证通过针对 VM constructor 的 `instanceof Promise` 或 `instanceof Error` 检查。请使用 `await`，并按值或错误消息断言。用户 callback 的返回值和错误会原样传递，不做 realm 转换；API 引用仍保持稳定，并在调用时读取当前文件的状态。
+两种 VM pool 都会复用 worker，但每个文件都有新的 VM context、module graph、test environment 和 worker scope fixture 生命周期。因此，[`isolate`](/config/test/isolate) 对它们不生效。
 
-请始终 await `rs.waitFor()` 和 `rs.waitUntil()`。如果它们在 VM 文件 teardown 时仍未完成，Rstest 会清理内部定时器，并让对应 Promise 保持 pending，而不是 resolve 或 reject，避免清理操作触发用户的后续回调。这不会取消用户 callback 内已经启动的工作。
+VM context 之外的状态可能留在复用的 worker 中，包括对 `process.env`、signal handler、native addon 和 `Buffer` 等共享 constructor 的修改。测试文件结束前，请 await 或主动取消异步任务。teardown 会清理受 Rstest 管理的 timer，但不会取消任意 Promise 链、原生 I/O 或后台任务。
 
-文件 teardown 时，Rstest 会清理通过其文件级定时器包装创建的待执行定时器，包括 `util.promisify(setTimeout)` 和 `util.promisify(setImmediate)`。这些 promisify 定时器中尚未完成的操作会以 `AbortError` 取消，与已包装的 `node:timers/promises` timeout 和 immediate 操作一致。测试仍需 await 或主动取消自己的异步任务：VM teardown 不会取消任意 Promise 链、原生 I/O 或后台任务。取消本身可能执行用户的 `catch` 或 `finally`，因此不保证 teardown 后完全没有用户代码执行。
+Pool 会先序列化 [`testEnvironment.options`](/config/test/test-environment#环境选项)，再把任务发给 worker。structured clone 和 Bun JSON IPC 的限制请参阅该配置项。
 
-VM context 不会隔离 worker 级状态。对 `process.env`、signal handler、native addon 以及 VM context 之外其他状态的修改，可能在同一个 worker 继续执行其他文件时保留下来。为兼容 Node.js 而从 worker realm 复制进来的 global（例如 `Buffer`）使用共享的 constructor，直接修改这些 constructor 可能跨文件保留；`ArrayBuffer` 和 `Uint8Array` 等 VM 原生 global 则会随每个文件重新创建。Node.js 不支持在任何 worker thread 内调用 `process.chdir()`，因此 `threads` 和 `vmThreads` 都无法运行调用它的测试或 setup 文件。VM context 还具有 cross-realm identity，因此一个文件创建的值可能无法通过另一个文件中 constructor 的 `instanceof` 检查。在 `happy-dom` 环境中，DOM 实现对象由 `happy-dom` 自身的 provider realm 创建；不要假设所有 DOM 值都能通过 VM intrinsic 的 `Object` 或 `Array` 的 `instanceof` 检查，应使用环境提供的 DOM constructor。
+### 跨 realm 的值
 
-Node worker pool 会通过 IPC 的 structured-clone 边界传递 `testEnvironment.options`，因此这些配置必须支持 structured clone。包含函数的选项（例如 `beforeParse`、自定义 callback hook），以及内部包含函数的实例，会在 dispatch 前被拒绝。如果环境依赖 host 侧 callback，请改用可克隆配置，或把等价的初始化逻辑移到 setup file。这个限制适用于 `forks`、`threads`、`vmForks` 和 `vmThreads`。
+值可能保留 worker、Node.js 或 DOM provider realm 的 constructor。对于 Promise、错误、Node.js 原生对象和 DOM 对象，不要依赖它们能通过 VM constructor 的 `instanceof` 检查。请使用 `await`，并断言具体值或错误的 `name`、`code`、`message` 等稳定字段。
 
-Bun 下的 `forks` 和 `vmForks` 使用 JSON IPC，因此环境选项还必须兼容 JSON。`Map`、`Set`、`Date`、class 实例和 `BigInt` 等值会因为 JSON IPC 改变数据形状或无法序列化而被拒绝。
+Rstest 会适配 Node.js builtin 直接返回或通过 Promise 返回的普通对象、数组和普通 Error。callback 参数、原生同步错误、Buffer、stream、typed array、native handle、`DOMException`，以及原生对象的方法返回值，仍保留原来的 prototype。
 
-每个 VM worker 还会在文件之间保留一份有大小上限的缓存，统一存放不可变的 bundle 字节、source map、external source text、解析结果和 V8 compilation data。第一个文件之后，未变化的资源会直接复用，不再重复传输；未变化的 module 也可以跳过部分解析、加载和编译工作。这些条目共用一个预算：64 MiB 与 worker `memoryLimit` 四分之一中的较小值。Rstest 会为这些 worker 关闭 V8 没有大小限制的 isolate 级 compilation cache，改由这份有上限的缓存提供可复用编译资源。watch rebuild 或 worker 回收时会清空缓存；已执行的 module instance、与 context 绑定的 script 和 setup 执行状态不会跨 VM Context 缓存。
+### 支持的模块加载方式
 
-在内存压力较大或并发较高时，`vmForks` 的内存占用通常更容易控制。每个 fork worker 都能报告自己的 RSS，Rstest 可以使用 fork 专用的 `MemoryGate`，在可用内存紧张时延后创建新的 worker。`vmThreads` 的所有 worker thread 共享宿主进程的 RSS，直接套用同样的按 worker RSS gate 会把整个进程的内存误算到每个 worker，导致并行度明显下降。这不表示 `vmForks` 在所有场景都更省内存：子进程有额外的启动开销，而且两种 VM pool 的 `memoryLimit` 都只是 worker heap 的回收阈值。
+| 加载方式                            | 支持范围与限制                                                                                                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 构建后的 test 和 setup bundle       | 在文件 VM 中运行；每个文件都会重新执行 setup 和 module。                                                                                                     |
+| External JavaScript ESM 和 CommonJS | 支持静态和动态 import。CommonJS named export 是快照，`interopDefault` 仍然生效。                                                                             |
+| External JSON 和 WebAssembly        | JSON ESM import 需要 `type: 'json'`；支持异步加载 WebAssembly，以及 JavaScript、JSON 和 base64 WebAssembly `data:` URL；不支持同步 `require()` WebAssembly。 |
+| 同步 `require(esm)`                 | 需要 Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await，否则请使用动态 `import()`。                                                               |
+| Native addon                        | 支持通过 CommonJS `require()` 直接加载，但 addon 状态不受 VM 隔离；不支持通过 VM ESM graph import `.node` 文件。                                             |
 
-跨过 Node builtin 边界时，Rstest 会将直接返回值和 Promise 结果中的普通对象、数组及 Error rejection reason 适配到当前 VM。callback 参数，以及 native builtin 同步抛出的异常，不在转换范围内。这不是对所有值的通用 realm 转换：Buffer、stream、typed array、native handle 等 Node 原生对象会保留原生 backing 和 prototype；jsdom 与 happy-dom 创建的 DOM 对象也会保留各自 provider realm 的 prototype。需要跨 realm 传值时，不要依赖不同 realm 之间的 constructor identity。
+路径和 export condition 由 Node.js 的 `require.resolve()` 决定。若选中的入口使用了 VM 不支持的操作，Rstest 不会自动改选其他入口。`Module._cache` 可以访问当前文件的 CommonJS 和 JSON 缓存，但同步 `require(esm)` 不会生成 CommonJS cache record 或 `module.children` 关联。
 
-在 Node 环境中，`fetch()` 返回 VM Promise，但保留原生 `Response`。它的 `json()`、`text()` 等 body 方法仍返回原生 Promise、结果和异常；转换不会延伸到返回的原生对象的方法。错误转换只针对普通错误，不包含原生 `DOMException`：使用 signal 的默认 reason 取消 `fetch()` 时，会保留同一个 `DOMException` 对象（`name: 'AbortError'`、`code: 20`）。`structuredClone()` 失败时也会保留 Node 原生 `DOMException`（`name: 'DataCloneError'`、`code: 25`）。对于这些值，请使用 `await`，并按内容或错误的 `name`／`code` 断言，避免用 VM constructor 做 `instanceof Promise`、`Object` 或 `Error` 检查。
+不支持自定义 Node.js loader 和直接运行 external TypeScript，请先编译或 bundle。
 
-#### 支持的模块加载方式
-
-| 加载方式                            | 支持的行为                                                                                                    | 边界                                                                                                                                       |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| 构建后的 test 和 setup bundle       | 在文件 VM 中执行；setup 每文件执行。                                                                          | 只复用不可变的编译资源，不复用 setup 或依赖的执行状态。                                                                                    |
-| External JavaScript ESM 和 CommonJS | 在文件 VM 中执行，包括 JavaScript 的静态和动态 import。                                                       | 不支持任意 Node loader hook 或运行时源码转换。                                                                                             |
-| CommonJS named export               | 从原始 `module.exports` receiver 读取静态识别出的自有导出，包括不可枚举属性和 getter。                        | named export 是值快照，不是 live binding。已有的 `interopDefault` 选项仍然生效；不能假设所有 CJS namespace 都与原生 ESM interop 完全一致。 |
-| External JSON 和 WebAssembly        | JSON 和异步加载的 WebAssembly 在文件 VM 中执行，同时支持 JavaScript、JSON 和 base64 WebAssembly `data:` URL。 | JSON ESM import 需要 `type: 'json'`；不支持同步 `require()` WebAssembly。                                                                  |
-| 同步 `require(esm)`                 | Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await 时支持。                                         | 异步依赖图抛出 `ERR_REQUIRE_ASYNC_MODULE`；更早的 VM 实现以 `ERR_REQUIRE_ESM` 拒绝 ESM require，请改用动态 `import()`。                    |
-| Native addon                        | 直接通过 CommonJS `require()` 加载时交给 Node 处理。                                                          | addon 状态不受 VM 隔离；不支持通过 VM ESM graph import `.node` 文件。                                                                      |
-
-CommonJS 路径和 export condition 的选择交给 Node 原生 `require.resolve()`，启动参数也由 Node 处理。Rstest 在解析完成后检查 VM 能否执行所选入口，不会为了绕过不支持的 VM 操作而改选另一个 package 入口。
-
-例如在 Node.js 22 上，package 的 `module-sync` condition 可能选中 VM 无法同步 require 的 ESM 入口。此时会抛出 `ERR_REQUIRE_ESM`，不会改选该 package 的 CommonJS fallback。请改用动态 `import()`，或将依赖 bundle 后运行。
-
-`Module._cache` 指向当前文件的 `require.cache`，支持查看和删除 CommonJS、JSON 缓存条目；不支持替换或删除 `_cache` 属性本身。同步 `require(esm)` 使用 VM 的 ESM 缓存，目前不会创建 CommonJS 缓存记录或 `module.children` 关联。请勿依赖这些 API 遍历 ESM 模块图或使其缓存失效。
-
-自定义 Node loader 和 external TypeScript 执行不在支持范围内，请先编译或 bundle。支持上述加载方式不代表完整兼容 Node loader 的内部元数据，也不代表提供通用跨 realm 转换或取消任意异步工作。已支持执行路径上的错误仍属于兼容性 bug。
+每个 VM worker 会缓存不可变的 bundle、source map、external source、解析结果和 V8 compilation data。缓存会在 rebuild 或 worker 回收时清空，上限取 64 MiB 与 `memoryLimit` 四分之一中的较小值。执行后的 module 和 setup 状态不会在 VM context 之间共享。
 
 ## 如何选择 pool 类型
 
-`forks` 是默认值，多数现有测试代码都依赖按文件维度的进程隔离。如果不确定要不要切换，建议先继续使用 `forks`。
+如果不确定该选哪种 pool，请使用默认的 `forks`。
 
-下列情况可以考虑切换到 `threads`：
-
-- 测试以小型用例为主、单文件耗时短，worker 启动开销在总时间中占比明显 — `worker_threads` 启动比 `child_process.fork` 快约 10×，watch 模式 rerun 体感几乎秒回。
-- Worker 启动是主要瓶颈，且测试套件可以共享同一个操作系统进程。各 worker 的 heap 仍然独立，并会计入同一个进程的 RSS。
-- 测试代码不调用 `process.chdir()`、不修改 worker 级状态，也不依赖在文件之间重置这些状态。
-
-下列情况可以考虑切换到 `vmThreads` 或 `vmForks`：
-
-- 每个文件都需要新的 global 或 DOM 环境，但每文件创建 worker thread 的成本占比明显。
-- 测试可以兼容 cross-realm value，且不依赖进程级隔离。
-- 共享配置设置了 `isolate: false`，但当前测试套件仍需保持文件级 JavaScript 隔离。
-
-如果测试套件需要 VM 隔离，同时依赖进程 API，并且可以接受分配到同一个子进程的文件共享进程级状态，可以考虑 `vmForks`。如果不希望承担子进程启动开销，并且测试兼容 worker thread 的限制，可以考虑 `vmThreads`。
-
-下列情况建议继续使用 `forks`：
-
-- 测试里会调用 `process.chdir()`、修改 worker 级状态，或依赖按文件维度的进程隔离。
-- 项目使用 native addon（如 `better-sqlite3`、`sharp`、`canvas`）—— 未针对 worker thread 设计的 addon 在 `threads` 下可能让整个运行直接 abort（`SIGSEGV` / `SIGABRT`，且无法捕获）。
-- 希望单个测试文件的硬性崩溃被限制在该 worker 内，不影响主进程和其他用例。
-- 需要每个测试文件都具备严格的进程级隔离。此时应使用 `forks` 并设置 `isolate: true`；`forks` 在 `isolate: false` 时也会复用子进程，而 `vmForks` 始终会复用子进程，只为每个文件创建新的 VM context。
+| Pool        | 适用场景                                                              | 主要取舍                                                                          |
+| ----------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `forks`     | 需要进程级隔离、兼容 native addon，或希望限制单个文件崩溃的影响范围。 | worker 启动成本最高。要为每个文件创建新进程，请使用 `isolate: true`。             |
+| `threads`   | worker 启动是主要瓶颈，而且测试套件兼容 worker thread。               | 不能调用 `process.chdir()`；worker 共享进程 RSS，测试不能依赖进程状态按文件重置。 |
+| `vmForks`   | 每个文件需要新 VM，同时依赖进程 API 或需要分别观测各子进程的内存。    | 文件之间可能共享进程状态，受跨 realm 限制，而且子进程有额外启动成本。             |
+| `vmThreads` | 每个文件需要新 VM，同时希望减少 worker 启动成本。                     | 受跨 realm 和 worker thread 限制；内存统一计入宿主进程 RSS。                      |
 
 ## 配置 worker 并行度和内存
 
@@ -183,6 +158,8 @@ npx rstest --pool.maxWorkers 1
 设置 `vmForks` 或 `vmThreads` worker 的 V8 heap 回收阈值。每个测试文件运行结束后，Rstest 会读取 worker 的 `heapUsed`；达到阈值时，会在分配下一个文件前回收 worker。这是 worker 回收阈值，不是进程 RSS 或 OOM 的硬上限。
 
 该配置当前仅作用于 `vmForks` 和 `vmThreads`，传给 `forks` 或 `threads` 时会被忽略。`(0, 1]` 的数字表示系统内存比例，更大的数字表示字节数；字符串支持 `%`、`KB`、`KiB`、`MB`、`MiB`、`GB` 和 `GiB`。未设置时，每个 VM worker 默认使用等额的系统内存（`系统内存 / maxWorkers`）。
+
+`vmForks` 还能根据每个子进程的 RSS 延后创建 worker。相比只能看到进程总 RSS 的 `vmThreads`，它更容易控制内存压力。但这不表示 `vmForks` 一定更省内存：子进程本身也有额外开销，而且两种 pool 的 `memoryLimit` 都不是内存硬上限。
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -88,6 +88,8 @@ Rstest 支持四种 pool，主要区别是 worker 的创建方式和文件隔离
 
 ## 如何选择 pool 类型
 
+性能不符合预期时，可以使用 `rstest-debugging` skill 辅助定位瓶颈，再决定是否调整 pool。安装方式和排查方法请参阅[性能分析](/guide/debug/profiling)。
+
 默认使用 `forks`，测量后再决定是否切换。worker 启动耗时较高时，可以尝试 `threads`；反复启动 worker，或加载、编译测试与 setup 依赖的成本较高时，可以尝试 VM pool。
 
 VM pool 会复用 worker 和不可变的编译资源，同时为每个文件创建新环境，可能更适合文件多、单文件测试短或 setup 依赖较大的套件。但 setup 文件、环境创建和模块求值仍会逐文件执行，数据库初始化、网络请求等 setup 工作不会因此省掉，收益需要用自己的测试套件验证。

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -48,6 +48,8 @@ const defaultPool = {
 
 配置 Rstest 如何创建 worker、隔离测试文件，以及控制并行度和内存。
 
+建议先使用默认的 `forks`，它的 Node.js 兼容性最好，并提供文件级进程隔离。性能不符合预期时，再根据 worker 启动、模块加载和 setup 的实际耗时选择其他 pool。
+
 ## Pool 类型
 
 Rstest 支持四种 pool，主要区别是 worker 的创建方式和文件隔离方式。
@@ -56,11 +58,21 @@ Rstest 支持四种 pool，主要区别是 worker 的创建方式和文件隔离
 
 默认 pool。使用默认的 [`isolate: true`](/config/test/isolate) 时，每个测试文件都会在 `child_process.fork` 创建的新 Node.js 子进程中运行。设置 `isolate: false` 后，子进程会在文件之间复用。
 
+四种 pool 中，`forks` 引入的执行限制最少：没有 worker thread 的 API 限制和 VM 的跨 realm 限制，对 native addon 通常也最兼容。原生崩溃的影响限于子进程，新进程还能在文件之间重置进程级状态。代价是每个文件都需要承担进程启动和初始化成本。
+
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
 
-通过 `node:worker_threads` 运行测试文件。每个 worker 都有独立的 V8 isolate 和 heap，但共享同一个操作系统进程，内存也会计入同一份 RSS。Node.js 不支持在 worker thread 中调用 `process.chdir()`。
+通过 `node:worker_threads` 运行测试文件。每个 worker 都有独立的 V8 isolate 和 heap，但共享同一个操作系统进程，内存也会计入同一份 RSS。
+
+以下 Node.js 限制同时适用于 `threads` 和 `vmThreads`：
+
+- 不支持 `process.chdir()`、`process.abort()` 和修改用户或用户组 ID 的方法，也不能修改 `process.title`。
+- `process.on()` 不会收到操作系统信号；`process.exit()` 只结束当前 worker thread。
+- native addon 必须支持在 worker thread 中使用，原生崩溃可能影响整个进程。
+
+完整差异请参阅 [Node.js Worker 文档](https://nodejs.org/api/worker_threads.html#class-worker)。
 
 ### vmForks
 
@@ -74,50 +86,18 @@ Rstest 支持四种 pool，主要区别是 worker 的创建方式和文件隔离
 
 复用 Node.js worker thread，同时为每个测试文件创建新的 `vm.Context`。它省去了子进程启动开销，并保持文件级 JavaScript 状态隔离，但仍受 worker thread 限制，例如不能调用 `process.chdir()`。
 
-## VM pool 的行为边界
-
-`vmForks` 和 `vmThreads` 提供文件级 VM 隔离，但不等同于进程级隔离，也不完全兼容 Node.js 模块加载机制。
-
-### 隔离与清理
-
-两种 VM pool 都会复用 worker，但每个文件都有新的 VM context、module graph、test environment 和 worker scope fixture 生命周期。因此，[`isolate`](/config/test/isolate) 对它们不生效。
-
-VM context 之外的状态可能留在复用的 worker 中，包括对 `process.env`、signal handler、native addon 和 `Buffer` 等共享 constructor 的修改。测试文件结束前，请 await 或主动取消异步任务。teardown 会清理受 Rstest 管理的 timer，但不会取消任意 Promise 链、原生 I/O 或后台任务。
-
-Pool 会先序列化 [`testEnvironment.options`](/config/test/test-environment#环境选项)，再把任务发给 worker。structured clone 和 Bun JSON IPC 的限制请参阅该配置项。
-
-### 跨 realm 的值
-
-值可能保留 worker、Node.js 或 DOM provider realm 的 constructor。对于 Promise、错误、Node.js 原生对象和 DOM 对象，不要依赖它们能通过 VM constructor 的 `instanceof` 检查。请使用 `await`，并断言具体值或错误的 `name`、`code`、`message` 等稳定字段。
-
-Rstest 会适配 Node.js builtin 直接返回或通过 Promise 返回的普通对象、数组和普通 Error。callback 参数、原生同步错误、Buffer、stream、typed array、native handle、`DOMException`，以及原生对象的方法返回值，仍保留原来的 prototype。
-
-### 支持的模块加载方式
-
-| 加载方式                            | 支持范围与限制                                                                                                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 构建后的 test 和 setup bundle       | 在文件 VM 中运行；每个文件都会重新执行 setup 和 module。                                                                                                     |
-| External JavaScript ESM 和 CommonJS | 支持静态和动态 import。CommonJS named export 是快照，`interopDefault` 仍然生效。                                                                             |
-| External JSON 和 WebAssembly        | JSON ESM import 需要 `type: 'json'`；支持异步加载 WebAssembly，以及 JavaScript、JSON 和 base64 WebAssembly `data:` URL；不支持同步 `require()` WebAssembly。 |
-| 同步 `require(esm)`                 | 需要 Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await，否则请使用动态 `import()`。                                                               |
-| Native addon                        | 支持通过 CommonJS `require()` 直接加载，但 addon 状态不受 VM 隔离；不支持通过 VM ESM graph import `.node` 文件。                                             |
-
-路径和 export condition 由 Node.js 的 `require.resolve()` 决定。若选中的入口使用了 VM 不支持的操作，Rstest 不会自动改选其他入口。`Module._cache` 可以访问当前文件的 CommonJS 和 JSON 缓存，但同步 `require(esm)` 不会生成 CommonJS cache record 或 `module.children` 关联。
-
-不支持自定义 Node.js loader 和直接运行 external TypeScript，请先编译或 bundle。
-
-每个 VM worker 会缓存不可变的 bundle、source map、external source、解析结果和 V8 compilation data。缓存会在 rebuild 或 worker 回收时清空，上限取 64 MiB 与 `memoryLimit` 四分之一中的较小值。执行后的 module 和 setup 状态不会在 VM context 之间共享。
-
 ## 如何选择 pool 类型
 
-如果不确定该选哪种 pool，请使用默认的 `forks`。
+默认使用 `forks`，测量后再决定是否切换。worker 启动耗时较高时，可以尝试 `threads`；反复启动 worker，或加载、编译测试与 setup 依赖的成本较高时，可以尝试 VM pool。
 
-| Pool        | 适用场景                                                              | 主要取舍                                                                          |
-| ----------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `forks`     | 需要进程级隔离、兼容 native addon，或希望限制单个文件崩溃的影响范围。 | worker 启动成本最高。要为每个文件创建新进程，请使用 `isolate: true`。             |
-| `threads`   | worker 启动是主要瓶颈，而且测试套件兼容 worker thread。               | 不能调用 `process.chdir()`；worker 共享进程 RSS，测试不能依赖进程状态按文件重置。 |
-| `vmForks`   | 每个文件需要新 VM，同时依赖进程 API 或需要分别观测各子进程的内存。    | 文件之间可能共享进程状态，受跨 realm 限制，而且子进程有额外启动成本。             |
-| `vmThreads` | 每个文件需要新 VM，同时希望减少 worker 启动成本。                     | 受跨 realm 和 worker thread 限制；内存统一计入宿主进程 RSS。                      |
+VM pool 会复用 worker 和不可变的编译资源，同时为每个文件创建新环境，可能更适合文件多、单文件测试短或 setup 依赖较大的套件。但 setup 文件、环境创建和模块求值仍会逐文件执行，数据库初始化、网络请求等 setup 工作不会因此省掉，收益需要用自己的测试套件验证。
+
+| Pool        | 适用场景                                                              | 主要取舍                                                              |
+| ----------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `forks`     | 默认选择，适合需要 Node.js 兼容性、进程隔离和限制崩溃影响范围的套件。 | `isolate: true` 时，每个文件都有新进程的启动和初始化成本。            |
+| `threads`   | worker 启动是主要瓶颈，而且测试套件兼容 worker thread。               | 受 worker thread API 和 native addon 限制，所有 worker 共享进程。     |
+| `vmForks`   | 每个文件需要新 VM，同时依赖进程 API 或需要分别观测各子进程的内存。    | 文件之间可能共享进程状态，受跨 realm 限制，而且子进程有额外启动成本。 |
+| `vmThreads` | 每个文件需要新 VM，同时希望减少 worker 启动成本。                     | 受跨 realm 和 worker thread 限制；内存统一计入宿主进程 RSS。          |
 
 ## 配置 worker 并行度和内存
 
@@ -205,3 +185,37 @@ export default defineConfig({
   },
 });
 ```
+
+## VM pool 的行为边界
+
+`vmForks` 和 `vmThreads` 提供文件级 VM 隔离，但不等同于进程级隔离，也不完全兼容 Node.js 模块加载机制。
+
+### 隔离与清理
+
+两种 VM pool 都会复用 worker，但每个文件都有新的 VM context、module graph、test environment 和 worker scope fixture 生命周期。因此，[`isolate`](/config/test/isolate) 对它们不生效。
+
+VM context 之外的状态可能留在复用的 worker 中，包括对 `process.env`、signal handler、native addon 和 `Buffer` 等共享 constructor 的修改。测试文件结束前，请 await 或主动取消异步任务。teardown 会清理受 Rstest 管理的 timer，但不会取消任意 Promise 链、原生 I/O 或后台任务。
+
+Pool 会先序列化 [`testEnvironment.options`](/config/test/test-environment#环境选项)，再把任务发给 worker。structured clone 和 Bun JSON IPC 的限制请参阅该配置项。
+
+### 跨 realm 的值
+
+值可能保留 worker、Node.js 或 DOM provider realm 的 constructor。对于 Promise、错误、Node.js 原生对象和 DOM 对象，不要依赖它们能通过 VM constructor 的 `instanceof` 检查。请使用 `await`，并断言具体值或错误的 `name`、`code`、`message` 等稳定字段。
+
+Rstest 会适配 Node.js builtin 直接返回或通过 Promise 返回的普通对象、数组和普通 Error。callback 参数、原生同步错误、Buffer、stream、typed array、native handle、`DOMException`，以及原生对象的方法返回值，仍保留原来的 prototype。
+
+### 支持的模块加载方式
+
+| 加载方式                            | 支持范围与限制                                                                                                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 构建后的 test 和 setup bundle       | 在文件 VM 中运行；每个文件都会重新执行 setup 和 module。                                                                                                     |
+| External JavaScript ESM 和 CommonJS | 支持静态和动态 import。CommonJS named export 是快照，`interopDefault` 仍然生效。                                                                             |
+| External JSON 和 WebAssembly        | JSON ESM import 需要 `type: 'json'`；支持异步加载 WebAssembly，以及 JavaScript、JSON 和 base64 WebAssembly `data:` URL；不支持同步 `require()` WebAssembly。 |
+| 同步 `require(esm)`                 | 需要 Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await，否则请使用动态 `import()`。                                                               |
+| Native addon                        | 支持通过 CommonJS `require()` 直接加载，但 addon 状态不受 VM 隔离；不支持通过 VM ESM graph import `.node` 文件。                                             |
+
+路径和 export condition 由 Node.js 的 `require.resolve()` 决定。若选中的入口使用了 VM 不支持的操作，Rstest 不会自动改选其他入口。`Module._cache` 可以访问当前文件的 CommonJS 和 JSON 缓存，但同步 `require(esm)` 不会生成 CommonJS cache record 或 `module.children` 关联。
+
+不支持自定义 Node.js loader 和直接运行 external TypeScript，请先编译或 bundle。
+
+每个 VM worker 会缓存不可变的 bundle、source map、external source、解析结果和 V8 compilation data。缓存会在 rebuild 或 worker 回收时清空，上限取 64 MiB 与 `memoryLimit` 四分之一中的较小值。执行后的 module 和 setup 状态不会在 VM context 之间共享。

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -167,6 +167,8 @@ npx rstest --pool vmThreads --pool.memoryLimit 256MB
 
 `memoryLimit` 只在文件之间触发回收，不是进程 RSS 的硬上限，也不能保证避免 OOM。
 
+它还会影响每个 VM worker 的缓存大小：不可变资源、external source、解析结果和编译数据共用一份缓存，上限取 64 MiB 与 `memoryLimit` 四分之一中的较小值。调低阈值可能缩小缓存，增加重复加载和编译的开销。
+
 此外，`vmForks` 能根据各子进程的 RSS，在内存紧张时延后创建 worker，因此比共享进程 RSS 的 `vmThreads` 更容易控制内存压力。这项调度机制与 `memoryLimit` 分开工作；子进程本身仍有额外开销，实际内存占用不一定更低。
 
 ## 向 worker 传递 Node.js flags
@@ -206,6 +208,8 @@ export default defineConfig({
 
 测试仍需在文件结束前 `await` 或取消异步任务。teardown 会清理受 Rstest 管理的定时器，但不会取消任意 Promise 链、原生 I/O 或后台任务。
 
+尚未完成的已包装 `node:timers/promises` 和 promisify timeout/immediate 操作会以 `AbortError` 取消。这可能触发用户的 `catch` 或 `finally`，因此不能保证 teardown 后不再执行用户代码。
+
 ### 跨 realm 断言
 
 来自 Node.js、worker 或 DOM 环境的值可能使用不同的 constructor，无法通过当前 VM 中的 `instanceof` 检查。请使用 `await` 和内容断言，判断错误时检查 `name`、`code` 或 `message`。
@@ -215,3 +219,20 @@ export default defineConfig({
 测试和 setup bundle、external JavaScript ESM 与 CommonJS 均可在 VM 中执行。自定义 Node.js loader 和 external TypeScript 执行不受支持，请先编译或 bundle。
 
 同步 `require(esm)` 需要 Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await，否则应改用动态 `import()`。native addon 仅支持通过 CommonJS `require()` 直接加载，其状态不受 VM 隔离。
+
+<details>
+<summary>查看模块加载兼容性</summary>
+
+VM 加载方式与 Node.js 原生 loader 存在以下差异：
+
+| 加载方式                                 | 支持范围与限制                                                                                                                                                                               |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| test/setup bundle 和 external JavaScript | 在文件 VM 中执行，支持静态和动态 import；setup 和模块执行状态按文件重新创建。                                                                                                                |
+| CommonJS named export                    | 从原始 `module.exports` receiver 读取静态识别出的自有导出，包括不可枚举属性和 getter。导出是快照而非 live binding；`interopDefault` 仍然生效。                                               |
+| JSON、WebAssembly 和 `data:` URL         | JSON ESM import 需要 `type: 'json'`。支持异步 WebAssembly，以及 JavaScript、JSON 和 base64 WebAssembly `data:` URL；不支持同步 `require()` WebAssembly。                                     |
+| 同步 `require(esm)`                      | 需要 Node.js 24.9+ 和 VM graph API。异步依赖图抛出 `ERR_REQUIRE_ASYNC_MODULE`；较早的 VM 实现会以 `ERR_REQUIRE_ESM` 拒绝 ESM require。                                                       |
+| Native addon                             | CommonJS `require()` 直接交给 Node.js 加载；不支持通过 VM ESM import `.node` 文件，addon 状态不受 VM 隔离。                                                                                  |
+| CommonJS 解析                            | 路径和 export condition 由 Node.js `require.resolve()` 选择；选中的入口无法在 VM 中执行时，不会自动改选其他入口。                                                                            |
+| `Module._cache`                          | 指向当前文件的 `require.cache`，支持查看和删除 CommonJS/JSON 条目；不支持替换或删除 `_cache` 本身。同步 `require(esm)` 使用 VM ESM 缓存，不生成 CommonJS 缓存记录或 `module.children` 关联。 |
+
+</details>

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -66,7 +66,7 @@ VM pool 会复用 worker 和编译资源，因此测试文件多、setup 依赖�
 
 `forks` 和 `threads` 分别使用子进程和线程运行测试；`vmForks` 和 `vmThreads` 则在复用这些 worker 的同时，为每个文件创建新的 `vm.Context`。
 
-所有 pool 都需要将环境选项序列化后传给 worker，不支持在这些选项中传入函数。具体要求见 [`testEnvironment.options`](/config/test/test-environment#环境选项)，其中也说明了 Bun 下的 JSON IPC 限制。
+所有 pool 都需要将环境选项序列化后传给 worker，不支持在这些选项中传入函数。具体要求见 [`testEnvironment.options`](/config/test/test-environment#环境选项)。
 
 ### forks
 
@@ -198,36 +198,20 @@ export default defineConfig({
 
 ## VM pool 的行为边界
 
-以下说明同时适用于 `vmForks` 和 `vmThreads`。切换前需要确认测试对隔离范围、跨 realm 的值和模块加载方式的要求。
+以下限制同时适用于 `vmForks` 和 `vmThreads`。
 
 ### 隔离与清理
 
-每个测试文件都会获得新的 VM context、模块图和测试环境，worker scope fixture 也按文件创建和清理。无论 [`isolate`](/config/test/isolate) 如何设置，这些行为都不变。
+每个文件都有新的 VM context、模块图和测试环境，worker scope fixture 也按文件创建和清理；[`isolate`](/config/test/isolate) 对此不生效。但 worker 会复用，`process.env`、native addon 等 VM 之外的状态可能跨文件保留。
 
-worker 本身仍会复用，所以 VM context 之外的状态可能跨文件保留，例如对 `process.env`、signal handler、native addon 和 `Buffer` 等共享 constructor 的修改。
+测试仍需在文件结束前 `await` 或取消异步任务。teardown 会清理受 Rstest 管理的定时器，但不会取消任意 Promise 链、原生 I/O 或后台任务。
 
-异步任务也需要测试自行管理。请在文件结束前 `await` 或主动取消这些任务；teardown 会清理受 Rstest 管理的定时器，但无法取消任意 Promise 链、原生 I/O 或后台任务。
+### 跨 realm 断言
 
-### 跨 realm 的值
+来自 Node.js、worker 或 DOM 环境的值可能使用不同的 constructor，无法通过当前 VM 中的 `instanceof` 检查。请使用 `await` 和内容断言，判断错误时检查 `name`、`code` 或 `message`。
 
-不同 realm 有各自的 constructor，因此来自 worker、Node.js 或 DOM provider 的值，可能无法通过当前 VM 中的 `instanceof` 检查。处理这些 Promise、错误或对象时，优先使用 `await` 和内容断言；判断错误则可以检查 `name`、`code` 或 `message`。
+### 模块加载
 
-Rstest 会将 Node.js builtin 直接返回或通过 Promise 返回的普通对象、数组，以及 Promise 拒绝时的普通 Error 适配到当前 VM。这种转换不覆盖 callback 参数、原生同步异常或返回的原生对象的方法。Buffer、stream、typed array、native handle、`DOMException` 和 DOM 对象仍保留原来的 prototype。
+测试和 setup bundle、external JavaScript ESM 与 CommonJS 均可在 VM 中执行。自定义 Node.js loader 和 external TypeScript 执行不受支持，请先编译或 bundle。
 
-### 支持的模块加载方式
-
-VM pool 支持以下加载方式，但不完全兼容 Node.js loader。自定义 Node.js loader 和直接执行 external TypeScript 不在支持范围内，请先编译或 bundle。
-
-| 加载方式                            | 支持范围与限制                                                                                                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 构建后的 test 和 setup bundle       | 在文件 VM 中运行；每个文件都会重新执行 setup 和 module。                                                                                                     |
-| External JavaScript ESM 和 CommonJS | 支持静态和动态 import。CommonJS named export 是快照，`interopDefault` 仍然生效。                                                                             |
-| External JSON 和 WebAssembly        | JSON ESM import 需要 `type: 'json'`；支持异步加载 WebAssembly，以及 JavaScript、JSON 和 base64 WebAssembly `data:` URL；不支持同步 `require()` WebAssembly。 |
-| 同步 `require(esm)`                 | 需要 Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await，否则请使用动态 `import()`。                                                               |
-| Native addon                        | 支持通过 CommonJS `require()` 直接加载，但 addon 状态不受 VM 隔离；不支持通过 VM ESM graph import `.node` 文件。                                             |
-
-CommonJS 路径和 export condition 由 Node.js 的 `require.resolve()` 决定。如果选中的入口无法在 VM 中执行，Rstest 不会自动改选其他入口。
-
-`Module._cache` 用于访问当前文件的 CommonJS 和 JSON 缓存。同步 `require(esm)` 使用独立的 VM ESM 缓存，不会生成 CommonJS 缓存记录或 `module.children` 关联。
-
-为减少重复加载和编译，每个 VM worker 会缓存不可变的 bundle、source map、external source、解析结果和 V8 compilation data。缓存上限为 64 MiB 与 `memoryLimit` 四分之一中的较小值，并在 rebuild 或 worker 回收时清空。执行后的模块实例和 setup 状态不会跨 VM context 复用。
+同步 `require(esm)` 需要 Node.js 24.9+、VM graph API 可用且依赖图不含 top-level await，否则应改用动态 `import()`。native addon 仅支持通过 CommonJS `require()` 直接加载，其状态不受 VM 隔离。


### PR DESCRIPTION
## Summary

The pool configuration page repeats selection advice and mixes practical VM limitations with implementation details. Reorganize the English and Chinese guides around choosing a pool, configuring workers, and checking VM compatibility.

- Recommend starting with `forks` and profiling before switching, with a link to the `rstest-debugging` skill guidance.
- Clarify worker-thread API restrictions, VM startup and setup trade-offs, and memory recycling behavior.
- Shorten the VM limitations section and move it to the end of the page.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
