### PR TITLE
fix(cli): watch root config dependencies

### DIFF
--- a/e2e/watch/restart.test.ts
+++ b/e2e/watch/restart.test.ts
@@ -55,4 +55,30 @@ export default defineConfig({});
     // Give the OS a moment to release file handles (especially on Windows CI).
     await new Promise((resolve) => setTimeout(resolve, 1000));
   });
+
+  it('should restart when a root config dependency changes', async () => {
+    const fixturesTargetPath = `${__dirname}/fixtures-test-config-dependency${process.env.RSTEST_OUTPUT_MODULE !== 'false' ? '-module' : ''}`;
+    const { fs } = await prepareFixtures({
+      fixturesPath: `${__dirname}/fixtures`,
+      fixturesTargetPath,
+    });
+    const configFile = path.join(fixturesTargetPath, 'config.mjs');
+    const dependency = path.join(fixturesTargetPath, 'shared.mjs');
+    fs.create(dependency, 'export default {};');
+    fs.create(configFile, "export { default } from './shared.mjs';");
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['watch', '-c', configFile],
+      options: { nodeOptions: { cwd: fixturesTargetPath } },
+    });
+    await cli.waitForStdout('Waiting for file changes...');
+    expect(cli.stdout).toContain('Tests 2 passed');
+
+    cli.resetStd();
+    fs.update(dependency, (content) => `${content}\n// trigger restart`);
+    await cli.waitForStdout('restarting Rstest as shared.mjs changed');
+    await cli.waitForStdout('Waiting for file changes...');
+    expect(cli.stdout).toContain('Tests 2 passed');
+  });
 });

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -663,6 +663,7 @@ export const runWatch = async ({
     await watchFilesForRestart({
       configFilePaths: [
         loaded.filePath,
+        ...loaded.dependencies,
         ...filterProjects(
           rstest.context.projects.map((project) => ({
             config: { name: project.name },


### PR DESCRIPTION
## Motivation

Changes to files imported by the root config do not restart `rstest watch`.

## Changes

Include the dependencies returned by `loadConfig()` in the CLI's configuration restart watcher.

Verified with the existing restart E2E and a temporary watch session that reloaded updated configuration after an imported file changed.