### PR TITLE
refactor(core): pass config load results internally

### DIFF
--- a/packages/core/src/api/createRstest.ts
+++ b/packages/core/src/api/createRstest.ts
@@ -116,11 +116,14 @@ export async function createRstestInstance(
   runtime: HostRuntime,
 ): Promise<RstestInstance> {
   initRstestEnv();
+
   const cwd = options.cwd
     ? getAbsolutePath(process.cwd(), options.cwd)
     : process.cwd();
   const config = options.config ?? {};
+
   let result: LoadConfigResult<RstestConfig>;
+
   if ('content' in config && 'filePath' in config) {
     result = {
       dependencies: [],
@@ -132,6 +135,7 @@ export async function createRstestInstance(
   } else {
     result = { content: config, filePath: null, dependencies: [] };
   }
+
   const initialInputs = await resolveRunnerInputs({
     result,
     options: { configLoader: options.configLoader },

--- a/packages/core/src/api/createRstest.ts
+++ b/packages/core/src/api/createRstest.ts
@@ -1,4 +1,5 @@
 /** Instance implementation shared by the public entry and the CLI. */
+import type { LoadConfigResult } from '@rsbuild/core';
 import type { CommonOptions } from '../cli/init';
 import { initRstestEnv } from '../cli/prepare';
 import {
@@ -30,7 +31,6 @@ import type {
   CreateRstestOptions,
   ListedTest,
   ListOptions,
-  LoadedRstestConfig,
   MergeReportsOptions,
   RstestContext,
   RstestInstance,
@@ -111,10 +111,6 @@ const flattenListedTests = (
   return listed;
 };
 
-const isLoadedRstestConfig = (
-  config: RstestConfig | LoadedRstestConfig,
-): config is LoadedRstestConfig => 'content' in config && 'filePath' in config;
-
 export async function createRstestInstance(
   options: CreateRstestOptions,
   runtime: HostRuntime,
@@ -124,24 +120,26 @@ export async function createRstestInstance(
     ? getAbsolutePath(process.cwd(), options.cwd)
     : process.cwd();
   const config = options.config ?? {};
+  let result: LoadConfigResult<RstestConfig>;
+  if ('content' in config && 'filePath' in config) {
+    result = {
+      dependencies: [],
+      ...config,
+      content: config.content,
+      filePath:
+        config.filePath === null ? null : getAbsolutePath(cwd, config.filePath),
+    };
+  } else {
+    result = { content: config, filePath: null, dependencies: [] };
+  }
   const initialInputs = await resolveRunnerInputs({
-    source: {
-      type: 'value',
-      config: isLoadedRstestConfig(config) ? config.content : config,
-      configFilePath:
-        isLoadedRstestConfig(config) && config.filePath !== null
-          ? getAbsolutePath(cwd, config.filePath)
-          : undefined,
-    },
+    result,
     options: { configLoader: options.configLoader },
     cwd,
   });
   const initialContext = createRstestContext(
     {
-      config: initialInputs.config,
-      configFilePath: initialInputs.configFilePath,
-      projects: initialInputs.projects,
-      cwd,
+      ...initialInputs,
       embedded: runtime.embedded,
       initializeReporters: false,
     },

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import type { LoadConfigOptions } from '@rsbuild/core';
+import type { LoadConfigOptions, LoadConfigResult } from '@rsbuild/core';
 import { basename, dirname, resolve } from 'pathe';
 import { type GlobOptions, glob, isDynamicPattern } from 'tinyglobby';
 import type { RunOptions } from '../api/types';
@@ -336,26 +336,16 @@ export function mergeWithCLIOptions(
 
 async function resolveConfig(
   options: CommonOptions & { cwd: string },
-): Promise<{
-  config: RstestConfig;
-  configFilePath?: string;
-}> {
-  const { content: config, filePath: configFilePath } = await loadConfig({
+): Promise<LoadConfigResult<RstestConfig>> {
+  const result = await loadConfig({
     cwd: options.cwd,
     path: options.config,
     configLoader: options.configLoader,
   });
 
-  const mergedConfig = mergeWithCLIOptions(config, options);
-
-  if (!mergedConfig.root) {
-    mergedConfig.root = options.cwd;
-  }
-
-  return {
-    config: mergedConfig,
-    configFilePath: configFilePath ?? undefined,
-  };
+  mergeWithCLIOptions(result.content, options);
+  result.content.root ||= options.cwd;
+  return result;
 }
 
 export const formatNoProjectsFoundError = (
@@ -416,10 +406,7 @@ export async function resolveProjects({
     const projectPaths: string[] = [];
     const projectPatterns: string[] = [];
     const inlineProjectConfigPromises: Promise<
-      | {
-          config: RstestConfig;
-          configFilePath: string | undefined;
-        }
+      | LoadConfigResult<RstestConfig>
       | {
           error: unknown;
         }
@@ -432,7 +419,7 @@ export async function resolveProjects({
         inlineProjectConfigPromises.push(
           resolveExtends({ ...p }).then(
             (projectConfig) => ({
-              config: mergeWithCLIOptions(
+              content: mergeWithCLIOptions(
                 {
                   root: projectRoot,
                   ...projectConfig,
@@ -440,7 +427,8 @@ export async function resolveProjects({
                 },
                 options,
               ),
-              configFilePath: undefined,
+              filePath: null,
+              dependencies: [],
             }),
             (error) => ({ error }),
           ),
@@ -479,38 +467,33 @@ export async function resolveProjects({
 
     projectPaths.push(...globbedProjectPaths);
 
-    const projects: {
-      config: RstestConfig;
-      configFilePath?: string;
-    }[] = [];
+    const projects: LoadConfigResult<RstestConfig>[] = [];
 
     await Promise.all(
       projectPaths.map(async (project) => {
         const isDirectory = statSync(project).isDirectory();
         const projectRoot = isDirectory ? project : dirname(project);
-        const { config, configFilePath } = await resolveConfig({
+        const result = await resolveConfig({
           ...options,
           config: isDirectory ? undefined : project,
           cwd: projectRoot,
         });
 
-        if (configFilePath) {
-          if (resolvedProjectPaths.has(configFilePath)) {
+        if (result.filePath) {
+          if (resolvedProjectPaths.has(result.filePath)) {
             return;
           }
-          resolvedProjectPaths.add(configFilePath);
+          resolvedProjectPaths.add(result.filePath);
         }
 
+        const config = result.content;
         config.name ??= getDefaultProjectName(projectRoot);
 
         if (config.projects?.length) {
           const childProjects = await getProjects(config, projectRoot);
           projects.push(...childProjects);
         } else {
-          projects.push({
-            config,
-            configFilePath,
-          });
+          projects.push(result);
         }
       }),
     );
@@ -524,7 +507,10 @@ export async function resolveProjects({
     throw formatNoProjectsFoundError(config);
   }
 
-  return declaredProjects;
+  return declaredProjects.map((result) => ({
+    config: result.content,
+    configFilePath: result.filePath ?? undefined,
+  }));
 }
 
 export function applyAgentReporterDefault(

--- a/packages/core/src/core/buildRunner.ts
+++ b/packages/core/src/core/buildRunner.ts
@@ -2,22 +2,14 @@ import { normalize, relative, resolve } from 'pathe';
 import picomatch from 'picomatch';
 import type { CommonOptions } from '../cli/init';
 import { exitReporters } from '../reporter';
-import type {
-  Project,
-  RstestCommand,
-  RstestConfig,
-  RstestInstance,
-} from '../types';
+import type { RstestCommand, RstestInstance } from '../types';
 import { logger, quoteFilter } from '../utils';
 import type { ResolvedRunnerInputs } from './resolveConfig';
 
 export type CreateRstestContextFn<
   Instance extends RstestInstance = RstestInstance,
 > = (
-  input: {
-    config: RstestConfig;
-    configFilePath?: string;
-    projects: Project[];
+  input: Pick<ResolvedRunnerInputs, 'result' | 'projects'> & {
     cwd?: string;
     trace?: boolean;
     embedded?: boolean;
@@ -214,9 +206,8 @@ const resolveEffectiveFilters = async ({
     );
   }
 
-  const { config, configFilePath, projects, cwd } = inputs;
   const rstest = createRstestContext(
-    { config, configFilePath, projects, cwd, embedded },
+    { ...inputs, embedded },
     'list',
     undefined,
   );
@@ -319,10 +310,7 @@ export async function buildResolvedRunner<Instance extends RstestInstance>({
   });
   const rstest = createRstestContext(
     {
-      config: inputs.config,
-      configFilePath: inputs.configFilePath,
-      projects: inputs.projects,
-      cwd: inputs.cwd,
+      ...inputs,
       trace: options.trace,
       embedded,
     },

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1,3 +1,4 @@
+import type { LoadConfigResult } from '@rsbuild/core';
 import type {
   ListCommandCollectOptions,
   Project,
@@ -13,16 +14,14 @@ export type CoreRstestInstance = Omit<RstestInstance, 'context'> & {
 
 export function createRstest(
   {
-    config,
+    result,
     projects,
-    configFilePath,
     trace,
     cwd = process.cwd(),
     embedded = false,
     initializeReporters,
   }: {
-    config: RstestConfig;
-    configFilePath?: string;
+    result: LoadConfigResult<RstestConfig>;
     projects: Project[];
     /** CLI-only `--trace` switch; not exposed via user config. */
     trace?: boolean;
@@ -44,13 +43,13 @@ export function createRstest(
       cwd,
       command,
       fileFilters,
-      configFilePath,
+      configFilePath: result.filePath ?? undefined,
       projects,
       trace,
       embedded,
       initializeReporters,
     },
-    config,
+    result.content,
   );
 
   const runTests = async (): Promise<void> => {

--- a/packages/core/src/core/resolveConfig.ts
+++ b/packages/core/src/core/resolveConfig.ts
@@ -1,7 +1,7 @@
+import type { LoadConfigResult } from '@rsbuild/core';
 import {
   type CommonOptions,
   formatNoProjectsFoundError,
-  loadCliConfig,
   mergeWithCLIOptions,
   resolveProjects,
 } from '../cli/init';
@@ -9,17 +9,8 @@ import { clonePlainConfig, resolveExtends } from '../config';
 import type { Project, RstestConfig } from '../types';
 import { filterProjects, getAbsolutePath } from '../utils';
 
-export type RunnerConfigSource =
-  | { type: 'discover' }
-  | {
-      type: 'value';
-      config: RstestConfig;
-      configFilePath?: string;
-    };
-
 export type ResolvedRunnerInputs = {
-  config: RstestConfig;
-  configFilePath?: string;
+  result: LoadConfigResult<RstestConfig>;
   projects: Project[];
   cwd: string;
 };
@@ -31,7 +22,10 @@ export function resolveRunnerOperationInputs({
   inputs: ResolvedRunnerInputs;
   options: CommonOptions;
 }): ResolvedRunnerInputs {
-  const config = mergeWithCLIOptions(clonePlainConfig(inputs.config), options);
+  const config = mergeWithCLIOptions(
+    clonePlainConfig(inputs.result.content),
+    options,
+  );
   config.root = config.root
     ? getAbsolutePath(inputs.cwd, config.root)
     : inputs.cwd;
@@ -49,40 +43,26 @@ export function resolveRunnerOperationInputs({
   }
 
   return {
-    config,
-    configFilePath: inputs.configFilePath,
+    result: { ...inputs.result, content: config },
     projects,
     cwd: inputs.cwd,
   };
 }
 
 export async function resolveRunnerInputs({
-  source,
+  result,
   options,
   cwd,
-  tweakConfig,
 }: {
-  source: RunnerConfigSource;
+  result: LoadConfigResult<RstestConfig>;
   options: CommonOptions;
   cwd: string;
-  tweakConfig?: (config: RstestConfig) => void;
 }): Promise<ResolvedRunnerInputs> {
-  let config: RstestConfig;
-  let configFilePath: string | undefined;
-
-  if (source.type === 'discover') {
-    const loaded = await loadCliConfig(options, cwd);
-    config = loaded.content;
-    configFilePath = loaded.filePath ?? undefined;
-  } else {
-    // Cloning must preserve exclude.override until defaults are applied.
-    config = await resolveExtends(clonePlainConfig(source.config));
-    configFilePath = source.configFilePath;
-  }
+  // Cloning must preserve exclude.override until defaults are applied.
+  const config = await resolveExtends(clonePlainConfig(result.content));
 
   mergeWithCLIOptions(config, options);
   config.root = config.root ? getAbsolutePath(cwd, config.root) : cwd;
-  tweakConfig?.(config);
 
   const projects = await resolveProjects({
     config,
@@ -104,5 +84,5 @@ ${conflictProjects.map((p) => `- ${p.configFilePath || p.config.root}`).join('\n
     names.add(project.config.name!);
   }
 
-  return { config, configFilePath, projects, cwd };
+  return { result: { ...result, content: config }, projects, cwd };
 }


### PR DESCRIPTION
## Motivation

Internal configuration handling repeatedly splits and rebuilds config content and file metadata, making dependency propagation harder.

## Changes

Pass `LoadConfigResult<RstestConfig>` through runner input resolution, runner creation, and project loading. Remove the unused discovery branch and `tweakConfig` callback while preserving public API inputs and existing configuration behavior.

Build, type checking, focused unit tests, and 39 E2E tests pass. Browser execution is unchanged; the programmatic E2E suite covers browser startup and watch.