### PR TITLE
fix(core): avoid reporting cancelled tests as worker failures

### DIFF
--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -354,6 +354,16 @@ describe('browser mode - globalSetup', () => {
           }
         }
         export async function createBrowserExecutor(...args) {
+          const context = args[0];
+          const updateResults = context.updateReporterResultState.bind(context);
+          context.updateReporterResultState = (...results) => {
+            updateResults(...results);
+            console.log('[results-finalized]');
+          };
+          context.reporters.push({
+            onTestRunStart() { console.log('[reporter-start]'); },
+            onTestRunEnd() { console.log('[reporter-end]'); },
+          });
           const executor = await create(...args);
           if ('${phase}' === 'load') await pause();
           return {
@@ -383,6 +393,9 @@ describe('browser mode - globalSetup', () => {
         expect(cli.stdout).not.toContain('[browser-global-setup] executed');
         expect(cli.stdout).not.toContain('[browser-global-setup-test] running');
         expect(cli.stdout.match(/\[executor-close\]/g)).toHaveLength(1);
+        expect(cli.stdout.match(/\[results-finalized\]/g)).toHaveLength(1);
+        expect(cli.stdout).not.toContain('[reporter-start]');
+        expect(cli.stdout).not.toContain('[reporter-end]');
         if (phase === 'load')
           expect(cli.stdout).not.toContain('[executor-init]');
       } finally {

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -8,6 +8,7 @@ import {
   deleteFixtureTarget,
   killCliProcessTree,
   runBrowserCli,
+  runBrowserCliWithCwd,
   runBrowserWatchCli,
   runBrowserWatchCliWithCwd,
 } from './utils';
@@ -70,12 +71,14 @@ const expectSignalExitDuringRestartCleanup = async ({
 };
 
 const expectSignalExitDuringGlobalSetup = async ({
+  mode,
   fixtureName,
   targetName,
   globalSetupPath,
   setupMarker,
   teardownMarker,
 }: {
+  mode: 'run' | 'watch';
   fixtureName: string;
   targetName: string;
   globalSetupPath: string;
@@ -96,7 +99,10 @@ const expectSignalExitDuringGlobalSetup = async ({
       `console.log('${setupMarker}');\n  await new Promise((resolve) => setTimeout(resolve, 1500));`,
     ),
   );
-  const result = await runBrowserWatchCliWithCwd(fixturesTargetPath);
+  const result =
+    mode === 'run'
+      ? await runBrowserCliWithCwd(fixturesTargetPath)
+      : await runBrowserWatchCliWithCwd(fixturesTargetPath);
   const { cli } = result;
 
   try {
@@ -721,12 +727,13 @@ it('receives globalSetup env in the added file', () => {
   // `runBrowserGlobalSetupStage` call site on both shapes and the SIGINT
   // handler is shape-agnostic; the mixed shape keeps its own signal coverage
   // in the restart-cleanup pair below, where a node teardown is what blocks.
-  it.skipIf(process.platform === 'win32')(
-    'handles SIGINT during browser-only globalSetup',
-    () =>
+  it.skipIf(process.platform === 'win32').for(['run', 'watch'] as const)(
+    'handles SIGINT during browser-only globalSetup in %s',
+    (mode) =>
       expectSignalExitDuringGlobalSetup({
         fixtureName: 'browser-global-setup',
-        targetName: 'browser-global-setup-signal',
+        mode,
+        targetName: `browser-global-setup-signal-${mode}`,
         globalSetupPath: 'globalSetup.ts',
         setupMarker: '[browser-global-setup] executed',
         teardownMarker: '[browser-global-teardown] executed',

--- a/e2e/browser-mode/globalSetup.test.ts
+++ b/e2e/browser-mode/globalSetup.test.ts
@@ -304,6 +304,94 @@ describe('browser mode - globalSetup', () => {
     }
   }, 60_000);
 
+  it.skipIf(process.platform === 'win32').for(['load', 'init'])(
+    'skips browser setup when SIGINT arrives during executor %s',
+    async (phase) => {
+      const fixturesTargetPath = path.join(
+        __dirname,
+        `fixtures/fixtures-test-browser-cancel-${phase}`,
+      );
+      const { fs: fixtureFs } = await prepareFixtures({
+        fixturesPath: path.join(__dirname, 'fixtures/browser-global-setup'),
+        fixturesTargetPath,
+      });
+      const browserPackagePath = path.join(
+        fixturesTargetPath,
+        'node_modules/@rstest/browser',
+      );
+      fs.mkdirSync(browserPackagePath, { recursive: true });
+      const browserPackage = JSON.parse(
+        fs.readFileSync(
+          path.join(__dirname, '../../packages/browser/package.json'),
+          'utf8',
+        ),
+      );
+      fs.writeFileSync(
+        path.join(browserPackagePath, 'package.json'),
+        JSON.stringify({
+          name: '@rstest/browser',
+          version: browserPackage.version,
+          type: 'module',
+          exports: {
+            './internal': './internal.js',
+            './package.json': './package.json',
+          },
+        }),
+      );
+      const browserEntry = pathToFileURL(
+        path.join(__dirname, '../../packages/browser/dist/index.js'),
+      ).href;
+      fs.writeFileSync(
+        path.join(browserPackagePath, 'internal.js'),
+        `
+        import { existsSync } from 'node:fs';
+        import { createBrowserExecutor as create } from ${JSON.stringify(browserEntry)};
+        export * from ${JSON.stringify(browserEntry)};
+        async function pause() {
+          console.log('[executor-pending]');
+          while (!existsSync('release-executor')) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+        }
+        export async function createBrowserExecutor(...args) {
+          const executor = await create(...args);
+          if ('${phase}' === 'load') await pause();
+          return {
+            ...executor,
+            async init() {
+              console.log('[executor-init]');
+              if ('${phase}' === 'init') await pause();
+              await executor.init();
+            },
+            async close() {
+              console.log('[executor-close]');
+              await executor.close();
+            },
+          };
+        }
+      `,
+      );
+      const result = await runBrowserCliWithCwd(fixturesTargetPath);
+      const { cli } = result;
+      try {
+        await cli.waitForStdout('[executor-pending]');
+        cli.exec.process!.kill('SIGINT');
+        await cli.waitForStdout('Received SIGINT');
+        fixtureFs.create(path.join(fixturesTargetPath, 'release-executor'), '');
+        await result.expectExecFailed();
+        expect(cli.exec.process!.exitCode).toBe(130);
+        expect(cli.stdout).not.toContain('[browser-global-setup] executed');
+        expect(cli.stdout).not.toContain('[browser-global-setup-test] running');
+        expect(cli.stdout.match(/\[executor-close\]/g)).toHaveLength(1);
+        if (phase === 'load')
+          expect(cli.stdout).not.toContain('[executor-init]');
+      } finally {
+        await killCliProcessTree(cli);
+        await deleteFixtureTarget(fixtureFs, fixturesTargetPath);
+      }
+    },
+  );
+
   it('validates the browser package before browser-only watch globalSetup', async () => {
     const fixturesTargetPath = path.join(
       __dirname,

--- a/e2e/globalSetup/index.test.ts
+++ b/e2e/globalSetup/index.test.ts
@@ -15,6 +15,7 @@ describe('globalSetup', async () => {
         { pool, phase: 'test', exitDuringCleanup: true },
         { pool, phase: 'run-start', exitDuringCleanup: false },
         { pool, phase: 'run-end', exitDuringCleanup: false },
+        { pool, phase: 'global-setup', exitDuringCleanup: false },
       ]),
     )(
       'cancels $phase under $pool (cleanup calls exit: $exitDuringCleanup)',
@@ -30,7 +31,7 @@ describe('globalSetup', async () => {
         fs.update(join(fixturesTargetPath, 'rstest.config.ts'), (content) =>
           content.replace(
             'globalSetup:',
-            `reporters: ['default', {
+            `reporters: ['blob', 'default', {
             onTestFileResult() { console.log('[unexpected-file-result]'); },
             async onTestRunStart() {
               if ('${phase}' === 'run-start') {
@@ -53,6 +54,22 @@ describe('globalSetup', async () => {
           }], globalSetup:`,
           ),
         );
+        if (phase === 'global-setup') {
+          fs.update(
+            join(fixturesTargetPath, 'setups/defaultExport.ts'),
+            (content) =>
+              content.replace(
+                "  console.log('[global-setup-default] executed');",
+                `  console.log('[setup-pending]');
+                 const { existsSync } = await import('node:fs');
+                 while (!existsSync('release-setup')) {
+                   await new Promise(resolve => setTimeout(resolve, 10));
+                 }
+                 console.log('[setup-finished]');
+                 console.log('[global-setup-default] executed');`,
+              ),
+          );
+        }
         if (exitDuringCleanup) {
           fs.update(join(fixturesTargetPath, 'rstest.config.ts'), (content) =>
             content.replace(
@@ -108,19 +125,30 @@ describe('globalSetup', async () => {
               ? '[run-start]'
               : phase === 'run-end'
                 ? '[run-end-pending]'
-                : '[test-running]',
+                : phase === 'global-setup'
+                  ? '[setup-pending]'
+                  : '[test-running]',
           );
           cli.exec.process!.kill('SIGINT');
+          if (phase === 'global-setup') {
+            await cli.waitForStdout('Received SIGINT');
+            fs.create(join(fixturesTargetPath, 'release-setup'), '');
+          }
           await expectExecFailed();
           expect(cli.exec.process!.exitCode).toBe(130);
           if (phase !== 'run-end')
             expect(cli.log).not.toContain('[unexpected-file-result]');
           expect(cli.stdout.match(/\[run-start\]/g)).toHaveLength(1);
+          expect(
+            existsSync(join(fixturesTargetPath, '.rstest-reports/blob.json')),
+          ).toBe(false);
           if (exitDuringCleanup) return;
           expect(cli.stdout.match(/\[run-end\]/g)).toHaveLength(1);
           expect(cli.log).not.toContain('No test files found');
-          if (phase === 'run-start')
+          if (phase === 'run-start' || phase === 'global-setup')
             expect(cli.log).not.toContain('[test-running]');
+          if (phase === 'global-setup')
+            expect(cli.log).toContain('[setup-finished]');
           expect(
             existsSync(
               join(fixturesTargetPath, 'coverage/coverage-final.json'),

--- a/e2e/globalSetup/index.test.ts
+++ b/e2e/globalSetup/index.test.ts
@@ -7,6 +7,83 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('globalSetup', async () => {
+  describe.skipIf(process.platform === 'win32')('SIGINT cancellation', () => {
+    it.for(['forks', 'threads', 'vmForks', 'vmThreads'] as const)(
+      'cancels queued tests and tears down once under %s',
+      async (pool) => {
+        const fixturesTargetPath = join(
+          __dirname,
+          `fixtures-test-sigint-${pool}`,
+        );
+        const { fs } = await prepareFixtures({
+          fixturesPath: join(__dirname, 'fixtures/basic'),
+          fixturesTargetPath,
+        });
+        fs.update(join(fixturesTargetPath, 'rstest.config.ts'), (content) =>
+          content.replace(
+            'globalSetup:',
+            `reporters: ['default', {
+            onTestFileResult() { console.log('[unexpected-file-result]'); },
+            onTestRunEnd() { console.log('[unexpected-run-end]'); },
+          }], globalSetup:`,
+          ),
+        );
+        for (const name of ['index.test.ts', 'index1.test.ts']) {
+          fs.update(
+            join(fixturesTargetPath, name),
+            () => `
+            import { test } from '@rstest/core';
+            test('wait for cancellation', async () => {
+              console.log('[test-running]');
+              await new Promise(resolve => setTimeout(resolve, 60000));
+            }, 65000);
+          `,
+          );
+        }
+        const { cli, expectExecFailed } = await runRstestCli({
+          command: 'rstest',
+          args: [
+            'run',
+            '--pool',
+            pool,
+            '--pool.maxWorkers',
+            '1',
+            '--disableConsoleIntercept',
+          ],
+          options: {
+            nodeOptions: {
+              cwd: fixturesTargetPath,
+              env: { ISOLATE: undefined },
+            },
+          },
+        });
+        try {
+          await cli.waitForStdout('[test-running]');
+          cli.exec.process!.kill('SIGINT');
+          await expectExecFailed();
+          expect(cli.exec.process!.exitCode).toBe(130);
+          expect(cli.log).not.toContain('[unexpected-file-result]');
+          expect(cli.log).not.toContain('[unexpected-run-end]');
+          expect(cli.log).not.toContain('pool is closed');
+          expect(cli.log).not.toContain('Worker stopped');
+          expect(cli.log).not.toContain('exited unexpectedly');
+          expect(
+            cli.stdout.match(/\[global-teardown-default\] executed/g),
+          ).toHaveLength(1);
+          expect(
+            cli.stdout.match(/\[global-teardown-named\] executed/g),
+          ).toHaveLength(1);
+          expect(cli.stdout.indexOf('[rstest-dev-server] closed')).toBeLessThan(
+            cli.stdout.indexOf('[global-teardown-default] executed'),
+          );
+        } finally {
+          await cli.killProcessTree();
+          fs.delete(fixturesTargetPath);
+        }
+      },
+    );
+  });
+
   it('should run global setup file correctly', async () => {
     const { cli, expectExecSuccess } = await runRstestCli({
       command: 'rstest',

--- a/e2e/globalSetup/index.test.ts
+++ b/e2e/globalSetup/index.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
@@ -9,15 +10,18 @@ const __dirname = dirname(__filename);
 describe('globalSetup', async () => {
   describe.skipIf(process.platform === 'win32')('SIGINT cancellation', () => {
     it.for(
-      ['forks', 'threads', 'vmForks', 'vmThreads'].flatMap((pool) =>
-        [false, true].map((exitDuringCleanup) => ({ pool, exitDuringCleanup })),
-      ),
+      ['forks', 'threads', 'vmForks', 'vmThreads'].flatMap((pool) => [
+        { pool, phase: 'test', exitDuringCleanup: false },
+        { pool, phase: 'test', exitDuringCleanup: true },
+        { pool, phase: 'run-start', exitDuringCleanup: false },
+        { pool, phase: 'run-end', exitDuringCleanup: false },
+      ]),
     )(
-      'cancels tests under $pool (cleanup calls exit: $exitDuringCleanup)',
-      async ({ pool, exitDuringCleanup }) => {
+      'cancels $phase under $pool (cleanup calls exit: $exitDuringCleanup)',
+      async ({ pool, phase, exitDuringCleanup }) => {
         const fixturesTargetPath = join(
           __dirname,
-          `fixtures-test-sigint-${pool}-${exitDuringCleanup}`,
+          `fixtures-test-sigint-${pool}-${phase}-${exitDuringCleanup}`,
         );
         const { fs } = await prepareFixtures({
           fixturesPath: join(__dirname, 'fixtures/basic'),
@@ -28,8 +32,21 @@ describe('globalSetup', async () => {
             'globalSetup:',
             `reporters: ['default', {
             onTestFileResult() { console.log('[unexpected-file-result]'); },
-            onTestRunStart() { console.log('[run-start]'); },
+            async onTestRunStart() {
+              if ('${phase}' === 'run-start') {
+                await new Promise(resolve => {
+                  process.once('SIGINT', resolve);
+                  console.log('[run-start]');
+                });
+              } else console.log('[run-start]');
+            },
             async onTestRunEnd() {
+              if ('${phase}' === 'run-end') {
+                await new Promise(resolve => {
+                  process.once('SIGINT', resolve);
+                  console.log('[run-end-pending]');
+                });
+              }
               await new Promise(resolve => setTimeout(resolve, 100));
               console.log('[run-end]');
             },
@@ -51,7 +68,9 @@ describe('globalSetup', async () => {
             import { test } from '@rstest/core';
             test('wait for cancellation', async () => {
               console.log('[test-running]');
-              await new Promise(resolve => setTimeout(resolve, 60000));
+              if ('${phase}' !== 'run-end') {
+                await new Promise(resolve => setTimeout(resolve, '${phase}' === 'run-start' ? 100 : 60000));
+              }
             }, 65000);
           `,
           );
@@ -65,6 +84,16 @@ describe('globalSetup', async () => {
             '--pool.maxWorkers',
             '1',
             '--disableConsoleIntercept',
+            '--trace',
+            ...(phase === 'run-end'
+              ? [
+                  '--coverage',
+                  '--coverage.provider',
+                  'v8',
+                  '--coverage.reporter',
+                  'json',
+                ]
+              : []),
           ],
           options: {
             nodeOptions: {
@@ -74,27 +103,52 @@ describe('globalSetup', async () => {
           },
         });
         try {
-          await cli.waitForStdout('[test-running]');
+          await cli.waitForStdout(
+            phase === 'run-start'
+              ? '[run-start]'
+              : phase === 'run-end'
+                ? '[run-end-pending]'
+                : '[test-running]',
+          );
           cli.exec.process!.kill('SIGINT');
           await expectExecFailed();
           expect(cli.exec.process!.exitCode).toBe(130);
-          expect(cli.log).not.toContain('[unexpected-file-result]');
+          if (phase !== 'run-end')
+            expect(cli.log).not.toContain('[unexpected-file-result]');
           expect(cli.stdout.match(/\[run-start\]/g)).toHaveLength(1);
           if (exitDuringCleanup) return;
           expect(cli.stdout.match(/\[run-end\]/g)).toHaveLength(1);
           expect(cli.log).not.toContain('No test files found');
+          if (phase === 'run-start')
+            expect(cli.log).not.toContain('[test-running]');
+          expect(
+            existsSync(
+              join(fixturesTargetPath, 'coverage/coverage-final.json'),
+            ),
+          ).toBe(false);
+          if (phase !== 'run-start') {
+            expect(cli.stdout.match(/Perfetto trace file:/g)).toHaveLength(1);
+            expect(cli.stdout.match(/Trace summary file:/g)).toHaveLength(1);
+          }
           expect(cli.log).not.toContain('pool is closed');
           expect(cli.log).not.toContain('Worker stopped');
           expect(cli.log).not.toContain('exited unexpectedly');
           expect(
-            cli.stdout.match(/\[global-teardown-default\] executed/g),
-          ).toHaveLength(1);
+            cli.stdout.match(/\[global-teardown-default\] executed/g) ?? [],
+          ).toHaveLength(phase === 'run-start' ? 0 : 1);
           expect(
-            cli.stdout.match(/\[global-teardown-named\] executed/g),
+            cli.stdout.match(/\[global-teardown-named\] executed/g) ?? [],
+          ).toHaveLength(phase === 'run-start' ? 0 : 1);
+          expect(
+            cli.stdout.match(/\[rstest-dev-server\] closed/g),
           ).toHaveLength(1);
-          expect(cli.stdout.indexOf('[rstest-dev-server] closed')).toBeLessThan(
-            cli.stdout.indexOf('[global-teardown-default] executed'),
-          );
+          if (phase !== 'run-start') {
+            expect(
+              cli.stdout.indexOf('[rstest-dev-server] closed'),
+            ).toBeLessThan(
+              cli.stdout.indexOf('[global-teardown-default] executed'),
+            );
+          }
         } finally {
           await cli.killProcessTree();
           fs.delete(fixturesTargetPath);

--- a/e2e/globalSetup/index.test.ts
+++ b/e2e/globalSetup/index.test.ts
@@ -8,12 +8,16 @@ const __dirname = dirname(__filename);
 
 describe('globalSetup', async () => {
   describe.skipIf(process.platform === 'win32')('SIGINT cancellation', () => {
-    it.for(['forks', 'threads', 'vmForks', 'vmThreads'] as const)(
-      'cancels queued tests and tears down once under %s',
-      async (pool) => {
+    it.for(
+      ['forks', 'threads', 'vmForks', 'vmThreads'].flatMap((pool) =>
+        [false, true].map((exitDuringCleanup) => ({ pool, exitDuringCleanup })),
+      ),
+    )(
+      'cancels tests under $pool (cleanup calls exit: $exitDuringCleanup)',
+      async ({ pool, exitDuringCleanup }) => {
         const fixturesTargetPath = join(
           __dirname,
-          `fixtures-test-sigint-${pool}`,
+          `fixtures-test-sigint-${pool}-${exitDuringCleanup}`,
         );
         const { fs } = await prepareFixtures({
           fixturesPath: join(__dirname, 'fixtures/basic'),
@@ -24,10 +28,22 @@ describe('globalSetup', async () => {
             'globalSetup:',
             `reporters: ['default', {
             onTestFileResult() { console.log('[unexpected-file-result]'); },
-            onTestRunEnd() { console.log('[unexpected-run-end]'); },
+            onTestRunStart() { console.log('[run-start]'); },
+            async onTestRunEnd() {
+              await new Promise(resolve => setTimeout(resolve, 100));
+              console.log('[run-end]');
+            },
           }], globalSetup:`,
           ),
         );
+        if (exitDuringCleanup) {
+          fs.update(join(fixturesTargetPath, 'rstest.config.ts'), (content) =>
+            content.replace(
+              "console.log('[rstest-dev-server] closed');",
+              "console.log('[rstest-dev-server] closed'); process.exit(0);",
+            ),
+          );
+        }
         for (const name of ['index.test.ts', 'index1.test.ts']) {
           fs.update(
             join(fixturesTargetPath, name),
@@ -63,7 +79,10 @@ describe('globalSetup', async () => {
           await expectExecFailed();
           expect(cli.exec.process!.exitCode).toBe(130);
           expect(cli.log).not.toContain('[unexpected-file-result]');
-          expect(cli.log).not.toContain('[unexpected-run-end]');
+          expect(cli.stdout.match(/\[run-start\]/g)).toHaveLength(1);
+          if (exitDuringCleanup) return;
+          expect(cli.stdout.match(/\[run-end\]/g)).toHaveLength(1);
+          expect(cli.log).not.toContain('No test files found');
           expect(cli.log).not.toContain('pool is closed');
           expect(cli.log).not.toContain('Worker stopped');
           expect(cli.log).not.toContain('exited unexpectedly');

--- a/e2e/globalSetup/index.test.ts
+++ b/e2e/globalSetup/index.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from '@rstest/core';
@@ -16,6 +16,7 @@ describe('globalSetup', async () => {
         { pool, phase: 'run-start', exitDuringCleanup: false },
         { pool, phase: 'run-end', exitDuringCleanup: false },
         { pool, phase: 'global-setup', exitDuringCleanup: false },
+        { pool, phase: 'blob-conflict', exitDuringCleanup: false },
       ]),
     )(
       'cancels $phase under $pool (cleanup calls exit: $exitDuringCleanup)',
@@ -54,6 +55,11 @@ describe('globalSetup', async () => {
           }], globalSetup:`,
           ),
         );
+        if (phase === 'blob-conflict') {
+          mkdirSync(join(fixturesTargetPath, '.rstest-reports/blob.json'), {
+            recursive: true,
+          });
+        }
         if (phase === 'global-setup') {
           fs.update(
             join(fixturesTargetPath, 'setups/defaultExport.ts'),
@@ -141,7 +147,11 @@ describe('globalSetup', async () => {
           expect(cli.stdout.match(/\[run-start\]/g)).toHaveLength(1);
           expect(
             existsSync(join(fixturesTargetPath, '.rstest-reports/blob.json')),
-          ).toBe(false);
+          ).toBe(phase === 'blob-conflict');
+          if (phase === 'blob-conflict') {
+            expect(cli.log).toContain('Failed to remove cancelled blob report');
+            expect(cli.log).not.toContain('Failed to run Rstest');
+          }
           if (exitDuringCleanup) return;
           expect(cli.stdout.match(/\[run-end\]/g)).toHaveLength(1);
           expect(cli.log).not.toContain('No test files found');
@@ -298,7 +308,7 @@ describe('globalSetup', async () => {
     });
     fs.update(
       join(fixturesTargetPath, 'globalSetup.ts'),
-      `import { existsSync } from 'node:fs';
+      `import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 

--- a/packages/core/src/core/executors/nodeExecutor.ts
+++ b/packages/core/src/core/executors/nodeExecutor.ts
@@ -533,14 +533,18 @@ export function createNodeExecutor(
     const coverageResourceLoaders = createCoverageResourceLoaders(returns);
 
     // Persist node results for next-run ordering. Skip partial runs
-    // (`testNamePattern` narrows within files; a bail abort synthesizes skips)
+    // (cancellation closes the executor; filters and bail omit tests)
     // so the perf-first cache is never poisoned. This is node-internal and does
     // not depend on the shared finalize, so it stays here.
     const bailLimit = context.normalizedConfig.bail;
     const bailAborted =
       bailLimit > 0 &&
       context.stateManager.getCountOfFailedTests() >= bailLimit;
-    if (!context.normalizedConfig.testNamePattern && !bailAborted) {
+    if (
+      !didClose &&
+      !context.normalizedConfig.testNamePattern &&
+      !bailAborted
+    ) {
       await writeResultsCache(
         rootPath,
         returns.flatMap((r) => r.results),

--- a/packages/core/src/core/finalizeRun.ts
+++ b/packages/core/src/core/finalizeRun.ts
@@ -182,6 +182,7 @@ export async function finalizeRunCycle(
     outcomes,
     mode,
     isWatchMode,
+    interrupted = false,
     coverageProvider,
     reportOnFailure,
     traceRun,
@@ -189,6 +190,7 @@ export async function finalizeRunCycle(
     outcomes: ExecutorCycleOutcome[];
     mode: 'all' | 'on-demand';
     isWatchMode: boolean;
+    interrupted?: boolean;
     coverageProvider: CoverageProvider | null;
     reportOnFailure: boolean;
     /**
@@ -220,7 +222,9 @@ export async function finalizeRunCycle(
   // `map` into the run's map, then resolve the concatenated v8 `raw` batches.
   // Each executor owns its own per-file merge (node in the pool, browser at
   // outcome assembly), so nothing is read off individual results here.
-  const mergedCoverageMap = coverageProvider?.createCoverageMap();
+  const mergedCoverageMap = interrupted
+    ? undefined
+    : coverageProvider?.createCoverageMap();
   for (const outcome of outcomes) {
     if (outcome.coverage?.map) {
       mergedCoverageMap?.merge(outcome.coverage.map);
@@ -243,7 +247,7 @@ export async function finalizeRunCycle(
 
   const rawCoverageResults = outcomes.flatMap((o) => o.coverage?.raw ?? []);
   await resolveAndMergeRawCoverage({
-    coverageProvider,
+    coverageProvider: interrupted ? null : coverageProvider,
     mergedCoverageMap,
     rawCoverageResults,
     resolveOptions: {
@@ -280,7 +284,7 @@ export async function finalizeRunCycle(
     outcomes.flatMap((o) => o.deletedTestPaths ?? []),
   );
 
-  if (noTestsDiscovered) {
+  if (!interrupted && noTestsDiscovered) {
     reportNoTestFiles({ context, mode });
   }
 
@@ -310,6 +314,7 @@ export async function finalizeRunCycle(
   // reports, and thresholds belong to the merge-reports process that sees the
   // complete coverage map rather than to every partial shard.
   if (
+    !interrupted &&
     coverageProvider &&
     !defersCoverageReport &&
     (!isFailure || reportOnFailure)
@@ -327,7 +332,7 @@ export async function finalizeRunCycle(
 
   await runLifecycleStep('trace run finalize', () => traceRun.finalize());
 
-  if (isFailure) {
+  if (!interrupted && isFailure) {
     const bail = context.normalizedConfig.bail;
     if (bail && context.stateManager.getCountOfFailedTests() >= bail) {
       logger.log(

--- a/packages/core/src/core/finalizeRun.ts
+++ b/packages/core/src/core/finalizeRun.ts
@@ -183,6 +183,7 @@ export async function finalizeRunCycle(
     mode,
     isWatchMode,
     isInterrupted = () => false,
+    reportersStarted = true,
     coverageProvider,
     reportOnFailure,
     traceRun,
@@ -191,6 +192,8 @@ export async function finalizeRunCycle(
     mode: 'all' | 'on-demand';
     isWatchMode: boolean;
     isInterrupted?: () => boolean;
+    /** Cancellation before run-start still finalizes state, without reporter callbacks. */
+    reportersStarted?: boolean;
     coverageProvider: CoverageProvider | null;
     reportOnFailure: boolean;
     /**
@@ -292,19 +295,21 @@ export async function finalizeRunCycle(
     context.exitCode.raise(1);
   }
 
-  await runLifecycleStep('reporter onTestRunEnd', () =>
-    notifyReportersOnTestRunEnd({
-      context,
-      coverage: isInterrupted() ? undefined : mergedCoverageMap,
-      duration,
-      getSourcemap,
-      unhandledErrors: errors,
-      // Only filter the failing-test summary in watch mode; a non-watch run
-      // surfaces every executor's failures (Appendix A bug 2).
-      filterRerunTestPaths:
-        isWatchMode && testPaths.length ? testPaths : undefined,
-    }),
-  );
+  if (reportersStarted) {
+    await runLifecycleStep('reporter onTestRunEnd', () =>
+      notifyReportersOnTestRunEnd({
+        context,
+        coverage: isInterrupted() ? undefined : mergedCoverageMap,
+        duration,
+        getSourcemap,
+        unhandledErrors: errors,
+        // Only filter the failing-test summary in watch mode; a non-watch run
+        // surfaces every executor's failures (Appendix A bug 2).
+        filterRerunTestPaths:
+          isWatchMode && testPaths.length ? testPaths : undefined,
+      }),
+    );
+  }
 
   const defersCoverageReport =
     coverageProvider?.supportsDeferredCoverageFinalization === true &&

--- a/packages/core/src/core/finalizeRun.ts
+++ b/packages/core/src/core/finalizeRun.ts
@@ -182,7 +182,7 @@ export async function finalizeRunCycle(
     outcomes,
     mode,
     isWatchMode,
-    interrupted = false,
+    isInterrupted = () => false,
     coverageProvider,
     reportOnFailure,
     traceRun,
@@ -190,7 +190,7 @@ export async function finalizeRunCycle(
     outcomes: ExecutorCycleOutcome[];
     mode: 'all' | 'on-demand';
     isWatchMode: boolean;
-    interrupted?: boolean;
+    isInterrupted?: () => boolean;
     coverageProvider: CoverageProvider | null;
     reportOnFailure: boolean;
     /**
@@ -222,7 +222,7 @@ export async function finalizeRunCycle(
   // `map` into the run's map, then resolve the concatenated v8 `raw` batches.
   // Each executor owns its own per-file merge (node in the pool, browser at
   // outcome assembly), so nothing is read off individual results here.
-  const mergedCoverageMap = interrupted
+  const mergedCoverageMap = isInterrupted()
     ? undefined
     : coverageProvider?.createCoverageMap();
   for (const outcome of outcomes) {
@@ -247,7 +247,7 @@ export async function finalizeRunCycle(
 
   const rawCoverageResults = outcomes.flatMap((o) => o.coverage?.raw ?? []);
   await resolveAndMergeRawCoverage({
-    coverageProvider: interrupted ? null : coverageProvider,
+    coverageProvider: isInterrupted() ? null : coverageProvider,
     mergedCoverageMap,
     rawCoverageResults,
     resolveOptions: {
@@ -284,7 +284,7 @@ export async function finalizeRunCycle(
     outcomes.flatMap((o) => o.deletedTestPaths ?? []),
   );
 
-  if (!interrupted && noTestsDiscovered) {
+  if (!isInterrupted() && noTestsDiscovered) {
     reportNoTestFiles({ context, mode });
   }
 
@@ -295,7 +295,7 @@ export async function finalizeRunCycle(
   await runLifecycleStep('reporter onTestRunEnd', () =>
     notifyReportersOnTestRunEnd({
       context,
-      coverage: mergedCoverageMap,
+      coverage: isInterrupted() ? undefined : mergedCoverageMap,
       duration,
       getSourcemap,
       unhandledErrors: errors,
@@ -314,25 +314,28 @@ export async function finalizeRunCycle(
   // reports, and thresholds belong to the merge-reports process that sees the
   // complete coverage map rather than to every partial shard.
   if (
-    !interrupted &&
+    !isInterrupted() &&
     coverageProvider &&
     !defersCoverageReport &&
     (!isFailure || reportOnFailure)
   ) {
     const { generateCoverage } = await import('../coverage/generate');
-    await runLifecycleStep('coverage report generation', () =>
-      generateCoverage(
-        context,
-        mergedCoverageMap!,
-        coverageProvider,
-        traceRun.span,
-      ),
+    await runLifecycleStep(
+      'coverage report generation',
+      async () =>
+        !isInterrupted() &&
+        generateCoverage(
+          context,
+          mergedCoverageMap!,
+          coverageProvider,
+          traceRun.span,
+        ),
     );
   }
 
   await runLifecycleStep('trace run finalize', () => traceRun.finalize());
 
-  if (!interrupted && isFailure) {
+  if (!isInterrupted() && isFailure) {
     const bail = context.normalizedConfig.bail;
     if (bail && context.stateManager.getCountOfFailedTests() >= bail) {
       logger.log(

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -289,9 +289,11 @@ export async function runTests(context: Rstest): Promise<void> {
           // Closing unblocks the cycle; its finalizer must finish before exit.
           await runFinished;
         }
-        await runLifecycleStep('trace run finalize', () =>
-          activeTraceRun.finalize(),
-        );
+        if (!isTeardown) {
+          await runLifecycleStep('trace run finalize', () =>
+            activeTraceRun.finalize(),
+          );
+        }
         await runLifecycleStep('trace controller cleanup', () =>
           traceController.close(),
         );
@@ -376,17 +378,22 @@ export async function runTests(context: Rstest): Promise<void> {
       // executor is still mid-cycle, truncating its tests and firing global
       // teardown early. The re-await unwraps the already-settled promises,
       // rejecting with the first failure in executor order.
-      const cyclePromises = executors.map((executor) =>
-        executor === browserExecutor && browserStage.errors.length
-          ? Promise.resolve(globalSetupFailureOutcome(browserStage.errors))
-          : executor.runCycle({
-              buildId: 1,
-              mode: 'all',
-              updateSnapshot: snapshotManager.options.updateSnapshot,
-              env: browserStage.env,
-              onTraceEvents: forwardBrowserTraceEvents,
-            }),
-      );
+      const cyclePromises =
+        signalExitCode === undefined
+          ? executors.map((executor) =>
+              executor === browserExecutor && browserStage.errors.length
+                ? Promise.resolve(
+                    globalSetupFailureOutcome(browserStage.errors),
+                  )
+                : executor.runCycle({
+                    buildId: 1,
+                    mode: 'all',
+                    updateSnapshot: snapshotManager.options.updateSnapshot,
+                    env: browserStage.env,
+                    onTraceEvents: forwardBrowserTraceEvents,
+                  }),
+            )
+          : [];
       const settledCycles = await Promise.allSettled(cyclePromises);
       const outcomes =
         signalExitCode === undefined
@@ -399,7 +406,7 @@ export async function runTests(context: Rstest): Promise<void> {
         outcomes,
         mode: 'all',
         isWatchMode: false,
-        interrupted: signalExitCode !== undefined,
+        isInterrupted: () => signalExitCode !== undefined,
         coverageProvider,
         reportOnFailure: coverage.reportOnFailure,
         traceRun: activeTraceRun,

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -359,24 +359,21 @@ export async function runTests(context: Rstest): Promise<void> {
           planner.getExecutorRunOptions(browserProjectsToRun),
         );
         executors.push(browserExecutor);
-        if (signalExitCode !== undefined) return;
-        await browserExecutor.init();
-        if (signalExitCode !== undefined) return;
+        if (signalExitCode === undefined) await browserExecutor.init();
         // Core-owned pre-cycle globalSetup stage over the resolved browser
         // subset. Its context-local env changes are visible to both the browser
         // cycle and node workers dispatched below.
-        browserStage = await runBrowserGlobalSetupStage(
-          context,
-          browserProjectsToRun,
-          { entriesCache: planner.getPlan().entriesCache },
-        );
+        if (signalExitCode === undefined) {
+          browserStage = await runBrowserGlobalSetupStage(
+            context,
+            browserProjectsToRun,
+            { entriesCache: planner.getPlan().entriesCache },
+          );
+        }
       }
 
-      // After the browser globalSetup stage, not before it: a setup that fails
-      // takes the run down before any reporter was told one started, which is
-      // the pairing every other shape already has.
-      if (signalExitCode !== undefined) return;
-      await notifyReportersOnTestRunStart(context);
+      const reportersStarted = signalExitCode === undefined;
+      if (reportersStarted) await notifyReportersOnTestRunStart(context);
       // Settle every cycle before propagating a failure: a fail-fast
       // `Promise.all` would reach the `finally` teardown while a sibling
       // executor is still mid-cycle, truncating its tests and firing global
@@ -411,6 +408,7 @@ export async function runTests(context: Rstest): Promise<void> {
         mode: 'all',
         isWatchMode: false,
         isInterrupted: () => signalExitCode !== undefined,
+        reportersStarted,
         coverageProvider,
         reportOnFailure: coverage.reportOnFailure,
         traceRun: activeTraceRun,

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -253,12 +253,9 @@ export async function runTests(context: Rstest): Promise<void> {
     // before user teardown starts, including on the signal path. The exit
     // handler is registered for non-embedded runs so a mid-run unexpected exit
     // prints and sets a failing code rather than ending quietly.
-    let didCloseExecutors = false;
-    const closeExecutors = async () => {
-      if (didCloseExecutors) {
-        return;
-      }
-      didCloseExecutors = true;
+    let closeExecutorsPromise: Promise<void> | undefined;
+    const closeExecutors = () => (closeExecutorsPromise ??= disposeExecutors());
+    const disposeExecutors = async () => {
       try {
         const closePromises = executors.map((executor) =>
           runLifecycleStep('executor cleanup', () => executor.close()),
@@ -273,6 +270,7 @@ export async function runTests(context: Rstest): Promise<void> {
       }
     };
 
+    let isInterrupted = false;
     let isTeardown = false;
     let isCleaningUp = false;
     const cleanup = async () => {
@@ -294,6 +292,7 @@ export async function runTests(context: Rstest): Promise<void> {
     };
 
     const unExpectedExit = (code?: number) => {
+      if (isInterrupted) return;
       if (isTeardown) {
         logger.log(
           color.yellow(
@@ -314,6 +313,7 @@ export async function runTests(context: Rstest): Promise<void> {
     };
 
     const handleSignal = async (signal: NodeJS.Signals) => {
+      isInterrupted = true;
       logger.log(color.yellow(`\nReceived ${signal}, cleaning up...`));
       await cleanup();
       process.exit(getSignalExitCode(signal));
@@ -370,6 +370,7 @@ export async function runTests(context: Rstest): Promise<void> {
             }),
       );
       await Promise.allSettled(cyclePromises);
+      if (isInterrupted) return;
       const outcomes = await Promise.all(cyclePromises);
 
       await finalizeRunCycle(context, {

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -270,7 +270,11 @@ export async function runTests(context: Rstest): Promise<void> {
       }
     };
 
-    let isInterrupted = false;
+    let signalExitCode: number | undefined;
+    let resolveRunFinished!: () => void;
+    const runFinished = new Promise<void>((resolve) => {
+      resolveRunFinished = resolve;
+    });
     let isTeardown = false;
     let isCleaningUp = false;
     const cleanup = async () => {
@@ -279,7 +283,12 @@ export async function runTests(context: Rstest): Promise<void> {
       }
       isCleaningUp = true;
       try {
-        await closeExecutors();
+        try {
+          await closeExecutors();
+        } finally {
+          // Closing unblocks the cycle; its finalizer must finish before exit.
+          await runFinished;
+        }
         await runLifecycleStep('trace run finalize', () =>
           activeTraceRun.finalize(),
         );
@@ -292,7 +301,14 @@ export async function runTests(context: Rstest): Promise<void> {
     };
 
     const unExpectedExit = (code?: number) => {
-      if (isInterrupted) return;
+      if (signalExitCode !== undefined) {
+        process.exitCode = Math.max(
+          Number(process.exitCode) || 0,
+          signalExitCode,
+          context.exitCode.current,
+        );
+        return;
+      }
       if (isTeardown) {
         logger.log(
           color.yellow(
@@ -313,10 +329,11 @@ export async function runTests(context: Rstest): Promise<void> {
     };
 
     const handleSignal = async (signal: NodeJS.Signals) => {
-      isInterrupted = true;
+      signalExitCode = getSignalExitCode(signal);
+      context.exitCode.raise(signalExitCode);
       logger.log(color.yellow(`\nReceived ${signal}, cleaning up...`));
       await cleanup();
-      process.exit(getSignalExitCode(signal));
+      process.exit(context.exitCode.current);
     };
 
     if (!context.embedded) {
@@ -352,6 +369,7 @@ export async function runTests(context: Rstest): Promise<void> {
       // After the browser globalSetup stage, not before it: a setup that fails
       // takes the run down before any reporter was told one started, which is
       // the pairing every other shape already has.
+      if (signalExitCode !== undefined) return;
       await notifyReportersOnTestRunStart(context);
       // Settle every cycle before propagating a failure: a fail-fast
       // `Promise.all` would reach the `finally` teardown while a sibling
@@ -369,14 +387,19 @@ export async function runTests(context: Rstest): Promise<void> {
               onTraceEvents: forwardBrowserTraceEvents,
             }),
       );
-      await Promise.allSettled(cyclePromises);
-      if (isInterrupted) return;
-      const outcomes = await Promise.all(cyclePromises);
+      const settledCycles = await Promise.allSettled(cyclePromises);
+      const outcomes =
+        signalExitCode === undefined
+          ? await Promise.all(cyclePromises)
+          : settledCycles.flatMap((cycle) =>
+              cycle.status === 'fulfilled' ? [cycle.value] : [],
+            );
 
       await finalizeRunCycle(context, {
         outcomes,
         mode: 'all',
         isWatchMode: false,
+        interrupted: signalExitCode !== undefined,
         coverageProvider,
         reportOnFailure: coverage.reportOnFailure,
         traceRun: activeTraceRun,
@@ -386,7 +409,9 @@ export async function runTests(context: Rstest): Promise<void> {
       try {
         await closeExecutors();
       } finally {
-        if (!context.embedded) {
+        resolveRunFinished();
+        if (signalExitCode !== undefined) context.exitCode.finishCycle();
+        if (!context.embedded && signalExitCode === undefined) {
           process.off('exit', unExpectedExit);
           for (const signal of FATAL_SIGNALS) {
             process.off(signal, handleSignal);
@@ -395,6 +420,7 @@ export async function runTests(context: Rstest): Promise<void> {
       }
     }
 
+    if (signalExitCode !== undefined) return;
     await runLifecycleStep('trace wait for exit', () =>
       traceController.waitForExit(),
     );

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -244,22 +244,20 @@ export async function runTests(context: Rstest): Promise<void> {
       ? [nodeExecutorToRun]
       : [];
 
-    // Single-exit-path rule: every executor closes through here exactly once
-    // (idempotent), so no early return or throw can reintroduce a #1363-class
-    // deferred-teardown hang. `executors` is read at close time, so the browser
-    // executor pushed inside the try below is covered — including when its own
-    // load/init fails with the node resources above already up.
-    //
-    // The run owns the shared globalSetup queue: every executor must close
-    // before user teardown starts, including on the signal path. The exit
-    // handler is registered for non-embedded runs so a mid-run unexpected exit
-    // prints and sets a failing code rather than ending quietly.
-    let closeExecutorsPromise: Promise<void> | undefined;
-    const closeExecutors = () => (closeExecutorsPromise ??= disposeExecutors());
-    const disposeExecutors = async () => {
-      const closePromises = executors.map((executor) =>
-        runLifecycleStep('executor cleanup', () => executor.close()),
-      );
+    // A signal can close existing executors while another is still loading.
+    // Memoize per executor so the final drain also closes late arrivals once.
+    const executorClosePromises = new Map<TestExecutor, Promise<void>>();
+    const closeExecutors = async () => {
+      const closePromises = executors.map((executor) => {
+        let promise = executorClosePromises.get(executor);
+        if (!promise) {
+          promise = runLifecycleStep('executor cleanup', () =>
+            executor.close(),
+          );
+          executorClosePromises.set(executor, promise);
+        }
+        return promise;
+      });
       await Promise.allSettled(closePromises);
       await Promise.all(closePromises);
     };
@@ -328,7 +326,14 @@ export async function runTests(context: Rstest): Promise<void> {
       signalExitCode = getSignalExitCode(signal);
       context.exitCode.raise(signalExitCode);
       for (const reporter of context.reporters) {
-        if (reporter instanceof BlobReporter) reporter.cancel();
+        if (reporter instanceof BlobReporter) {
+          try {
+            reporter.cancel();
+          } catch (error) {
+            // Invalidation must not prevent executor and global teardown.
+            logger.warn(`Failed to remove cancelled blob report: ${error}`);
+          }
+        }
       }
       logger.log(color.yellow(`\nReceived ${signal}, cleaning up...`));
       await cleanup();
@@ -354,7 +359,9 @@ export async function runTests(context: Rstest): Promise<void> {
           planner.getExecutorRunOptions(browserProjectsToRun),
         );
         executors.push(browserExecutor);
+        if (signalExitCode !== undefined) return;
         await browserExecutor.init();
+        if (signalExitCode !== undefined) return;
         // Core-owned pre-cycle globalSetup stage over the resolved browser
         // subset. Its context-local env changes are visible to both the browser
         // cycle and node workers dispatched below.

--- a/packages/core/src/core/runTests.ts
+++ b/packages/core/src/core/runTests.ts
@@ -1,3 +1,4 @@
+import { BlobReporter } from '../reporter/blob';
 import {
   cleanCoverageReports,
   createCoverageProviderWithLog,
@@ -256,18 +257,11 @@ export async function runTests(context: Rstest): Promise<void> {
     let closeExecutorsPromise: Promise<void> | undefined;
     const closeExecutors = () => (closeExecutorsPromise ??= disposeExecutors());
     const disposeExecutors = async () => {
-      try {
-        const closePromises = executors.map((executor) =>
-          runLifecycleStep('executor cleanup', () => executor.close()),
-        );
-        await Promise.allSettled(closePromises);
-        await Promise.all(closePromises);
-      } finally {
-        // User teardown must still run when an executor close throws.
-        await runLifecycleStep('global teardown', () =>
-          runGlobalTeardown(context),
-        );
-      }
+      const closePromises = executors.map((executor) =>
+        runLifecycleStep('executor cleanup', () => executor.close()),
+      );
+      await Promise.allSettled(closePromises);
+      await Promise.all(closePromises);
     };
 
     let signalExitCode: number | undefined;
@@ -333,6 +327,9 @@ export async function runTests(context: Rstest): Promise<void> {
     const handleSignal = async (signal: NodeJS.Signals) => {
       signalExitCode = getSignalExitCode(signal);
       context.exitCode.raise(signalExitCode);
+      for (const reporter of context.reporters) {
+        if (reporter instanceof BlobReporter) reporter.cancel();
+      }
       logger.log(color.yellow(`\nReceived ${signal}, cleaning up...`));
       await cleanup();
       process.exit(context.exitCode.current);
@@ -414,7 +411,15 @@ export async function runTests(context: Rstest): Promise<void> {
       isTeardown = true;
     } finally {
       try {
-        await closeExecutors();
+        try {
+          await closeExecutors();
+        } finally {
+          // Setup can register teardown until the active run settles. The
+          // signal path closes executors early but must not drain this queue.
+          await runLifecycleStep('global teardown', () =>
+            runGlobalTeardown(context),
+          );
+        }
       } finally {
         resolveRunFinished();
         if (signalExitCode !== undefined) context.exitCode.finishCycle();

--- a/packages/core/src/pool/index.ts
+++ b/packages/core/src/pool/index.ts
@@ -512,7 +512,7 @@ export const createPool = async ({
       // pipelined, only the enqueue is serialized.
       let dispatchGate: Promise<void> = Promise.resolve();
 
-      const results = await Promise.all(
+      const dispatchedResults = await Promise.all(
         entries.map(async (entryInfo, index) => {
           const gate = dispatchGate;
           let releaseGate!: () => void;
@@ -521,6 +521,7 @@ export const createPool = async ({
           });
 
           try {
+            if (pool.closing) return;
             const traceArgs = {
               project: projectName,
               testPath: entryInfo.testPath,
@@ -557,6 +558,7 @@ export const createPool = async ({
             );
 
             await gate;
+            if (pool.closing) return;
             // `pool.runTest` claims a slot (or parks in `slotWaiters`)
             // synchronously before its first await, and `traceSpan` invokes
             // its callback synchronously, so releasing after this returns
@@ -570,6 +572,9 @@ export const createPool = async ({
             releaseGate();
 
             const result = await resultPromise.catch(async (err: unknown) => {
+              // Closing deliberately rejects queued and running tasks. They
+              // must not become worker-crash results during cancellation.
+              if (pool.closing) return;
               const { fileResult, crashedResults } = workerErrorToResult(
                 err,
                 entryInfo.testPath,
@@ -591,6 +596,8 @@ export const createPool = async ({
               }
               return fileResult;
             });
+
+            if (!result || pool.closing) return;
 
             if (result.coverage) {
               onCoverageResult?.(result.coverage);
@@ -625,6 +632,9 @@ export const createPool = async ({
         }),
       );
 
+      const results = dispatchedResults.filter(
+        (result) => result !== undefined,
+      );
       const fileResults = results.map(({ result }) => result);
       const testResults = fileResults.flatMap((r) => r.results);
 

--- a/packages/core/src/pool/pool.ts
+++ b/packages/core/src/pool/pool.ts
@@ -41,6 +41,10 @@ export class Pool {
   private isClosing = false;
   private isClosed = false;
 
+  get closing(): boolean {
+    return this.isClosing;
+  }
+
   constructor(options: PoolOptions) {
     this.options = options;
   }

--- a/packages/core/src/reporter/blob.ts
+++ b/packages/core/src/reporter/blob.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'pathe';
 import type { RunnerLifecycleEvent } from '../core/runnerEventSink';
 import type {
@@ -115,6 +115,7 @@ export class BlobReporter implements Reporter {
 
   private readonly config: NormalizedConfig;
   private readonly outputDir: string;
+  private cancelled = false;
   // One track per file, for a single one-shot run: watch mode is rejected at
   // reporter construction (`rstest.ts`), so no track ever spans two cycles.
   private readonly files = new Map<string, BlobFileData>();
@@ -190,6 +191,13 @@ export class BlobReporter implements Reporter {
     return data;
   }
 
+  cancel(): void {
+    this.cancelled = true;
+    rmSync(join(this.outputDir, blobFileName(this.config.shard)), {
+      force: true,
+    });
+  }
+
   async onTestRunEnd({
     results,
     coverage,
@@ -205,6 +213,7 @@ export class BlobReporter implements Reporter {
     snapshotSummary: SnapshotSummary;
     unhandledErrors?: Error[];
   }): Promise<void> {
+    if (this.cancelled) return;
     const shard = this.config.shard;
     const fileName = blobFileName(shard);
 

--- a/packages/core/tests/core/finalizeRun.test.ts
+++ b/packages/core/tests/core/finalizeRun.test.ts
@@ -7,9 +7,10 @@ import type { CoverageMap, CoverageProvider } from '../../src/types/coverage';
 import { noopTraceSpan } from '../../src/utils';
 
 describe('finalizeRunCycle', () => {
-  it.for([false, true])(
-    'finalizes blob runs with interruption %s',
-    async (interrupted) => {
+  it.for(['none', 'before', 'reporter', 'raw'])(
+    'finalizes blob runs with interruption at %s',
+    async (phase) => {
+      let interrupted = phase === 'before';
       const generatedReports: number[] = [];
       const coverageMap: CoverageMap = {
         data: {},
@@ -28,6 +29,14 @@ describe('finalizeRunCycle', () => {
       const coverageProvider = {
         init() {},
         collect: () => null,
+        async resolveRawCoverage() {
+          if (phase === 'raw') {
+            await Promise.resolve();
+            interrupted = true;
+            context.exitCode.raise(130);
+          }
+          return null;
+        },
         createCoverageMap: () => coverageMap,
         generateCoverageForUntestedFiles: async () => [],
         async generateReports() {
@@ -38,7 +47,13 @@ describe('finalizeRunCycle', () => {
       const blobReporter = Object.create(
         BlobReporter.prototype,
       ) as BlobReporter;
-      blobReporter.onTestRunEnd = rs.fn(async () => {});
+      blobReporter.onTestRunEnd = rs.fn(async () => {
+        if (phase === 'reporter') {
+          await Promise.resolve();
+          interrupted = true;
+          context.exitCode.raise(130);
+        }
+      });
       const finalizeTrace = rs.fn(async () => {});
 
       const context = {
@@ -55,10 +70,19 @@ describe('finalizeRunCycle', () => {
 
       if (interrupted) context.exitCode.raise(130);
       await finalizeRunCycle(context, {
-        outcomes: [],
+        outcomes: [
+          {
+            results: [],
+            testResults: [],
+            errors: [],
+            testPaths: [],
+            duration: { buildTime: 0, testTime: 0 },
+            coverage: { raw: [{}] },
+          },
+        ],
         mode: 'all',
         isWatchMode: false,
-        interrupted,
+        isInterrupted: () => interrupted,
         coverageProvider,
         reportOnFailure: false,
         traceRun: {

--- a/packages/core/tests/core/finalizeRun.test.ts
+++ b/packages/core/tests/core/finalizeRun.test.ts
@@ -7,10 +7,10 @@ import type { CoverageMap, CoverageProvider } from '../../src/types/coverage';
 import { noopTraceSpan } from '../../src/utils';
 
 describe('finalizeRunCycle', () => {
-  it.for(['none', 'before', 'reporter', 'raw'])(
+  it.for(['none', 'pre-start', 'before', 'reporter', 'raw'])(
     'finalizes blob runs with interruption at %s',
     async (phase) => {
-      let interrupted = phase === 'before';
+      let interrupted = phase === 'before' || phase === 'pre-start';
       const generatedReports: number[] = [];
       const coverageMap: CoverageMap = {
         data: {},
@@ -65,7 +65,7 @@ describe('finalizeRunCycle', () => {
         reporterResults: { results: [], testResults: [] },
         snapshotManager: { summary: {} },
         exitCode: createExitCode(),
-        updateReporterResultState() {},
+        updateReporterResultState: rs.fn(),
       } as unknown as InternalContext;
 
       if (interrupted) context.exitCode.raise(130);
@@ -83,6 +83,7 @@ describe('finalizeRunCycle', () => {
         mode: 'all',
         isWatchMode: false,
         isInterrupted: () => interrupted,
+        reportersStarted: phase !== 'pre-start',
         coverageProvider,
         reportOnFailure: false,
         traceRun: {
@@ -93,7 +94,10 @@ describe('finalizeRunCycle', () => {
       });
 
       expect(generatedReports).toEqual(interrupted ? [] : [1]);
-      expect(blobReporter.onTestRunEnd).toHaveBeenCalledTimes(1);
+      expect(blobReporter.onTestRunEnd).toHaveBeenCalledTimes(
+        phase === 'pre-start' ? 0 : 1,
+      );
+      expect(context.updateReporterResultState).toHaveBeenCalledTimes(1);
       expect(finalizeTrace).toHaveBeenCalledTimes(1);
       expect(context.exitCode.current).toBe(interrupted ? 130 : 0);
     },

--- a/packages/core/tests/core/finalizeRun.test.ts
+++ b/packages/core/tests/core/finalizeRun.test.ts
@@ -7,60 +7,71 @@ import type { CoverageMap, CoverageProvider } from '../../src/types/coverage';
 import { noopTraceSpan } from '../../src/utils';
 
 describe('finalizeRunCycle', () => {
-  it('finalizes blob coverage for providers without deferred finalization support', async () => {
-    const generatedReports: number[] = [];
-    const coverageMap: CoverageMap = {
-      data: {},
-      addFileCoverage() {},
-      files: () => [],
-      fileCoverageFor() {
-        throw new Error('No file coverage');
-      },
-      filter() {},
-      getCoverageSummary() {
-        throw new Error('No coverage summary');
-      },
-      merge() {},
-      toJSON: () => ({}),
-    };
-    const coverageProvider = {
-      init() {},
-      collect: () => null,
-      createCoverageMap: () => coverageMap,
-      generateCoverageForUntestedFiles: async () => [],
-      async generateReports() {
-        generatedReports.push(1);
-      },
-      cleanup() {},
-    } satisfies CoverageProvider;
-    const blobReporter = Object.create(BlobReporter.prototype) as BlobReporter;
-    blobReporter.onTestRunEnd = async () => {};
+  it.for([false, true])(
+    'finalizes blob runs with interruption %s',
+    async (interrupted) => {
+      const generatedReports: number[] = [];
+      const coverageMap: CoverageMap = {
+        data: {},
+        addFileCoverage() {},
+        files: () => [],
+        fileCoverageFor() {
+          throw new Error('No file coverage');
+        },
+        filter() {},
+        getCoverageSummary() {
+          throw new Error('No coverage summary');
+        },
+        merge() {},
+        toJSON: () => ({}),
+      };
+      const coverageProvider = {
+        init() {},
+        collect: () => null,
+        createCoverageMap: () => coverageMap,
+        generateCoverageForUntestedFiles: async () => [],
+        async generateReports() {
+          generatedReports.push(1);
+        },
+        cleanup() {},
+      } satisfies CoverageProvider;
+      const blobReporter = Object.create(
+        BlobReporter.prototype,
+      ) as BlobReporter;
+      blobReporter.onTestRunEnd = rs.fn(async () => {});
+      const finalizeTrace = rs.fn(async () => {});
 
-    const context = {
-      command: 'run',
-      rootPath: process.cwd(),
-      normalizedConfig: withDefaultConfig({ passWithNoTests: true }),
-      projects: [],
-      reporters: [blobReporter],
-      reporterResults: { results: [], testResults: [] },
-      snapshotManager: { summary: {} },
-      exitCode: createExitCode(),
-      updateReporterResultState() {},
-    } as unknown as InternalContext;
+      const context = {
+        command: 'run',
+        rootPath: process.cwd(),
+        normalizedConfig: withDefaultConfig({ passWithNoTests: true }),
+        projects: [],
+        reporters: [blobReporter],
+        reporterResults: { results: [], testResults: [] },
+        snapshotManager: { summary: {} },
+        exitCode: createExitCode(),
+        updateReporterResultState() {},
+      } as unknown as InternalContext;
 
-    await finalizeRunCycle(context, {
-      outcomes: [],
-      mode: 'all',
-      isWatchMode: false,
-      coverageProvider,
-      reportOnFailure: false,
-      traceRun: {
-        onEvents: undefined,
-        span: noopTraceSpan,
-        finalize: async () => {},
-      },
-    });
+      if (interrupted) context.exitCode.raise(130);
+      await finalizeRunCycle(context, {
+        outcomes: [],
+        mode: 'all',
+        isWatchMode: false,
+        interrupted,
+        coverageProvider,
+        reportOnFailure: false,
+        traceRun: {
+          onEvents: undefined,
+          span: noopTraceSpan,
+          finalize: finalizeTrace,
+        },
+      });
 
-    expect(generatedReports).toEqual([1]);
-  });
+      expect(generatedReports).toEqual(interrupted ? [] : [1]);
+      expect(blobReporter.onTestRunEnd).toHaveBeenCalledTimes(1);
+      expect(finalizeTrace).toHaveBeenCalledTimes(1);
+      expect(context.exitCode.current).toBe(interrupted ? 130 : 0);
+    },
+  );
 });

--- a/packages/core/tests/reporter/blob.test.ts
+++ b/packages/core/tests/reporter/blob.test.ts
@@ -1,6 +1,12 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { withDefaultConfig } from '../../src/config';
+import { emptyDuration, emptySnapshotSummary } from './helpers';
 import { describe, expect, it } from '@rstest/core';
 import {
   BLOB_TRACK_MATCHES_RUNNER_EVENTS,
+  BlobReporter,
   blobFileName,
   isBlobFile,
   parseBlobFile,
@@ -44,4 +50,38 @@ describe('blob wire-format', () => {
     expect(isBlobFile('prefix-blob.json')).toBe(false);
     expect(isBlobFile('blob-a-b.json')).toBe(false);
   });
+});
+
+describe('blob cancellation', () => {
+  it.for([false, true])(
+    'invalidates only its shard (already written: %s)',
+    async (alreadyWritten, { onTestFinished }) => {
+      const rootPath = mkdtempSync(join(tmpdir(), 'rstest-blob-cancel-'));
+      onTestFinished(() => rmSync(rootPath, { recursive: true, force: true }));
+      const reporter = new BlobReporter({
+        rootPath,
+        config: { ...withDefaultConfig({}), shard: { index: 1, count: 2 } },
+      });
+      const sibling = new BlobReporter({
+        rootPath,
+        config: { ...withDefaultConfig({}), shard: { index: 2, count: 2 } },
+      });
+      const result = {
+        results: [],
+        testResults: [],
+        duration: emptyDuration,
+        snapshotSummary: emptySnapshotSummary,
+      };
+      await sibling.onTestRunEnd(result);
+      if (alreadyWritten) await reporter.onTestRunEnd(result);
+      const path = join(rootPath, '.rstest-reports', 'blob-1-2.json');
+      expect(existsSync(path)).toBe(alreadyWritten);
+      reporter.cancel();
+      await reporter.onTestRunEnd(result);
+      expect(existsSync(path)).toBe(false);
+      expect(
+        existsSync(join(rootPath, '.rstest-reports', 'blob-2-2.json')),
+      ).toBe(true);
+    },
+  );
 });


### PR DESCRIPTION
## Motivation

Ctrl+C during a run reports queued files as `[rstest-pool]: pool is closed` and marks the active test as a worker failure. Reported in https://github.com/web-infra-dev/rstest/issues/767#issuecomment-5614085091.

## Changes

Stop dispatching and reporting cancelled Node pool tasks, and avoid caching incomplete results. Recheck interruption after asynchronous run-start hooks. Interrupted runs still use the shared finalizer and complete ordinary reporter lifecycle callbacks, with live checks suppressing subsequent no-tests diagnostics and coverage generation. Trace output is finalized once, and signal exit codes survive host teardown hooks calling `process.exit(0)`.

Close executors early on interruption, but drain global teardowns only after the active run has settled so in-flight Node/browser setup workers can register cleanup. Cancelled blob reporters suppress new output and remove their own shard file if already written, leaving other shards untouched.

Already-running reporter/provider callbacks complete normally; cancellation does not forcibly interrupt user callbacks. The reported 30-second delay was not reproduced, so this PR makes no speedup claim. No public API changes.

Validation: 38 global-setup/node-pool/trace/browser e2e tests and 12 blob/finalizer unit tests pass. Coverage includes cancellation during setup, run-start, tests, and run-end; asynchronous reporter completion; early cleanup exits; single trace output; coverage suppression; and removal of cancelled blob artifacts. The review scenarios were observed failing before their fixes. Build and typecheck pass. `check-unused` reports nine files in three unrelated, untracked Playwright temporary directories, excluded from this PR.