### PR TITLE
fix(browser): apply the node pool's watch ignore rules

### DIFF
--- a/packages/browser/src/browserRsbuild.ts
+++ b/packages/browser/src/browserRsbuild.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
 import type { Rspack } from '@rstest/core';
 import {
+  applyRstestWatchIgnored,
   applyWatchInvalidation,
   applyWebMockRspackConfig,
   color,
@@ -309,16 +310,10 @@ export const mapViewportByProject = (
   return map;
 };
 
-const castArray = <T>(arr?: T | T[]): T[] => {
-  if (arr === undefined) {
-    return [];
-  }
-  return Array.isArray(arr) ? arr : [arr];
-};
-
 const applyDefaultWatchOptions = (
   rspackConfig: Rspack.Configuration,
   isWatchMode: boolean,
+  config: InternalContext['normalizedConfig'],
 ) => {
   rspackConfig.watchOptions ??= {};
 
@@ -327,17 +322,11 @@ const applyDefaultWatchOptions = (
     return;
   }
 
-  rspackConfig.watchOptions.ignored = castArray(
-    rspackConfig.watchOptions.ignored || [],
-  ) as string[];
-
-  if (rspackConfig.watchOptions.ignored.length === 0) {
-    rspackConfig.watchOptions.ignored.push('**/.git', '**/node_modules');
-  }
-
-  if (rspackConfig.output?.path) {
-    rspackConfig.watchOptions.ignored.push(rspackConfig.output.path);
-  }
+  applyRstestWatchIgnored(
+    rspackConfig,
+    config,
+    rspackConfig.output?.path ? [rspackConfig.output.path] : [],
+  );
 };
 
 type LazyCompilationModule = {
@@ -1780,7 +1769,11 @@ export const createBrowserRuntime = async ({
                         });
                       }
 
-                      applyDefaultWatchOptions(rspackConfig, isWatchMode);
+                      applyDefaultWatchOptions(
+                        rspackConfig,
+                        isWatchMode,
+                        context.normalizedConfig,
+                      );
                     },
                   },
                 },

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -50,6 +50,7 @@ export { logWatchReadyMessage } from './core/cliShortcuts';
 // so the browser watch plugin applies the same rerun rules as the node
 // dev-compile pipeline, with baselines keyed per project.
 export {
+  applyRstestWatchIgnored,
   applyWatchInvalidation,
   type EntryHashSnapshot,
   type WatchInvalidationState,

--- a/packages/core/src/core/plugins/entry.ts
+++ b/packages/core/src/core/plugins/entry.ts
@@ -1,7 +1,7 @@
 import { rspack, type RsbuildPlugin, type Rspack } from '@rsbuild/core';
 import path from 'pathe';
 import type { InternalContext } from '../../types';
-import { castArray, getTempRstestOutputDirGlob } from '../../utils';
+import { applyRstestWatchIgnored } from '../watchInvalidation';
 import type { TestEntryPathState } from './moduleCacheControl';
 
 class TestFileWatchPlugin {
@@ -48,7 +48,6 @@ export const pluginEntryWatch: (params: {
 }) => ({
   name: 'rstest:entry-watch',
   setup: (api) => {
-    const outputDistPathRoot = context.normalizedConfig.output.distPath.root;
     const getSourceEntries = async (environmentName: string) => {
       const sourceEntries = await globTestSourceEntries(environmentName);
       if (testEntryPathState) {
@@ -84,36 +83,19 @@ export const pluginEntryWatch: (params: {
           };
         };
 
-        config.watchOptions ??= {};
-        config.watchOptions.aggregateTimeout = 100;
-        // TODO: rspack should support `(string | RegExp)[]` type
-        // https://github.com/web-infra-dev/rspack/issues/10596
-        config.watchOptions.ignored = castArray(
-          config.watchOptions.ignored || [],
-        ) as string[];
-
-        if (config.watchOptions.ignored.length === 0) {
-          config.watchOptions.ignored.push(
-            // apply default ignored patterns
-            ...['**/.git', '**/node_modules'],
-          );
-        }
-
-        config.watchOptions.ignored.push(
-          getTempRstestOutputDirGlob(outputDistPathRoot),
-          context.normalizedConfig.coverage.reportsDirectory,
-          '**/*.snap',
-        );
-
-        config.experiments ??= {};
-        config.experiments.nativeWatcher ??= true;
         const configFilePath = context.projects.find(
           (project) => project.environmentName === environment.name,
         )?.configFilePath;
 
-        if (configFilePath) {
-          config.watchOptions.ignored.push(configFilePath);
-        }
+        config.watchOptions = { ...config.watchOptions, aggregateTimeout: 100 };
+        applyRstestWatchIgnored(
+          config,
+          context.normalizedConfig,
+          configFilePath ? [configFilePath] : [],
+        );
+
+        config.experiments ??= {};
+        config.experiments.nativeWatcher ??= true;
       } else {
         // watch false seems not effect when rspack.watch()
         config.watch = false;

--- a/packages/core/src/core/watchInvalidation.ts
+++ b/packages/core/src/core/watchInvalidation.ts
@@ -4,12 +4,37 @@
  * (hostController). Callers translate their compiler stats into per-entry
  * chunk-hash snapshots; this module owns the diff and the
  * setup-change => rerun-all rule.
+ * It also owns the default watchOptions.ignored set both pools apply.
  *
  * Baselines are keyed per project/environment by the caller — one mutable
  * state handle per key, never one per executor — so sibling projects with
  * separate compilers cannot clobber each other's baselines or collide on
  * compiler-local chunk keys.
  */
+
+import type { Rspack } from '@rsbuild/core';
+import type { NormalizedConfig } from '../types';
+import { castArray, getTempRstestOutputDirGlob } from '../utils';
+
+export const applyRstestWatchIgnored = (
+  rspackConfig: Rspack.Configuration,
+  config: NormalizedConfig,
+  extraIgnored: string[] = [],
+): void => {
+  // TODO: rspack should support `(string | RegExp)[]` type
+  // https://github.com/web-infra-dev/rspack/issues/10596
+  const existing = castArray(rspackConfig.watchOptions?.ignored) as string[];
+  rspackConfig.watchOptions = {
+    ...rspackConfig.watchOptions,
+    ignored: [
+      ...(existing.length ? existing : ['**/.git', '**/node_modules']),
+      getTempRstestOutputDirGlob(config.output.distPath.root),
+      config.coverage.reportsDirectory,
+      '**/*.snap',
+      ...extraIgnored,
+    ],
+  };
+};
 
 /** Chunk hashes for one entry: stable chunk key -> chunk hash. */
 export type EntryChunkHashes = Record<string, string>;


### PR DESCRIPTION
## Summary

The browser watcher did not ignore rstest's own writes, so a snapshot update, a coverage report, or the `DEBUG=rstest` config dump could retrigger a build during a watch session. The node pool already ignores these paths; the two lists had drifted.

`applyRstestWatchIgnored` in core now owns the default `watchOptions.ignored` set (`.git` and `node_modules` when nothing is configured, the rstest temp output root, the coverage reports directory, `*.snap`) and both pools apply it. Node adds its config file and browser adds its per-project output path through the same call, so the next rstest-owned path only has to be added once.

Readiness of the first browser watch cycle is handled by #1828, which this PR is rebased on.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
