### PR TITLE
chore(deps): upgrade Rsbuild to 2.2.5

### DIFF
--- a/e2e/dom/fixtures/package.json
+++ b/e2e/dom/fixtures/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@module-federation/rstest": "2.9.0",
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "~1.0.0",
     "@rstest/browser": "workspace:*",

--- a/e2e/playwright/fixtures/package.json
+++ b/e2e/playwright/fixtures/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rstest/core": "workspace:*",
     "@rstest/playwright": "workspace:*",
     "playwright": "^1.63.0"

--- a/e2e/projects/fixtures/packages/client-vue/package.json
+++ b/e2e/projects/fixtures/packages/client-vue/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.42"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@rstest/core": "workspace:*",
     "@vue/compiler-dom": "^3.5.42",

--- a/e2e/projects/fixtures/packages/client/package.json
+++ b/e2e/projects/fixtures/packages/client/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/e2e/vue/fixtures/package.json
+++ b/e2e/vue/fixtures/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.42"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@rsbuild/plugin-vue-jsx": "^2.0.1",

--- a/examples/federation/component-app/package.json
+++ b/examples/federation/component-app/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "2.9.0",
     "@module-federation/rstest": "2.9.0",
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/core": "workspace:*",
     "concurrently": "8.2.2",

--- a/examples/federation/main-app/package.json
+++ b/examples/federation/main-app/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "2.9.0",
     "@module-federation/rstest": "2.9.0",
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/browser": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/examples/federation/node-local-remote/package.json
+++ b/examples/federation/node-local-remote/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "2.9.0",
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "serve": "14.2.6"
   }
 }

--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rstest/core": "workspace:*",
     "@rstest/playwright": "workspace:*",
     "playwright": "^1.63.0",

--- a/examples/react-rsbuild/package.json
+++ b/examples/react-rsbuild/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/adapter-rsbuild": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/core": "workspace:*",
     "@testing-library/dom": "^10.4.1",

--- a/examples/svelte-rsbuild/package.json
+++ b/examples/svelte-rsbuild/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-svelte": "^2.0.1",
     "@rstest/adapter-rsbuild": "workspace:*",
     "@rstest/core": "workspace:*",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -13,7 +13,7 @@
     "vue": "^3.5.42"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-babel": "^2.1.0",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@rsbuild/plugin-vue-jsx": "^2.0.1",

--- a/packages/adapter-rsbuild/package.json
+++ b/packages/adapter-rsbuild/package.json
@@ -36,7 +36,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*"

--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-svgr": "^2.0.5",
     "@tailwindcss/postcss": "^4.3.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,7 +70,7 @@
     "test": "npx rstest --globals"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@types/chai": "^5.2.3",
     "cjs-module-lexer": "^2.2.1"
   },

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -41,7 +41,7 @@
     "swc-plugin-coverage-instrument": "0.0.33"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -42,7 +42,7 @@
     "yuku-parser": "^0.9.4"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@rstest/tsconfig": "workspace:*",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -269,7 +269,7 @@
     "workspaceContains:**/*rstest.{workspace,projects}*.{ts,js,mjs,cjs,cts,mts,json}"
   ],
   "devDependencies": {
-    "@rsbuild/core": "~2.2.4",
+    "@rsbuild/core": "~2.2.5",
     "@rslib/core": "~1.0.0",
     "@rstest/core": "workspace:*",
     "@types/istanbul-lib-report": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3649,16 +3649,6 @@ packages:
     resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
     engines: {node: '>= 10'}
 
-  '@rsbuild/core@2.2.4':
-    resolution: {integrity: sha512-36Znklavtu2iSp7tGsn4VLRmMik60N50SFrimSORypBaGHHreDq/IpdSFJiu9xXdy4SmzK9LkTlmvSJ9L4gvfQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.2.5':
     resolution: {integrity: sha512-nf34ri1iZduYhHUr5Vc79L7Eml+IlN0nFIaF/g3OW4WR/gShxuf5wVXS69/H8FTHJYN4SdYlNcefSZQluEMKgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -11338,13 +11328,6 @@ snapshots:
       '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
       '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
-  '@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0)':
-    dependencies:
-      '@rspack/core': 2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0)':
     dependencies:
       '@rspack/core': 2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
@@ -11430,15 +11413,6 @@ snapshots:
       vm-browserify: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
-
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
 
   '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
     dependencies:
@@ -11813,8 +11787,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@8.1.1)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -11876,7 +11850,7 @@ snapshots:
 
   '@rspress/shared@2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@8.1.1)':
     dependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,13 +90,13 @@ importers:
     devDependencies:
       '@module-federation/rstest':
         specifier: 2.9.0
-        version: 2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)
+        version: 2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
@@ -229,10 +229,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -255,11 +255,11 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -358,7 +358,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -401,8 +401,8 @@ importers:
   e2e/playwright/fixtures:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -432,11 +432,11 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -466,11 +466,11 @@ importers:
         version: 3.5.42(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../../../packages/core
@@ -520,7 +520,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -565,17 +565,17 @@ importers:
         version: 3.5.42(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../../packages/browser
@@ -609,7 +609,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -645,16 +645,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 2.9.0
-        version: 2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@module-federation/rstest':
         specifier: 2.9.0
-        version: 2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)
+        version: 2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -676,16 +676,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 2.9.0
-        version: 2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@module-federation/rstest':
         specifier: 2.9.0
-        version: 2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)
+        version: 2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/browser':
         specifier: workspace:*
         version: link:../../../packages/browser
