### PR TITLE
test: avoid teardown timing race in VM isolation fixture

### DIFF
--- a/e2e/node-pool/fixtures/vm-isolate-false/first.test.ts
+++ b/e2e/node-pool/fixtures/vm-isolate-false/first.test.ts
@@ -83,9 +83,3 @@ workerTest('isolates the first file', ({ workerValue }) => {
   expect(getCount()).toBe(1);
   console.log(`VM_THREAD_ID:${threadId}`);
 });
-
-it('does not leave timers attached to the disposed VM context', () => {
-  setTimeout(() => {
-    throw new Error('stale VM timer');
-  }, 50);
-});

--- a/e2e/node-pool/fixtures/vm-isolate-false/second.test.ts
+++ b/e2e/node-pool/fixtures/vm-isolate-false/second.test.ts
@@ -31,10 +31,6 @@ workerTest('isolates the second file', ({ workerValue }) => {
   console.log(`VM_THREAD_ID:${threadId}`);
 });
 
-it('runs after the previous VM context has been disposed', async () => {
-  await new Promise((resolve) => setTimeout(resolve, 100));
-});
-
 it('re-homes host fetch errors into the VM realm', async () => {
   await expect(fetch('not a url')).rejects.toThrow(TypeError);
 });

--- a/e2e/node-pool/fixtures/vm-isolate-false/setup.ts
+++ b/e2e/node-pool/fixtures/vm-isolate-false/setup.ts
@@ -2,7 +2,13 @@ import { resolveObjectURL } from 'node:buffer';
 import { appendFileSync } from 'node:fs';
 import { setTimeout as nodeSetTimeout } from 'node:timers';
 import { promisify } from 'node:util';
-import { afterAll, expect, registerFileCleanup, rs } from '@rstest/core';
+import {
+  afterAll,
+  beforeAll,
+  expect,
+  registerFileCleanup,
+  rs,
+} from '@rstest/core';
 
 expect(typeof globalThis.crypto.subtle.digest).toBe('function');
 expect(globalThis.crypto.randomUUID()).toMatch(/^[0-9a-f-]{36}$/);
@@ -47,6 +53,14 @@ afterAll(async () => {
   }
   const marker = process.env.RSTEST_VM_WAIT_MARKER;
   if (!marker) throw new Error('RSTEST_VM_WAIT_MARKER is required');
+  // Cleanup may take longer than the interval. Only callbacks surviving into
+  // the next file are leaks; callbacks during this file's teardown are valid.
+  const env = process.env;
+  setInterval(() => {
+    if (env.RSTEST_VM_PREVIOUS_OBJECT_URL !== objectURL) {
+      appendFileSync(marker, 'stale VM timer\n');
+    }
+  }, 10);
   const options = { timeout: 60_000, interval: 10_000 };
   const waits = [
     rs.waitUntil(() => false, options),
@@ -76,6 +90,11 @@ if (previousObjectURL) {
 const objectURL = URL.createObjectURL(new Blob(['file-scoped']));
 expect(resolveObjectURL(objectURL)).toBeDefined();
 process.env.RSTEST_VM_PREVIOUS_OBJECT_URL = objectURL;
+if (previousObjectURL) {
+  beforeAll(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+}
 
 if (process.env.RSTEST_VM_FILE_CLEANUP_FAIL === 'true') {
   registerFileCleanup(() => {


### PR DESCRIPTION
## Summary

The VM isolation fixture could fail on Windows when its 50ms timer fired while asynchronous file cleanup was still running. Replace the unconditional throw with an interval that records callbacks only after the next file starts. Run the check through the shared setup so it covers either file execution order. Runtime behavior and public APIs are unchanged.

Reproduced the original failure by delaying file cleanup to 150ms; the revised fixture passes with that delay and fails when native timer cleanup is deliberately disabled. Focused ESM/CommonJS e2e tests, the workspace build, type checking, formatting/spelling, and unused-code checks pass locally. Windows CI verification is pending.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).