### PR TITLE
fix(core): retry a failed globalSetup on the next watch cycle

### DIFF
--- a/e2e/globalSetup/index.test.ts
+++ b/e2e/globalSetup/index.test.ts
@@ -109,6 +109,76 @@ describe('globalSetup', async () => {
     expectStderrLog(/globalSetup\.ts:3/);
   });
 
+  it('retries failed globalSetup on the next watch cycle and keeps a successful claim', async () => {
+    const fixturesTargetPath = join(
+      __dirname,
+      'fixtures-test-watch-setup-retry',
+    );
+    const { fs } = await prepareFixtures({
+      fixturesPath: join(__dirname, 'fixtures/error'),
+      fixturesTargetPath,
+    });
+    fs.update(
+      join(fixturesTargetPath, 'globalSetup.ts'),
+      `import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export default async function globalSetup() {
+  if (!existsSync(join(dirname(fileURLToPath(import.meta.url)), 'ok.flag'))) {
+    throw new Error('Global setup failed intentionally');
+  }
+  console.log('[global-setup-retry] executed');
+  return () => console.log('[global-teardown-retry] executed');
+}`,
+    );
+    fs.create(
+      join(fixturesTargetPath, 'second.test.ts'),
+      `import { describe, it } from '@rstest/core';
+describe('second file', () => {
+  it('passes after setup succeeds', () => {});
+});`,
+    );
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['watch', '--disableConsoleIntercept'],
+      options: {
+        nodeOptions: {
+          env: { ISOLATE: undefined },
+          cwd: fixturesTargetPath,
+        },
+      },
+    });
+
+    try {
+      await cli.waitForStderr('Global setup failed intentionally');
+      await cli.waitForStdout('Waiting for file changes...');
+      fs.create(join(fixturesTargetPath, 'ok.flag'), '');
+      fs.update(
+        join(fixturesTargetPath, 'index.test.ts'),
+        (content) => `${content}\n// trigger setup retry`,
+      );
+      await cli.waitForStdout('Test Files 2 passed');
+      expect(cli.stdout.match(/\[global-setup-retry\] executed/g)).toHaveLength(
+        1,
+      );
+
+      cli.resetStd();
+      fs.update(
+        join(fixturesTargetPath, 'index.test.ts'),
+        (content) => `${content}\n// trigger another cycle`,
+      );
+      // The summary retains results from files not rerun in this cycle.
+      await cli.waitForStdout('Test Files 2 passed');
+      expect(cli.stdout).toContain('index.test.ts (1)');
+      expect(cli.stdout).not.toContain('[global-setup-retry] executed');
+      expect(cli.stdout).not.toContain('second.test.ts');
+    } finally {
+      await cli.killProcessTree();
+      fs.delete(fixturesTargetPath);
+    }
+  }, 60_000);
+
   it.skipIf(process.platform === 'win32')(
     'tears down the current watch session on SIGINT after a config restart',
     async () => {

--- a/packages/core/src/core/browser/globalSetupStage.ts
+++ b/packages/core/src/core/browser/globalSetupStage.ts
@@ -7,7 +7,7 @@ import type {
   ProjectEntries,
 } from '../../types';
 import { isDebug, resolveShardedEntries } from '../../utils';
-import { claimGlobalSetupOnce, runGlobalSetup } from '../globalSetup';
+import { shouldRunGlobalSetup, runGlobalSetup } from '../globalSetup';
 import {
   getRsbuildEnvironmentConfig,
   initModifyRstestConfigHooks,
@@ -237,7 +237,7 @@ export async function runBrowserGlobalSetupStage(
 
   for (const item of prepared) {
     if (
-      !claimGlobalSetupOnce(
+      !shouldRunGlobalSetup(
         item.project,
         watch ? Math.max(1, item.entryCount) : item.entryCount,
         item.globalSetupEntries.length,
@@ -249,7 +249,7 @@ export async function runBrowserGlobalSetupStage(
       success,
       errors: setupErrors,
       envChanges,
-    } = await runGlobalSetup(context, {
+    } = await runGlobalSetup(context, item.project, {
       globalSetupEntries: item.globalSetupEntries,
       assetFiles: item.assetFiles,
       sourceMaps: item.sourceMaps,

--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -16,7 +16,7 @@ import type {
 import { clearScreen, color, logger, type TraceRun } from '../../utils';
 import { writeBundleCoverageResults } from '../bundleCoverage';
 import { ensureTestEnvironmentDependencies } from '../envDependencies';
-import { claimGlobalSetupOnce, runGlobalSetup } from '../globalSetup';
+import { shouldRunGlobalSetup, runGlobalSetup } from '../globalSetup';
 import { applyOnlyFailuresSelection } from '../onlyFailures';
 import type { ProjectPlan } from '../projectPlan';
 import { createRsbuildServer } from '../rsbuild';
@@ -374,22 +374,30 @@ export function createNodeExecutor(
 
         let finalEntries: EntryInfo[] = entries;
         if (mode === 'on-demand') {
-          if (affectedEntries.length === 0) {
-            logger.debug(
-              color.yellow(
-                `No test files need re-run in project(${p.environmentName}).`,
-              ),
-            );
+          if (
+            shouldRunGlobalSetup(p, entries.length, globalSetupEntries.length)
+          ) {
+            // No entry of this project has run under a successful setup yet,
+            // so the cycle that runs setup covers the whole project.
+            finalEntries = entries;
           } else {
-            logger.debug(
-              color.yellow(
-                `Test files to re-run in project(${p.environmentName}):\n`,
-              ) +
-                affectedEntries.map((e) => e.testPath).join('\n') +
-                '\n',
-            );
+            if (affectedEntries.length === 0) {
+              logger.debug(
+                color.yellow(
+                  `No test files need re-run in project(${p.environmentName}).`,
+                ),
+              );
+            } else {
+              logger.debug(
+                color.yellow(
+                  `Test files to re-run in project(${p.environmentName}):\n`,
+                ) +
+                  affectedEntries.map((e) => e.testPath).join('\n') +
+                  '\n',
+              );
+            }
+            finalEntries = affectedEntries;
           }
-          finalEntries = affectedEntries;
         } else {
           logger.debug(
             color.yellow(
@@ -402,7 +410,7 @@ export function createNodeExecutor(
 
         const execute = async (selectedEntries: EntryInfo[]) => {
           if (
-            claimGlobalSetupOnce(
+            shouldRunGlobalSetup(
               p,
               selectedEntries.length,
               globalSetupEntries.length,
@@ -424,7 +432,7 @@ export function createNodeExecutor(
               'host:global-setup',
               'host',
               () =>
-                runGlobalSetup(context, {
+                runGlobalSetup(context, p, {
                   globalSetupEntries,
                   assetFiles,
                   sourceMaps,

--- a/packages/core/src/core/globalSetup.ts
+++ b/packages/core/src/core/globalSetup.ts
@@ -18,23 +18,11 @@ import { prepareAssetFilesForIPC } from '../utils/assetFiles';
 import { composeWorkerEnv } from './workerEnv';
 
 /**
- * Single owner of the once-per-project global-setup gate.
- *
- * Global setup runs at most once per project and only when the project has at
- * least one running test. This collapses the read-check-and-set that was
- * hand-copied across {@link runTests} and {@link listTests} into one named,
- * test-covered operation, preserving the exact short-circuit order and the
- * set-before-await semantics (a failed setup is not retried within the run).
- *
- * The `_globalSetups` marker lives on the per-project {@link InternalProjectContext} and
- * is intentionally never reset between watch reruns — only re-seeded `false`
- * when a fresh context is constructed — so this helper mutates the passed object
- * by reference and never touches module-level state.
- *
- * @returns `true` when the caller should run global setup now (and the marker
- * has been claimed); `false` otherwise.
+ * Runs setup once per project, only when the project has running tests.
+ * The marker is set by runGlobalSetup on success, never by callers.
+ * A failed setup therefore retries on the next watch cycle.
  */
-export function claimGlobalSetupOnce(
+export function shouldRunGlobalSetup(
   project: Pick<InternalProjectContext, '_globalSetups'>,
   entriesLength: number,
   globalSetupEntriesLength: number,
@@ -42,7 +30,6 @@ export function claimGlobalSetupOnce(
   if (!(entriesLength && globalSetupEntriesLength) || project._globalSetups) {
     return false;
   }
-  project._globalSetups = true;
   return true;
 }
 
@@ -188,6 +175,7 @@ export class GlobalSetupWorker {
 
 export async function runGlobalSetup(
   context: InternalContext,
+  project: Pick<InternalProjectContext, '_globalSetups'>,
   {
     globalSetupEntries,
     assetFiles,
@@ -233,6 +221,7 @@ export async function runGlobalSetup(
   });
 
   if (result.success) {
+    project._globalSetups = true;
     if (result.envChanges) {
       Object.assign(context.workerEnv, result.envChanges);
     }

--- a/packages/core/src/core/listTests.ts
+++ b/packages/core/src/core/listTests.ts
@@ -6,7 +6,7 @@ import type {
   ListCommandResult,
 } from '../types';
 import {
-  claimGlobalSetupOnce,
+  shouldRunGlobalSetup,
   runGlobalSetup,
   runGlobalTeardown,
 } from './globalSetup';
@@ -110,7 +110,7 @@ const collectNodeTests = async ({
         });
 
         if (
-          claimGlobalSetupOnce(
+          shouldRunGlobalSetup(
             project,
             entries.length,
             globalSetupEntries.length,
@@ -124,7 +124,7 @@ const collectNodeTests = async ({
             sourceMapsPromise,
           ]);
 
-          const { success, errors } = await runGlobalSetup(context, {
+          const { success, errors } = await runGlobalSetup(context, project, {
             globalSetupEntries,
             assetFiles,
             sourceMaps,

--- a/packages/core/src/core/plugins/entry.ts
+++ b/packages/core/src/core/plugins/entry.ts
@@ -102,8 +102,6 @@ export const pluginEntryWatch: (params: {
         config.watchOptions.ignored.push(
           getTempRstestOutputDirGlob(outputDistPathRoot),
           context.normalizedConfig.coverage.reportsDirectory,
-          // ignore global setup files since they are only run once
-          ...Object.values(globalSetupFiles?.[environment.name] || {}),
           '**/*.snap',
         );
 

--- a/packages/core/src/core/rsbuild.ts
+++ b/packages/core/src/core/rsbuild.ts
@@ -603,7 +603,7 @@ export const createRsbuildServer = async ({
             buildData[environmentName],
             outputPath!,
             runtimeChunkNameForEnvironment(environmentName),
-            setupEntries,
+            [...setupEntries, ...globalSetupEntries],
           )
         : { affectedEntries: [], deletedEntries: [] };
 

--- a/packages/core/tests/core/globalSetup.test.ts
+++ b/packages/core/tests/core/globalSetup.test.ts
@@ -2,7 +2,6 @@ import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { afterAll, describe, expect, it, rs } from '@rstest/core';
 import {
-  claimGlobalSetupOnce,
   GlobalSetupWorker,
   runGlobalSetup,
   runGlobalTeardown,
@@ -58,34 +57,6 @@ afterAll(() => {
   delete process.env.RSTEST_GS_UNIT;
 });
 
-describe('claimGlobalSetupOnce', () => {
-  it('claims the gate once when there are running tests and setup entries', () => {
-    const project = { _globalSetups: false };
-    expect(claimGlobalSetupOnce(project, 3, 1)).toBe(true);
-    expect(project._globalSetups).toBe(true);
-    // Idempotent: a second call does not re-run setup.
-    expect(claimGlobalSetupOnce(project, 3, 1)).toBe(false);
-  });
-
-  it('does not claim when there are no running tests', () => {
-    const project = { _globalSetups: false };
-    expect(claimGlobalSetupOnce(project, 0, 1)).toBe(false);
-    expect(project._globalSetups).toBe(false);
-  });
-
-  it('does not claim when there are no global setup entries', () => {
-    const project = { _globalSetups: false };
-    expect(claimGlobalSetupOnce(project, 3, 0)).toBe(false);
-    expect(project._globalSetups).toBe(false);
-  });
-
-  it('does not re-claim when the marker is already set', () => {
-    const project = { _globalSetups: true };
-    expect(claimGlobalSetupOnce(project, 3, 1)).toBe(false);
-    expect(project._globalSetups).toBe(true);
-  });
-});
-
 class MockChildProcess extends EventEmitter {
   stdout = new EventEmitter();
   stderr = new EventEmitter();
@@ -133,14 +104,18 @@ describe('runGlobalSetup', () => {
     } as unknown as InternalContext;
 
     try {
-      const result = await runGlobalSetup(context, {
-        globalSetupEntries: [],
-        assetFiles: {},
-        sourceMaps: {},
-        federation: false,
-        interopDefault: true,
-        outputModule: false,
-      });
+      const result = await runGlobalSetup(
+        context,
+        { _globalSetups: false },
+        {
+          globalSetupEntries: [],
+          assetFiles: {},
+          sourceMaps: {},
+          federation: false,
+          interopDefault: true,
+          outputModule: false,
+        },
+      );
 
       expect(result.success).toBe(true);
       expect(result.envChanges).toEqual({ RSTEST_GS_UNIT: 'from-worker' });


### PR DESCRIPTION
## Summary

In node watch mode, a `globalSetup` that failed on the first cycle was never run again: the once-per-project marker was set before the setup ran and nothing cleared it on failure, so after the user fixed the setup the next cycle ran tests with no setup (missing env, or false passes). The setup file was also excluded from the watcher, so saving the fix did not even trigger a rebuild.

- The marker is now set only after `runGlobalSetup` succeeds, so a failed setup retries on the next watch cycle. `claimGlobalSetupOnce` becomes the pure predicate `shouldRunGlobalSetup`; node, list and browser callers no longer write the marker themselves.
- `globalSetup` files are watched again and participate in watch invalidation under the existing setup-file rule: saving one reruns all tests, which is what schedules the retry. After a successful setup they still run once per session, as before.
- Non-watch runs and browser projects (setup runs before the session opens; a failure still rejects startup) are unchanged.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