@@ -715,10 +715,10 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 2.9.0
-        version: 2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       serve:
         specifier: 14.2.6
         version: 14.2.6(supports-color@8.1.1)
@@ -741,8 +741,8 @@ importers:
   examples/playwright:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -766,11 +766,11 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -806,11 +806,11 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -937,11 +937,11 @@ importers:
   examples/svelte-rsbuild:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-svelte':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.57.0)(typescript@6.0.3)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.57.0)(typescript@6.0.3)
       '@rstest/adapter-rsbuild':
         specifier: workspace:*
         version: link:../../packages/adapter-rsbuild
@@ -965,17 +965,17 @@ importers:
         version: 3.5.42(typescript@6.0.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
       '@rstest/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -998,8 +998,8 @@ importers:
   packages/adapter-rsbuild:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
@@ -1147,14 +1147,14 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)
+        version: 2.0.5(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1174,8 +1174,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@types/chai':
         specifier: ^5.2.3
         version: 5.2.3
@@ -1200,13 +1200,13 @@ importers:
         version: 7.59.0(@types/node@22.18.6)
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+        version: 1.4.6(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       '@rslib/core':
         specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
@@ -1340,8 +1340,8 @@ importers:
         version: 0.0.33
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
@@ -1395,8 +1395,8 @@ importers:
         version: 0.9.4
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
@@ -1446,8 +1446,8 @@ importers:
   packages/vscode:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.2.4
-        version: 2.2.4(@module-federation/runtime-tools@2.9.0)
+        specifier: ~2.2.5
+        version: 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rslib/core':
         specifier: ~1.0.0
         version: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)
@@ -1507,7 +1507,7 @@ importers:
     dependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.6.3
-        version: 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
+        version: 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
       '@rstest/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1519,10 +1519,10 @@ importers:
         version: 0.7.0
       rsbuild-plugin-arethetypeswrong:
         specifier: ^0.4.0
-        version: 0.4.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3)
+        version: 0.4.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+        version: 1.0.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       shell-quote:
         specifier: ^1.10.0
         version: 1.10.0
