### PR TITLE
fix(coverage-v8): preserve template counters and implicit else hits

### DIFF
--- a/packages/coverage-v8/src/v8AstConverter.ts
+++ b/packages/coverage-v8/src/v8AstConverter.ts
@@ -106,7 +106,6 @@ type PreparedCoverage = {
   statements: StatementDescriptor[];
   branches: BranchDescriptor[];
 };
-type FileCoverageLike = FileCoverageData | { data: FileCoverageData };
 
 type ConvertOptions = {
   ast: ParseResult | (() => ParseResult);
@@ -367,6 +366,16 @@ async function prepareCoverage(
             expression.value !== 'use strict'
           ) {
             builder.addStatement(current);
+          }
+          return;
+        }
+        case 'ExportDefaultDeclaration': {
+          const declaration = current.declaration as AstNode;
+          if (
+            declaration.type !== 'FunctionDeclaration' &&
+            declaration.type !== 'ClassDeclaration'
+          ) {
+            builder.addStatement(declaration);
           }
           return;
         }
@@ -936,13 +945,7 @@ function applyCoverageToMap(
   prepared: PreparedCoverage,
   ranges: NormalizedRange[],
 ): void {
-  const data: Record<string, FileCoverageData> = {};
-
-  for (const [filename, template] of Object.entries(prepared.files)) {
-    data[filename] = getOrCreateFileCoverage(coverageMap, filename, template);
-  }
-
-  applyCoverageHits(data, prepared, ranges);
+  coverageMap.merge(applyCoverage(prepared, ranges));
 }
 
 function createFileCoverage(template: FileTemplate): FileCoverageData {
@@ -967,25 +970,6 @@ function createFileCoverage(template: FileTemplate): FileCoverageData {
   }
 
   return fileCoverage;
-}
-
-function getOrCreateFileCoverage(
-  coverageMap: CoverageMap,
-  filename: string,
-  template: FileTemplate,
-): FileCoverageData {
-  const existingCoverage = coverageMap.data[filename] as
-    FileCoverageLike | undefined;
-
-  if (existingCoverage) {
-    return 'data' in existingCoverage
-      ? existingCoverage.data
-      : existingCoverage;
-  }
-
-  coverageMap.addFileCoverage(createFileCoverage(template));
-  const fileCoverage = coverageMap.data[filename] as FileCoverageLike;
-  return 'data' in fileCoverage ? fileCoverage.data : fileCoverage;
 }
 
 function applyCoverageHits(
@@ -1014,7 +998,16 @@ function applyCoverageHits(
     for (let index = 0; index < descriptor.ranges.length; index++) {
       const range = descriptor.ranges[index]!;
       const count = getCount(range, ranges);
-      const hit = range.implicit ? count - previousHit : count;
+      let hit = count;
+      if (range.implicit) {
+        // A conditional await can count only resumptions at the if header.
+        const parent = Math.max(
+          count,
+          getCount({ startOffset: range.endOffset }, ranges),
+          previousHit,
+        );
+        hit = parent - previousHit;
+      }
       hits[index] = hits[index]! + hit;
       previousHit = hit;
     }
@@ -1183,7 +1176,7 @@ function getMostSpecificRange(ranges: RawCoverageRange[]) {
 }
 
 function getCount(
-  offset: { startOffset: number; endOffset: number },
+  offset: { startOffset: number },
   coverages: NormalizedRange[],
 ) {
   let count = 0;

--- a/packages/coverage-v8/tests/converter.test.ts
+++ b/packages/coverage-v8/tests/converter.test.ts
@@ -1,0 +1,293 @@
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { Worker } from 'node:worker_threads';
+import type { Profiler } from 'node:inspector';
+import { rspack } from '@rsbuild/core';
+import { decodedMappings, TraceMap } from '@jridgewell/trace-mapping';
+import libCoverage from 'istanbul-lib-coverage';
+import { parse } from 'yuku-parser';
+import {
+  convertV8CoverageWithAst,
+  applyV8CoverageWithAst,
+} from '../src/v8AstConverter';
+
+const { createCoverageMap } = libCoverage;
+
+const collision = `function run(value: { n: number } | null) {
+  const n = value?.n ?? 0;
+  if (n) {
+    globalThis.total = n;
+  }
+  return n;
+}
+run({ n: 3 });
+run(null);
+`;
+
+const reordered = `function first(value: number) {
+  if (value) { globalThis.total = value; }
+  return value;
+}
+function second(value: number) {
+  if (value) { globalThis.total = value; }
+  return value;
+}
+first(1);
+first(2);
+second(0);
+`;
+
+const conditionalAwait = `type Body = { code: number } | undefined;
+async function loadBody(err: { status: number }): Promise<Body> {
+  return { code: err.status === 400 ? 2 : 1 };
+}
+function isFiltered(body: Body): boolean {
+  return body?.code === 2;
+}
+async function handle(passed: Body, err: { status: number }) {
+  if (err.status === 404) {
+    return 'not-found';
+  }
+  const body = passed ?? (await loadBody(err));
+  if (!isFiltered(body)) {
+    globalThis.reported += 1;
+  }
+  return body;
+}
+async function main() {
+  globalThis.reported = 0;
+  await handle(undefined, { status: 404 });
+  for (let i = 0; i < 4; i++) await handle({ code: 1 }, { status: 500 });
+  for (let i = 0; i < 6; i++) await handle(undefined, { status: 500 });
+  for (let i = 0; i < 2; i++) await handle(undefined, { status: 400 });
+}
+globalThis.done = main();
+`;
+
+async function collect(
+  code: string,
+  url: string,
+): Promise<Profiler.ScriptCoverage> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      `
+      const { parentPort, workerData } = require('node:worker_threads');
+      const { Session } = require('node:inspector/promises');
+      const vm = require('node:vm');
+      (async () => {
+        const session = new Session();
+        session.connect();
+        try {
+          await session.post('Profiler.enable');
+          await session.post('Profiler.startPreciseCoverage', { callCount: true, detailed: true });
+          const context = vm.createContext({ make: value => value });
+          const module = new vm.SourceTextModule(workerData.code, {
+            context, identifier: workerData.url,
+          });
+          await module.link(() => new vm.SourceTextModule('export const value = 42;', { context }));
+          await module.evaluate();
+          await vm.runInContext('globalThis.done', context);
+          const { result } = await session.post('Profiler.takePreciseCoverage');
+          parentPort.postMessage(result.find(entry => entry.url === workerData.url));
+        } finally {
+          session.disconnect();
+        }
+      })();
+      `,
+      {
+        eval: true,
+        workerData: { code, url },
+        execArgv: ['--experimental-vm-modules'],
+      },
+    );
+    let coverage: Profiler.ScriptCoverage | undefined;
+    worker.on('message', (value: Profiler.ScriptCoverage) => {
+      coverage = value;
+    });
+    worker.on('error', reject);
+    worker.on('exit', (code) => {
+      if (code === 0 && coverage) resolve(coverage);
+      else reject(new Error(`Coverage worker exited with ${code}`));
+    });
+  });
+}
+
+async function prepare(
+  source: string,
+  name: string,
+  form: 'es2022' | 'es2016' | 'es5' | 'reordered',
+) {
+  const file = join(tmpdir(), 'rstest-converter', `${name}.ts`);
+  const generated = join(tmpdir(), 'rstest-converter', `${name}-${form}.js`);
+  const result = await rspack.experiments.swc.transform(source, {
+    filename: file,
+    inlineSourcesContent: true,
+    jsc: {
+      parser: { syntax: 'typescript' },
+      target: form === 'reordered' ? 'es2022' : form,
+    },
+    sourceMaps: true,
+  });
+  const trace = new TraceMap(result.map!);
+  let mappings = [...decodedMappings(trace)];
+  let code = result.code;
+  if (form === 'reordered') {
+    const middle = code.indexOf('function second');
+    const end = code.indexOf('\nfirst(', middle) + 1;
+    const first = code.slice(0, middle);
+    const second = code.slice(middle, end);
+    const firstLines = first.split('\n').length - 1;
+    const secondLines = second.split('\n').length - 1;
+    mappings = [
+      ...mappings.slice(firstLines, firstLines + secondLines),
+      ...mappings.slice(0, firstLines),
+      ...mappings.slice(firstLines + secondLines),
+    ];
+    code = second + first + code.slice(end);
+  }
+  const url = pathToFileURL(generated).href;
+  return {
+    file,
+    options: {
+      ast: parse(code, { sourceType: 'module', preserveParens: false }),
+      cacheKey: generated,
+      code,
+      coverage: await collect(code, url),
+      sourceMap: {
+        version: 3,
+        sources: trace.sources,
+        sourcesContent: trace.sourcesContent,
+        names: trace.names,
+        mappings,
+      },
+    },
+  };
+}
+
+describe('coverage-v8 converter regressions', () => {
+  it.each([
+    { name: 'two-form', source: collision, forms: ['es2022', 'es5'] as const },
+    {
+      name: 'reordered',
+      source: reordered,
+      forms: ['es2022', 'reordered'] as const,
+    },
+    {
+      name: 'same-form',
+      source: collision,
+      forms: ['es2022', 'es2022'] as const,
+    },
+  ])(
+    'merges $name templates by source location',
+    async ({ name, source, forms }) => {
+      const inputs = [];
+      for (const form of forms) inputs.push(await prepare(source, name, form));
+      const oracle = createCoverageMap();
+      for (const { options } of inputs) {
+        oracle.merge(await convertV8CoverageWithAst(options));
+      }
+      for (const order of [inputs, [...inputs].reverse()]) {
+        const actual = createCoverageMap();
+        const expected = createCoverageMap();
+        for (const { options } of order) {
+          expected.merge(await convertV8CoverageWithAst(options));
+          await applyV8CoverageWithAst({ ...options, coverageMap: actual });
+        }
+        expect(actual.toJSON()).toEqual(expected.toJSON());
+        expect(actual.getCoverageSummary()).toEqual(
+          oracle.getCoverageSummary(),
+        );
+        for (const file of actual.files()) {
+          const data = actual.fileCoverageFor(file);
+          for (const counts of [
+            Object.values(data.s),
+            Object.values(data.f),
+            Object.values(data.b).flat(),
+          ]) {
+            expect(
+              counts.every((count) => Number.isFinite(count) && count >= 0),
+            ).toBe(true);
+          }
+        }
+      }
+    },
+  );
+
+  it.each(['es2022', 'es2016', 'es5'] as const)(
+    'counts the implicit else after a conditional await (%s)',
+    async (form) => {
+      const { file, options } = await prepare(
+        conditionalAwait,
+        'conditional-await',
+        form,
+      );
+      const coverage = (await convertV8CoverageWithAst(options))[file]!;
+      const branch = Object.entries(coverage.branchMap).find(
+        ([, value]) => value.type === 'if' && value.loc.start.line === 13,
+      );
+      expect(branch).toBeDefined();
+      expect(coverage.b[branch![0]]).toEqual([10, 2]);
+    },
+  );
+
+  it.each([
+    'export default globalThis.make({ answer: 42 });\n',
+    'export default { answer: 42 };\n',
+  ])('counts executed and unexecuted default expressions: %s', async (code) => {
+    const file = join(
+      tmpdir(),
+      'rstest-converter',
+      `default-${code.includes('make') ? 'call' : 'object'}.js`,
+    );
+    const url = pathToFileURL(file).href;
+    for (const count of [0, 1]) {
+      const coverage = await convertV8CoverageWithAst({
+        ast: parse(code, { sourceType: 'module', preserveParens: false }),
+        cacheKey: file,
+        code,
+        coverage:
+          count === 1
+            ? await collect(code, url)
+            : {
+                url,
+                functions: [
+                  {
+                    functionName: '',
+                    isBlockCoverage: true,
+                    ranges: [
+                      { startOffset: 0, endOffset: code.length, count: 0 },
+                    ],
+                  },
+                ],
+              },
+      });
+      expect(
+        Object.values(coverage[file]!.statementMap).map((loc) => loc.start),
+      ).toContainEqual({ line: 1, column: 15 });
+      expect(Object.values(coverage[file]!.s)).toEqual([count]);
+    }
+  });
+
+  it.each([
+    'export default function sample() {}\n',
+    'export default class Sample {}\n',
+    "export { value } from './helper';\n",
+  ])(
+    'does not add expression statements for declarations or re-exports: %s',
+    async (code) => {
+      const file = join(
+        tmpdir(),
+        'rstest-converter',
+        `${code.split(' ')[2]}.js`,
+      );
+      const coverage = await convertV8CoverageWithAst({
+        ast: parse(code, { sourceType: 'module', preserveParens: false }),
+        cacheKey: file,
+        code,
+        coverage: await collect(code, pathToFileURL(file).href),
+      });
+      expect(coverage[file]!.statementMap).toEqual({});
+    },
+  );
+});


