### PR TITLE
fix(core): spy on accessor-backed module exports in VM pools

### DIFF
--- a/e2e/node-pool/fixtures/src/index.ts
+++ b/e2e/node-pool/fixtures/src/index.ts
@@ -7,3 +7,7 @@ export function increment() {
 export function getCount() {
   return count;
 }
+
+export function getLabel() {
+  return 'real';
+}

--- a/e2e/node-pool/fixtures/test/basic.test.ts
+++ b/e2e/node-pool/fixtures/test/basic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, rs } from '@rstest/core';
-import { getCount, increment } from '../src/index';
+import * as source from '../src/index';
 
 const FILE_MARKER = '__rstest_threads_pool_file_marker__';
 
@@ -35,8 +35,16 @@ describe('node pool - basic', () => {
   });
 
   it('can import source modules and observe local mutation', () => {
-    increment();
-    expect(getCount()).toBe(1);
+    source.increment();
+    expect(source.getCount()).toBe(1);
+  });
+
+  it('can spy on a bundled namespace export', () => {
+    const spy = rs.spyOn(source, 'getLabel').mockReturnValue('mocked');
+
+    expect(source.getLabel()).toBe('mocked');
+    spy.mockRestore();
+    expect(source.getLabel()).toBe('real');
   });
 
   it('runs in the expected worker transport', () => {

--- a/packages/core/src/runtime/api/spy.ts
+++ b/packages/core/src/runtime/api/spy.ts
@@ -463,7 +463,11 @@ export const initSpy = (
       descriptor = Object.getOwnPropertyDescriptor(obj, propertyName);
       if (descriptor) {
         if (typeof methodName === 'string') {
-          descriptor.value = realmSpy;
+          if ('value' in descriptor) {
+            descriptor.value = realmSpy;
+          } else {
+            descriptor.get = () => realmSpy;
+          }
         } else if ('getter' in methodName) {
           descriptor.get = realmSpy;
         } else {

--- a/packages/core/tests/runtime/api/spy.test.ts
+++ b/packages/core/tests/runtime/api/spy.test.ts
@@ -118,6 +118,30 @@ describe('initSpy fn()', () => {
     expect(object.method).toBe(original);
   });
 
+  it('installs a VM-realm spy for an accessor-backed method', () => {
+    const context = runInNewContext('globalThis', {}) as Record<
+      string,
+      unknown
+    >;
+    const { spyOn } = initSpy(
+      () => '',
+      () => context,
+    );
+    const original = () => 'real';
+    const object = {} as { method: () => string };
+    Object.defineProperty(object, 'method', {
+      configurable: true,
+      enumerable: true,
+      get: () => original,
+    });
+
+    const spy = spyOn(object, 'method').mockReturnValue('mocked');
+
+    expect(object.method()).toBe('mocked');
+    spy.mockRestore();
+    expect(object.method).toBe(original);
+  });
+
   it('tracks calls, results and invocationCallOrder', () => {
     const { fn } = initSpy();
     const spy = fn((x: number) => x * 2);


### PR DESCRIPTION
## Motivation

VM pools wrap spies in the test realm. Bundled namespace exports are accessor-backed, so assigning `descriptor.value` produced an invalid descriptor containing both `get` and `value`. As a result, `rs.spyOn(namespace, exportName)` threw before the test could run under both `vmThreads` and `vmForks`. This was found while testing the preview from https://github.com/web-infra-dev/rstest/issues/767#issuecomment-5596983197.

## Changes

Preserve the descriptor shape when installing the realm-wrapped spy: data descriptors receive the wrapped value, while accessor descriptors receive a getter that returns it. Add unit coverage for accessor-backed methods and node-pool e2e coverage for spying and restoring a bundled namespace export under `threads`, `vmThreads`, and `vmForks`.

No public API, configuration, adapter, documentation, or browser-mode behavior changes.

Validation: focused unit tests, flip-verified node-pool e2e, core lint, root typecheck, workspace build, and `check-unused`.