@@ -1536,7 +1536,7 @@ importers:
         version: 2.6.2
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+        version: 2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       '@rspress/core':
         specifier: 2.0.21
         version: 2.0.21(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
@@ -1569,10 +1569,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+        version: 1.0.6(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+        version: 1.1.3(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
         version: 1.0.4(@rspress/core@2.0.21(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1))
@@ -3651,6 +3651,16 @@ packages:
 
   '@rsbuild/core@2.2.4':
     resolution: {integrity: sha512-36Znklavtu2iSp7tGsn4VLRmMik60N50SFrimSORypBaGHHreDq/IpdSFJiu9xXdy4SmzK9LkTlmvSJ9L4gvfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
+  '@rsbuild/core@2.2.5':
+    resolution: {integrity: sha512-nf34ri1iZduYhHUr5Vc79L7Eml+IlN0nFIaF/g3OW4WR/gShxuf5wVXS69/H8FTHJYN4SdYlNcefSZQluEMKgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -10513,13 +10523,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)':
     dependencies:
       '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@module-federation/node': 2.7.50(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@module-federation/sdk': 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -10544,13 +10554,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rstest@2.9.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)':
+  '@module-federation/rstest@2.9.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@rstest/core@packages+core)(typescript@6.0.3)':
     dependencies:
       '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@module-federation/node': 2.7.50(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@module-federation/sdk': 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
       '@rstest/core': link:packages/core
     transitivePeerDependencies:
       - '@rspack/core'
@@ -11335,7 +11345,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)':
+  '@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0)':
+    dependencies:
+      '@rspack/core': 2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
@@ -11344,11 +11361,11 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)':
+  '@rsbuild/plugin-babel@2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
@@ -11358,13 +11375,13 @@ snapshots:
       babel-loader: 10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       acorn: 8.17.0
       browserslist-to-es-version: 1.2.0
@@ -11372,21 +11389,21 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
       less-loader: 12.3.3(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -11412,9 +11429,9 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
@@ -11423,7 +11440,16 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -11431,15 +11457,15 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.57.0)(typescript@6.0.3)':
+  '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.57.0)(typescript@6.0.3)':
     dependencies:
       svelte: 5.57.0
       svelte-loader: 3.2.4(svelte@5.57.0)
       svelte-preprocess: 6.0.5(@babel/core@7.29.7(supports-color@8.1.1))(less@4.6.7)(postcss@8.5.19)(sass@1.100.0)(svelte@5.57.0)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -11452,37 +11478,37 @@ snapshots:
       - sugarss
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(supports-color@8.1.1)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-vue-jsx@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)':
+  '@rsbuild/plugin-vue-jsx@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(supports-color@8.1.1)
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       babel-plugin-vue-jsx-hmr: 1.0.0(supports-color@8.1.1)
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       rspack-vue-loader: 17.5.1(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(vue@3.5.42(typescript@6.0.3))
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -11490,9 +11516,9 @@ snapshots:
 
   '@rsdoctor/client@1.6.3': {}
 
-  '@rsdoctor/core@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)':
+  '@rsdoctor/core@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))
       '@rsdoctor/graph': 1.6.3(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rsdoctor/sdk': 1.6.3(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
       '@rsdoctor/types': 1.6.3(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
@@ -11525,9 +11551,9 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)':
+  '@rsdoctor/rspack-plugin@1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)':
     dependencies:
-      '@rsdoctor/core': 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
+      '@rsdoctor/core': 1.6.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
       '@rsdoctor/graph': 1.6.3(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
       '@rsdoctor/sdk': 1.6.3(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))(supports-color@8.1.1)
       '@rsdoctor/types': 1.6.3(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
@@ -11592,8 +11618,8 @@ snapshots:
 
   '@rslib/core@1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@module-federation/runtime-tools@2.9.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
-      rsbuild-plugin-dts: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.4)(typescript@6.0.3)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
+      rsbuild-plugin-dts: 1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.5)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@22.18.6)
       typescript: 6.0.3
@@ -11788,7 +11814,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1(supports-color@8.1.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(@rspack/core@2.2.3(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))
       '@rspress/shared': 2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@8.1.1)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -16545,33 +16571,33 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-arethetypeswrong@0.4.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3):
+  rsbuild-plugin-arethetypeswrong@0.4.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0))(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-dts@1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.4)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0(@microsoft/api-extractor@7.59.0(@types/node@22.18.6))(@rsbuild/core@2.2.5)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.45.2
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@22.18.6)
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0)):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0)):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.4(@module-federation/runtime-tools@2.9.0)):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.5(@module-federation/runtime-tools@2.9.0)):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.2.4(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.5(@module-federation/runtime-tools@2.9.0)
 
   rslog@2.3.0: {}
 


### PR DESCRIPTION
## Motivation

Adopt [Rsbuild 2.2.5](https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.5), which includes `@rstackjs/load-config` 1.0.0.

## Changes

Upgrade `@rsbuild/core` to `~2.2.5` across packages, examples, and test fixtures to keep workspace versions consistent, and regenerate the lockfile.