### PR TITLE
fix(core): support VM constructors in expect.any

### DIFF
--- a/e2e/node-pool/fixtures/test/basic.test.ts
+++ b/e2e/node-pool/fixtures/test/basic.test.ts
@@ -34,6 +34,20 @@ describe('node pool - basic', () => {
     ]);
   });
 
+  it('matches VM-realm constructors in asymmetric matchers', () => {
+    expect('value').toEqual(expect.any(String));
+    expect(42).toEqual(expect.any(Number));
+    expect(Object('value')).toEqual(expect.any(String));
+    expect(Object(42)).toEqual(expect.any(Number));
+    expect(Object(true)).toEqual(expect.any(Boolean));
+    expect(Object(42n)).toEqual(expect.any(BigInt));
+    expect(Object(Symbol('value'))).toEqual(expect.any(Symbol));
+    expect(new (class extends String {})('value')).toEqual(expect.any(String));
+    expect({ value: 42 }).toEqual(
+      expect.objectContaining({ value: expect.any(Number) }),
+    );
+  });
+
   it('can import source modules and observe local mutation', () => {
     increment();
     expect(getCount()).toBe(1);

--- a/e2e/node-pool/fixtures/test/basic.test.ts
+++ b/e2e/node-pool/fixtures/test/basic.test.ts
@@ -43,6 +43,8 @@ describe('node pool - basic', () => {
     expect(Object(42n)).toEqual(expect.any(BigInt));
     expect(Object(Symbol('value'))).toEqual(expect.any(Symbol));
     expect(new (class extends String {})('value')).toEqual(expect.any(String));
+    expect(() => {}).not.toEqual(expect.any(Object));
+    expect(Object.create(Function.prototype)).not.toEqual(expect.any(Function));
     expect({ value: 42 }).toEqual(
       expect.objectContaining({ value: expect.any(Number) }),
     );

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -223,14 +223,15 @@ export function createExpect({
     for (const name of ANY_PRIMITIVE_CONSTRUCTOR_NAMES) {
       if (constructor === runtimeGlobal?.[name]) {
         const matcher = Reflect.apply(any, expect, [globalThis[name]]);
+        if (name === 'Function' || name === 'Object') {
+          return matcher;
+        }
         const asymmetricMatch = matcher.asymmetricMatch.bind(matcher);
         matcher.asymmetricMatch = (value: unknown) =>
           asymmetricMatch(value) ||
-          Reflect.apply(
-            Function.prototype[Symbol.hasInstance],
-            constructor,
-            [value],
-          );
+          Reflect.apply(Function.prototype[Symbol.hasInstance], constructor, [
+            value,
+          ]);
         return matcher;
       }
     }

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -59,6 +59,16 @@ const defaultChaiConfig: ChaiConfig = {
   truncateThreshold: chaiConfig.truncateThreshold,
 };
 
+const ANY_PRIMITIVE_CONSTRUCTOR_NAMES = [
+  'String',
+  'Number',
+  'Function',
+  'Boolean',
+  'BigInt',
+  'Symbol',
+  'Object',
+] as const;
+
 export function setupChaiConfig(config: ChaiConfig = {}): void {
   Object.assign(chaiConfig, defaultChaiConfig, config);
 }
@@ -206,6 +216,26 @@ export function createExpect({
   }) as RstestExpect;
   Object.assign(expect, chaiExpect);
   Object.assign(expect, (globalThis as any)[ASYMMETRIC_MATCHERS_OBJECT]);
+
+  const any = expect.any;
+  expect.any = (constructor) => {
+    const runtimeGlobal = fileContext().runtimeGlobal;
+    for (const name of ANY_PRIMITIVE_CONSTRUCTOR_NAMES) {
+      if (constructor === runtimeGlobal?.[name]) {
+        const matcher = Reflect.apply(any, expect, [globalThis[name]]);
+        const asymmetricMatch = matcher.asymmetricMatch.bind(matcher);
+        matcher.asymmetricMatch = (value: unknown) =>
+          asymmetricMatch(value) ||
+          Reflect.apply(
+            Function.prototype[Symbol.hasInstance],
+            constructor,
+            [value],
+          );
+        return matcher;
+      }
+    }
+    return Reflect.apply(any, expect, [constructor]);
+  };
 
   expect.getState = () => getState<MatcherState>(expect);
   expect.setState = (state) => setState(state, expect);

--- a/packages/core/tests/runtime/api/expect.test.ts
+++ b/packages/core/tests/runtime/api/expect.test.ts
@@ -182,6 +182,18 @@ describe('file-level expect singleton (isolate: false)', () => {
     expect(stringMatcher.asymmetricMatch('value')).toBe(true);
     expect(numberMatcher.asymmetricMatch(42)).toBe(true);
     expect(objectMatcher.asymmetricMatch({ value: 42 })).toBe(true);
+    expect(
+      fileExpect
+        .any(runtimeGlobal.Object as ObjectConstructor)
+        .asymmetricMatch(() => {}),
+    ).toBe(false);
+    expect(
+      fileExpect
+        .any(runtimeGlobal.Function as FunctionConstructor)
+        .asymmetricMatch(
+          vm.runInContext('Object.create(Function.prototype)', context),
+        ),
+    ).toBe(false);
     for (const [index, constructorName] of [
       'String',
       'Number',

--- a/packages/core/tests/runtime/api/expect.test.ts
+++ b/packages/core/tests/runtime/api/expect.test.ts
@@ -27,9 +27,11 @@ const publishFile = (
   testPath: string,
   currentTestName: string,
   concurrent = false,
+  runtimeGlobal?: Record<string, unknown>,
 ) => {
   setFileContext({
     workerState: { testPath, runtimeConfig: {} } as WorkerState,
+    runtimeGlobal,
     testRunner: {
       getCurrentTest: () => fakeTest(currentTestName, concurrent),
       getCurrentTimeoutContext: () => undefined,
@@ -145,6 +147,54 @@ describe('file-level expect singleton (isolate: false)', () => {
     expect(localExpect.getState().assertionCalls).toBe(3);
     // The file singleton's state is untouched by the local expect.
     expect(fileExpect.getState().assertionCalls).toBe(0);
+  });
+
+  it('matches primitives against constructors from the running VM realm', () => {
+    const context = vm.createContext({});
+    const runtimeGlobal = vm.runInContext('globalThis', context) as Record<
+      string,
+      unknown
+    >;
+    publishFile('/f1', 't1', false, runtimeGlobal);
+    const fileExpect = createFileExpect(() => {});
+
+    const stringMatcher = fileExpect.any(
+      runtimeGlobal.String as StringConstructor,
+    );
+    const numberMatcher = fileExpect.any(
+      runtimeGlobal.Number as NumberConstructor,
+    );
+    const objectMatcher = fileExpect.objectContaining({
+      value: numberMatcher,
+    });
+    const boxedPrimitives = vm.runInContext(
+      `[
+        Object('value'),
+        Object(42),
+        Object(true),
+        Object(42n),
+        Object(Symbol('value')),
+        new (class extends String {})('value'),
+      ]`,
+      context,
+    ) as unknown[];
+
+    expect(stringMatcher.asymmetricMatch('value')).toBe(true);
+    expect(numberMatcher.asymmetricMatch(42)).toBe(true);
+    expect(objectMatcher.asymmetricMatch({ value: 42 })).toBe(true);
+    for (const [index, constructorName] of [
+      'String',
+      'Number',
+      'Boolean',
+      'BigInt',
+      'Symbol',
+      'String',
+    ].entries()) {
+      const matcher = fileExpect.any(
+        runtimeGlobal[constructorName] as StringConstructor,
+      );
+      expect(matcher.asymmetricMatch(boxedPrimitives[index])).toBe(true);
+    }
   });
 
   it('does not use the shared test deadline for concurrent tests', () => {


### PR DESCRIPTION
## Motivation

VM pools execute test files in a separate JavaScript realm. The constructors passed by tests to expect.any therefore differ by identity from the host-realm built-ins that @vitest/expect special-cases, causing primitive asymmetric matches such as expect.any(String) to fail under vmThreads and vmForks.

Related to #767.

## Changes

Normalize VM-realm primitive constructors to their host equivalents before delegating to the existing asymmetric matcher implementation.

Add focused runtime coverage plus node-pool e2e coverage that runs under threads, vmThreads, and vmForks.