### PR DESCRIPTION
## Motivation

The AST converter can apply a script's descriptor indexes to counters created for a different generated form of the same source file. Compiling an optional-chain/nullish-coalescing fixture to ES2022 and ES5 reproduces a missing branch-counter error. Reordering two generated functions, with their source-map lines, keeps the same number of entries but assigns hits to the wrong locations:

```text
                           before                 after
first/second function hits  [3, 3]                 [4, 2]
first/second branch hits    [2, 1], [2, 1]         [4, 0], [0, 2]
```

A separate fixture calls a function 13 times: one early return, four calls that skip an await, and eight that await. Ten enter the following `if`; two take its implicit else. V8 counts only eight resumptions at the `if` header:

```js
const body = passed ?? (await loadBody(err));
if (!isFiltered(body)) {
  globalThis.reported += 1;
}
return body;
```

```text
implicit-else branch: [10, -2] -> [10, 2]
```

Default-export expressions also have no statement entry:

```js
export default globalThis.make({ answer: 42 });
```

```text
before: no statement
after:  statement at line 1, column 15; hit 0 when unexecuted, 1 when executed
```

## Changes

Apply counters to their own prepared template, then use the public coverage-map merge to combine source locations. For an implicit else, subtract the consequent count from the maximum measured count at the header, the continuation after the `if`, and the consequent. Recognize default-export expressions as statements while leaving function/class declarations and re-exports unchanged.

The regressions collect native precise V8 coverage in isolated workers. They compare both merge orders against separately converted maps, retain a same-form control, and check conditional await under ES2022, ES2016 and ES5. Default expressions use native execution for hit 1 and a zero-hit V8 range for the unexecuted case. No new dependencies or public APIs.

Validation on Node 24.15.0:

- Coverage-v8 package: 64 tests pass, including 11 new cases. Before the fix, six new cases fail and five controls pass.
- All package builds, root `pnpm lint`, and `pnpm check-unused` pass. Knip reports two existing configuration hints.

To reproduce locally, install with the pinned pnpm version, build the workspace, and run `pnpm --filter @rstest/coverage-v8 test --pool.maxWorkers=1`. The fixtures are self-contained in `packages/coverage-v8/tests/converter.test.ts`.

This does not address existing implicit-else counts that are too high when V8 supplies only an enclosing function range. No performance claim is made for the changed merge path.
