### PR TITLE
docs: add CLI and config examples for each pool

### DIFF
--- a/website/docs/en/config/test/pool.mdx
+++ b/website/docs/en/config/test/pool.mdx
@@ -4,6 +4,7 @@ overviewHeaders: []
 ---
 
 import { ApiMeta } from '@components/ApiMeta';
+import { Tab, Tabs } from '@theme';
 
 # pool
 
@@ -75,6 +76,23 @@ Creates Node.js child processes with `child_process.fork`. Each worker has separ
 
 With the default isolation setting, each file incurs process startup and initialization costs.
 
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool forks
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'forks',
+});
+```
+  </Tab>
+</Tabs>
+
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
@@ -89,11 +107,45 @@ Threads generally start faster than child processes, but have some Node.js API r
 
 See the [Node.js Worker documentation](https://nodejs.org/api/worker_threads.html#class-worker) for the full list of differences.
 
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool threads
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'threads',
+});
+```
+  </Tab>
+</Tabs>
+
 ### vmForks
 
 <ApiMeta addedVersion="0.12.0" />
 
 Reuses child processes and creates a fresh `vm.Context` for each test file, reducing repeated process startup. Process APIs such as `process.chdir()` remain available, but files in the same child process can share process-level state.
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool vmForks
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'vmForks',
+});
+```
+  </Tab>
+</Tabs>
 
 ### vmThreads
 
@@ -102,6 +154,26 @@ Reuses child processes and creates a fresh `vm.Context` for each test file, redu
 Reuses worker threads and creates a fresh `vm.Context` for each test file, reducing repeated thread startup. It provides the same VM isolation as `vmForks`, with the worker-thread restrictions described above.
 
 For the isolation scope and compatibility requirements of both VM pools, see [VM pool behavior](#vm-pool-behavior) at the end of this page.
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool vmThreads --pool.memoryLimit 256MB
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: {
+    type: 'vmThreads',
+    memoryLimit: '256MB',
+  },
+});
+```
+  </Tab>
+</Tabs>
 
 ## Configure worker concurrency and memory
 

--- a/website/docs/zh/config/test/pool.mdx
+++ b/website/docs/zh/config/test/pool.mdx
@@ -4,6 +4,7 @@ overviewHeaders: []
 ---
 
 import { ApiMeta } from '@components/ApiMeta';
+import { Tab, Tabs } from '@theme';
 
 # pool
 
@@ -74,6 +75,23 @@ VM pool 会复用 worker 和编译资源，因此测试文件多、setup 依赖�
 
 默认隔离模式下，每个文件都需要承担进程启动和初始化成本。
 
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool forks
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'forks',
+});
+```
+  </Tab>
+</Tabs>
+
 ### threads
 
 <ApiMeta addedVersion="0.10.0" />
@@ -88,11 +106,45 @@ VM pool 会复用 worker 和编译资源，因此测试文件多、setup 依赖�
 
 完整差异见 [Node.js Worker 文档](https://nodejs.org/api/worker_threads.html#class-worker)。
 
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool threads
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'threads',
+});
+```
+  </Tab>
+</Tabs>
+
 ### vmForks
 
 <ApiMeta addedVersion="0.12.0" />
 
 复用子进程，并为每个测试文件创建新的 `vm.Context`，减少反复启动进程的开销。`process.chdir()` 等进程 API 仍然可用，但同一子进程中的文件可能共享进程级状态。
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool vmForks
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: 'vmForks',
+});
+```
+  </Tab>
+</Tabs>
 
 ### vmThreads
 
@@ -101,6 +153,26 @@ VM pool 会复用 worker 和编译资源，因此测试文件多、setup 依赖�
 复用 worker thread，并为每个测试文件创建新的 `vm.Context`，减少反复启动线程的开销。它与 `vmForks` 提供相同的 VM 隔离，同时受上述 worker thread 限制。
 
 两种 VM pool 的隔离范围和兼容性要求见文末的 [VM pool 的行为边界](#vm-pool-的行为边界)。
+
+<Tabs defaultValue='rstest.config.ts'>
+  <Tab label="CLI">
+  ```bash
+  npx rstest --pool vmThreads --pool.memoryLimit 256MB
+  ```
+  </Tab>
+  <Tab label="rstest.config.ts">
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  pool: {
+    type: 'vmThreads',
+    memoryLimit: '256MB',
+  },
+});
+```
+  </Tab>
+</Tabs>
 
 ## 配置 worker 并行度和内存
 


### PR DESCRIPTION
## Summary

Add CLI and config examples after each pool type so users can enable it directly from the pool guide. Include a `256MB` memory limit in the `vmThreads` example and keep the English and Chinese docs in sync.

## Related Links

Follow-up to #1814.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).