### PR TITLE
fix(cli): watch project config dependencies

### DIFF
--- a/e2e/programmatic/index.test.ts
+++ b/e2e/programmatic/index.test.ts
@@ -284,8 +284,8 @@ describe('programmatic createRstest', () => {
     expect(result.context).toEqual({
       rootPathMatches: true,
       projects: [
-        { name: 'alpha', rootPath: 'alpha' },
-        { name: 'beta', rootPath: 'beta' },
+        { name: 'alpha', rootPath: 'alpha', configFileDependencies: [] },
+        { name: 'beta', rootPath: 'beta', configFileDependencies: [] },
       ],
     });
     expect(result.files).toEqual([

--- a/e2e/watch/restart.test.ts
+++ b/e2e/watch/restart.test.ts
@@ -81,4 +81,39 @@ export default defineConfig({});
     await cli.waitForStdout('Waiting for file changes...');
     expect(cli.stdout).toContain('Tests 2 passed');
   });
+
+  it('watches project config dependencies', async () => {
+    const root = `${__dirname}/fixtures-test-project-dependencies-${process.env.RSTEST_OUTPUT_MODULE}`;
+    const { fs } = await prepareFixtures({
+      fixturesPath: `${__dirname}/fixtures`,
+      fixturesTargetPath: root,
+    });
+    const configs = {
+      'root.config.mjs':
+        "export default { projects: ['./parent.config.mjs'] };",
+      'parent.config.mjs':
+        "import './parent.mjs'; export default { projects: ['./project.config.mjs'] };",
+      'parent.mjs': 'export default {};',
+      'project.config.mjs': "export { default } from './shared.mjs';",
+      'shared.mjs': "export default { name: 'watched' };",
+    };
+    for (const [file, content] of Object.entries(configs)) {
+      fs.create(path.join(root, file), content);
+    }
+
+    const { cli } = await runRstestCli({
+      command: 'rstest',
+      args: ['watch', '-c', 'root.config.mjs', '--project', 'watched'],
+      options: { nodeOptions: { cwd: root } },
+    });
+    await cli.waitForStdout('Waiting for file changes...');
+
+    for (const file of ['shared.mjs', 'parent.mjs', 'parent.config.mjs']) {
+      cli.resetStd();
+      fs.update(path.join(root, file), (content) => `${content}\n// changed`);
+      await cli.waitForStdout(`restarting Rstest as ${file} changed`);
+      await cli.waitForStdout('Tests 2 passed');
+      await cli.waitForStdout('Waiting for file changes...');
+    }
+  });
 });

--- a/packages/core/src/api/createRstest.ts
+++ b/packages/core/src/api/createRstest.ts
@@ -158,6 +158,7 @@ export async function createRstestInstance(
       name: project.name,
       rootPath: project.rootPath,
       configFilePath: project.configFilePath,
+      configFileDependencies: project.configFileDependencies,
     })),
   };
 

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -39,6 +39,7 @@ export interface ProjectContext {
   name: string;
   rootPath: string;
   configFilePath?: string;
+  configFileDependencies?: string[];
 }
 
 /** @experimental Subject to change until 1.0.0. */

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -668,9 +668,13 @@ export const runWatch = async ({
           rstest.context.projects.map((project) => ({
             config: { name: project.name },
             configFilePath: project.configFilePath,
+            configFileDependencies: project.configFileDependencies,
           })),
           options,
-        ).map((project) => project.configFilePath),
+        ).flatMap((project) => [
+          project.configFilePath,
+          ...(project.configFileDependencies ?? []),
+        ]),
       ].filter((filePath): filePath is string => !!filePath),
       rootPath: rstest.context.rootPath,
       restart: async () => {

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -491,6 +491,12 @@ export async function resolveProjects({
 
         if (config.projects?.length) {
           const childProjects = await getProjects(config, projectRoot);
+          for (const child of childProjects) {
+            child.dependencies.push(...result.dependencies);
+            if (result.filePath) {
+              child.dependencies.push(result.filePath);
+            }
+          }
           projects.push(...childProjects);
         } else {
           projects.push(result);
@@ -510,6 +516,7 @@ export async function resolveProjects({
   return declaredProjects.map((result) => ({
     config: result.content,
     configFilePath: result.filePath ?? undefined,
+    configFileDependencies: result.dependencies,
   }));
 }
 

--- a/packages/core/src/core/rstest.ts
+++ b/packages/core/src/core/rstest.ts
@@ -247,6 +247,7 @@ export class Rstest implements InternalContext {
 
           return {
             configFilePath: project.configFilePath,
+            configFileDependencies: project.configFileDependencies,
             rootPath: config.root,
             name: config.name,
             _globalSetups: false,

--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -24,7 +24,11 @@ export type ProjectEntries = {
 
 export type RstestCommand = 'watch' | 'run' | 'list' | 'merge-reports';
 
-export type Project = { config: RstestConfig; configFilePath?: string };
+export type Project = {
+  config: RstestConfig;
+  configFilePath?: string;
+  configFileDependencies?: string[];
+};
 
 export type InternalProjectContext = {
   name: string;
@@ -46,6 +50,7 @@ export type InternalProjectContext = {
   /** Whether to output es module. */
   outputModule: boolean;
   configFilePath?: string;
+  configFileDependencies?: string[];
   normalizedConfig: NormalizedProjectConfig;
   _globalSetups: boolean;
 };

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -111,6 +111,7 @@ interface ProjectContext {
   name: string; // Project name.
   rootPath: string; // Absolute project root path.
   configFilePath?: string; // Project config file path, when one is associated with the project.
+  configFileDependencies?: string[]; // Project config dependencies, including parent project configuration files.
 }
 
 interface RstestContext {

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -111,6 +111,7 @@ interface ProjectContext {
   name: string; // 项目名称。
   rootPath: string; // 项目的绝对根路径。
   configFilePath?: string; // 与项目关联的配置文件路径（如果有）。
+  configFileDependencies?: string[]; // 项目配置依赖，包括父级项目的配置文件。
 }
 
 interface RstestContext {


### PR DESCRIPTION
## Motivation

Changes to files imported by project configs, or to parent configs of nested projects, do not restart `rstest watch`.

## Changes

Preserve project configuration dependencies, including parent config files, and expose them through the optional `ProjectContext.configFileDependencies` field. Include these files in the restart watcher for selected projects.

Update the English and Chinese API types and add a regression test covering project dependencies, parent dependencies, and parent config changes. The test passes in ESM and CommonJS modes; browser lifecycle code is unchanged.