### PR TITLE
fix(core): handle cross-realm constructors in toStrictEqual

### DIFF
--- a/e2e/node-pool/fixtures/test/basic.test.ts
+++ b/e2e/node-pool/fixtures/test/basic.test.ts
@@ -34,6 +34,14 @@ describe('node pool - basic', () => {
     ]);
   });
 
+  it('strictly equals built-ins created in the host realm', () => {
+    expect(new URLSearchParams('a=1').getAll('a')).toStrictEqual(['1']);
+    expect(new TextEncoder().encodeInto('a', new Uint8Array(1))).toStrictEqual({
+      read: 1,
+      written: 1,
+    });
+  });
+
   it('matches VM-realm constructors in asymmetric matchers', () => {
     expect('value').toEqual(expect.any(String));
     expect(42).toEqual(expect.any(Number));

--- a/packages/core/src/runtime/api/expect.ts
+++ b/packages/core/src/runtime/api/expect.ts
@@ -20,15 +20,22 @@
 import {
   ASYMMETRIC_MATCHERS_OBJECT,
   addCustomEqualityTesters,
+  arrayBufferEquality,
   ChaiStyleAssertions,
   type ChaiPlugin,
   customMatchers,
+  equals,
   GLOBAL_EXPECT,
   getState,
+  iterableEquality,
+  JEST_MATCHERS_OBJECT,
   JestAsymmetricMatchers,
   JestChaiExpect,
   JestExtend,
   setState,
+  sparseArrayEquality,
+  typeEquality,
+  wrapAssertion,
 } from '@vitest/expect';
 import {
   assert,
@@ -174,12 +181,67 @@ const CrossRealmToThrow: ChaiPlugin = (chai, utils) => {
   utils.overwriteMethod(chai.Assertion.prototype, 'toThrowError', overwrite);
 };
 
+const isNativeFunction = (fn: unknown): boolean =>
+  typeof fn === 'function' &&
+  Function.prototype.toString.call(fn).includes('[native code]');
+
+// `typeEquality` compares constructors, which differ across realms: host APIs
+// such as `URLSearchParams#getAll()` and `TextEncoder#encodeInto()` return
+// values built with host constructors. Like Jest, treat two arrays, or two
+// native built-ins with the same constructor name, as the same type. User
+// classes still need identity.
+// https://github.com/jestjs/jest/issues/2549
+// https://github.com/jestjs/jest/pull/15959
+const crossRealmTypeEquality: typeof typeEquality = (a, b) =>
+  (Array.isArray(a) && Array.isArray(b)) ||
+  (a?.constructor?.name === b?.constructor?.name &&
+    isNativeFunction(a?.constructor) &&
+    isNativeFunction(b?.constructor))
+    ? undefined
+    : typeEquality(a, b);
+
+// Keep in sync with `toStrictEqual` in `@vitest/expect`'s `JestChaiExpect`.
+const CrossRealmToStrictEqual: ChaiPlugin = (chai, utils) => {
+  const { customEqualityTesters, matchers } = (globalThis as any)[
+    JEST_MATCHERS_OBJECT
+  ];
+  const toStrictEqual = wrapAssertion(
+    utils,
+    'toStrictEqual',
+    function (expected: unknown) {
+      const actual = utils.flag(this, 'object');
+      const pass = equals(
+        actual,
+        expected,
+        [
+          ...customEqualityTesters,
+          iterableEquality,
+          crossRealmTypeEquality,
+          sparseArrayEquality,
+          arrayBufferEquality,
+        ],
+        true,
+      );
+      return this.assert(
+        pass,
+        'expected #{this} to strictly equal #{exp}',
+        'expected #{this} to not strictly equal #{exp}',
+        expected,
+        actual,
+      );
+    },
+  );
+  utils.addMethod(chai.Assertion.prototype, 'toStrictEqual', toStrictEqual);
+  utils.addMethod(matchers, 'toStrictEqual', toStrictEqual);
+};
+
 // These plugins mutate Chai's process-level prototype, not an expect instance.
 use(JestExtend);
 use(JestChaiExpect);
 use(ChaiStyleAssertions);
 use(ReturnedAlias);
 use(CrossRealmToThrow);
+use(CrossRealmToStrictEqual);
 use(JestAsymmetricMatchers);
 
 export function createExpect({

--- a/packages/core/tests/runtime/api/expect.test.ts
+++ b/packages/core/tests/runtime/api/expect.test.ts
@@ -70,6 +70,23 @@ it('keeps toThrow promise-aware for regular and cross-realm regexps', async () =
   );
 });
 
+it('treats cross-realm built-ins as the same type in toStrictEqual', () => {
+  publishFile('/f1', 't1');
+  const fileExpect = createFileExpect(() => {});
+  class Point {
+    x = 1;
+  }
+
+  fileExpect(vm.runInNewContext("['1']")).toStrictEqual(['1']);
+  fileExpect(vm.runInNewContext('({ x: 1 })')).toStrictEqual({ x: 1 });
+  fileExpect(vm.runInNewContext("[, '1']")).not.toStrictEqual([undefined, '1']);
+  fileExpect(
+    vm.runInNewContext('new (class Point { x = 1 })()'),
+  ).not.toStrictEqual(new Point());
+  fileExpect(new Point()).not.toStrictEqual({ x: 1 });
+  fileExpect({ x: undefined }).not.toStrictEqual({});
+});
+
 /**
  * Regression for https://github.com/web-infra-dev/rstest/issues/1376: the
  * file-level `expect` is a build-once singleton, so a reference (or a


### PR DESCRIPTION
## Motivation

Under `vmThreads` and `vmForks`, `toStrictEqual` fails on values that come from another realm, with "Compared values have no visual difference". Host APIs create such values: `URLSearchParams#getAll()` returns a host `Array`, and `TextEncoder#encodeInto()` returns a host `Object`. On the 2725-file suite from #767, on `73725ba`, this is the last cross-realm class left: 12 files and 65 tests. The same files pass under `forks`.

```ts
it('values from the host realm', () => {
  expect(new URLSearchParams('a=1').getAll('a')).toStrictEqual(['1']);
  expect(new TextEncoder().encodeInto('a', new Uint8Array(1))).toStrictEqual({
    read: 1,
    written: 1,
  });
});
```

`@vitest/expect`'s `typeEquality` returns `false` when `a.constructor !== b.constructor`, and a value from another realm has different built-in constructors. Jest treats two arrays as the same type (jestjs/jest#2549), and two native built-ins with the same constructor name as the same type (jestjs/jest#15959). User classes still need identity. The gap also exists outside VM pools: `expect(vm.runInNewContext("['1']")).toStrictEqual(['1'])` fails under `forks`.

## Changes

- Add a `CrossRealmToStrictEqual` Chai plugin in `runtime/api/expect.ts`, next to `CrossRealmToThrow`. It redefines `toStrictEqual` the way `JestChaiExpect` does, with the same testers from `@vitest/expect`, but with a `typeEquality` that follows Jest's two cross-realm rules. It wraps the matcher with `wrapAssertion`, so `expect.soft` keeps working. No patch of `@vitest/expect` is needed.
- Add a unit test in `tests/runtime/api/expect.test.ts`. A cross-realm array and a cross-realm plain object strictly equal their literals. The matcher stays strict: a cross-realm sparse array, a same-name user class from another realm, a class instance, and an `undefined` property still fail. Each assertion fails when its part of the matcher is removed.
- Extend the node-pool e2e fixture, which runs on `threads`, `vmThreads` and `vmForks`, with both host-realm values.

Not covered: Jest applies the same constructor-name rule inside `iterableEquality`, which covers cross-realm `Map` and `Set`. In `@vitest/expect`, `toEqual`, `toStrictEqual`, `toMatchObject` and the call-argument matchers call that module-private tester directly, so it belongs in Vitest's `jest-utils.ts`, not in a plugin here.
